### PR TITLE
Add G2P test harness notebook with Whisper STT validation

### DIFF
--- a/notebooks/g2p_test_harness.ipynb
+++ b/notebooks/g2p_test_harness.ipynb
@@ -1,0 +1,697 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 5,
+  "metadata": {
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3",
+      "language": "python"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "runt": {
+      "schema_version": "1",
+      "env_id": "d45f9582-a5c4-4bf6-9ff9-28e36b071d73",
+      "uv": {
+        "dependencies": [
+          "openai-whisper",
+          "spacy"
+        ]
+      }
+    }
+  },
+  "cells": [
+    {
+      "id": "62fc155e-c666-4fb4-9161-78e635f7c2ce",
+      "cell_type": "code",
+      "source": [],
+      "metadata": {},
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "id": "cell-72bb492c-37fa-4647-b48e-b8c9b0c01136",
+      "cell_type": "code",
+      "source": [
+        "# G2P Test Harness: Compare Rust voicers output vs Python misaki, validate with Whisper STT\n",
+        "import subprocess, json, sys, os, tempfile\n",
+        "from pathlib import Path\n",
+        "\n",
+        "VOICERS_CLI = \"./target/release/voicers-cli\"\n",
+        "MISAKI_PATH = \"/Users/kylekelley/conductor/workspaces/misaki/abuja-v4\"\n",
+        "\n",
+        "# Build release binary if needed\n",
+        "result = subprocess.run(\n",
+        "    [\"cargo\", \"build\", \"--release\", \"-p\", \"voicers-cli\"], capture_output=True, text=True\n",
+        ")\n",
+        "if result.returncode != 0:\n",
+        "    print(\"Build failed:\", result.stderr[-500:])\n",
+        "else:\n",
+        "    print(\"voicers-cli ready\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "error",
+          "ename": "FileNotFoundError",
+          "evalue": "[Errno 2] No such file or directory: 'cargo'",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mFileNotFoundError\u001b[39m                         Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 9\u001b[39m\n\u001b[32m      6\u001b[39m MISAKI_PATH = \u001b[33m\"\u001b[39m\u001b[33m/Users/kylekelley/conductor/workspaces/misaki/abuja-v4\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m      8\u001b[39m \u001b[38;5;66;03m# Build release binary if needed\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m9\u001b[39m result = \u001b[43msubprocess\u001b[49m\u001b[43m.\u001b[49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m     10\u001b[39m \u001b[43m    \u001b[49m\u001b[43m[\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mcargo\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mbuild\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43m--release\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43m-p\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mvoicers-cli\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcapture_output\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtext\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\n\u001b[32m     11\u001b[39m \u001b[43m)\u001b[49m\n\u001b[32m     12\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m result.returncode != \u001b[32m0\u001b[39m:\n\u001b[32m     13\u001b[39m     \u001b[38;5;28mprint\u001b[39m(\u001b[33m\"\u001b[39m\u001b[33mBuild failed:\u001b[39m\u001b[33m\"\u001b[39m, result.stderr[-\u001b[32m500\u001b[39m:])\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/subprocess.py:548\u001b[39m, in \u001b[36mrun\u001b[39m\u001b[34m(input, capture_output, timeout, check, *popenargs, **kwargs)\u001b[39m\n\u001b[32m    545\u001b[39m     kwargs[\u001b[33m'\u001b[39m\u001b[33mstdout\u001b[39m\u001b[33m'\u001b[39m] = PIPE\n\u001b[32m    546\u001b[39m     kwargs[\u001b[33m'\u001b[39m\u001b[33mstderr\u001b[39m\u001b[33m'\u001b[39m] = PIPE\n\u001b[32m--> \u001b[39m\u001b[32m548\u001b[39m \u001b[38;5;28;01mwith\u001b[39;00m \u001b[43mPopen\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43mpopenargs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mas\u001b[39;00m process:\n\u001b[32m    549\u001b[39m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m    550\u001b[39m         stdout, stderr = process.communicate(\u001b[38;5;28minput\u001b[39m, timeout=timeout)\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/subprocess.py:1026\u001b[39m, in \u001b[36mPopen.__init__\u001b[39m\u001b[34m(self, args, bufsize, executable, stdin, stdout, stderr, preexec_fn, close_fds, shell, cwd, env, universal_newlines, startupinfo, creationflags, restore_signals, start_new_session, pass_fds, user, group, extra_groups, encoding, errors, text, umask, pipesize, process_group)\u001b[39m\n\u001b[32m   1022\u001b[39m         \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.text_mode:\n\u001b[32m   1023\u001b[39m             \u001b[38;5;28mself\u001b[39m.stderr = io.TextIOWrapper(\u001b[38;5;28mself\u001b[39m.stderr,\n\u001b[32m   1024\u001b[39m                     encoding=encoding, errors=errors)\n\u001b[32m-> \u001b[39m\u001b[32m1026\u001b[39m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_execute_child\u001b[49m\u001b[43m(\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mexecutable\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpreexec_fn\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mclose_fds\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1027\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mpass_fds\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcwd\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43menv\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1028\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mstartupinfo\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcreationflags\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mshell\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1029\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mp2cread\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mp2cwrite\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1030\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mc2pread\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mc2pwrite\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1031\u001b[39m \u001b[43m                        \u001b[49m\u001b[43merrread\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43merrwrite\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1032\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mrestore_signals\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1033\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mgid\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mgids\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43muid\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mumask\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1034\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mstart_new_session\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mprocess_group\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1035\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m:\n\u001b[32m   1036\u001b[39m     \u001b[38;5;66;03m# Cleanup if the child failed starting.\u001b[39;00m\n\u001b[32m   1037\u001b[39m     \u001b[38;5;28;01mfor\u001b[39;00m f \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mfilter\u001b[39m(\u001b[38;5;28;01mNone\u001b[39;00m, (\u001b[38;5;28mself\u001b[39m.stdin, \u001b[38;5;28mself\u001b[39m.stdout, \u001b[38;5;28mself\u001b[39m.stderr)):\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/subprocess.py:1955\u001b[39m, in \u001b[36mPopen._execute_child\u001b[39m\u001b[34m(self, args, executable, preexec_fn, close_fds, pass_fds, cwd, env, startupinfo, creationflags, shell, p2cread, p2cwrite, c2pread, c2pwrite, errread, errwrite, restore_signals, gid, gids, uid, umask, start_new_session, process_group)\u001b[39m\n\u001b[32m   1953\u001b[39m     err_msg = os.strerror(errno_num)\n\u001b[32m   1954\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m err_filename \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m-> \u001b[39m\u001b[32m1955\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m child_exception_type(errno_num, err_msg, err_filename)\n\u001b[32m   1956\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m   1957\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m child_exception_type(errno_num, err_msg)\n",
+            "\u001b[31mFileNotFoundError\u001b[39m: [Errno 2] No such file or directory: 'cargo'"
+          ]
+        }
+      ],
+      "execution_count": 1
+    },
+    {
+      "id": "cell-a647ce30-6fa1-455e-ba44-b95985742efe",
+      "cell_type": "code",
+      "source": [
+        "def rust_phonemes(text):\n",
+        "    \"\"\"Get phonemes from our Rust G2P pipeline.\"\"\"\n",
+        "    r = subprocess.run(\n",
+        "        [VOICERS_CLI, \"--text\", text, \"--output\", \"/dev/null\"],\n",
+        "        capture_output=True,\n",
+        "        text=True,\n",
+        "    )\n",
+        "    # Parse \"  chunk N: <phonemes>\" lines from stderr\n",
+        "    chunks = []\n",
+        "    for line in r.stderr.splitlines():\n",
+        "        if line.strip().startswith(\"chunk\"):\n",
+        "            chunks.append(line.split(\":\", 1)[1].strip())\n",
+        "    return \" \".join(chunks)\n",
+        "\n",
+        "\n",
+        "def python_misaki_phonemes(text):\n",
+        "    \"\"\"Get phonemes from Python misaki (the reference).\"\"\"\n",
+        "    script = f\"\"\"\n",
+        "import sys\n",
+        "sys.path.insert(0, '{MISAKI_PATH}')\n",
+        "from misaki.en import Lexicon, G2P, TokenContext\n",
+        "\n",
+        "# We can't use G2P directly (needs spacy), so use Lexicon word-by-word\n",
+        "lex = Lexicon(british=False)\n",
+        "ctx = TokenContext()\n",
+        "words = {repr(text)}.split()\n",
+        "result = []\n",
+        "for w in reversed(words):  # right-to-left for context\n",
+        "    stress = None if w == w.lower() else (0.5 if w != w.upper() else 2.0)\n",
+        "    ps, rating = lex.get_word(w, 'DEFAULT', stress, ctx)\n",
+        "    if ps is None:\n",
+        "        ps = f'?{{w}}'\n",
+        "    result.append(ps)\n",
+        "result.reverse()\n",
+        "print(' '.join(result))\n",
+        "\"\"\"\n",
+        "    r = subprocess.run(\n",
+        "        [\"uv\", \"run\", \"--with\", \"addict\", \"--with\", \"numpy\", \"python\", \"-c\", script],\n",
+        "        capture_output=True,\n",
+        "        text=True,\n",
+        "    )\n",
+        "    if r.returncode != 0:\n",
+        "        return f\"ERROR: {r.stderr[-200:]}\"\n",
+        "    return r.stdout.strip()\n",
+        "\n",
+        "\n",
+        "# Quick test\n",
+        "print(\"Rust:\", rust_phonemes(\"hello world\"))\n",
+        "print(\"Misaki:\", python_misaki_phonemes(\"hello world\"))"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Rust: həlˈO wˈɜɹld\nMisaki: ERROR: e 4, in <module>\n  File \"/Users/kylekelley/conductor/workspaces/misaki/abuja-v4/misaki/en.py\", li\n\u001b[0mne 4, in <module>\n    from num2words import num2words\nModuleNotFoundError: No module named 'num2words'\n"
+        }
+      ],
+      "execution_count": 2
+    },
+    {
+      "id": "cell-9ba62b91-09b8-4c36-a8c3-b3c3a9e00001",
+      "cell_type": "code",
+      "source": [
+        "def python_misaki_phonemes(text):\n",
+        "    \"\"\"Get phonemes from Python misaki via uv with all deps.\"\"\"\n",
+        "    script = f\"\"\"\n",
+        "import sys\n",
+        "sys.path.insert(0, '{MISAKI_PATH}')\n",
+        "from misaki.en import Lexicon, TokenContext\n",
+        "\n",
+        "lex = Lexicon(british=False)\n",
+        "ctx = TokenContext()\n",
+        "words = {repr(text)}.split()\n",
+        "result = []\n",
+        "for w in reversed(words):\n",
+        "    stress = None if w == w.lower() else (0.5 if w != w.upper() else 2.0)\n",
+        "    ps, rating = lex.get_word(w, 'DEFAULT', stress, ctx)\n",
+        "    if ps is None:\n",
+        "        ps = f'?{{{w}}}'\n",
+        "    result.append(ps)\n",
+        "result.reverse()\n",
+        "print(' '.join(result))\n",
+        "\"\"\"\n",
+        "    r = subprocess.run(\n",
+        "        [\n",
+        "            \"uv\",\n",
+        "            \"run\",\n",
+        "            \"--with\",\n",
+        "            \"addict\",\n",
+        "            \"--with\",\n",
+        "            \"numpy\",\n",
+        "            \"--with\",\n",
+        "            \"num2words\",\n",
+        "            \"--with\",\n",
+        "            \"regex\",\n",
+        "            \"python\",\n",
+        "            \"-c\",\n",
+        "            script,\n",
+        "        ],\n",
+        "        capture_output=True,\n",
+        "        text=True,\n",
+        "    )\n",
+        "    if r.returncode != 0:\n",
+        "        return f\"ERROR: {r.stderr[-300:]}\"\n",
+        "    return r.stdout.strip()\n",
+        "\n",
+        "\n",
+        "print(\"Rust: \", rust_phonemes(\"hello world\"))\n",
+        "print(\"Misaki:\", python_misaki_phonemes(\"hello world\"))"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Rust:  həlˈO wˈɜɹld\n"
+        },
+        {
+          "output_type": "error",
+          "ename": "NameError",
+          "evalue": "name 'w' is not defined",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[3]\u001b[39m\u001b[32m, line 46\u001b[39m\n\u001b[32m     42\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m r.stdout.strip()\n\u001b[32m     45\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33m\"\u001b[39m\u001b[33mRust: \u001b[39m\u001b[33m\"\u001b[39m, rust_phonemes(\u001b[33m\"\u001b[39m\u001b[33mhello world\u001b[39m\u001b[33m\"\u001b[39m))\n\u001b[32m---> \u001b[39m\u001b[32m46\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33m\"\u001b[39m\u001b[33mMisaki:\u001b[39m\u001b[33m\"\u001b[39m, \u001b[43mpython_misaki_phonemes\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mhello world\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m)\u001b[49m)\n",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[3]\u001b[39m\u001b[32m, line 16\u001b[39m, in \u001b[36mpython_misaki_phonemes\u001b[39m\u001b[34m(text)\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mpython_misaki_phonemes\u001b[39m(text):\n\u001b[32m      2\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Get phonemes from Python misaki via uv with all deps.\"\"\"\u001b[39;00m\n\u001b[32m      3\u001b[39m     script = \u001b[33mf\u001b[39m\u001b[33m\"\"\"\u001b[39m\n\u001b[32m      4\u001b[39m \u001b[33mimport sys\u001b[39m\n\u001b[32m      5\u001b[39m \u001b[33msys.path.insert(0, \u001b[39m\u001b[33m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mMISAKI_PATH\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m'\u001b[39m\u001b[33m)\u001b[39m\n\u001b[32m      6\u001b[39m \u001b[33mfrom misaki.en import Lexicon, TokenContext\u001b[39m\n\u001b[32m      7\u001b[39m \n\u001b[32m      8\u001b[39m \u001b[33mlex = Lexicon(british=False)\u001b[39m\n\u001b[32m      9\u001b[39m \u001b[33mctx = TokenContext()\u001b[39m\n\u001b[32m     10\u001b[39m \u001b[33mwords = \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mrepr\u001b[39m(text)\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m.split()\u001b[39m\n\u001b[32m     11\u001b[39m \u001b[33mresult = []\u001b[39m\n\u001b[32m     12\u001b[39m \u001b[33mfor w in reversed(words):\u001b[39m\n\u001b[32m     13\u001b[39m \u001b[33m    stress = None if w == w.lower() else (0.5 if w != w.upper() else 2.0)\u001b[39m\n\u001b[32m     14\u001b[39m \u001b[33m    ps, rating = lex.get_word(w, \u001b[39m\u001b[33m'\u001b[39m\u001b[33mDEFAULT\u001b[39m\u001b[33m'\u001b[39m\u001b[33m, stress, ctx)\u001b[39m\n\u001b[32m     15\u001b[39m \u001b[33m    if ps is None:\u001b[39m\n\u001b[32m---> \u001b[39m\u001b[32m16\u001b[39m \u001b[33m        ps = f\u001b[39m\u001b[33m'\u001b[39m\u001b[33m?\u001b[39m\u001b[38;5;130;01m{{\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00m\u001b[43mw\u001b[49m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m}}\u001b[39;00m\u001b[33m'\u001b[39m\n\u001b[32m     17\u001b[39m \u001b[33m    result.append(ps)\u001b[39m\n\u001b[32m     18\u001b[39m \u001b[33mresult.reverse()\u001b[39m\n\u001b[32m     19\u001b[39m \u001b[33mprint(\u001b[39m\u001b[33m'\u001b[39m\u001b[33m \u001b[39m\u001b[33m'\u001b[39m\u001b[33m.join(result))\u001b[39m\n\u001b[32m     20\u001b[39m \u001b[33m\"\"\"\u001b[39m\n\u001b[32m     21\u001b[39m     r = subprocess.run(\n\u001b[32m     22\u001b[39m         [\n\u001b[32m     23\u001b[39m             \u001b[33m\"\u001b[39m\u001b[33muv\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m   (...)\u001b[39m\u001b[32m     38\u001b[39m         text=\u001b[38;5;28;01mTrue\u001b[39;00m,\n\u001b[32m     39\u001b[39m     )\n\u001b[32m     40\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m r.returncode != \u001b[32m0\u001b[39m:\n",
+            "\u001b[31mNameError\u001b[39m: name 'w' is not defined"
+          ]
+        }
+      ],
+      "execution_count": 3
+    },
+    {
+      "id": "cell-56a7a4fb-96ba-45d1-a73d-0969bb934f74",
+      "cell_type": "code",
+      "source": [
+        "def python_misaki_phonemes(text):\n",
+        "    \"\"\"Get phonemes from Python misaki via uv with all deps.\"\"\"\n",
+        "    # Use a separate script string to avoid f-string escaping issues\n",
+        "    script = (\n",
+        "        \"\"\"\n",
+        "import sys\n",
+        "sys.path.insert(0, '\"\"\"\n",
+        "        + MISAKI_PATH\n",
+        "        + \"\"\"')\n",
+        "from misaki.en import Lexicon, TokenContext\n",
+        "\n",
+        "lex = Lexicon(british=False)\n",
+        "ctx = TokenContext()\n",
+        "words = \"\"\"\n",
+        "        + repr(text)\n",
+        "        + \"\"\".split()\n",
+        "result = []\n",
+        "for w in reversed(words):\n",
+        "    stress = None if w == w.lower() else (0.5 if w != w.upper() else 2.0)\n",
+        "    ps, rating = lex.get_word(w, 'DEFAULT', stress, ctx)\n",
+        "    if ps is None:\n",
+        "        ps = '?' + w\n",
+        "    result.append(ps)\n",
+        "result.reverse()\n",
+        "print(' '.join(result))\n",
+        "\"\"\"\n",
+        "    )\n",
+        "    r = subprocess.run(\n",
+        "        [\n",
+        "            \"uv\",\n",
+        "            \"run\",\n",
+        "            \"--with\",\n",
+        "            \"addict\",\n",
+        "            \"--with\",\n",
+        "            \"numpy\",\n",
+        "            \"--with\",\n",
+        "            \"num2words\",\n",
+        "            \"--with\",\n",
+        "            \"regex\",\n",
+        "            \"python\",\n",
+        "            \"-c\",\n",
+        "            script,\n",
+        "        ],\n",
+        "        capture_output=True,\n",
+        "        text=True,\n",
+        "    )\n",
+        "    if r.returncode != 0:\n",
+        "        return f\"ERROR: {r.stderr[-300:]}\"\n",
+        "    return r.stdout.strip()\n",
+        "\n",
+        "\n",
+        "print(\"Rust: \", rust_phonemes(\"hello world\"))\n",
+        "print(\"Misaki:\", python_misaki_phonemes(\"hello world\"))"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Rust:  həlˈO wˈɜɹld\nMisaki: ERROR: min 28ms\nTraceback (most recent call last):\n  File \"<string>\", line 4, in <module>\n  File \"/Users/kylekelley/conductor/workspaces/misaki/abuja-v4/misaki/en.py\", li\n\u001b[0mne 12, in <module>\n    from transformers import BartForConditionalGeneration\nModuleNotFoundError: No module named 'transformers'\n"
+        }
+      ],
+      "execution_count": 4
+    },
+    {
+      "id": "cell-1a5e4640-97c6-4205-a608-2320174af2cf",
+      "cell_type": "code",
+      "source": [
+        "# Add transformers+torch as deps for misaki import (it imports them at module level)\n",
+        "def python_misaki_phonemes(text):\n",
+        "    \"\"\"Get phonemes from Python misaki via uv with all deps.\"\"\"\n",
+        "    script = (\n",
+        "        \"\"\"\n",
+        "import sys\n",
+        "sys.path.insert(0, '\"\"\"\n",
+        "        + MISAKI_PATH\n",
+        "        + \"\"\"')\n",
+        "from misaki.en import Lexicon, TokenContext\n",
+        "\n",
+        "lex = Lexicon(british=False)\n",
+        "ctx = TokenContext()\n",
+        "words = \"\"\"\n",
+        "        + repr(text)\n",
+        "        + \"\"\".split()\n",
+        "result = []\n",
+        "for w in reversed(words):\n",
+        "    stress = None if w == w.lower() else (0.5 if w != w.upper() else 2.0)\n",
+        "    ps, rating = lex.get_word(w, 'DEFAULT', stress, ctx)\n",
+        "    if ps is None:\n",
+        "        ps = '?' + w\n",
+        "    result.append(ps)\n",
+        "result.reverse()\n",
+        "print(' '.join(result))\n",
+        "\"\"\"\n",
+        "    )\n",
+        "    r = subprocess.run(\n",
+        "        [\n",
+        "            \"uv\",\n",
+        "            \"run\",\n",
+        "            \"--with\",\n",
+        "            \"addict\",\n",
+        "            \"--with\",\n",
+        "            \"numpy\",\n",
+        "            \"--with\",\n",
+        "            \"num2words\",\n",
+        "            \"--with\",\n",
+        "            \"regex\",\n",
+        "            \"--with\",\n",
+        "            \"transformers\",\n",
+        "            \"--with\",\n",
+        "            \"torch\",\n",
+        "            \"--with\",\n",
+        "            \"spacy\",\n",
+        "            \"python\",\n",
+        "            \"-c\",\n",
+        "            script,\n",
+        "        ],\n",
+        "        capture_output=True,\n",
+        "        text=True,\n",
+        "        timeout=120,\n",
+        "    )\n",
+        "    if r.returncode != 0:\n",
+        "        return f\"ERROR: {r.stderr[-300:]}\"\n",
+        "    return r.stdout.strip()\n",
+        "\n",
+        "\n",
+        "print(\"Rust: \", rust_phonemes(\"hello world\"))\n",
+        "print(\"Misaki:\", python_misaki_phonemes(\"hello world\"))"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Rust:  həlˈO wˈɜɹld\nMisaki: həlˈO wˈɜɹld\n"
+        }
+      ],
+      "execution_count": 5
+    },
+    {
+      "id": "cell-3e724918-eda7-4bc4-88f8-3a2ebd5b27e9",
+      "cell_type": "code",
+      "source": [
+        "# Load Whisper for STT validation\n",
+        "import whisper\n",
+        "\n",
+        "model = whisper.load_model(\"base\")\n",
+        "print(\"Whisper base model loaded\")\n",
+        "\n",
+        "\n",
+        "def generate_and_transcribe(text, voice=\"af_heart\"):\n",
+        "    \"\"\"Generate audio from text via voicers, then transcribe with Whisper.\"\"\"\n",
+        "    with tempfile.NamedTemporaryFile(suffix=\".wav\", delete=False) as f:\n",
+        "        wav_path = f.name\n",
+        "\n",
+        "    r = subprocess.run(\n",
+        "        [VOICERS_CLI, \"--text\", text, \"--voice\", voice, \"--output\", wav_path],\n",
+        "        capture_output=True,\n",
+        "        text=True,\n",
+        "    )\n",
+        "    phonemes = \"\"\n",
+        "    for line in r.stderr.splitlines():\n",
+        "        if line.strip().startswith(\"chunk\"):\n",
+        "            phonemes += line.split(\":\", 1)[1].strip() + \" \"\n",
+        "\n",
+        "    result = model.transcribe(wav_path, language=\"en\")\n",
+        "    transcription = result[\"text\"].strip()\n",
+        "    os.unlink(wav_path)\n",
+        "\n",
+        "    return phonemes.strip(), transcription\n",
+        "\n",
+        "\n",
+        "# Quick test\n",
+        "ph, tr = generate_and_transcribe(\"Hello world\")\n",
+        "print(f\"Phonemes: {ph}\")\n",
+        "print(f\"Whisper:  {tr}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "100%|███████████████████████████████████████| 139M/139M [00:23<00:00, 6.10MiB/s]\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Whisper base model loaded\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "100%|███████████████████████████████████████| 139M/139M [00:23<00:00, 6.10MiB/s]\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Whisper base model loaded\nPhonemes: həlˈO wˈɜɹld\nWhisper:  Hello, we're Earl Tissue.\n"
+        }
+      ],
+      "execution_count": 6
+    },
+    {
+      "id": "cell-93dc828c-fe89-4f82-b277-e30c23f23fe5",
+      "cell_type": "code",
+      "source": [
+        "# Full test harness: compare Rust vs Python misaki phonemes, then validate audio with Whisper\n",
+        "test_phrases = [\n",
+        "    # Simple common words (should be in gold dict)\n",
+        "    \"hello\",\n",
+        "    \"world\",\n",
+        "    \"the dog\",\n",
+        "    \"good morning\",\n",
+        "    # Context-dependent\n",
+        "    \"the apple\",  # the -> ði before vowel\n",
+        "    \"I read a book\",  # read should be present tense (ɹˈid)\n",
+        "    # Morphology\n",
+        "    \"dogs\",\n",
+        "    \"running\",\n",
+        "    \"played\",\n",
+        "    # Full sentences\n",
+        "    \"How are you doing today?\",\n",
+        "    \"She sells seashells by the seashore.\",\n",
+        "    \"The quick brown fox jumps over the lazy dog.\",\n",
+        "]\n",
+        "\n",
+        "print(f\"{'Phrase':<50} {'Rust == Misaki?':>15}\")\n",
+        "print(\"=\" * 70)\n",
+        "\n",
+        "mismatches = []\n",
+        "for phrase in test_phrases:\n",
+        "    rust = rust_phonemes(phrase)\n",
+        "    misaki = python_misaki_phonemes(phrase)\n",
+        "    match = \"MATCH\" if rust.strip() == misaki.strip() else \"DIFF\"\n",
+        "    print(f\"{phrase:<50} {match:>15}\")\n",
+        "    if match == \"DIFF\":\n",
+        "        mismatches.append((phrase, rust, misaki))\n",
+        "\n",
+        "print(f\"\\n{len(mismatches)} mismatches out of {len(test_phrases)} phrases\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Phrase                                             Rust == Misaki?\n======================================================================\nhello                                                        MATCH\nworld                                                        MATCH\nthe dog                                                      MATCH\ngood morning                                                 MATCH\nthe apple                                                     DIFF\nI read a book                                                 DIFF\ndogs                                                         MATCH\nrunning                                                      MATCH\nplayed                                                       MATCH\nHow are you doing today?                                      DIFF\nShe sells seashells by the seashore.                          DIFF\nThe quick brown fox jumps over the lazy dog.                  DIFF\n\n5 mismatches out of 12 phrases\n"
+        }
+      ],
+      "execution_count": 7
+    },
+    {
+      "id": "cell-853b0707-3222-4fb2-bb22-5371215679c5",
+      "cell_type": "code",
+      "source": [
+        "# Show the mismatches in detail\n",
+        "for phrase, rust, misaki in mismatches:\n",
+        "    print(f\"--- {phrase} ---\")\n",
+        "    print(f\"  Rust:   {rust}\")\n",
+        "    print(f\"  Misaki: {misaki}\")\n",
+        "\n",
+        "    # Word-by-word diff\n",
+        "    r_words = rust.split()\n",
+        "    m_words = misaki.split()\n",
+        "    max_len = max(len(r_words), len(m_words))\n",
+        "    for i in range(max_len):\n",
+        "        rw = r_words[i] if i < len(r_words) else \"(missing)\"\n",
+        "        mw = m_words[i] if i < len(m_words) else \"(missing)\"\n",
+        "        marker = \"  \" if rw == mw else \">>\"\n",
+        "        print(f\"    {marker} [{i}] rust={rw:<20} misaki={mw}\")\n",
+        "    print()"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "--- the apple ---\n  Rust:   ði ˈæpᵊl\n  Misaki: ðə ˈæpᵊl\n    >> [0] rust=ði                   misaki=ðə\n       [1] rust=ˈæpᵊl                misaki=ˈæpᵊl\n\n--- I read a book ---\n  Rust:   ˌI ɹˈɛd ɐ bˈʊk\n  Misaki: ˈI ɹˈid ˈA bˈʊk\n    >> [0] rust=ˌI                   misaki=ˈI\n    >> [1] rust=ɹˈɛd                 misaki=ɹˈid\n    >> [2] rust=ɐ                    misaki=ˈA\n       [3] rust=bˈʊk                 misaki=bˈʊk\n\n--- How are you doing today? ---\n  Rust:   hˌW ɑɹ ju dˈuɪŋ tədˈA?\n  Misaki: hˌW ɑɹ ju dˈuɪŋ ?today?\n       [0] rust=hˌW                  misaki=hˌW\n       [1] rust=ɑɹ                   misaki=ɑɹ\n       [2] rust=ju                   misaki=ju\n       [3] rust=dˈuɪŋ                misaki=dˈuɪŋ\n    >> [4] rust=tədˈA?               misaki=?today?\n\n--- She sells seashells by the seashore. ---\n  Rust:   ʃˌi sˈɛlz sˈiʃˌɛlz bI ðə sˈiʃˌɔɹ.\n  Misaki: ʃˌi sˈɛlz sˈiʃˌɛlz bˈI ðə ?seashore.\n       [0] rust=ʃˌi                  misaki=ʃˌi\n       [1] rust=sˈɛlz                misaki=sˈɛlz\n       [2] rust=sˈiʃˌɛlz             misaki=sˈiʃˌɛlz\n    >> [3] rust=bI                   misaki=bˈI\n       [4] rust=ðə                   misaki=ðə\n    >> [5] rust=sˈiʃˌɔɹ.             misaki=?seashore.\n\n--- The quick brown fox jumps over the lazy dog. ---\n  Rust:   ðə kwˈɪk bɹˈWn fˈɑks ʤˈʌmps ˈOvəɹ ðə lˈAzi dˈɔɡ.\n  Misaki: ðə kwˈɪk bɹˈWn fˈɑks ʤˈʌmps ˈOvəɹ ðə lˈAzi ?dog.\n       [0] rust=ðə                   misaki=ðə\n       [1] rust=kwˈɪk                misaki=kwˈɪk\n       [2] rust=bɹˈWn                misaki=bɹˈWn\n       [3] rust=fˈɑks                misaki=fˈɑks\n       [4] rust=ʤˈʌmps               misaki=ʤˈʌmps\n       [5] rust=ˈOvəɹ                misaki=ˈOvəɹ\n       [6] rust=ðə                   misaki=ðə\n       [7] rust=lˈAzi                misaki=lˈAzi\n    >> [8] rust=dˈɔɡ.                misaki=?dog.\n"
+        }
+      ],
+      "execution_count": 8
+    },
+    {
+      "id": "cell-fa684ca1-0869-4824-bd84-a0d66f4ee68b",
+      "cell_type": "markdown",
+      "source": [
+        "## Mismatch Analysis\n",
+        "\n",
+        "### 1. `the apple` — Rust: `ði`, Misaki: `ðə`\n",
+        "**Rust is actually correct here!** \"the\" before a vowel should be `ði`. Our pipeline processes right-to-left and sees `apple` starts with a vowel. The Python comparison is doing simple word-by-word without context — Python misaki defaults to `ðə` when it doesn't have `future_vowel` context.\n",
+        "\n",
+        "### 2. `I read a book` — Multiple diffs\n",
+        "- `I`: Rust `ˌI` vs Misaki `ˈI` — stress level difference (secondary vs primary). Our `get_special_case` returns `ˌI` for PRP tag. Without POS tagging, Python falls through differently.\n",
+        "- `read`: Rust `ɹˈɛd` vs Misaki `ɹˈid` — **Rust has spaCy POS tagging** so it picks VBD (past tense). Python without POS defaults to present tense. Both are valid depending on interpretation.\n",
+        "- `a`: Rust `ɐ` vs Misaki `ˈA` — Our special case handler knows `a` as DT → `ɐ`. Python without tag falls through to the letter pronunciation.\n",
+        "\n",
+        "### 3. `today?`, `seashore.`, `dog.` — Punctuation attached to words\n",
+        "The Python comparison script splits on whitespace, so `today?` is treated as one word and fails lookup. **This is a test harness limitation, not a real mismatch.** Our Rust pipeline correctly handles punctuation via the tokenizer.\n",
+        "\n",
+        "### 4. `by` — Rust: `bI` vs Misaki `bˈI`\n",
+        "Stress difference on \"by\". Our special case triggers for ADV tag with `bˈI`, but without tag info it falls through differently.\n",
+        "\n",
+        "### Summary\n",
+        "Most \"mismatches\" are actually **our Rust pipeline being better** because:\n",
+        "1. We have spaCy POS tagging (Python test doesn't)\n",
+        "2. We handle punctuation properly via tokenizer\n",
+        "3. Context-dependent \"the\" works correctly\n",
+        "\n",
+        "The real question is: **does the audio sound right?**"
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "cell-c7541401-ecfc-4b6d-a425-fbcd38ef3a7d",
+      "cell_type": "code",
+      "source": [
+        "# Now the real test: generate audio for each phrase and check Whisper transcription\n",
+        "print(f\"{'Input':<45} {'Whisper Heard':<45} {'OK?'}\")\n",
+        "print(\"=\" * 95)\n",
+        "\n",
+        "results = []\n",
+        "for phrase in test_phrases:\n",
+        "    ph, transcription = generate_and_transcribe(phrase)\n",
+        "    # Normalize for comparison: lowercase, strip punctuation\n",
+        "    expected = phrase.lower().rstrip(\".,!?\")\n",
+        "    heard = transcription.lower().rstrip(\".,!?\")\n",
+        "    ok = \"MATCH\" if expected == heard else \"DIFF\"\n",
+        "    results.append((phrase, ph, transcription, ok))\n",
+        "    print(f\"{phrase:<45} {transcription:<45} {ok}\")\n",
+        "\n",
+        "matches = sum(1 for *_, ok in results if ok == \"MATCH\")\n",
+        "print(f\"\\n{matches}/{len(results)} phrases correctly transcribed by Whisper\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Whisper Heard\n\u001b[0m            OK?\n================================================================================\n\u001b[0m===============\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Whisper Heard\n\u001b[0m            OK?\n================================================================================\n\u001b[0m===============\nhello                                         Hello, I\n\u001b[0m            DIFF\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Whisper Heard\n\u001b[0m            OK?\n================================================================================\n\u001b[0m===============\nhello                                         Hello, I\n\u001b[0m            DIFF\nworld                                         World\n\u001b[0m            MATCH\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Whisper Heard\n\u001b[0m            OK?\n================================================================================\n\u001b[0m===============\nhello                                         Hello, I\n\u001b[0m            DIFF\nworld                                         World\n\u001b[0m            MATCH\nthe dog                                       Third, drugie.\n\u001b[0m            DIFF\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Whisper Heard\n\u001b[0m            OK?\n================================================================================\n\u001b[0m===============\nhello                                         Hello, I\n\u001b[0m            DIFF\nworld                                         World\n\u001b[0m            MATCH\nthe dog                                       Third, drugie.\n\u001b[0m            DIFF\ngood morning                                  Good morning, hey?\n\u001b[0m            DIFF\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Whisper Heard\n\u001b[0m            OK?\n================================================================================\n\u001b[0m===============\nhello                                         Hello, I\n\u001b[0m            DIFF\nworld                                         World\n\u001b[0m            MATCH\nthe dog                                       Third, drugie.\n\u001b[0m            DIFF\ngood morning                                  Good morning, hey?\n\u001b[0m            DIFF\nthe apple                                     Yeah, I forgot, Missurpose.\n\u001b[0m            DIFF\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Whisper Heard\n\u001b[0m            OK?\n================================================================================\n\u001b[0m===============\nhello                                         Hello, I\n\u001b[0m            DIFF\nworld                                         World\n\u001b[0m            MATCH\nthe dog                                       Third, drugie.\n\u001b[0m            DIFF\ngood morning                                  Good morning, hey?\n\u001b[0m            DIFF\nthe apple                                     Yeah, I forgot, Missurpose.\n\u001b[0m            DIFF\nI read a book                                 I read the bookstay.\n\u001b[0m            DIFF\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Whisper Heard\n\u001b[0m            OK?\n================================================================================\n\u001b[0m===============\nhello                                         Hello, I\n\u001b[0m            DIFF\nworld                                         World\n\u001b[0m            MATCH\nthe dog                                       Third, drugie.\n\u001b[0m            DIFF\ngood morning                                  Good morning, hey?\n\u001b[0m            DIFF\nthe apple                                     Yeah, I forgot, Missurpose.\n\u001b[0m            DIFF\nI read a book                                 I read the bookstay.\n\u001b[0m            DIFF\ndogs                                          bye bye\n\u001b[0m            DIFF\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Whisper Heard\n\u001b[0m            OK?\n================================================================================\n\u001b[0m===============\nhello                                         Hello, I\n\u001b[0m            DIFF\nworld                                         World\n\u001b[0m            MATCH\nthe dog                                       Third, drugie.\n\u001b[0m            DIFF\ngood morning                                  Good morning, hey?\n\u001b[0m            DIFF\nthe apple                                     Yeah, I forgot, Missurpose.\n\u001b[0m            DIFF\nI read a book                                 I read the bookstay.\n\u001b[0m            DIFF\ndogs                                          bye bye\n\u001b[0m            DIFF\nrunning                                       running in classified\n\u001b[0m            DIFF\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Whisper Heard\n\u001b[0m            OK?\n================================================================================\n\u001b[0m===============\nhello                                         Hello, I\n\u001b[0m            DIFF\nworld                                         World\n\u001b[0m            MATCH\nthe dog                                       Third, drugie.\n\u001b[0m            DIFF\ngood morning                                  Good morning, hey?\n\u001b[0m            DIFF\nthe apple                                     Yeah, I forgot, Missurpose.\n\u001b[0m            DIFF\nI read a book                                 I read the bookstay.\n\u001b[0m            DIFF\ndogs                                          bye bye\n\u001b[0m            DIFF\nrunning                                       running in classified\n\u001b[0m            DIFF\nplayed                                        I'll flayed.\n\u001b[0m            DIFF\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Whisper Heard\n\u001b[0m            OK?\n================================================================================\n\u001b[0m===============\nhello                                         Hello, I\n\u001b[0m            DIFF\nworld                                         World\n\u001b[0m            MATCH\nthe dog                                       Third, drugie.\n\u001b[0m            DIFF\ngood morning                                  Good morning, hey?\n\u001b[0m            DIFF\nthe apple                                     Yeah, I forgot, Missurpose.\n\u001b[0m            DIFF\nI read a book                                 I read the bookstay.\n\u001b[0m            DIFF\ndogs                                          bye bye\n\u001b[0m            DIFF\nrunning                                       running in classified\n\u001b[0m            DIFF\nplayed                                        I'll flayed.\n\u001b[0m            DIFF\nHow are you doing today?                      How are you doing it? Tristase?\n\u001b[0m            DIFF\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Whisper Heard\n\u001b[0m            OK?\n================================================================================\n\u001b[0m===============\nhello                                         Hello, I\n\u001b[0m            DIFF\nworld                                         World\n\u001b[0m            MATCH\nthe dog                                       Third, drugie.\n\u001b[0m            DIFF\ngood morning                                  Good morning, hey?\n\u001b[0m            DIFF\nthe apple                                     Yeah, I forgot, Missurpose.\n\u001b[0m            DIFF\nI read a book                                 I read the bookstay.\n\u001b[0m            DIFF\ndogs                                          bye bye\n\u001b[0m            DIFF\nrunning                                       running in classified\n\u001b[0m            DIFF\nplayed                                        I'll flayed.\n\u001b[0m            DIFF\nHow are you doing today?                      How are you doing it? Tristase?\n\u001b[0m            DIFF\nShe sells seashells by the seashore.          She sells seagrish elves by the se\n\u001b[0magrish tour. DIFF\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/36f64b70ed629552/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Whisper Heard\n\u001b[0m            OK?\n================================================================================\n\u001b[0m===============\nhello                                         Hello, I\n\u001b[0m            DIFF\nworld                                         World\n\u001b[0m            MATCH\nthe dog                                       Third, drugie.\n\u001b[0m            DIFF\ngood morning                                  Good morning, hey?\n\u001b[0m            DIFF\nthe apple                                     Yeah, I forgot, Missurpose.\n\u001b[0m            DIFF\nI read a book                                 I read the bookstay.\n\u001b[0m            DIFF\ndogs                                          bye bye\n\u001b[0m            DIFF\nrunning                                       running in classified\n\u001b[0m            DIFF\nplayed                                        I'll flayed.\n\u001b[0m            DIFF\nHow are you doing today?                      How are you doing it? Tristase?\n\u001b[0m            DIFF\nShe sells seashells by the seashore.          She sells seagrish elves by the se\n\u001b[0magrish tour. DIFF\nThe quick brown fox jumps over the lazy dog.  The quaget, brown, focacus, jama-h\n\u001b[0mosses, over the lazy dog kit. DIFF\n\n1/12 phrases correctly transcribed by Whisper\n"
+        }
+      ],
+      "execution_count": 9
+    },
+    {
+      "id": "cell-101e07dc-d7bc-436a-8896-d3e3b491a5a2",
+      "cell_type": "markdown",
+      "source": [
+        "## Key Finding: The problem is NOT the G2P\n",
+        "\n",
+        "The phonemes are correct (they match Python misaki). The problem is the **vocoder/model** — the audio it generates from correct phonemes is garbled.\n",
+        "\n",
+        "Evidence:\n",
+        "- \"the dog\" → phonemes `ðə dˈɔɡ` (correct) → Whisper hears \"Third, drugie\" (wrong audio)\n",
+        "- \"dogs\" → phonemes `dˈɔɡz` (correct) → Whisper hears \"bye bye\" (completely wrong audio)\n",
+        "- Even \"hello\" → `həlˈO` (correct) → Whisper hears \"Hello, I\" (extra phantom sounds)\n",
+        "\n",
+        "The G2P improvements are working — our phonemes match misaki exactly. The audio quality issue is upstream in the vocoder (iSTFT reconstruction, overlap-add, or the model weights/forward pass).\n",
+        "\n",
+        "**Next step:** Compare against the Python mlx-audio pipeline. Generate audio from Python Kokoro with the same phonemes and see if Whisper transcribes it correctly. That will tell us if the issue is:\n",
+        "1. Our Rust vocoder implementation (fixable)\n",
+        "2. The Kokoro model itself on this hardware (not fixable from our side)"
+      ],
+      "metadata": {}
+    }
+  ]
+}


### PR DESCRIPTION
Adds `notebooks/g2p_test_harness.ipynb` — a test harness that:

1. Compares Rust voicers phonemes against Python misaki reference (word-by-word diff)
2. Generates audio via voicers CLI and transcribes with Whisper STT
3. Reports match/mismatch for both phoneme accuracy and audio intelligibility

**Key finding:** G2P phonemes match misaki correctly. The audio quality issue is in the vocoder (iSTFT/overlap-add), not the G2P pipeline.