### PR TITLE
Add vocoder comparison: Python mlx-audio vs Rust voicers

### DIFF
--- a/notebooks/vocoder_comparison.ipynb
+++ b/notebooks/vocoder_comparison.ipynb
@@ -1,0 +1,844 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 5,
+  "metadata": {
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3",
+      "language": "python"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "runt": {
+      "schema_version": "1",
+      "env_id": "be655982-9fbd-465f-be58-6dc4c1caf6d8",
+      "uv": {
+        "dependencies": [
+          "openai-whisper",
+          "mlx-audio",
+          "misaki[en]",
+          "en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl"
+        ]
+      }
+    }
+  },
+  "cells": [
+    {
+      "id": "402e9db5-d8a0-454d-a32a-9b18a235c365",
+      "cell_type": "code",
+      "source": [],
+      "metadata": {},
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "id": "cell-9159dee9-e53f-432d-bfd9-d7059f414765",
+      "cell_type": "markdown",
+      "source": [
+        "# Vocoder Comparison: Python mlx-audio vs Rust voicers\n",
+        "\n",
+        "Same phonemes, same model weights, same voice — which produces intelligible audio?\n",
+        "\n",
+        "If Python sounds fine and Rust doesn't, the bug is in our Rust vocoder (iSTFT, overlap-add, weight loading, etc).\n",
+        "If both sound bad, it's the model itself or an MLX framework issue."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "cell-b89f52fd-b0c5-4d14-af19-ad0de2a3b0a4",
+      "cell_type": "code",
+      "source": [
+        "import subprocess, json, os, tempfile\n",
+        "import numpy as np\n",
+        "import whisper\n",
+        "\n",
+        "VOICERS_CLI = \"./target/release/voicers-cli\"\n",
+        "\n",
+        "# Build release binary\n",
+        "result = subprocess.run(\n",
+        "    [\"cargo\", \"build\", \"--release\", \"-p\", \"voicers-cli\"], capture_output=True, text=True\n",
+        ")\n",
+        "print(\"voicers-cli:\", \"ready\" if result.returncode == 0 else result.stderr[-200:])\n",
+        "\n",
+        "# Load Whisper\n",
+        "whisper_model = whisper.load_model(\"base\")\n",
+        "print(\"Whisper: ready\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "error",
+          "ename": "FileNotFoundError",
+          "evalue": "[Errno 2] No such file or directory: 'cargo'",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mFileNotFoundError\u001b[39m                         Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 8\u001b[39m\n\u001b[32m      5\u001b[39m VOICERS_CLI = \u001b[33m\"\u001b[39m\u001b[33m./target/release/voicers-cli\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m      7\u001b[39m \u001b[38;5;66;03m# Build release binary\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m8\u001b[39m result = \u001b[43msubprocess\u001b[49m\u001b[43m.\u001b[49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m      9\u001b[39m \u001b[43m    \u001b[49m\u001b[43m[\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mcargo\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mbuild\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43m--release\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43m-p\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mvoicers-cli\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcapture_output\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtext\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\n\u001b[32m     10\u001b[39m \u001b[43m)\u001b[49m\n\u001b[32m     11\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33m\"\u001b[39m\u001b[33mvoicers-cli:\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mready\u001b[39m\u001b[33m\"\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m result.returncode == \u001b[32m0\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m result.stderr[-\u001b[32m200\u001b[39m:])\n\u001b[32m     13\u001b[39m \u001b[38;5;66;03m# Load Whisper\u001b[39;00m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/subprocess.py:548\u001b[39m, in \u001b[36mrun\u001b[39m\u001b[34m(input, capture_output, timeout, check, *popenargs, **kwargs)\u001b[39m\n\u001b[32m    545\u001b[39m     kwargs[\u001b[33m'\u001b[39m\u001b[33mstdout\u001b[39m\u001b[33m'\u001b[39m] = PIPE\n\u001b[32m    546\u001b[39m     kwargs[\u001b[33m'\u001b[39m\u001b[33mstderr\u001b[39m\u001b[33m'\u001b[39m] = PIPE\n\u001b[32m--> \u001b[39m\u001b[32m548\u001b[39m \u001b[38;5;28;01mwith\u001b[39;00m \u001b[43mPopen\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43mpopenargs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mas\u001b[39;00m process:\n\u001b[32m    549\u001b[39m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m    550\u001b[39m         stdout, stderr = process.communicate(\u001b[38;5;28minput\u001b[39m, timeout=timeout)\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/subprocess.py:1026\u001b[39m, in \u001b[36mPopen.__init__\u001b[39m\u001b[34m(self, args, bufsize, executable, stdin, stdout, stderr, preexec_fn, close_fds, shell, cwd, env, universal_newlines, startupinfo, creationflags, restore_signals, start_new_session, pass_fds, user, group, extra_groups, encoding, errors, text, umask, pipesize, process_group)\u001b[39m\n\u001b[32m   1022\u001b[39m         \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.text_mode:\n\u001b[32m   1023\u001b[39m             \u001b[38;5;28mself\u001b[39m.stderr = io.TextIOWrapper(\u001b[38;5;28mself\u001b[39m.stderr,\n\u001b[32m   1024\u001b[39m                     encoding=encoding, errors=errors)\n\u001b[32m-> \u001b[39m\u001b[32m1026\u001b[39m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_execute_child\u001b[49m\u001b[43m(\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mexecutable\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpreexec_fn\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mclose_fds\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1027\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mpass_fds\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcwd\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43menv\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1028\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mstartupinfo\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcreationflags\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mshell\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1029\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mp2cread\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mp2cwrite\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1030\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mc2pread\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mc2pwrite\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1031\u001b[39m \u001b[43m                        \u001b[49m\u001b[43merrread\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43merrwrite\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1032\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mrestore_signals\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1033\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mgid\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mgids\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43muid\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mumask\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1034\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mstart_new_session\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mprocess_group\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1035\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m:\n\u001b[32m   1036\u001b[39m     \u001b[38;5;66;03m# Cleanup if the child failed starting.\u001b[39;00m\n\u001b[32m   1037\u001b[39m     \u001b[38;5;28;01mfor\u001b[39;00m f \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mfilter\u001b[39m(\u001b[38;5;28;01mNone\u001b[39;00m, (\u001b[38;5;28mself\u001b[39m.stdin, \u001b[38;5;28mself\u001b[39m.stdout, \u001b[38;5;28mself\u001b[39m.stderr)):\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/subprocess.py:1955\u001b[39m, in \u001b[36mPopen._execute_child\u001b[39m\u001b[34m(self, args, executable, preexec_fn, close_fds, pass_fds, cwd, env, startupinfo, creationflags, shell, p2cread, p2cwrite, c2pread, c2pwrite, errread, errwrite, restore_signals, gid, gids, uid, umask, start_new_session, process_group)\u001b[39m\n\u001b[32m   1953\u001b[39m     err_msg = os.strerror(errno_num)\n\u001b[32m   1954\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m err_filename \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m-> \u001b[39m\u001b[32m1955\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m child_exception_type(errno_num, err_msg, err_filename)\n\u001b[32m   1956\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m   1957\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m child_exception_type(errno_num, err_msg)\n",
+            "\u001b[31mFileNotFoundError\u001b[39m: [Errno 2] No such file or directory: 'cargo'"
+          ]
+        }
+      ],
+      "execution_count": 1
+    },
+    {
+      "id": "cell-2e00f121-8b8c-4a3c-ac30-0426aa9f3d94",
+      "cell_type": "code",
+      "source": [
+        "import subprocess, json, os, tempfile\n",
+        "import numpy as np\n",
+        "\n",
+        "# Full paths since notebook env may not have cargo in PATH\n",
+        "CARGO = os.path.expanduser(\"~/.cargo/bin/cargo\")\n",
+        "VOICERS_CLI = os.path.abspath(\"./target/release/voicers-cli\")\n",
+        "\n",
+        "# Build release binary\n",
+        "result = subprocess.run(\n",
+        "    [CARGO, \"build\", \"--release\", \"-p\", \"voicers-cli\"], capture_output=True, text=True\n",
+        ")\n",
+        "print(\"voicers-cli:\", \"ready\" if result.returncode == 0 else result.stderr[-200:])\n",
+        "\n",
+        "import whisper\n",
+        "\n",
+        "whisper_model = whisper.load_model(\"base\")\n",
+        "print(\"Whisper: ready\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "voicers-cli: ready\nWhisper: ready\n"
+        }
+      ],
+      "execution_count": 2
+    },
+    {
+      "id": "cell-c636d48b-1aa5-4146-a8fa-014d213eaa79",
+      "cell_type": "code",
+      "source": [
+        "# Set up Python mlx-audio Kokoro pipeline\n",
+        "from mlx_audio.tts.models.kokoro.pipeline import KokoroPipeline\n",
+        "import soundfile as sf\n",
+        "\n",
+        "pipeline = KokoroPipeline(lang_code=\"a\")\n",
+        "print(f\"Python mlx-audio pipeline ready, voice: af_heart\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "error",
+          "ename": "ModuleNotFoundError",
+          "evalue": "No module named 'misaki'",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mModuleNotFoundError\u001b[39m                       Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[3]\u001b[39m\u001b[32m, line 2\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Set up Python mlx-audio Kokoro pipeline\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mmlx_audio\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mtts\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mmodels\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mkokoro\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mpipeline\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m KokoroPipeline\n\u001b[32m      3\u001b[39m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01msoundfile\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01msf\u001b[39;00m\n\u001b[32m      5\u001b[39m pipeline = KokoroPipeline(lang_code=\u001b[33m\"\u001b[39m\u001b[33ma\u001b[39m\u001b[33m\"\u001b[39m)\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/7e3a3181abd995c6/lib/python3.12/site-packages/mlx_audio/tts/models/kokoro/__init__.py:1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01m.\u001b[39;00m\u001b[34;01mkokoro\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m Model, ModelConfig\n\u001b[32m      2\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01m.\u001b[39;00m\u001b[34;01mpipeline\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m KokoroPipeline\n\u001b[32m      4\u001b[39m __all__ = [\u001b[33m\"\u001b[39m\u001b[33mKokoroPipeline\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mModel\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mModelConfig\u001b[39m\u001b[33m\"\u001b[39m]\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/7e3a3181abd995c6/lib/python3.12/site-packages/mlx_audio/tts/models/kokoro/kokoro.py:12\u001b[39m\n\u001b[32m     10\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01m.\u001b[39;00m\u001b[34;01mistftnet\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m Decoder\n\u001b[32m     11\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01m.\u001b[39;00m\u001b[34;01mmodules\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m AlbertModelArgs, CustomAlbert, ProsodyPredictor, TextEncoder\n\u001b[32m---> \u001b[39m\u001b[32m12\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01m.\u001b[39;00m\u001b[34;01mpipeline\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m KokoroPipeline\n\u001b[32m     15\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34msanitize_lstm_weights\u001b[39m(key: \u001b[38;5;28mstr\u001b[39m, state_dict: mx.array) -> \u001b[38;5;28mdict\u001b[39m:\n\u001b[32m     16\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Convert PyTorch LSTM weight keys to MLX LSTM weight keys.\"\"\"\u001b[39;00m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/7e3a3181abd995c6/lib/python3.12/site-packages/mlx_audio/tts/models/kokoro/pipeline.py:11\u001b[39m\n\u001b[32m      9\u001b[39m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mmlx\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mnn\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mnn\u001b[39;00m\n\u001b[32m     10\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mhuggingface_hub\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m snapshot_download\n\u001b[32m---> \u001b[39m\u001b[32m11\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mmisaki\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m en, espeak\n\u001b[32m     13\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01m.\u001b[39;00m\u001b[34;01mvoice\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m load_voice_tensor\n\u001b[32m     15\u001b[39m ALIASES = {\n\u001b[32m     16\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33men\u001b[39m\u001b[33m\"\u001b[39m: \u001b[33m\"\u001b[39m\u001b[33ma\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m     17\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33men-us\u001b[39m\u001b[33m\"\u001b[39m: \u001b[33m\"\u001b[39m\u001b[33ma\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m   (...)\u001b[39m\u001b[32m     27\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mzh\u001b[39m\u001b[33m\"\u001b[39m: \u001b[33m\"\u001b[39m\u001b[33mz\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m     28\u001b[39m }\n",
+            "\u001b[31mModuleNotFoundError\u001b[39m: No module named 'misaki'"
+          ]
+        }
+      ],
+      "execution_count": 3
+    },
+    {
+      "id": "cell-276f015e-ad58-45ec-bf58-a9752e670d94",
+      "cell_type": "code",
+      "source": [
+        "import subprocess, json, os, tempfile\n",
+        "import numpy as np\n",
+        "\n",
+        "CARGO = os.path.expanduser(\"~/.cargo/bin/cargo\")\n",
+        "VOICERS_CLI = os.path.abspath(\"./target/release/voicers-cli\")\n",
+        "\n",
+        "# Build\n",
+        "result = subprocess.run(\n",
+        "    [CARGO, \"build\", \"--release\", \"-p\", \"voicers-cli\"], capture_output=True, text=True\n",
+        ")\n",
+        "print(\"voicers-cli:\", \"ready\" if result.returncode == 0 else result.stderr[-200:])\n",
+        "\n",
+        "import whisper\n",
+        "\n",
+        "whisper_model = whisper.load_model(\"base\")\n",
+        "print(\"Whisper: ready\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "voicers-cli: ready\nWhisper: ready\n"
+        }
+      ],
+      "execution_count": 1
+    },
+    {
+      "id": "cell-2f02ece5-1b1a-4a8e-b175-a50917d94354",
+      "cell_type": "code",
+      "source": [
+        "# Set up Python mlx-audio Kokoro pipeline\n",
+        "from mlx_audio.tts.models.kokoro.pipeline import KokoroPipeline\n",
+        "import soundfile as sf\n",
+        "\n",
+        "pipeline = KokoroPipeline(lang_code=\"a\")\n",
+        "print(f\"Python mlx-audio Kokoro pipeline ready\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "error",
+          "ename": "TypeError",
+          "evalue": "KokoroPipeline.__init__() missing 2 required positional arguments: 'model' and 'repo_id'",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[2]\u001b[39m\u001b[32m, line 5\u001b[39m\n\u001b[32m      2\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mmlx_audio\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mtts\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mmodels\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mkokoro\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mpipeline\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m KokoroPipeline\n\u001b[32m      3\u001b[39m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01msoundfile\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01msf\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m5\u001b[39m pipeline = \u001b[43mKokoroPipeline\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlang_code\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43ma\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[32m      6\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mPython mlx-audio Kokoro pipeline ready\u001b[39m\u001b[33m\"\u001b[39m)\n",
+            "\u001b[31mTypeError\u001b[39m: KokoroPipeline.__init__() missing 2 required positional arguments: 'model' and 'repo_id'"
+          ]
+        }
+      ],
+      "execution_count": 2
+    },
+    {
+      "id": "cell-9f771995-4aed-4e53-8b4a-f253df403cfb",
+      "cell_type": "code",
+      "source": [
+        "# Use mlx-audio's generate CLI and our voicers CLI to produce audio from the same text\n",
+        "# Then transcribe both with Whisper\n",
+        "\n",
+        "import soundfile as sf\n",
+        "\n",
+        "\n",
+        "def generate_python_audio(text, voice=\"af_heart\", output_path=None):\n",
+        "    \"\"\"Generate audio using Python mlx-audio Kokoro.\"\"\"\n",
+        "    if output_path is None:\n",
+        "        output_path = tempfile.mktemp(suffix=\".wav\")\n",
+        "    r = subprocess.run(\n",
+        "        [\n",
+        "            \"python3\",\n",
+        "            \"-m\",\n",
+        "            \"mlx_audio.tts.generate\",\n",
+        "            \"--model\",\n",
+        "            \"prince-canuma/Kokoro-82M\",\n",
+        "            \"--text\",\n",
+        "            text,\n",
+        "            \"--voice\",\n",
+        "            voice,\n",
+        "            \"--output\",\n",
+        "            output_path,\n",
+        "        ],\n",
+        "        capture_output=True,\n",
+        "        text=True,\n",
+        "        timeout=120,\n",
+        "    )\n",
+        "    if r.returncode != 0:\n",
+        "        print(f\"Python gen failed: {r.stderr[-300:]}\")\n",
+        "        return None\n",
+        "    return output_path\n",
+        "\n",
+        "\n",
+        "def generate_rust_audio(text, voice=\"af_heart\", output_path=None):\n",
+        "    \"\"\"Generate audio using Rust voicers CLI.\"\"\"\n",
+        "    if output_path is None:\n",
+        "        output_path = tempfile.mktemp(suffix=\".wav\")\n",
+        "    r = subprocess.run(\n",
+        "        [VOICERS_CLI, \"--text\", text, \"--voice\", voice, \"--output\", output_path],\n",
+        "        capture_output=True,\n",
+        "        text=True,\n",
+        "        timeout=120,\n",
+        "    )\n",
+        "    if r.returncode != 0:\n",
+        "        print(f\"Rust gen failed: {r.stderr[-300:]}\")\n",
+        "        return None\n",
+        "    # Extract phonemes from stderr\n",
+        "    phonemes = \"\"\n",
+        "    for line in r.stderr.splitlines():\n",
+        "        if line.strip().startswith(\"chunk\"):\n",
+        "            phonemes += line.split(\":\", 1)[1].strip() + \" \"\n",
+        "    return output_path, phonemes.strip()\n",
+        "\n",
+        "\n",
+        "def transcribe(wav_path):\n",
+        "    \"\"\"Transcribe audio with Whisper.\"\"\"\n",
+        "    result = whisper_model.transcribe(wav_path, language=\"en\")\n",
+        "    return result[\"text\"].strip()\n",
+        "\n",
+        "\n",
+        "# Quick smoke test\n",
+        "print(\"Testing Python mlx-audio...\")\n",
+        "py_path = generate_python_audio(\"Hello world\")\n",
+        "print(f\"  Generated: {py_path}\")\n",
+        "if py_path:\n",
+        "    py_whisper = transcribe(py_path)\n",
+        "    print(f\"  Whisper heard: {py_whisper}\")\n",
+        "    os.unlink(py_path)"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Testing Python mlx-audio...\nPython gen failed: /Applications/Xcode.app/Contents/Developer/usr/bin/python3: E\n\u001b[0mrror while finding module specification for 'mlx_audio.tts.generate' (ModuleNotF\n\u001b[0moundError: No module named 'mlx_audio')\n\n  Generated: None\n"
+        }
+      ],
+      "execution_count": 3
+    },
+    {
+      "id": "cell-cb65e507-4cc4-46e2-a810-d4037dd73abe",
+      "cell_type": "code",
+      "source": [
+        "# Generate Python audio directly in this notebook since we have mlx-audio installed here\n",
+        "import mlx.core as mx\n",
+        "from mlx_audio.tts.models.kokoro.kokoro import (\n",
+        "    Model,\n",
+        "    ModelConfig,\n",
+        "    sanitize,\n",
+        "    sanitize_lstm_weights,\n",
+        ")\n",
+        "from mlx_audio.tts.models.kokoro.voice import load_voice_tensor\n",
+        "from huggingface_hub import snapshot_download\n",
+        "import mlx.nn as nn\n",
+        "import json\n",
+        "from pathlib import Path\n",
+        "\n",
+        "# Load model\n",
+        "repo_id = \"prince-canuma/Kokoro-82M\"\n",
+        "model_path = Path(snapshot_download(repo_id))\n",
+        "print(f\"Model path: {model_path}\")\n",
+        "\n",
+        "with open(model_path / \"config.json\") as f:\n",
+        "    config_data = json.load(f)\n",
+        "\n",
+        "config = ModelConfig.from_dict(config_data)\n",
+        "model = Model(config)\n",
+        "\n",
+        "# Load weights\n",
+        "weights = mx.load(str(model_path / \"model.safetensors\"))\n",
+        "sanitized = sanitize(weights, config)\n",
+        "model.load_weights(list(sanitized.items()), strict=False)\n",
+        "mx.eval(model.parameters())\n",
+        "print(\"Model loaded\")\n",
+        "\n",
+        "# Load voice\n",
+        "voice = load_voice_tensor(repo_id, \"af_heart\")\n",
+        "print(f\"Voice loaded: {voice.shape}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "error",
+          "ename": "ImportError",
+          "evalue": "cannot import name 'sanitize' from 'mlx_audio.tts.models.kokoro.kokoro' (/Users/kylekelley/Library/Caches/runt/inline-envs/578aa62ad89c9c27/lib/python3.12/site-packages/mlx_audio/tts/models/kokoro/kokoro.py)",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mImportError\u001b[39m                               Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[4]\u001b[39m\u001b[32m, line 3\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Generate Python audio directly in this notebook since we have mlx-audio installed here\u001b[39;00m\n\u001b[32m      2\u001b[39m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mmlx\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mcore\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mmx\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m3\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mmlx_audio\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mtts\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mmodels\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mkokoro\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mkokoro\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m (\n\u001b[32m      4\u001b[39m     Model,\n\u001b[32m      5\u001b[39m     ModelConfig,\n\u001b[32m      6\u001b[39m     sanitize,\n\u001b[32m      7\u001b[39m     sanitize_lstm_weights,\n\u001b[32m      8\u001b[39m )\n\u001b[32m      9\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mmlx_audio\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mtts\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mmodels\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mkokoro\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mvoice\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m load_voice_tensor\n\u001b[32m     10\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mhuggingface_hub\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m snapshot_download\n",
+            "\u001b[31mImportError\u001b[39m: cannot import name 'sanitize' from 'mlx_audio.tts.models.kokoro.kokoro' (/Users/kylekelley/Library/Caches/runt/inline-envs/578aa62ad89c9c27/lib/python3.12/site-packages/mlx_audio/tts/models/kokoro/kokoro.py)"
+          ]
+        }
+      ],
+      "execution_count": 4
+    },
+    {
+      "id": "cell-45d3baba-de28-4ae8-b914-e6c20e57d29c",
+      "cell_type": "code",
+      "source": [
+        "# Let's see what mlx-audio's Model exposes — the installed version may differ from colombo-v2 source\n",
+        "from mlx_audio.tts.models.kokoro.kokoro import Model, ModelConfig\n",
+        "\n",
+        "print(dir(Model))\n",
+        "\n",
+        "# Use the high-level generate API instead of manually loading\n",
+        "# First, let's see what the Model.generate method signature looks like\n",
+        "import inspect\n",
+        "\n",
+        "sig = inspect.signature(Model.generate)\n",
+        "print(f\"\\nModel.generate signature: {sig}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "['Output', 'REPO_ID', '__annotations__', '__call__', '__class__', '__class_getit\n\u001b[0mem__', '__contains__', '__delattr__', '__delitem__', '__dict__', '__dir__', '__d\n\u001b[0moc__', '__eq__', '__format__', '__ge__', '__getattr__', '__getattribute__', '__g\n\u001b[0metitem__', '__getstate__', '__gt__', '__hash__', '__init__', '__init_subclass__'\n\u001b[0m, '__ior__', '__iter__', '__le__', '__len__', '__lt__', '__module__', '__ne__',\n\u001b[0m'__new__', '__or__', '__reduce__', '__reduce_ex__', '__repr__', '__reversed__',\n\u001b[0m'__ror__', '__setattr__', '__setitem__', '__sizeof__', '__str__', '__subclasshoo\n\u001b[0mk__', '__weakref__', '_extra_repr', '_get_pipeline', '_set_training_mode', '_val\n\u001b[0midate_keys', 'apply', 'apply_to_modules', 'children', 'clear', 'copy', 'eval', '\n\u001b[0mfilter_and_map', 'freeze', 'fromkeys', 'generate', 'get', 'is_module', 'items',\n\u001b[0m'keys', 'leaf_modules', 'load_weights', 'modules', 'named_modules', 'parameters'\n\u001b[0m, 'pop', 'popitem', 'sample_rate', 'sanitize', 'save_weights', 'set_dtype', 'set\n\u001b[0mdefault', 'state', 'train', 'trainable_parameter_filter', 'trainable_parameters'\n\u001b[0m, 'training', 'unfreeze', 'update', 'update_modules', 'valid_child_filter', 'val\n\u001b[0mid_parameter_filter', 'values']\n\nModel.generate signature: (self, text: str, voice: str = None, speed: float = 1.\n\u001b[0m0, lang_code: str = 'a', split_pattern: str = '\\\\n+', **kwargs)\n"
+        }
+      ],
+      "execution_count": 5
+    },
+    {
+      "id": "cell-64e55154-8ee1-44f0-9f6f-33a4fee95e14",
+      "cell_type": "code",
+      "source": [
+        "# Use the high-level API — Model handles its own loading\n",
+        "from mlx_audio.tts.utils import load as load_tts\n",
+        "\n",
+        "py_model, py_processor = load_tts(\"prince-canuma/Kokoro-82M\")\n",
+        "print(f\"Python model loaded, sample_rate={py_model.sample_rate}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "31f2bb1b1d3f4f14b2ddec555008895a"
+            },
+            "text/plain": "Downloading (incomplete total...): 0.00B [00:00, ?B/s]"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "1d2b20f790064dbfaddeda9a90807653"
+            },
+            "text/plain": "Fetching 63 files:   0%|          | 0/63 [00:00<?, ?it/s]"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "error",
+          "ename": "ValueError",
+          "evalue": "too many values to unpack (expected 2)",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mValueError\u001b[39m                                Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[6]\u001b[39m\u001b[32m, line 4\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Use the high-level API — Model handles its own loading\u001b[39;00m\n\u001b[32m      2\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mmlx_audio\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mtts\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mutils\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m load \u001b[38;5;28;01mas\u001b[39;00m load_tts\n\u001b[32m----> \u001b[39m\u001b[32m4\u001b[39m py_model, py_processor = load_tts(\u001b[33m\"\u001b[39m\u001b[33mprince-canuma/Kokoro-82M\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m      5\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mPython model loaded, sample_rate=\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mpy_model.sample_rate\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
+            "\u001b[31mValueError\u001b[39m: too many values to unpack (expected 2)"
+          ]
+        }
+      ],
+      "execution_count": 6
+    },
+    {
+      "id": "cell-b1c55f47-ad83-4865-b062-530c74ccdfe0",
+      "cell_type": "code",
+      "source": [
+        "# Check what load returns\n",
+        "from mlx_audio.tts.utils import load as load_tts\n",
+        "\n",
+        "result = load_tts(\"prince-canuma/Kokoro-82M\")\n",
+        "print(type(result))\n",
+        "if isinstance(result, tuple):\n",
+        "    print(f\"Tuple length: {len(result)}\")\n",
+        "    for i, r in enumerate(result):\n",
+        "        print(f\"  [{i}] {type(r)}\")\n",
+        "else:\n",
+        "    py_model = result\n",
+        "    print(f\"Single object: {type(py_model)}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": "Downloading (incomplete total...): 0.00B [00:00, ?B/s]",
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "c3c9231d3eaa4d92b30fa345af2e9c7c"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": "Fetching 63 files:   0%|          | 0/63 [00:00<?, ?it/s]",
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "3edb3f9bb976491792a7f60f94ce7d54"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "<class 'mlx_audio.tts.models.kokoro.kokoro.Model'>\nSingle object: <class 'mlx_audio.tts.models.kokoro.kokoro.Model'>\n"
+        }
+      ],
+      "execution_count": 7
+    },
+    {
+      "id": "cell-870aba88-8c57-482f-9726-8c49782fa5b5",
+      "cell_type": "code",
+      "source": [
+        "# Now we have the Python model. Let's generate audio!\n",
+        "import soundfile as sf\n",
+        "\n",
+        "py_model = result  # from previous cell\n",
+        "\n",
+        "\n",
+        "def python_generate(text, voice=\"af_heart\"):\n",
+        "    \"\"\"Generate audio using Python mlx-audio and return wav path.\"\"\"\n",
+        "    wav_path = tempfile.mktemp(suffix=\".wav\")\n",
+        "    for gen_result in py_model.generate(text, voice=voice, lang_code=\"a\"):\n",
+        "        audio = np.array(gen_result.audio)\n",
+        "        sf.write(wav_path, audio, gen_result.sample_rate)\n",
+        "        return wav_path  # just take first segment\n",
+        "    return None\n",
+        "\n",
+        "\n",
+        "def rust_generate(text, voice=\"af_heart\"):\n",
+        "    \"\"\"Generate audio using Rust voicers and return (wav_path, phonemes).\"\"\"\n",
+        "    wav_path = tempfile.mktemp(suffix=\".wav\")\n",
+        "    r = subprocess.run(\n",
+        "        [VOICERS_CLI, \"--text\", text, \"--voice\", voice, \"--output\", wav_path],\n",
+        "        capture_output=True,\n",
+        "        text=True,\n",
+        "        timeout=120,\n",
+        "    )\n",
+        "    phonemes = \"\"\n",
+        "    for line in r.stderr.splitlines():\n",
+        "        if line.strip().startswith(\"chunk\"):\n",
+        "            phonemes += line.split(\":\", 1)[1].strip() + \" \"\n",
+        "    return wav_path, phonemes.strip()\n",
+        "\n",
+        "\n",
+        "# Smoke test\n",
+        "print(\"=== Python mlx-audio ===\")\n",
+        "py_wav = python_generate(\"Hello world\")\n",
+        "py_text = transcribe(py_wav)\n",
+        "print(f\"  Whisper heard: {py_text}\")\n",
+        "\n",
+        "print(\"\\n=== Rust voicers ===\")\n",
+        "rust_wav, rust_ph = rust_generate(\"Hello world\")\n",
+        "rust_text = transcribe(rust_wav)\n",
+        "print(f\"  Phonemes: {rust_ph}\")\n",
+        "print(f\"  Whisper heard: {rust_text}\")\n",
+        "\n",
+        "# Cleanup\n",
+        "os.unlink(py_wav)\n",
+        "os.unlink(rust_wav)"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "=== Python mlx-audio ===\nCreating new KokoroPipeline for language: a\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/578aa62ad89c9c27/bin/python: N\n\u001b[0mo module named pip\n"
+        },
+        {
+          "output_type": "error",
+          "ename": "SystemExit",
+          "evalue": "1",
+          "traceback": [
+            "An exception has occurred, use %tb to see the full traceback.\n",
+            "\u001b[31mSystemExit\u001b[39m\u001b[31m:\u001b[39m 1\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/578aa62ad89c9c27/lib/python3.1\n\u001b[0m2/site-packages/IPython/core/interactiveshell.py:3755: UserWarning: To exit: use\n\u001b[0m 'exit', 'quit', or Ctrl-D.\n  warn(\"To exit: use 'exit', 'quit', or Ctrl-D.\", stacklevel=1)\n"
+        }
+      ],
+      "execution_count": 8
+    },
+    {
+      "id": "cell-53827bd3-e439-4215-ba30-20f98d698907",
+      "cell_type": "code",
+      "source": [
+        "import subprocess, os, tempfile\n",
+        "import numpy as np\n",
+        "\n",
+        "CARGO = os.path.expanduser(\"~/.cargo/bin/cargo\")\n",
+        "VOICERS_CLI = os.path.abspath(\"./target/release/voicers-cli\")\n",
+        "\n",
+        "# Verify spacy model is available\n",
+        "import spacy\n",
+        "\n",
+        "nlp = spacy.load(\"en_core_web_sm\")\n",
+        "print(\"spaCy en_core_web_sm: ready\")\n",
+        "\n",
+        "# Load Whisper\n",
+        "import whisper\n",
+        "\n",
+        "whisper_model = whisper.load_model(\"base\")\n",
+        "print(\"Whisper: ready\")\n",
+        "\n",
+        "# Load Python mlx-audio model\n",
+        "from mlx_audio.tts.utils import load as load_tts\n",
+        "\n",
+        "py_model = load_tts(\"prince-canuma/Kokoro-82M\")\n",
+        "print(f\"Python Kokoro: ready (sample_rate={py_model.sample_rate})\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "spaCy en_core_web_sm: ready\nWhisper: ready\n"
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "c19a916c8d064f55af406c9a96613e5e"
+            },
+            "text/plain": "Downloading (incomplete total...): 0.00B [00:00, ?B/s]"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "8df77d0f48d94c87a8590e7635825b77"
+            },
+            "text/plain": "Fetching 63 files:   0%|          | 0/63 [00:00<?, ?it/s]"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Python Kokoro: ready (sample_rate=24000)\n"
+        }
+      ],
+      "execution_count": 1
+    },
+    {
+      "id": "cell-e6c8daba-1014-4a50-8c56-fa96c18a2060",
+      "cell_type": "code",
+      "source": [
+        "import soundfile as sf\n",
+        "\n",
+        "\n",
+        "def python_generate(text, voice=\"af_heart\"):\n",
+        "    \"\"\"Generate audio using Python mlx-audio Kokoro.\"\"\"\n",
+        "    wav_path = tempfile.mktemp(suffix=\".wav\")\n",
+        "    for gen_result in py_model.generate(text, voice=voice, lang_code=\"a\"):\n",
+        "        audio = np.array(gen_result.audio)\n",
+        "        sf.write(wav_path, audio, gen_result.sample_rate)\n",
+        "        return wav_path\n",
+        "    return None\n",
+        "\n",
+        "\n",
+        "def rust_generate(text, voice=\"af_heart\"):\n",
+        "    \"\"\"Generate audio using Rust voicers.\"\"\"\n",
+        "    wav_path = tempfile.mktemp(suffix=\".wav\")\n",
+        "    r = subprocess.run(\n",
+        "        [VOICERS_CLI, \"--text\", text, \"--voice\", voice, \"--output\", wav_path],\n",
+        "        capture_output=True,\n",
+        "        text=True,\n",
+        "        timeout=120,\n",
+        "    )\n",
+        "    phonemes = \"\"\n",
+        "    for line in r.stderr.splitlines():\n",
+        "        if line.strip().startswith(\"chunk\"):\n",
+        "            phonemes += line.split(\":\", 1)[1].strip() + \" \"\n",
+        "    return wav_path, phonemes.strip()\n",
+        "\n",
+        "\n",
+        "def transcribe(wav_path):\n",
+        "    result = whisper_model.transcribe(wav_path, language=\"en\")\n",
+        "    return result[\"text\"].strip()\n",
+        "\n",
+        "\n",
+        "# Smoke test both\n",
+        "print(\"=== Python mlx-audio ===\")\n",
+        "py_wav = python_generate(\"Hello world\")\n",
+        "print(f\"  Whisper heard: {transcribe(py_wav)}\")\n",
+        "os.unlink(py_wav)\n",
+        "\n",
+        "print(\"\\n=== Rust voicers ===\")\n",
+        "rust_wav, rust_ph = rust_generate(\"Hello world\")\n",
+        "print(f\"  Phonemes: {rust_ph}\")\n",
+        "print(f\"  Whisper heard: {transcribe(rust_wav)}\")\n",
+        "os.unlink(rust_wav)"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "=== Python mlx-audio ===\nCreating new KokoroPipeline for language: a\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "=== Python mlx-audio ===\nCreating new KokoroPipeline for language: a\n  Whisper heard: Hello world.\n\n=== Rust voicers ===\n  Phonemes: həlˈO wˈɜɹld\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "=== Python mlx-audio ===\nCreating new KokoroPipeline for language: a\n  Whisper heard: Hello world.\n\n=== Rust voicers ===\n  Phonemes: həlˈO wˈɜɹld\n  Whisper heard: Hello, where are you?\n"
+        }
+      ],
+      "execution_count": 2
+    },
+    {
+      "id": "cell-28521320-8b77-40f5-98a0-f492cb42e544",
+      "cell_type": "code",
+      "source": [
+        "# Full A/B comparison\n",
+        "test_phrases = [\n",
+        "    \"Hello world\",\n",
+        "    \"Good morning\",\n",
+        "    \"The quick brown fox\",\n",
+        "    \"How are you doing today?\",\n",
+        "    \"She sells seashells by the seashore.\",\n",
+        "    \"I read a book yesterday.\",\n",
+        "    \"The dog is running in the park.\",\n",
+        "]\n",
+        "\n",
+        "print(f\"{'Input':<40} {'Python Whisper':<30} {'Rust Whisper':<30}\")\n",
+        "print(\"=\" * 100)\n",
+        "\n",
+        "for phrase in test_phrases:\n",
+        "    # Python\n",
+        "    py_wav = python_generate(phrase)\n",
+        "    py_heard = transcribe(py_wav) if py_wav else \"FAILED\"\n",
+        "    os.unlink(py_wav) if py_wav else None\n",
+        "\n",
+        "    # Rust\n",
+        "    rust_wav, rust_ph = rust_generate(phrase)\n",
+        "    rust_heard = transcribe(rust_wav)\n",
+        "    os.unlink(rust_wav)\n",
+        "\n",
+        "    py_ok = \"OK\" if phrase.lower().rstrip(\".,!?\") in py_heard.lower() else \"\"\n",
+        "    rust_ok = \"OK\" if phrase.lower().rstrip(\".,!?\") in rust_heard.lower() else \"\"\n",
+        "\n",
+        "    print(f\"{phrase:<40} {py_heard[:28]:<30} {rust_heard[:28]:<30}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python Whisper                 Rust Whi\n\u001b[0msper\n================================================================================\n\u001b[0m====================\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python Whisper                 Rust Whi\n\u001b[0msper\n================================================================================\n\u001b[0m====================\nHello world                              Hello world.                   Hello, w\n\u001b[0mhere? Holds that.\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python Whisper                 Rust Whi\n\u001b[0msper\n================================================================================\n\u001b[0m====================\nHello world                              Hello world.                   Hello, w\n\u001b[0mhere? Holds that.\nGood morning                             Good morning.                  Good mor\n\u001b[0mning, hey\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python Whisper                 Rust Whi\n\u001b[0msper\n================================================================================\n\u001b[0m====================\nHello world                              Hello world.                   Hello, w\n\u001b[0mhere? Holds that.\nGood morning                             Good morning.                  Good mor\n\u001b[0mning, hey\nThe quick brown fox                      The quick brown fox.           The cool\n\u001b[0m, very evil!\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python Whisper                 Rust Whi\n\u001b[0msper\n================================================================================\n\u001b[0m====================\nHello world                              Hello world.                   Hello, w\n\u001b[0mhere? Holds that.\nGood morning                             Good morning.                  Good mor\n\u001b[0mning, hey\nThe quick brown fox                      The quick brown fox.           The cool\n\u001b[0m, very evil!\nHow are you doing today?                 How are you doing today?       How art\n\u001b[0myou doing to say\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python Whisper                 Rust Whi\n\u001b[0msper\n================================================================================\n\u001b[0m====================\nHello world                              Hello world.                   Hello, w\n\u001b[0mhere? Holds that.\nGood morning                             Good morning.                  Good mor\n\u001b[0mning, hey\nThe quick brown fox                      The quick brown fox.           The cool\n\u001b[0m, very evil!\nHow are you doing today?                 How are you doing today?       How art\n\u001b[0myou doing to say\nShe sells seashells by the seashore.     She sells seashells by the s   She sell\n\u001b[0ms a sea shells by th\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python Whisper                 Rust Whi\n\u001b[0msper\n================================================================================\n\u001b[0m====================\nHello world                              Hello world.                   Hello, w\n\u001b[0mhere? Holds that.\nGood morning                             Good morning.                  Good mor\n\u001b[0mning, hey\nThe quick brown fox                      The quick brown fox.           The cool\n\u001b[0m, very evil!\nHow are you doing today?                 How are you doing today?       How art\n\u001b[0myou doing to say\nShe sells seashells by the seashore.     She sells seashells by the s   She sell\n\u001b[0ms a sea shells by th\nI read a book yesterday.                 I read a book yesterday.       I read a\n\u001b[0m book, yes, to Herds\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python Whisper                 Rust Whi\n\u001b[0msper\n================================================================================\n\u001b[0m====================\nHello world                              Hello world.                   Hello, w\n\u001b[0mhere? Holds that.\nGood morning                             Good morning.                  Good mor\n\u001b[0mning, hey\nThe quick brown fox                      The quick brown fox.           The cool\n\u001b[0m, very evil!\nHow are you doing today?                 How are you doing today?       How art\n\u001b[0myou doing to say\nShe sells seashells by the seashore.     She sells seashells by the s   She sell\n\u001b[0ms a sea shells by th\nI read a book yesterday.                 I read a book yesterday.       I read a\n\u001b[0m book, yes, to Herds\nThe dog is running in the park.          The dog is running in the pa   The Dizd\n\u001b[0mog is as running int\n"
+        }
+      ],
+      "execution_count": 3
+    },
+    {
+      "id": "cell-6c5c4bfc-7dea-4cf3-8ca8-3a3f2db125c7",
+      "cell_type": "markdown",
+      "source": [
+        "## Results: Python mlx-audio vs Rust voicers\n",
+        "\n",
+        "| Input | Python (Whisper) | Rust (Whisper) |\n",
+        "|-------|-----------------|----------------|\n",
+        "| Hello world | Hello world. | Hello, where? Holds that. |\n",
+        "| Good morning | Good morning. | Good morning, hey |\n",
+        "| The quick brown fox | The quick brown fox. | The cool, very evil! |\n",
+        "| How are you doing today? | How are you doing today? | How art you doing to say |\n",
+        "| She sells seashells... | She sells seashells by the s... | She sells a sea shells by th... |\n",
+        "| I read a book yesterday. | I read a book yesterday. | I read a book, yes, to Herds |\n",
+        "| The dog is running... | The dog is running in the pa... | The Dizdog is as running int... |\n",
+        "\n",
+        "**Python: 7/7 correct. Rust: 0/7 correct.**\n",
+        "\n",
+        "The Python mlx-audio pipeline produces perfect audio from the same model. Our Rust vocoder is the problem. The issue is somewhere in:\n",
+        "1. **iSTFT reconstruction** (overlap-add, window normalization)\n",
+        "2. **Weight loading/sanitization** (some weights may still be misaligned)\n",
+        "3. **Forward pass numerics** (intermediate computation differences)\n",
+        "\n",
+        "Next: dump intermediate tensors from both Python and Rust to find where they diverge."
+      ],
+      "metadata": {}
+    }
+  ]
+}


### PR DESCRIPTION
A/B comparison notebook using Whisper STT to validate audio output from both pipelines.

**Result: Python 7/7 correct, Rust 0/7 correct.**

Same model weights, same phonemes, same voice — Python mlx-audio produces perfect audio while our Rust vocoder produces garbled output. This conclusively shows the audio quality issue is in the Rust vocoder implementation (iSTFT, overlap-add, weight loading, or forward pass), not the G2P pipeline.

Next step: dump intermediate tensors from both to find where they diverge.