### PR TITLE
Fix TTS audio: weight loading, AdaIN, iSTFT

### DIFF
--- a/notebooks/stt_comparison.ipynb
+++ b/notebooks/stt_comparison.ipynb
@@ -1,0 +1,344 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 5,
+  "metadata": {
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3",
+      "language": "python"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "runt": {
+      "schema_version": "1",
+      "env_id": "8671774f-8b4a-482e-954b-a3c7552a38c9",
+      "uv": {
+        "dependencies": [
+          "mlx-whisper"
+        ]
+      }
+    }
+  },
+  "cells": [
+    {
+      "id": "7e27aac9-4407-4dd5-abc8-d95fa0475687",
+      "cell_type": "code",
+      "source": [],
+      "metadata": {},
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "id": "cell-9d04f719-155c-4db2-bd54-dc0e6622eb3d",
+      "cell_type": "markdown",
+      "source": [
+        "# Voicers TTS vs Whisper STT Comparison\n",
+        "\n",
+        "Generate audio with voicers, transcribe with Whisper, compare what was said vs what was heard."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "cell-37c1b09a-b6cf-4cc0-b7ef-28d2b2cbafe5",
+      "cell_type": "code",
+      "source": [
+        "import subprocess, json, os\n",
+        "\n",
+        "test_phrases = [\n",
+        "    \"Hello world\",\n",
+        "    \"The quick brown fox jumps over the lazy dog\",\n",
+        "    \"How are you doing today?\",\n",
+        "    \"Welcome to the voice synthesis engine\",\n",
+        "    \"She sells seashells by the seashore\",\n",
+        "]\n",
+        "\n",
+        "output_dir = \"/tmp/voicers_stt_test\"\n",
+        "os.makedirs(output_dir, exist_ok=True)\n",
+        "\n",
+        "# Generate audio for each phrase\n",
+        "for i, phrase in enumerate(test_phrases):\n",
+        "    wav_path = f\"{output_dir}/phrase_{i}.wav\"\n",
+        "    result = subprocess.run(\n",
+        "        [\n",
+        "            \"cargo\",\n",
+        "            \"run\",\n",
+        "            \"--release\",\n",
+        "            \"-p\",\n",
+        "            \"voicers-cli\",\n",
+        "            \"--\",\n",
+        "            \"--text\",\n",
+        "            phrase,\n",
+        "            \"--output\",\n",
+        "            wav_path,\n",
+        "        ],\n",
+        "        capture_output=True,\n",
+        "        text=True,\n",
+        "        cwd=\"/Users/kylekelley/conductor/workspaces/voicers/algiers\",\n",
+        "    )\n",
+        "    print(f\"[{i}] '{phrase}' -> {wav_path}\")\n",
+        "    if result.stderr:\n",
+        "        # Show the phoneme chunks from G2P\n",
+        "        for line in result.stderr.strip().split(\"\\n\"):\n",
+        "            if \"chunk\" in line.lower():\n",
+        "                print(f\"    {line.strip()}\")\n",
+        "    if result.returncode != 0:\n",
+        "        print(f\"    ERROR: {result.stderr[-200:]}\")\n",
+        "\n",
+        "print(f\"\\nGenerated {len(test_phrases)} audio files in {output_dir}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "error",
+          "ename": "FileNotFoundError",
+          "evalue": "[Errno 2] No such file or directory: 'cargo'",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mFileNotFoundError\u001b[39m                         Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 17\u001b[39m\n\u001b[32m     15\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m i, phrase \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28menumerate\u001b[39m(test_phrases):\n\u001b[32m     16\u001b[39m     wav_path = \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00moutput_dir\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m/phrase_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mi\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m.wav\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m---> \u001b[39m\u001b[32m17\u001b[39m     result = \u001b[43msubprocess\u001b[49m\u001b[43m.\u001b[49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m     18\u001b[39m \u001b[43m        \u001b[49m\u001b[43m[\u001b[49m\n\u001b[32m     19\u001b[39m \u001b[43m            \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mcargo\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     20\u001b[39m \u001b[43m            \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mrun\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     21\u001b[39m \u001b[43m            \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43m--release\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     22\u001b[39m \u001b[43m            \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43m-p\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     23\u001b[39m \u001b[43m            \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mvoicers-cli\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     24\u001b[39m \u001b[43m            \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43m--\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     25\u001b[39m \u001b[43m            \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43m--text\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     26\u001b[39m \u001b[43m            \u001b[49m\u001b[43mphrase\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     27\u001b[39m \u001b[43m            \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43m--output\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     28\u001b[39m \u001b[43m            \u001b[49m\u001b[43mwav_path\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     29\u001b[39m \u001b[43m        \u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     30\u001b[39m \u001b[43m        \u001b[49m\u001b[43mcapture_output\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[32m     31\u001b[39m \u001b[43m        \u001b[49m\u001b[43mtext\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[32m     32\u001b[39m \u001b[43m        \u001b[49m\u001b[43mcwd\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43m/Users/kylekelley/conductor/workspaces/voicers/algiers\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     33\u001b[39m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     34\u001b[39m     \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m[\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mi\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m] \u001b[39m\u001b[33m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mphrase\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m'\u001b[39m\u001b[33m -> \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mwav_path\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n\u001b[32m     35\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m result.stderr:\n\u001b[32m     36\u001b[39m         \u001b[38;5;66;03m# Show the phoneme chunks from G2P\u001b[39;00m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/subprocess.py:548\u001b[39m, in \u001b[36mrun\u001b[39m\u001b[34m(input, capture_output, timeout, check, *popenargs, **kwargs)\u001b[39m\n\u001b[32m    545\u001b[39m     kwargs[\u001b[33m'\u001b[39m\u001b[33mstdout\u001b[39m\u001b[33m'\u001b[39m] = PIPE\n\u001b[32m    546\u001b[39m     kwargs[\u001b[33m'\u001b[39m\u001b[33mstderr\u001b[39m\u001b[33m'\u001b[39m] = PIPE\n\u001b[32m--> \u001b[39m\u001b[32m548\u001b[39m \u001b[38;5;28;01mwith\u001b[39;00m \u001b[43mPopen\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43mpopenargs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mas\u001b[39;00m process:\n\u001b[32m    549\u001b[39m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m    550\u001b[39m         stdout, stderr = process.communicate(\u001b[38;5;28minput\u001b[39m, timeout=timeout)\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/subprocess.py:1026\u001b[39m, in \u001b[36mPopen.__init__\u001b[39m\u001b[34m(self, args, bufsize, executable, stdin, stdout, stderr, preexec_fn, close_fds, shell, cwd, env, universal_newlines, startupinfo, creationflags, restore_signals, start_new_session, pass_fds, user, group, extra_groups, encoding, errors, text, umask, pipesize, process_group)\u001b[39m\n\u001b[32m   1022\u001b[39m         \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.text_mode:\n\u001b[32m   1023\u001b[39m             \u001b[38;5;28mself\u001b[39m.stderr = io.TextIOWrapper(\u001b[38;5;28mself\u001b[39m.stderr,\n\u001b[32m   1024\u001b[39m                     encoding=encoding, errors=errors)\n\u001b[32m-> \u001b[39m\u001b[32m1026\u001b[39m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_execute_child\u001b[49m\u001b[43m(\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mexecutable\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpreexec_fn\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mclose_fds\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1027\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mpass_fds\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcwd\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43menv\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1028\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mstartupinfo\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcreationflags\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mshell\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1029\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mp2cread\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mp2cwrite\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1030\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mc2pread\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mc2pwrite\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1031\u001b[39m \u001b[43m                        \u001b[49m\u001b[43merrread\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43merrwrite\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1032\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mrestore_signals\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1033\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mgid\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mgids\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43muid\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mumask\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1034\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mstart_new_session\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mprocess_group\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1035\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m:\n\u001b[32m   1036\u001b[39m     \u001b[38;5;66;03m# Cleanup if the child failed starting.\u001b[39;00m\n\u001b[32m   1037\u001b[39m     \u001b[38;5;28;01mfor\u001b[39;00m f \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mfilter\u001b[39m(\u001b[38;5;28;01mNone\u001b[39;00m, (\u001b[38;5;28mself\u001b[39m.stdin, \u001b[38;5;28mself\u001b[39m.stdout, \u001b[38;5;28mself\u001b[39m.stderr)):\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/subprocess.py:1955\u001b[39m, in \u001b[36mPopen._execute_child\u001b[39m\u001b[34m(self, args, executable, preexec_fn, close_fds, pass_fds, cwd, env, startupinfo, creationflags, shell, p2cread, p2cwrite, c2pread, c2pwrite, errread, errwrite, restore_signals, gid, gids, uid, umask, start_new_session, process_group)\u001b[39m\n\u001b[32m   1953\u001b[39m     err_msg = os.strerror(errno_num)\n\u001b[32m   1954\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m err_filename \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m-> \u001b[39m\u001b[32m1955\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m child_exception_type(errno_num, err_msg, err_filename)\n\u001b[32m   1956\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m   1957\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m child_exception_type(errno_num, err_msg)\n",
+            "\u001b[31mFileNotFoundError\u001b[39m: [Errno 2] No such file or directory: 'cargo'"
+          ]
+        }
+      ],
+      "execution_count": 1
+    },
+    {
+      "id": "cell-12cee6f8-a343-444e-bba7-aa5b63cc493b",
+      "cell_type": "code",
+      "source": [
+        "import subprocess, os\n",
+        "\n",
+        "VOICERS = (\n",
+        "    \"/Users/kylekelley/conductor/workspaces/voicers/algiers/target/release/voicers-cli\"\n",
+        ")\n",
+        "\n",
+        "test_phrases = [\n",
+        "    \"Hello world\",\n",
+        "    \"The quick brown fox jumps over the lazy dog\",\n",
+        "    \"How are you doing today?\",\n",
+        "    \"Welcome to the voice synthesis engine\",\n",
+        "    \"She sells seashells by the seashore\",\n",
+        "]\n",
+        "\n",
+        "output_dir = \"/tmp/voicers_stt_test\"\n",
+        "os.makedirs(output_dir, exist_ok=True)\n",
+        "\n",
+        "env = os.environ.copy()\n",
+        "env[\"PATH\"] = \"/opt/homebrew/bin:\" + env.get(\"PATH\", \"\")\n",
+        "\n",
+        "for i, phrase in enumerate(test_phrases):\n",
+        "    wav_path = f\"{output_dir}/phrase_{i}.wav\"\n",
+        "    result = subprocess.run(\n",
+        "        [VOICERS, \"--text\", phrase, \"--output\", wav_path],\n",
+        "        capture_output=True,\n",
+        "        text=True,\n",
+        "        env=env,\n",
+        "    )\n",
+        "    status = \"ok\" if result.returncode == 0 else \"FAIL\"\n",
+        "    print(f\"[{i}] {status} | '{phrase}' -> {wav_path}\")\n",
+        "    for line in result.stderr.strip().split(\"\\n\"):\n",
+        "        if \"chunk\" in line.lower():\n",
+        "            print(f\"    {line.strip()}\")\n",
+        "    if result.returncode != 0:\n",
+        "        print(f\"    {result.stderr[-300:]}\")\n",
+        "\n",
+        "print(f\"\\nDone: {len(test_phrases)} files in {output_dir}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "[0] ok | 'Hello world' -> /tmp/voicers_stt_test/phrase_0.wav\n    chunk 1: həlˈO wˈɜɹld\n[1] ok | 'The quick brown fox jumps over the lazy dog' -> /tmp/voicers_stt_test/\n\u001b[0mphrase_1.wav\n    chunk 1: ðə kwˈɪk bɹˈWn fˈɑks ʤˈʌmps ˌOvɚ ðə lˈAzi dˈɑɡ\n[2] ok | 'How are you doing today?' -> /tmp/voicers_stt_test/phrase_2.wav\n    chunk 1: hˌW ɑɹ ju dˌuɪŋ tədˈA\n[3] ok | 'Welcome to the voice synthesis engine' -> /tmp/voicers_stt_test/phrase\n\u001b[0m_3.wav\n    chunk 1: wˈɛlkʌm tə ðə vˈYs sˈɪnθəsˌɪs ˈɛnʤɪn\n[4] ok | 'She sells seashells by the seashore' -> /tmp/voicers_stt_test/phrase_4\n\u001b[0m.wav\n    chunk 1: ʃi sˈɛlz sˈiʃɛlz bI ðə sˈiʃɔɹ\n\nDone: 5 files in /tmp/voicers_stt_test\n"
+        }
+      ],
+      "execution_count": 1
+    },
+    {
+      "id": "cell-1a700187-384c-4137-a619-c9879127ef2e",
+      "cell_type": "code",
+      "source": [
+        "import mlx_whisper\n",
+        "\n",
+        "# Transcribe each generated file\n",
+        "results = []\n",
+        "for i, phrase in enumerate(test_phrases):\n",
+        "    wav_path = f\"{output_dir}/phrase_{i}.wav\"\n",
+        "    transcription = mlx_whisper.transcribe(\n",
+        "        wav_path, path_or_hf_repo=\"mlx-community/whisper-small\"\n",
+        "    )\n",
+        "    heard = transcription[\"text\"].strip()\n",
+        "    match = (\n",
+        "        \"MATCH\"\n",
+        "        if heard.lower().rstrip(\".!?,\") == phrase.lower().rstrip(\".!?,\")\n",
+        "        else \"DIFF\"\n",
+        "    )\n",
+        "    results.append((phrase, heard, match))\n",
+        "    print(f\"[{i}] {match}\")\n",
+        "    print(f\"    Sent:  {phrase}\")\n",
+        "    print(f\"    Heard: {heard}\")\n",
+        "    print()"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "error",
+          "ename": "RepositoryNotFoundError",
+          "evalue": "404 Client Error. (Request ID: Root=1-69b9f19b-7649795313cee07e54fcd413;21da5744-cf23-45cc-8eb0-fe2d4703437c)\n\nRepository Not Found for url: https://huggingface.co/api/models/mlx-community/whisper-small/revision/main.\nPlease make sure you specified the correct `repo_id` and `repo_type`.\nIf you are trying to access a private or gated repo, make sure you are authenticated. For more details, see https://huggingface.co/docs/huggingface_hub/authentication",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mHTTPStatusError\u001b[39m                           Traceback (most recent call last)",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/9357abdd89cae1cb/lib/python3.12/site-packages/huggingface_hub/utils/_http.py:761\u001b[39m, in \u001b[36mhf_raise_for_status\u001b[39m\u001b[34m(response, endpoint_name)\u001b[39m\n\u001b[32m    760\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m761\u001b[39m     \u001b[43mresponse\u001b[49m\u001b[43m.\u001b[49m\u001b[43mraise_for_status\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    762\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m httpx.HTTPStatusError \u001b[38;5;28;01mas\u001b[39;00m e:\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/9357abdd89cae1cb/lib/python3.12/site-packages/httpx/_models.py:829\u001b[39m, in \u001b[36mResponse.raise_for_status\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m    828\u001b[39m message = message.format(\u001b[38;5;28mself\u001b[39m, error_type=error_type)\n\u001b[32m--> \u001b[39m\u001b[32m829\u001b[39m \u001b[38;5;28;01mraise\u001b[39;00m HTTPStatusError(message, request=request, response=\u001b[38;5;28mself\u001b[39m)\n",
+            "\u001b[31mHTTPStatusError\u001b[39m: Client error '404 Not Found' for url 'https://huggingface.co/api/models/mlx-community/whisper-small/revision/main'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404",
+            "\nThe above exception was the direct cause of the following exception:\n",
+            "\u001b[31mRepositoryNotFoundError\u001b[39m                   Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[4]\u001b[39m\u001b[32m, line 7\u001b[39m\n\u001b[32m      5\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m i, phrase \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28menumerate\u001b[39m(test_phrases):\n\u001b[32m      6\u001b[39m     wav_path = \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00moutput_dir\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m/phrase_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mi\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m.wav\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m7\u001b[39m     transcription = \u001b[43mmlx_whisper\u001b[49m\u001b[43m.\u001b[49m\u001b[43mtranscribe\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m      8\u001b[39m \u001b[43m        \u001b[49m\u001b[43mwav_path\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpath_or_hf_repo\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mmlx-community/whisper-small\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\n\u001b[32m      9\u001b[39m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     10\u001b[39m     heard = transcription[\u001b[33m\"\u001b[39m\u001b[33mtext\u001b[39m\u001b[33m\"\u001b[39m].strip()\n\u001b[32m     11\u001b[39m     match = (\n\u001b[32m     12\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mMATCH\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m     13\u001b[39m         \u001b[38;5;28;01mif\u001b[39;00m heard.lower().rstrip(\u001b[33m\"\u001b[39m\u001b[33m.!?,\u001b[39m\u001b[33m\"\u001b[39m) == phrase.lower().rstrip(\u001b[33m\"\u001b[39m\u001b[33m.!?,\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m     14\u001b[39m         \u001b[38;5;28;01melse\u001b[39;00m \u001b[33m\"\u001b[39m\u001b[33mDIFF\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m     15\u001b[39m     )\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/9357abdd89cae1cb/lib/python3.12/site-packages/mlx_whisper/transcribe.py:147\u001b[39m, in \u001b[36mtranscribe\u001b[39m\u001b[34m(audio, path_or_hf_repo, verbose, temperature, compression_ratio_threshold, logprob_threshold, no_speech_threshold, condition_on_previous_text, initial_prompt, word_timestamps, prepend_punctuations, append_punctuations, clip_timestamps, hallucination_silence_threshold, **decode_options)\u001b[39m\n\u001b[32m     80\u001b[39m \u001b[38;5;250m\u001b[39m\u001b[33;03m\"\"\"\u001b[39;00m\n\u001b[32m     81\u001b[39m \u001b[33;03mTranscribe an audio file using Whisper\u001b[39;00m\n\u001b[32m     82\u001b[39m \n\u001b[32m   (...)\u001b[39m\u001b[32m    143\u001b[39m \u001b[33;03mthe spoken language (\"language\"), which is detected when `decode_options[\"language\"]` is None.\u001b[39;00m\n\u001b[32m    144\u001b[39m \u001b[33;03m\"\"\"\u001b[39;00m\n\u001b[32m    146\u001b[39m dtype = mx.float16 \u001b[38;5;28;01mif\u001b[39;00m decode_options.get(\u001b[33m\"\u001b[39m\u001b[33mfp16\u001b[39m\u001b[33m\"\u001b[39m, \u001b[38;5;28;01mTrue\u001b[39;00m) \u001b[38;5;28;01melse\u001b[39;00m mx.float32\n\u001b[32m--> \u001b[39m\u001b[32m147\u001b[39m model = \u001b[43mModelHolder\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget_model\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpath_or_hf_repo\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdtype\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    149\u001b[39m \u001b[38;5;66;03m# Pad 30-seconds of silence to the input audio, for slicing\u001b[39;00m\n\u001b[32m    150\u001b[39m mel = log_mel_spectrogram(audio, n_mels=model.dims.n_mels, padding=N_SAMPLES)\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/9357abdd89cae1cb/lib/python3.12/site-packages/mlx_whisper/transcribe.py:57\u001b[39m, in \u001b[36mModelHolder.get_model\u001b[39m\u001b[34m(cls, model_path, dtype)\u001b[39m\n\u001b[32m     54\u001b[39m \u001b[38;5;129m@classmethod\u001b[39m\n\u001b[32m     55\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mget_model\u001b[39m(\u001b[38;5;28mcls\u001b[39m, model_path: \u001b[38;5;28mstr\u001b[39m, dtype: mx.Dtype):\n\u001b[32m     56\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mcls\u001b[39m.model \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mor\u001b[39;00m model_path != \u001b[38;5;28mcls\u001b[39m.model_path:\n\u001b[32m---> \u001b[39m\u001b[32m57\u001b[39m         \u001b[38;5;28mcls\u001b[39m.model = \u001b[43mload_model\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmodel_path\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdtype\u001b[49m\u001b[43m=\u001b[49m\u001b[43mdtype\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     58\u001b[39m         \u001b[38;5;28mcls\u001b[39m.model_path = model_path\n\u001b[32m     59\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mcls\u001b[39m.model\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/9357abdd89cae1cb/lib/python3.12/site-packages/mlx_whisper/load_models.py:20\u001b[39m, in \u001b[36mload_model\u001b[39m\u001b[34m(path_or_hf_repo, dtype)\u001b[39m\n\u001b[32m     18\u001b[39m model_path = Path(path_or_hf_repo)\n\u001b[32m     19\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m model_path.exists():\n\u001b[32m---> \u001b[39m\u001b[32m20\u001b[39m     model_path = Path(\u001b[43msnapshot_download\u001b[49m\u001b[43m(\u001b[49m\u001b[43mrepo_id\u001b[49m\u001b[43m=\u001b[49m\u001b[43mpath_or_hf_repo\u001b[49m\u001b[43m)\u001b[49m)\n\u001b[32m     22\u001b[39m \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28mopen\u001b[39m(\u001b[38;5;28mstr\u001b[39m(model_path / \u001b[33m\"\u001b[39m\u001b[33mconfig.json\u001b[39m\u001b[33m\"\u001b[39m), \u001b[33m\"\u001b[39m\u001b[33mr\u001b[39m\u001b[33m\"\u001b[39m) \u001b[38;5;28;01mas\u001b[39;00m f:\n\u001b[32m     23\u001b[39m     config = json.loads(f.read())\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/9357abdd89cae1cb/lib/python3.12/site-packages/huggingface_hub/utils/_validators.py:89\u001b[39m, in \u001b[36mvalidate_hf_hub_args.<locals>._inner_fn\u001b[39m\u001b[34m(*args, **kwargs)\u001b[39m\n\u001b[32m     85\u001b[39m         validate_repo_id(arg_value)\n\u001b[32m     87\u001b[39m kwargs = smoothly_deprecate_legacy_arguments(fn_name=fn.\u001b[34m__name__\u001b[39m, kwargs=kwargs)\n\u001b[32m---> \u001b[39m\u001b[32m89\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfn\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/9357abdd89cae1cb/lib/python3.12/site-packages/huggingface_hub/_snapshot_download.py:321\u001b[39m, in \u001b[36msnapshot_download\u001b[39m\u001b[34m(repo_id, repo_type, revision, cache_dir, local_dir, library_name, library_version, user_agent, etag_timeout, force_download, token, local_files_only, allow_patterns, ignore_patterns, max_workers, tqdm_class, headers, endpoint, dry_run)\u001b[39m\n\u001b[32m    312\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m LocalEntryNotFoundError(\n\u001b[32m    313\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mCannot find an appropriate cached snapshot folder for the specified revision on the local disk and \u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    314\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33moutgoing traffic has been disabled. To enable repo look-ups and downloads online, set \u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    315\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33m'\u001b[39m\u001b[33mHF_HUB_OFFLINE=0\u001b[39m\u001b[33m'\u001b[39m\u001b[33m as environment variable.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    316\u001b[39m     ) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mapi_call_error\u001b[39;00m\n\u001b[32m    317\u001b[39m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(api_call_error, (RepositoryNotFoundError, GatedRepoError)) \u001b[38;5;129;01mor\u001b[39;00m (\n\u001b[32m    318\u001b[39m     \u001b[38;5;28misinstance\u001b[39m(api_call_error, HfHubHTTPError) \u001b[38;5;129;01mand\u001b[39;00m api_call_error.response.status_code == \u001b[32m401\u001b[39m\n\u001b[32m    319\u001b[39m ):\n\u001b[32m    320\u001b[39m     \u001b[38;5;66;03m# Repo not found, gated, or specific authentication error => let's raise the actual error\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m321\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m api_call_error\n\u001b[32m    322\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    323\u001b[39m     \u001b[38;5;66;03m# Otherwise: most likely a connection issue or Hub downtime => let's warn the user\u001b[39;00m\n\u001b[32m    324\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m LocalEntryNotFoundError(\n\u001b[32m    325\u001b[39m         \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mGot: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mapi_call_error.\u001b[34m__class__\u001b[39m.\u001b[34m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mapi_call_error\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m\n\u001b[32m    326\u001b[39m         \u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33mAn error happened while trying to locate the files on the Hub and we cannot find the appropriate\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    327\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33m snapshot folder for the specified revision on the local disk. Please check your internet connection\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    328\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33m and try again.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    329\u001b[39m     ) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mapi_call_error\u001b[39;00m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/9357abdd89cae1cb/lib/python3.12/site-packages/huggingface_hub/_snapshot_download.py:240\u001b[39m, in \u001b[36msnapshot_download\u001b[39m\u001b[34m(repo_id, repo_type, revision, cache_dir, local_dir, library_name, library_version, user_agent, etag_timeout, force_download, token, local_files_only, allow_patterns, ignore_patterns, max_workers, tqdm_class, headers, endpoint, dry_run)\u001b[39m\n\u001b[32m    236\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m local_files_only:\n\u001b[32m    237\u001b[39m     \u001b[38;5;66;03m# try/except logic to handle different errors => taken from `hf_hub_download`\u001b[39;00m\n\u001b[32m    238\u001b[39m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m    239\u001b[39m         \u001b[38;5;66;03m# if we have internet connection we want to list files to download\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m240\u001b[39m         repo_info = \u001b[43mapi\u001b[49m\u001b[43m.\u001b[49m\u001b[43mrepo_info\u001b[49m\u001b[43m(\u001b[49m\u001b[43mrepo_id\u001b[49m\u001b[43m=\u001b[49m\u001b[43mrepo_id\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrepo_type\u001b[49m\u001b[43m=\u001b[49m\u001b[43mrepo_type\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrevision\u001b[49m\u001b[43m=\u001b[49m\u001b[43mrevision\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    241\u001b[39m     \u001b[38;5;28;01mexcept\u001b[39;00m httpx.ProxyError:\n\u001b[32m    242\u001b[39m         \u001b[38;5;66;03m# Actually raise on proxy error\u001b[39;00m\n\u001b[32m    243\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/9357abdd89cae1cb/lib/python3.12/site-packages/huggingface_hub/utils/_validators.py:89\u001b[39m, in \u001b[36mvalidate_hf_hub_args.<locals>._inner_fn\u001b[39m\u001b[34m(*args, **kwargs)\u001b[39m\n\u001b[32m     85\u001b[39m         validate_repo_id(arg_value)\n\u001b[32m     87\u001b[39m kwargs = smoothly_deprecate_legacy_arguments(fn_name=fn.\u001b[34m__name__\u001b[39m, kwargs=kwargs)\n\u001b[32m---> \u001b[39m\u001b[32m89\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfn\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/9357abdd89cae1cb/lib/python3.12/site-packages/huggingface_hub/hf_api.py:3146\u001b[39m, in \u001b[36mHfApi.repo_info\u001b[39m\u001b[34m(self, repo_id, revision, repo_type, timeout, files_metadata, expand, token)\u001b[39m\n\u001b[32m   3144\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m   3145\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[33m\"\u001b[39m\u001b[33mUnsupported repo type.\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m-> \u001b[39m\u001b[32m3146\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mmethod\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m   3147\u001b[39m \u001b[43m    \u001b[49m\u001b[43mrepo_id\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   3148\u001b[39m \u001b[43m    \u001b[49m\u001b[43mrevision\u001b[49m\u001b[43m=\u001b[49m\u001b[43mrevision\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   3149\u001b[39m \u001b[43m    \u001b[49m\u001b[43mtoken\u001b[49m\u001b[43m=\u001b[49m\u001b[43mtoken\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   3150\u001b[39m \u001b[43m    \u001b[49m\u001b[43mtimeout\u001b[49m\u001b[43m=\u001b[49m\u001b[43mtimeout\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   3151\u001b[39m \u001b[43m    \u001b[49m\u001b[43mexpand\u001b[49m\u001b[43m=\u001b[49m\u001b[43mexpand\u001b[49m\u001b[43m,\u001b[49m\u001b[43m  \u001b[49m\u001b[38;5;66;43;03m# type: ignore[arg-type]\u001b[39;49;00m\n\u001b[32m   3152\u001b[39m \u001b[43m    \u001b[49m\u001b[43mfiles_metadata\u001b[49m\u001b[43m=\u001b[49m\u001b[43mfiles_metadata\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   3153\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/9357abdd89cae1cb/lib/python3.12/site-packages/huggingface_hub/utils/_validators.py:89\u001b[39m, in \u001b[36mvalidate_hf_hub_args.<locals>._inner_fn\u001b[39m\u001b[34m(*args, **kwargs)\u001b[39m\n\u001b[32m     85\u001b[39m         validate_repo_id(arg_value)\n\u001b[32m     87\u001b[39m kwargs = smoothly_deprecate_legacy_arguments(fn_name=fn.\u001b[34m__name__\u001b[39m, kwargs=kwargs)\n\u001b[32m---> \u001b[39m\u001b[32m89\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfn\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/9357abdd89cae1cb/lib/python3.12/site-packages/huggingface_hub/hf_api.py:2940\u001b[39m, in \u001b[36mHfApi.model_info\u001b[39m\u001b[34m(self, repo_id, revision, timeout, securityStatus, files_metadata, expand, token)\u001b[39m\n\u001b[32m   2938\u001b[39m     params[\u001b[33m\"\u001b[39m\u001b[33mexpand\u001b[39m\u001b[33m\"\u001b[39m] = expand\n\u001b[32m   2939\u001b[39m r = get_session().get(path, headers=headers, timeout=timeout, params=params)\n\u001b[32m-> \u001b[39m\u001b[32m2940\u001b[39m \u001b[43mhf_raise_for_status\u001b[49m\u001b[43m(\u001b[49m\u001b[43mr\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   2941\u001b[39m data = r.json()\n\u001b[32m   2942\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m ModelInfo(**data)\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/9357abdd89cae1cb/lib/python3.12/site-packages/huggingface_hub/utils/_http.py:847\u001b[39m, in \u001b[36mhf_raise_for_status\u001b[39m\u001b[34m(response, endpoint_name)\u001b[39m\n\u001b[32m    845\u001b[39m     repo_err.repo_type = repo_type\n\u001b[32m    846\u001b[39m     repo_err.repo_id = repo_id\n\u001b[32m--> \u001b[39m\u001b[32m847\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m repo_err \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01me\u001b[39;00m\n\u001b[32m    849\u001b[39m \u001b[38;5;28;01melif\u001b[39;00m response.status_code == \u001b[32m400\u001b[39m:\n\u001b[32m    850\u001b[39m     message = (\n\u001b[32m    851\u001b[39m         \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33mBad request for \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mendpoint_name\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m endpoint:\u001b[39m\u001b[33m\"\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m endpoint_name \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;28;01melse\u001b[39;00m \u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33mBad request:\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    852\u001b[39m     )\n",
+            "\u001b[31mRepositoryNotFoundError\u001b[39m: 404 Client Error. (Request ID: Root=1-69b9f19b-7649795313cee07e54fcd413;21da5744-cf23-45cc-8eb0-fe2d4703437c)\n\nRepository Not Found for url: https://huggingface.co/api/models/mlx-community/whisper-small/revision/main.\nPlease make sure you specified the correct `repo_id` and `repo_type`.\nIf you are trying to access a private or gated repo, make sure you are authenticated. For more details, see https://huggingface.co/docs/huggingface_hub/authentication"
+          ]
+        }
+      ],
+      "execution_count": 4
+    },
+    {
+      "id": "cell-3eb39d27-0db1-4a37-9bdd-6eb27d538e62",
+      "cell_type": "code",
+      "source": [
+        "import mlx_whisper\n",
+        "\n",
+        "WHISPER_MODEL = \"mlx-community/whisper-large-v3-turbo-asr-fp16\"\n",
+        "\n",
+        "results = []\n",
+        "for i, phrase in enumerate(test_phrases):\n",
+        "    wav_path = f\"{output_dir}/phrase_{i}.wav\"\n",
+        "    transcription = mlx_whisper.transcribe(wav_path, path_or_hf_repo=WHISPER_MODEL)\n",
+        "    heard = transcription[\"text\"].strip()\n",
+        "    match = (\n",
+        "        \"MATCH\"\n",
+        "        if heard.lower().rstrip(\".!?, \") == phrase.lower().rstrip(\".!?, \")\n",
+        "        else \"DIFF\"\n",
+        "    )\n",
+        "    results.append((phrase, heard, match))\n",
+        "    print(f\"[{i}] {match}\")\n",
+        "    print(f\"    Sent:  {phrase}\")\n",
+        "    print(f\"    Heard: {heard}\")\n",
+        "    print()"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "9162efd1cd684ba6a3bae0e15acabe6c"
+            },
+            "text/plain": "Downloading (incomplete total...): 0.00B [00:00, ?B/s]"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": "Fetching 14 files:   0%|          | 0/14 [00:00<?, ?it/s]",
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "2f08cd93761544b68a57fe0fd0b03d85"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "error",
+          "ename": "TypeError",
+          "evalue": "ModelDimensions.__init__() got an unexpected keyword argument 'activation_dropout'",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[5]\u001b[39m\u001b[32m, line 8\u001b[39m\n\u001b[32m      6\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m i, phrase \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28menumerate\u001b[39m(test_phrases):\n\u001b[32m      7\u001b[39m     wav_path = \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00moutput_dir\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m/phrase_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mi\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m.wav\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m8\u001b[39m     transcription = \u001b[43mmlx_whisper\u001b[49m\u001b[43m.\u001b[49m\u001b[43mtranscribe\u001b[49m\u001b[43m(\u001b[49m\u001b[43mwav_path\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpath_or_hf_repo\u001b[49m\u001b[43m=\u001b[49m\u001b[43mWHISPER_MODEL\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m      9\u001b[39m     heard = transcription[\u001b[33m\"\u001b[39m\u001b[33mtext\u001b[39m\u001b[33m\"\u001b[39m].strip()\n\u001b[32m     10\u001b[39m     match = (\n\u001b[32m     11\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mMATCH\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m     12\u001b[39m         \u001b[38;5;28;01mif\u001b[39;00m heard.lower().rstrip(\u001b[33m\"\u001b[39m\u001b[33m.!?, \u001b[39m\u001b[33m\"\u001b[39m) == phrase.lower().rstrip(\u001b[33m\"\u001b[39m\u001b[33m.!?, \u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m     13\u001b[39m         \u001b[38;5;28;01melse\u001b[39;00m \u001b[33m\"\u001b[39m\u001b[33mDIFF\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m     14\u001b[39m     )\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/9357abdd89cae1cb/lib/python3.12/site-packages/mlx_whisper/transcribe.py:147\u001b[39m, in \u001b[36mtranscribe\u001b[39m\u001b[34m(audio, path_or_hf_repo, verbose, temperature, compression_ratio_threshold, logprob_threshold, no_speech_threshold, condition_on_previous_text, initial_prompt, word_timestamps, prepend_punctuations, append_punctuations, clip_timestamps, hallucination_silence_threshold, **decode_options)\u001b[39m\n\u001b[32m     80\u001b[39m \u001b[38;5;250m\u001b[39m\u001b[33;03m\"\"\"\u001b[39;00m\n\u001b[32m     81\u001b[39m \u001b[33;03mTranscribe an audio file using Whisper\u001b[39;00m\n\u001b[32m     82\u001b[39m \n\u001b[32m   (...)\u001b[39m\u001b[32m    143\u001b[39m \u001b[33;03mthe spoken language (\"language\"), which is detected when `decode_options[\"language\"]` is None.\u001b[39;00m\n\u001b[32m    144\u001b[39m \u001b[33;03m\"\"\"\u001b[39;00m\n\u001b[32m    146\u001b[39m dtype = mx.float16 \u001b[38;5;28;01mif\u001b[39;00m decode_options.get(\u001b[33m\"\u001b[39m\u001b[33mfp16\u001b[39m\u001b[33m\"\u001b[39m, \u001b[38;5;28;01mTrue\u001b[39;00m) \u001b[38;5;28;01melse\u001b[39;00m mx.float32\n\u001b[32m--> \u001b[39m\u001b[32m147\u001b[39m model = \u001b[43mModelHolder\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget_model\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpath_or_hf_repo\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdtype\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    149\u001b[39m \u001b[38;5;66;03m# Pad 30-seconds of silence to the input audio, for slicing\u001b[39;00m\n\u001b[32m    150\u001b[39m mel = log_mel_spectrogram(audio, n_mels=model.dims.n_mels, padding=N_SAMPLES)\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/9357abdd89cae1cb/lib/python3.12/site-packages/mlx_whisper/transcribe.py:57\u001b[39m, in \u001b[36mModelHolder.get_model\u001b[39m\u001b[34m(cls, model_path, dtype)\u001b[39m\n\u001b[32m     54\u001b[39m \u001b[38;5;129m@classmethod\u001b[39m\n\u001b[32m     55\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mget_model\u001b[39m(\u001b[38;5;28mcls\u001b[39m, model_path: \u001b[38;5;28mstr\u001b[39m, dtype: mx.Dtype):\n\u001b[32m     56\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mcls\u001b[39m.model \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mor\u001b[39;00m model_path != \u001b[38;5;28mcls\u001b[39m.model_path:\n\u001b[32m---> \u001b[39m\u001b[32m57\u001b[39m         \u001b[38;5;28mcls\u001b[39m.model = \u001b[43mload_model\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmodel_path\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdtype\u001b[49m\u001b[43m=\u001b[49m\u001b[43mdtype\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     58\u001b[39m         \u001b[38;5;28mcls\u001b[39m.model_path = model_path\n\u001b[32m     59\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mcls\u001b[39m.model\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/9357abdd89cae1cb/lib/python3.12/site-packages/mlx_whisper/load_models.py:27\u001b[39m, in \u001b[36mload_model\u001b[39m\u001b[34m(path_or_hf_repo, dtype)\u001b[39m\n\u001b[32m     24\u001b[39m     config.pop(\u001b[33m\"\u001b[39m\u001b[33mmodel_type\u001b[39m\u001b[33m\"\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m)\n\u001b[32m     25\u001b[39m     quantization = config.pop(\u001b[33m\"\u001b[39m\u001b[33mquantization\u001b[39m\u001b[33m\"\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m)\n\u001b[32m---> \u001b[39m\u001b[32m27\u001b[39m model_args = \u001b[43mwhisper\u001b[49m\u001b[43m.\u001b[49m\u001b[43mModelDimensions\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mconfig\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     29\u001b[39m wf = model_path / \u001b[33m\"\u001b[39m\u001b[33mweights.safetensors\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m     30\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m wf.exists():\n",
+            "\u001b[31mTypeError\u001b[39m: ModelDimensions.__init__() got an unexpected keyword argument 'activation_dropout'"
+          ]
+        }
+      ],
+      "execution_count": 5
+    },
+    {
+      "id": "cell-86958bbc-793b-4919-91c0-0960308d9e4c",
+      "cell_type": "code",
+      "source": [
+        "import mlx_whisper\n",
+        "\n",
+        "WHISPER_MODEL = \"mlx-community/whisper-large-v3-turbo\"\n",
+        "\n",
+        "results = []\n",
+        "for i, phrase in enumerate(test_phrases):\n",
+        "    wav_path = f\"{output_dir}/phrase_{i}.wav\"\n",
+        "    transcription = mlx_whisper.transcribe(wav_path, path_or_hf_repo=WHISPER_MODEL)\n",
+        "    heard = transcription[\"text\"].strip()\n",
+        "    match = (\n",
+        "        \"MATCH\"\n",
+        "        if heard.lower().rstrip(\".!?, \") == phrase.lower().rstrip(\".!?, \")\n",
+        "        else \"DIFF\"\n",
+        "    )\n",
+        "    results.append((phrase, heard, match))\n",
+        "    print(f\"[{i}] {match}\")\n",
+        "    print(f\"    Sent:  {phrase}\")\n",
+        "    print(f\"    Heard: {heard}\")\n",
+        "    print()"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "c9b8e4e6ef6848428e51f843317b7078"
+            },
+            "text/plain": "Downloading (incomplete total...): 0.00B [00:00, ?B/s]"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "96222df858ce4453af5c765e061d80cb"
+            },
+            "text/plain": "Fetching 4 files:   0%|          | 0/4 [00:00<?, ?it/s]"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "[0] DIFF\n    Sent:  Hello world\n    Heard: Hello, world.\n\n[1] DIFF\n    Sent:  The quick brown fox jumps over the lazy dog\n    Heard: the quick brown foxes over the lazy dog again.\n\n[2] MATCH\n    Sent:  How are you doing today?\n    Heard: How are you doing today?\n\n[3] DIFF\n    Sent:  Welcome to the voice synthesis engine\n    Heard: Well, come to the voice synthesis engine\n\n[4] DIFF\n    Sent:  She sells seashells by the seashore\n    Heard: J-E-Selsa-Z-S-S-S-Elza-Bai-I-The-Z-S-S-S-Or-\n"
+        }
+      ],
+      "execution_count": 3
+    }
+  ]
+}

--- a/notebooks/stt_comparison.ipynb
+++ b/notebooks/stt_comparison.ipynb
@@ -256,12 +256,12 @@
         {
           "output_type": "display_data",
           "data": {
-            "text/plain": "Fetching 14 files:   0%|          | 0/14 [00:00<?, ?it/s]",
             "application/vnd.jupyter.widget-view+json": {
               "version_major": 2,
               "version_minor": 0,
               "model_id": "2f08cd93761544b68a57fe0fd0b03d85"
-            }
+            },
+            "text/plain": "Fetching 14 files:   0%|          | 0/14 [00:00<?, ?it/s]"
           },
           "metadata": {}
         },
@@ -323,12 +323,12 @@
         {
           "output_type": "display_data",
           "data": {
+            "text/plain": "Fetching 4 files:   0%|          | 0/4 [00:00<?, ?it/s]",
             "application/vnd.jupyter.widget-view+json": {
               "version_major": 2,
               "version_minor": 0,
               "model_id": "96222df858ce4453af5c765e061d80cb"
-            },
-            "text/plain": "Fetching 4 files:   0%|          | 0/4 [00:00<?, ?it/s]"
+            }
           },
           "metadata": {}
         },
@@ -339,6 +339,210 @@
         }
       ],
       "execution_count": 3
+    },
+    {
+      "id": "cell-2a80e428-c6c4-4f06-8aa2-3f2d712fd7ba",
+      "cell_type": "code",
+      "source": [
+        "# Test: is the sibilant issue G2P or vocoder?\n",
+        "import mlx_whisper\n",
+        "\n",
+        "WHISPER_MODEL = \"mlx-community/whisper-large-v3-turbo\"\n",
+        "\n",
+        "files = {\n",
+        "    \"seashells (G2P)\": \"/tmp/seashells.wav\",\n",
+        "    \"seashells (raw phonemes)\": \"/tmp/seashells_raw.wav\",\n",
+        "    \"this is a test (raw)\": \"/tmp/test_simple.wav\",\n",
+        "}\n",
+        "\n",
+        "for label, path in files.items():\n",
+        "    result = mlx_whisper.transcribe(path, path_or_hf_repo=WHISPER_MODEL)\n",
+        "    print(f\"{label}:\")\n",
+        "    print(f\"  Heard: {result['text'].strip()}\")\n",
+        "    print()"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "seashells (G2P):\n  Heard: Gee, salsa, c-helza, by the c-sh-sh-sh-shore.\n\nseashells (raw phonemes):\n  Heard: She sells sea shells by the seashore.\n\nthis is a test (raw):\n  Heard: This is... ...Tesla Day.\n"
+        }
+      ],
+      "execution_count": 4
+    },
+    {
+      "id": "cell-0d3e38d5-e487-4a21-a341-477d8eae332d",
+      "cell_type": "code",
+      "source": [
+        "# Is the garbling from G2P tokens or from something in the CLI text path?\n",
+        "files2 = {\n",
+        "    \"G2P (via --text)\": \"/tmp/seashells.wav\",\n",
+        "    \"G2P phonemes (via --phonemes)\": \"/tmp/seashells_g2p_raw.wav\",\n",
+        "    \"Raw phonemes (no stress/collapse)\": \"/tmp/seashells_raw.wav\",\n",
+        "}\n",
+        "\n",
+        "for label, path in files2.items():\n",
+        "    result = mlx_whisper.transcribe(path, path_or_hf_repo=WHISPER_MODEL)\n",
+        "    print(f\"{label}:\")\n",
+        "    print(f\"  Heard: {result['text'].strip()}\")\n",
+        "    print()"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "G2P (via --text):\n  Heard: Gee, salsa, c-helza, by the c-sh-sh-sh-shore.\n\nG2P phonemes (via --phonemes):\n  Heard: She ain't sells a sea shells and buy that sea shore.\n\nRaw phonemes (no stress/collapse):\n  Heard: She sells sea shells by the seashore.\n"
+        }
+      ],
+      "execution_count": 5
+    },
+    {
+      "id": "cell-4a58be02-ca26-4aab-96ec-90290563595a",
+      "cell_type": "code",
+      "source": [
+        "# Check if random seed causes inconsistency\n",
+        "runs = {\n",
+        "    \"run 1\": \"/tmp/seashells_run1.wav\",\n",
+        "    \"run 2\": \"/tmp/seashells_run2.wav\",\n",
+        "    \"run 3\": \"/tmp/seashells_run3.wav\",\n",
+        "}\n",
+        "\n",
+        "for label, path in runs.items():\n",
+        "    result = mlx_whisper.transcribe(path, path_or_hf_repo=WHISPER_MODEL)\n",
+        "    print(f\"{label}: {result['text'].strip()}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "run 1: J. Sells. C. Sells. By the... C. S. Sure.\nrun 2: He sells seed shells by the seedish whore.\nrun 3: Shaggy. The cells. Sea shells. By the sea shore.\n"
+        }
+      ],
+      "execution_count": 6
+    },
+    {
+      "id": "cell-2c279d00-6a82-454d-b199-b120e47cddd0",
+      "cell_type": "code",
+      "source": [
+        "# Test consistency with fixed seed\n",
+        "print(\"=== Consistency test (same phonemes, 3 runs) ===\")\n",
+        "for i in range(1, 4):\n",
+        "    result = mlx_whisper.transcribe(\n",
+        "        f\"/tmp/seashells_seed{i}.wav\", path_or_hf_repo=WHISPER_MODEL\n",
+        "    )\n",
+        "    print(f\"  run {i}: {result['text'].strip()}\")\n",
+        "\n",
+        "print(\"\\n=== Full comparison (with fixed seed) ===\")\n",
+        "test_phrases = [\n",
+        "    \"Hello world\",\n",
+        "    \"The quick brown fox jumps over the lazy dog\",\n",
+        "    \"How are you doing today?\",\n",
+        "    \"Welcome to the voice synthesis engine\",\n",
+        "    \"She sells seashells by the seashore\",\n",
+        "]\n",
+        "for i, phrase in enumerate(test_phrases):\n",
+        "    result = mlx_whisper.transcribe(\n",
+        "        f\"/tmp/voicers_stt_test/phrase_{i}.wav\", path_or_hf_repo=WHISPER_MODEL\n",
+        "    )\n",
+        "    heard = result[\"text\"].strip()\n",
+        "    match = (\n",
+        "        \"MATCH\"\n",
+        "        if heard.lower().rstrip(\".!?, \") == phrase.lower().rstrip(\".!?, \")\n",
+        "        else \"DIFF\"\n",
+        "    )\n",
+        "    print(f\"[{i}] {match}\")\n",
+        "    print(f\"    Sent:  {phrase}\")\n",
+        "    print(f\"    Heard: {heard}\")\n",
+        "    print()"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "=== Consistency test (same phonemes, 3 runs) ===\n  run 1: He sells... Seed shells... By... The... Seed shesht shore...\n  run 2: Hey, cells, seashells, but I thought seashells were\n  run 3: She sells seashells by the seashore.\n\n=== Full comparison (with fixed seed) ===\n[0] DIFF\n    Sent:  Hello world\n    Heard: Hello, world.\n\n[1] DIFF\n    Sent:  The quick brown fox jumps over the lazy dog\n    Heard: This quick brown fox. I'ma pass it over the lazy dog.\n\n[2] MATCH\n    Sent:  How are you doing today?\n    Heard: How are you doing today?\n\n[3] MATCH\n    Sent:  Welcome to the voice synthesis engine\n    Heard: Welcome to the voice synthesis engine.\n\n[4] DIFF\n    Sent:  She sells seashells by the seashore\n    Heard: Gee.. SALZA.. SALZA.. SALZA.. SALZA.. SALZA.. SALZA..\n"
+        }
+      ],
+      "execution_count": 7
+    },
+    {
+      "id": "cell-b19e32ff-7ada-40d6-b446-ab2da90886b6",
+      "cell_type": "code",
+      "source": [
+        "# Test with zero phase initialization\n",
+        "print(\"=== Consistency test (zero phase, 3 runs) ===\")\n",
+        "for i in range(1, 4):\n",
+        "    result = mlx_whisper.transcribe(\n",
+        "        f\"/tmp/seashells_zero{i}.wav\", path_or_hf_repo=WHISPER_MODEL\n",
+        "    )\n",
+        "    print(f\"  run {i}: {result['text'].strip()}\")\n",
+        "\n",
+        "print(\"\\n=== Full comparison (zero phase) ===\")\n",
+        "for i, phrase in enumerate(test_phrases):\n",
+        "    result = mlx_whisper.transcribe(\n",
+        "        f\"/tmp/voicers_stt_test/phrase_{i}.wav\", path_or_hf_repo=WHISPER_MODEL\n",
+        "    )\n",
+        "    heard = result[\"text\"].strip()\n",
+        "    match = (\n",
+        "        \"MATCH\"\n",
+        "        if heard.lower().rstrip(\".!?, \") == phrase.lower().rstrip(\".!?, \")\n",
+        "        else \"DIFF\"\n",
+        "    )\n",
+        "    print(f\"[{i}] {match}\")\n",
+        "    print(f\"    Sent:  {phrase}\")\n",
+        "    print(f\"    Heard: {heard}\")\n",
+        "    print()"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "=== Consistency test (zero phase, 3 runs) ===\n  run 1: Gee SALZA Sea shi shi SALZA Baye C-sh-sh-sh-or.\n  run 2: She sells seashells by the seashells.\n  run 3: G SALZA SALZA SALZA SALZA SALZA SALZA\n\n=== Full comparison (zero phase) ===\n[0] DIFF\n    Sent:  Hello world\n    Heard: Hello? Where? World?\n\n[1] DIFF\n    Sent:  The quick brown fox jumps over the lazy dog\n    Heard: The Gatwick Brown Foxxs. I'mma pass this over the lazy didog.\n\n[2] MATCH\n    Sent:  How are you doing today?\n    Heard: How are you doing today?\n\n[3] DIFF\n    Sent:  Welcome to the voice synthesis engine\n    Heard: Welcome to the voice synthesis at NJJN.\n\n[4] DIFF\n    Sent:  She sells seashells by the seashore\n    Heard: She sells seashells by the seashells.\n"
+        }
+      ],
+      "execution_count": 8
+    },
+    {
+      "id": "cell-04e47896-0681-4148-9a24-53295fb93b16",
+      "cell_type": "code",
+      "source": [
+        "# Test with eval mode (dropout disabled) + zero phase\n",
+        "print(\"=== Consistency test (eval mode, 3 runs) ===\")\n",
+        "for i in range(1, 4):\n",
+        "    result = mlx_whisper.transcribe(\n",
+        "        f\"/tmp/seashells_eval{i}.wav\", path_or_hf_repo=WHISPER_MODEL\n",
+        "    )\n",
+        "    print(f\"  run {i}: {result['text'].strip()}\")\n",
+        "\n",
+        "print(\"\\n=== Full comparison (eval mode) ===\")\n",
+        "for i, phrase in enumerate(test_phrases):\n",
+        "    result = mlx_whisper.transcribe(\n",
+        "        f\"/tmp/voicers_stt_test/phrase_{i}.wav\", path_or_hf_repo=WHISPER_MODEL\n",
+        "    )\n",
+        "    heard = result[\"text\"].strip()\n",
+        "    match = (\n",
+        "        \"MATCH\"\n",
+        "        if heard.lower().rstrip(\".!?, \") == phrase.lower().rstrip(\".!?, \")\n",
+        "        else \"DIFF\"\n",
+        "    )\n",
+        "    print(f\"[{i}] {match}\")\n",
+        "    print(f\"    Sent:  {phrase}\")\n",
+        "    print(f\"    Heard: {heard}\")\n",
+        "    print()"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "=== Consistency test (eval mode, 3 runs) ===\n  run 1: She sells a sea-shell-zuh by a sea-she-or.\n  run 2: J SALZA Sea sh- SALZA BAE Sea sh- Sea sh- Sea sh- Sea sh- Sea sh- Sea S\n\u001b[0mea Hore or\n  run 3: J. Sells a sea-shell-zah by that sea-she-or.\n\n=== Full comparison (eval mode) ===\n[0] DIFF\n    Sent:  Hello world\n    Heard: Hello? Where?\n\n[1] DIFF\n    Sent:  The quick brown fox jumps over the lazy dog\n    Heard: The quick brown fogs-s-jump-s-over the lazy d-dog.\n\n[2] DIFF\n    Sent:  How are you doing today?\n    Heard: How are you to sue wings to stay?\n\n[3] DIFF\n    Sent:  Welcome to the voice synthesis engine\n    Heard: Welcome to the voice synthesis at Engigen.\n\n[4] DIFF\n    Sent:  She sells seashells by the seashore\n    Heard: Sea Sea Seashales, uh, by the seashore.\n"
+        }
+      ],
+      "execution_count": 9
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Fix `(1 + gamma)` scaling in AdaIN1d/AdaLayerNorm (was causing ~25x amplitude suppression)
- Add phase unwrapping in iSTFT inverse for proper audio reconstruction
- Fix 185 unmatched weight keys by remapping PyTorch naming to Rust field names
- Load snake1d alpha parameters manually (not exposed via `#[param]`)

## Test plan
- [x] `cargo run --release -p voicers-cli` produces audible speech output
- [x] iSTFT round-trip test added