### PR TITLE
Fix audio quality: ALBERT dropout + LSTM recurrence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+output.wav

--- a/crates/voicers/src/model.rs
+++ b/crates/voicers/src/model.rs
@@ -95,6 +95,15 @@ impl KokoroModel {
         ref_s: &Array,
         speed: f32,
     ) -> Result<Array, Exception> {
+        // Disable nn.Dropout in all modules (eval mode) — Python MLX modules default
+        // to eval mode where nn.Dropout is a no-op. mlx-rs defaults to training=true.
+        // Note: The prosody predictor intentionally uses raw mx.dropout(p=0.5) at
+        // inference which is NOT an nn.Dropout and is always active.
+        self.bert.training_mode(false);
+        self.text_encoder.training_mode(false);
+        self.decoder.training_mode(false);
+        self.predictor.training_mode(false);
+
         // Map phonemes to token IDs
         let input_ids: Vec<i32> = phonemes
             .chars()
@@ -143,7 +152,6 @@ impl KokoroModel {
             .transpose_axes(&[0, 2, 1])?;
 
         // Extract style from ref_s
-        // ref_s shape: (1, 256) -> s = ref_s[:, 128:] (prosody style)
         // ref_s is a voice pack of shape (510, 1, 256).
         // Index by phoneme count - 1 to get the style for this length.
         let phoneme_count = input_ids.len() as i32; // excludes BOS/EOS

--- a/crates/voicers/src/modules/lstm.rs
+++ b/crates/voicers/src/modules/lstm.rs
@@ -1,10 +1,69 @@
 use mlx_rs::builder::Builder;
 use mlx_rs::error::Exception;
-use mlx_rs::module::Module;
-use mlx_rs::nn::{Lstm, LstmBuilder, LstmInput};
+use mlx_rs::nn::{Lstm, LstmBuilder};
 use mlx_rs::ops::indexing::IndexOp;
+use mlx_rs::ops::{addmm, split, stack_axis};
 use mlx_rs::Array;
+
 use mlx_macros::ModuleParameters;
+
+/// Run a single-direction LSTM with proper hidden state propagation.
+///
+/// The mlx-rs built-in `Lstm::step` doesn't propagate hidden/cell state between
+/// timesteps (each step uses the initial hidden state). This function fixes that
+/// by manually iterating over timesteps and feeding back the hidden/cell state.
+fn lstm_forward_recurrent(
+    lstm: &Lstm,
+    x: &Array, // (batch, seq_len, features)
+) -> Result<(Array, Array), Exception> {
+    // Pre-compute input projection: x @ wx.T + bias
+    let x_proj = if let Some(b) = &lstm.bias.value {
+        addmm(b, x, &lstm.wx.value.t(), None, None)?
+    } else {
+        x.matmul(&lstm.wx.value.t())?
+    };
+
+    let seq_len = x.dim(-2);
+    let mut all_hidden = Vec::with_capacity(seq_len as usize);
+    let mut all_cell = Vec::with_capacity(seq_len as usize);
+
+    // No initial hidden/cell state — start from zeros (implicit in the math)
+    let mut hidden: Option<Array> = None;
+    let mut cell: Option<Array> = None;
+
+    for idx in 0..seq_len {
+        let mut ifgo = x_proj.index((.., idx, ..));
+
+        // Add hidden state contribution if we have one from the previous step
+        if let Some(ref h) = hidden {
+            ifgo = addmm(&ifgo, h, &lstm.wh.value.t(), None, None)?;
+        }
+
+        let pieces = split(&ifgo, 4, -1)?;
+        let i = mlx_rs::ops::sigmoid(&pieces[0])?;
+        let f = mlx_rs::ops::sigmoid(&pieces[1])?;
+        let g = mlx_rs::ops::tanh(&pieces[2])?;
+        let o = mlx_rs::ops::sigmoid(&pieces[3])?;
+
+        let new_cell = match &cell {
+            Some(c) => f.multiply(c)?.add(i.multiply(&g)?)?,
+            None => i.multiply(&g)?,
+        };
+
+        let new_hidden = o.multiply(mlx_rs::ops::tanh(&new_cell)?)?;
+
+        all_hidden.push(new_hidden.clone());
+        all_cell.push(new_cell.clone());
+
+        hidden = Some(new_hidden);
+        cell = Some(new_cell);
+    }
+
+    let hidden_refs: Vec<&Array> = all_hidden.iter().collect();
+    let cell_refs: Vec<&Array> = all_cell.iter().collect();
+
+    Ok((stack_axis(&hidden_refs, -2)?, stack_axis(&cell_refs, -2)?))
+}
 
 /// Bidirectional LSTM that processes a sequence in both forward and backward directions
 /// and concatenates the outputs.
@@ -47,19 +106,15 @@ impl BiLstm {
 
         let seq_len = x.shape()[1];
 
-        // Forward direction: process the full sequence
-        // Lstm.step processes (batch, seq_len, features) -> ((batch, seq_len, hidden_size), cell)
-        let fwd_input = LstmInput::from(&x);
-        let (fwd_out, _fwd_cell) = self.forward_lstm.forward(fwd_input)?;
+        // Forward direction with proper recurrence
+        let (fwd_out, _fwd_cell) = lstm_forward_recurrent(&self.forward_lstm, &x)?;
 
-        // Backward direction: reverse the input along the sequence dimension (axis 1)
+        // Backward direction: reverse input, run forward, reverse output
         let rev_indices: Vec<i32> = (0..seq_len).rev().collect();
         let rev_idx = Array::from_slice(&rev_indices, &[seq_len]);
-        // x_rev = x[:, rev_indices, :]
         let x_rev = x.index((0.., &rev_idx, 0..));
 
-        let bwd_input = LstmInput::from(&x_rev);
-        let (bwd_out_rev, _bwd_cell) = self.backward_lstm.forward(bwd_input)?;
+        let (bwd_out_rev, _bwd_cell) = lstm_forward_recurrent(&self.backward_lstm, &x_rev)?;
 
         // Reverse the backward output back to the original temporal order
         let bwd_out = bwd_out_rev.index((0.., &rev_idx, 0..));
@@ -71,6 +126,6 @@ impl BiLstm {
 
     /// Set training mode on both LSTMs.
     pub fn training_mode(&mut self, _mode: bool) {
-        // mlx-rs Lstm doesn't have training mode, but we keep the interface
+        // Lstm doesn't have dropout, nothing to toggle
     }
 }

--- a/notebooks/vocoder_comparison.ipynb
+++ b/notebooks/vocoder_comparison.ipynb
@@ -385,24 +385,24 @@
         {
           "output_type": "display_data",
           "data": {
+            "text/plain": "Downloading (incomplete total...): 0.00B [00:00, ?B/s]",
             "application/vnd.jupyter.widget-view+json": {
               "version_major": 2,
               "version_minor": 0,
               "model_id": "31f2bb1b1d3f4f14b2ddec555008895a"
-            },
-            "text/plain": "Downloading (incomplete total...): 0.00B [00:00, ?B/s]"
+            }
           },
           "metadata": {}
         },
         {
           "output_type": "display_data",
           "data": {
+            "text/plain": "Fetching 63 files:   0%|          | 0/63 [00:00<?, ?it/s]",
             "application/vnd.jupyter.widget-view+json": {
               "version_major": 2,
               "version_minor": 0,
               "model_id": "1d2b20f790064dbfaddeda9a90807653"
-            },
-            "text/plain": "Fetching 63 files:   0%|          | 0/63 [00:00<?, ?it/s]"
+            }
           },
           "metadata": {}
         },
@@ -442,24 +442,24 @@
         {
           "output_type": "display_data",
           "data": {
-            "text/plain": "Downloading (incomplete total...): 0.00B [00:00, ?B/s]",
             "application/vnd.jupyter.widget-view+json": {
               "version_major": 2,
               "version_minor": 0,
               "model_id": "c3c9231d3eaa4d92b30fa345af2e9c7c"
-            }
+            },
+            "text/plain": "Downloading (incomplete total...): 0.00B [00:00, ?B/s]"
           },
           "metadata": {}
         },
         {
           "output_type": "display_data",
           "data": {
-            "text/plain": "Fetching 63 files:   0%|          | 0/63 [00:00<?, ?it/s]",
             "application/vnd.jupyter.widget-view+json": {
               "version_major": 2,
               "version_minor": 0,
               "model_id": "3edb3f9bb976491792a7f60f94ce7d54"
-            }
+            },
+            "text/plain": "Fetching 63 files:   0%|          | 0/63 [00:00<?, ?it/s]"
           },
           "metadata": {}
         },
@@ -590,12 +590,12 @@
         {
           "output_type": "display_data",
           "data": {
+            "text/plain": "Downloading (incomplete total...): 0.00B [00:00, ?B/s]",
             "application/vnd.jupyter.widget-view+json": {
               "version_major": 2,
               "version_minor": 0,
               "model_id": "c19a916c8d064f55af406c9a96613e5e"
-            },
-            "text/plain": "Downloading (incomplete total...): 0.00B [00:00, ?B/s]"
+            }
           },
           "metadata": {}
         },
@@ -839,6 +839,1708 @@
         "Next: dump intermediate tensors from both Python and Rust to find where they diverge."
       ],
       "metadata": {}
+    },
+    {
+      "id": "cell-9f235f00-3174-46b8-b013-54df59e5ab40",
+      "cell_type": "code",
+      "source": [
+        "import subprocess, os, tempfile\n",
+        "import numpy as np\n",
+        "import soundfile as sf\n",
+        "\n",
+        "CARGO = os.path.expanduser(\"~/.cargo/bin/cargo\")\n",
+        "VOICERS_CLI = os.path.abspath(\"./target/release/voicers-cli\")\n",
+        "\n",
+        "import whisper\n",
+        "\n",
+        "whisper_model = whisper.load_model(\"base\")\n",
+        "print(\"Whisper: ready\")\n",
+        "\n",
+        "from mlx_audio.tts.utils import load as load_tts\n",
+        "\n",
+        "py_model = load_tts(\"prince-canuma/Kokoro-82M\")\n",
+        "print(f\"Python Kokoro: ready\")\n",
+        "\n",
+        "\n",
+        "def transcribe(wav_path):\n",
+        "    return whisper_model.transcribe(wav_path, language=\"en\")[\"text\"].strip()\n",
+        "\n",
+        "\n",
+        "def python_generate(text, voice=\"af_heart\"):\n",
+        "    wav_path = tempfile.mktemp(suffix=\".wav\")\n",
+        "    for gen_result in py_model.generate(text, voice=voice, lang_code=\"a\"):\n",
+        "        audio = np.array(gen_result.audio)\n",
+        "        sf.write(wav_path, audio, gen_result.sample_rate)\n",
+        "        return wav_path\n",
+        "    return None\n",
+        "\n",
+        "\n",
+        "def rust_generate(text, voice=\"af_heart\"):\n",
+        "    wav_path = tempfile.mktemp(suffix=\".wav\")\n",
+        "    r = subprocess.run(\n",
+        "        [VOICERS_CLI, \"--text\", text, \"--voice\", voice, \"--output\", wav_path],\n",
+        "        capture_output=True,\n",
+        "        text=True,\n",
+        "        timeout=120,\n",
+        "    )\n",
+        "    phonemes = \"\"\n",
+        "    for line in r.stderr.splitlines():\n",
+        "        if line.strip().startswith(\"chunk\"):\n",
+        "            phonemes += line.split(\":\", 1)[1].strip() + \" \"\n",
+        "    return wav_path, phonemes.strip()\n",
+        "\n",
+        "\n",
+        "print(\"All ready.\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Whisper: ready\n"
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "4b183efa833e4bfca67954b6604da4ee"
+            },
+            "text/plain": "Downloading (incomplete total...): 0.00B [00:00, ?B/s]"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": "Fetching 63 files:   0%|          | 0/63 [00:00<?, ?it/s]",
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "0916c69d7bda4249a5b9e2f67643b52c"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Python Kokoro: ready\nAll ready.\n"
+        }
+      ],
+      "execution_count": 1
+    },
+    {
+      "id": "cell-b8a7fc54-1ce4-483f-912a-8179f82ab32a",
+      "cell_type": "code",
+      "source": [
+        "# The specific test phrase\n",
+        "test_text = \"Now the spaCy tokenizer uses uv run with spacy. Zero setup needed beyond having uv installed. And we get proper POS tagging.\"\n",
+        "\n",
+        "# Python reference\n",
+        "print(\"=== Python mlx-audio ===\")\n",
+        "py_wav = python_generate(test_text)\n",
+        "py_heard = transcribe(py_wav)\n",
+        "print(f\"  Whisper: {py_heard}\")\n",
+        "\n",
+        "# Rust voicers (with iSTFT fix)\n",
+        "print(\"\\n=== Rust voicers ===\")\n",
+        "rust_wav, rust_ph = rust_generate(test_text)\n",
+        "rust_heard = transcribe(rust_wav)\n",
+        "print(f\"  Phonemes: {rust_ph}\")\n",
+        "print(f\"  Whisper:  {rust_heard}\")\n",
+        "\n",
+        "os.unlink(py_wav)\n",
+        "os.unlink(rust_wav)"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "=== Python mlx-audio ===\nCreating new KokoroPipeline for language: a\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "WARNING:phonemizer:words count mismatch on 100.0% of the lines (1/1)\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "=== Python mlx-audio ===\nCreating new KokoroPipeline for language: a\n  Whisper: Now the SpawSci tokenizer uses UV run with Spacy. Zero setup needed b\n\u001b[0meyond having UV installed, and we get proper POS tagging.\n\n=== Rust voicers ===\n"
+        },
+        {
+          "output_type": "error",
+          "ename": "FileNotFoundError",
+          "evalue": "[Errno 2] No such file or directory: '/Users/kylekelley/conductor/workspaces/voicers/algiers/notebooks/target/release/voicers-cli'",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mFileNotFoundError\u001b[39m                         Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[2]\u001b[39m\u001b[32m, line 12\u001b[39m\n\u001b[32m     10\u001b[39m \u001b[38;5;66;03m# Rust voicers (with iSTFT fix)\u001b[39;00m\n\u001b[32m     11\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33m=== Rust voicers ===\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m---> \u001b[39m\u001b[32m12\u001b[39m rust_wav, rust_ph = \u001b[43mrust_generate\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtest_text\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     13\u001b[39m rust_heard = transcribe(rust_wav)\n\u001b[32m     14\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m  Phonemes: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mrust_ph\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 34\u001b[39m, in \u001b[36mrust_generate\u001b[39m\u001b[34m(text, voice)\u001b[39m\n\u001b[32m     32\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mrust_generate\u001b[39m(text, voice=\u001b[33m\"\u001b[39m\u001b[33maf_heart\u001b[39m\u001b[33m\"\u001b[39m):\n\u001b[32m     33\u001b[39m     wav_path = tempfile.mktemp(suffix=\u001b[33m\"\u001b[39m\u001b[33m.wav\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m---> \u001b[39m\u001b[32m34\u001b[39m     r = \u001b[43msubprocess\u001b[49m\u001b[43m.\u001b[49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m     35\u001b[39m \u001b[43m        \u001b[49m\u001b[43m[\u001b[49m\u001b[43mVOICERS_CLI\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43m--text\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtext\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43m--voice\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mvoice\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43m--output\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mwav_path\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     36\u001b[39m \u001b[43m        \u001b[49m\u001b[43mcapture_output\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[32m     37\u001b[39m \u001b[43m        \u001b[49m\u001b[43mtext\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[32m     38\u001b[39m \u001b[43m        \u001b[49m\u001b[43mtimeout\u001b[49m\u001b[43m=\u001b[49m\u001b[32;43m120\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     39\u001b[39m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     40\u001b[39m     phonemes = \u001b[33m\"\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m     41\u001b[39m     \u001b[38;5;28;01mfor\u001b[39;00m line \u001b[38;5;129;01min\u001b[39;00m r.stderr.splitlines():\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/subprocess.py:548\u001b[39m, in \u001b[36mrun\u001b[39m\u001b[34m(input, capture_output, timeout, check, *popenargs, **kwargs)\u001b[39m\n\u001b[32m    545\u001b[39m     kwargs[\u001b[33m'\u001b[39m\u001b[33mstdout\u001b[39m\u001b[33m'\u001b[39m] = PIPE\n\u001b[32m    546\u001b[39m     kwargs[\u001b[33m'\u001b[39m\u001b[33mstderr\u001b[39m\u001b[33m'\u001b[39m] = PIPE\n\u001b[32m--> \u001b[39m\u001b[32m548\u001b[39m \u001b[38;5;28;01mwith\u001b[39;00m \u001b[43mPopen\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43mpopenargs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mas\u001b[39;00m process:\n\u001b[32m    549\u001b[39m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m    550\u001b[39m         stdout, stderr = process.communicate(\u001b[38;5;28minput\u001b[39m, timeout=timeout)\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/subprocess.py:1026\u001b[39m, in \u001b[36mPopen.__init__\u001b[39m\u001b[34m(self, args, bufsize, executable, stdin, stdout, stderr, preexec_fn, close_fds, shell, cwd, env, universal_newlines, startupinfo, creationflags, restore_signals, start_new_session, pass_fds, user, group, extra_groups, encoding, errors, text, umask, pipesize, process_group)\u001b[39m\n\u001b[32m   1022\u001b[39m         \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.text_mode:\n\u001b[32m   1023\u001b[39m             \u001b[38;5;28mself\u001b[39m.stderr = io.TextIOWrapper(\u001b[38;5;28mself\u001b[39m.stderr,\n\u001b[32m   1024\u001b[39m                     encoding=encoding, errors=errors)\n\u001b[32m-> \u001b[39m\u001b[32m1026\u001b[39m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_execute_child\u001b[49m\u001b[43m(\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mexecutable\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpreexec_fn\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mclose_fds\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1027\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mpass_fds\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcwd\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43menv\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1028\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mstartupinfo\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcreationflags\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mshell\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1029\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mp2cread\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mp2cwrite\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1030\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mc2pread\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mc2pwrite\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1031\u001b[39m \u001b[43m                        \u001b[49m\u001b[43merrread\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43merrwrite\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1032\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mrestore_signals\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1033\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mgid\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mgids\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43muid\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mumask\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1034\u001b[39m \u001b[43m                        \u001b[49m\u001b[43mstart_new_session\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mprocess_group\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1035\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m:\n\u001b[32m   1036\u001b[39m     \u001b[38;5;66;03m# Cleanup if the child failed starting.\u001b[39;00m\n\u001b[32m   1037\u001b[39m     \u001b[38;5;28;01mfor\u001b[39;00m f \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mfilter\u001b[39m(\u001b[38;5;28;01mNone\u001b[39;00m, (\u001b[38;5;28mself\u001b[39m.stdin, \u001b[38;5;28mself\u001b[39m.stdout, \u001b[38;5;28mself\u001b[39m.stderr)):\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/subprocess.py:1955\u001b[39m, in \u001b[36mPopen._execute_child\u001b[39m\u001b[34m(self, args, executable, preexec_fn, close_fds, pass_fds, cwd, env, startupinfo, creationflags, shell, p2cread, p2cwrite, c2pread, c2pwrite, errread, errwrite, restore_signals, gid, gids, uid, umask, start_new_session, process_group)\u001b[39m\n\u001b[32m   1953\u001b[39m     err_msg = os.strerror(errno_num)\n\u001b[32m   1954\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m err_filename \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m-> \u001b[39m\u001b[32m1955\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m child_exception_type(errno_num, err_msg, err_filename)\n\u001b[32m   1956\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m   1957\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m child_exception_type(errno_num, err_msg)\n",
+            "\u001b[31mFileNotFoundError\u001b[39m: [Errno 2] No such file or directory: '/Users/kylekelley/conductor/workspaces/voicers/algiers/notebooks/target/release/voicers-cli'"
+          ]
+        }
+      ],
+      "execution_count": 2
+    },
+    {
+      "id": "cell-1058c684-b773-44b6-9dc3-cd7b0616125a",
+      "cell_type": "code",
+      "source": [
+        "# Fix path - use absolute path from repo root\n",
+        "import os\n",
+        "\n",
+        "REPO_ROOT = os.path.dirname(os.getcwd())  # parent of notebooks/\n",
+        "VOICERS_CLI = os.path.join(REPO_ROOT, \"target/release/voicers-cli\")\n",
+        "print(f\"CLI: {VOICERS_CLI}\")\n",
+        "print(f\"Exists: {os.path.exists(VOICERS_CLI)}\")\n",
+        "\n",
+        "\n",
+        "def rust_generate(text, voice=\"af_heart\"):\n",
+        "    wav_path = tempfile.mktemp(suffix=\".wav\")\n",
+        "    r = subprocess.run(\n",
+        "        [VOICERS_CLI, \"--text\", text, \"--voice\", voice, \"--output\", wav_path],\n",
+        "        capture_output=True,\n",
+        "        text=True,\n",
+        "        timeout=120,\n",
+        "    )\n",
+        "    phonemes = \"\"\n",
+        "    for line in r.stderr.splitlines():\n",
+        "        if line.strip().startswith(\"chunk\"):\n",
+        "            phonemes += line.split(\":\", 1)[1].strip() + \" \"\n",
+        "    return wav_path, phonemes.strip()\n",
+        "\n",
+        "\n",
+        "# Now test Rust\n",
+        "print(\"\\n=== Rust voicers (after iSTFT fix) ===\")\n",
+        "rust_wav, rust_ph = rust_generate(test_text)\n",
+        "rust_heard = transcribe(rust_wav)\n",
+        "print(f\"  Phonemes: {rust_ph}\")\n",
+        "print(f\"  Whisper:  {rust_heard}\")\n",
+        "os.unlink(rust_wav)"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "CLI: /Users/kylekelley/conductor/workspaces/voicers/algiers/target/release/voice\n\u001b[0mrs-cli\nExists: True\n\n=== Rust voicers (after iSTFT fix) ===\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "CLI: /Users/kylekelley/conductor/workspaces/voicers/algiers/target/release/voice\n\u001b[0mrs-cli\nExists: True\n\n=== Rust voicers (after iSTFT fix) ===\n  Phonemes: nˈW ðə spˈɑ sˈI tˈOkənˌIzəɹ jˈuzᵻz jˌuvˈi ɹˈʌn wɪð spˈAsi. zˈɪɹO sˈɛ\n\u001b[0mTˌʌp nˈidᵻd bijˈɑnd hˈævɪŋ jˌuvˈi ɪnstˈɔld. ˌænd wi ɡɛt pɹˈɑpəɹ pˌiˌOˈɛs tˈæɡɪŋ.\n  Whisper:  Now the spupa, cy, touger, canonizer uses this 2v run with spiff bas\n\u001b[0me AC, zero set up, an idiot, pionned, having the uv insist alled, and we get a r\n\u001b[0mobber, p-a-o-s tagging.\n"
+        }
+      ],
+      "execution_count": 3
+    },
+    {
+      "id": "cell-bf5bf3cd-2c90-4fed-a535-f6875336daef",
+      "cell_type": "code",
+      "source": [
+        "# Full A/B comparison with the standard test phrases\n",
+        "test_phrases = [\n",
+        "    \"Hello world\",\n",
+        "    \"Good morning\",\n",
+        "    \"The quick brown fox\",\n",
+        "    \"How are you doing today?\",\n",
+        "    \"She sells seashells by the seashore.\",\n",
+        "    \"I read a book yesterday.\",\n",
+        "    \"The dog is running in the park.\",\n",
+        "]\n",
+        "\n",
+        "print(f\"{'Input':<40} {'Python':<35} {'Rust':<35}\")\n",
+        "print(\"=\" * 110)\n",
+        "\n",
+        "py_score = 0\n",
+        "rust_score = 0\n",
+        "\n",
+        "for phrase in test_phrases:\n",
+        "    py_wav = python_generate(phrase)\n",
+        "    py_heard = transcribe(py_wav) if py_wav else \"FAILED\"\n",
+        "    os.unlink(py_wav) if py_wav else None\n",
+        "\n",
+        "    rust_wav, _ = rust_generate(phrase)\n",
+        "    rust_heard = transcribe(rust_wav)\n",
+        "    os.unlink(rust_wav)\n",
+        "\n",
+        "    # Loose match: check if most words appear\n",
+        "    p_norm = phrase.lower().rstrip(\".,!?\")\n",
+        "    py_ok = p_norm in py_heard.lower().rstrip(\".,!?\")\n",
+        "    rust_ok = p_norm in rust_heard.lower().rstrip(\".,!?\")\n",
+        "    py_score += int(py_ok)\n",
+        "    rust_score += int(rust_ok)\n",
+        "\n",
+        "    print(f\"{phrase:<40} {py_heard[:33]:<35} {rust_heard[:33]:<35}\")\n",
+        "\n",
+        "print(\n",
+        "    f\"\\nPython: {py_score}/{len(test_phrases)}   Rust: {rust_score}/{len(test_phrases)}\"\n",
+        ")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python                              Rus\n\u001b[0mt\n================================================================================\n\u001b[0m==============================\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python                              Rus\n\u001b[0mt\n================================================================================\n\u001b[0m==============================\nHello world                              Hello world.                        Hel\n\u001b[0mlo, we're a heraldsess.\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python                              Rus\n\u001b[0mt\n================================================================================\n\u001b[0m==============================\nHello world                              Hello world.                        Hel\n\u001b[0mlo, we're a heraldsess.\nGood morning                             Good morning.                       Goo\n\u001b[0md. More anything.\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python                              Rus\n\u001b[0mt\n================================================================================\n\u001b[0m==============================\nHello world                              Hello world.                        Hel\n\u001b[0mlo, we're a heraldsess.\nGood morning                             Good morning.                       Goo\n\u001b[0md. More anything.\nThe quick brown fox                      The quick brown fox.                The\n\u001b[0my...wicked brown fagus.\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python                              Rus\n\u001b[0mt\n================================================================================\n\u001b[0m==============================\nHello world                              Hello world.                        Hel\n\u001b[0mlo, we're a heraldsess.\nGood morning                             Good morning.                       Goo\n\u001b[0md. More anything.\nThe quick brown fox                      The quick brown fox.                The\n\u001b[0my...wicked brown fagus.\nHow are you doing today?                 How are you doing today?            How\n\u001b[0m art you do wings to daddy?\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python                              Rus\n\u001b[0mt\n================================================================================\n\u001b[0m==============================\nHello world                              Hello world.                        Hel\n\u001b[0mlo, we're a heraldsess.\nGood morning                             Good morning.                       Goo\n\u001b[0md. More anything.\nThe quick brown fox                      The quick brown fox.                The\n\u001b[0my...wicked brown fagus.\nHow are you doing today?                 How are you doing today?            How\n\u001b[0m art you do wings to daddy?\nShe sells seashells by the seashore.     She sells seashells by the seasho   She\n\u001b[0m sells a seashells at my the s\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python                              Rus\n\u001b[0mt\n================================================================================\n\u001b[0m==============================\nHello world                              Hello world.                        Hel\n\u001b[0mlo, we're a heraldsess.\nGood morning                             Good morning.                       Goo\n\u001b[0md. More anything.\nThe quick brown fox                      The quick brown fox.                The\n\u001b[0my...wicked brown fagus.\nHow are you doing today?                 How are you doing today?            How\n\u001b[0m art you do wings to daddy?\nShe sells seashells by the seashore.     She sells seashells by the seasho   She\n\u001b[0m sells a seashells at my the s\nI read a book yesterday.                 I read a book yesterday.            I r\n\u001b[0mead a book, yes, standard, say\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python                              Rus\n\u001b[0mt\n================================================================================\n\u001b[0m==============================\nHello world                              Hello world.                        Hel\n\u001b[0mlo, we're a heraldsess.\nGood morning                             Good morning.                       Goo\n\u001b[0md. More anything.\nThe quick brown fox                      The quick brown fox.                The\n\u001b[0my...wicked brown fagus.\nHow are you doing today?                 How are you doing today?            How\n\u001b[0m art you do wings to daddy?\nShe sells seashells by the seashore.     She sells seashells by the seasho   She\n\u001b[0m sells a seashells at my the s\nI read a book yesterday.                 I read a book yesterday.            I r\n\u001b[0mead a book, yes, standard, say\nThe dog is running in the park.          The dog is running in the park.     The\n\u001b[0m... the dog is running in the\n\nPython: 7/7   Rust: 1/7\n"
+        }
+      ],
+      "execution_count": 4
+    },
+    {
+      "id": "cell-5143efec-e492-4e46-aa9b-c3362b427d6f",
+      "cell_type": "code",
+      "source": [
+        "import subprocess, os, tempfile\n",
+        "import numpy as np\n",
+        "import soundfile as sf\n",
+        "\n",
+        "REPO_ROOT = os.path.dirname(os.getcwd())\n",
+        "VOICERS_CLI = os.path.join(REPO_ROOT, \"target/release/voicers-cli\")\n",
+        "print(f\"CLI exists: {os.path.exists(VOICERS_CLI)}\")\n",
+        "\n",
+        "import whisper\n",
+        "\n",
+        "whisper_model = whisper.load_model(\"base\")\n",
+        "print(\"Whisper: ready\")\n",
+        "\n",
+        "from mlx_audio.tts.utils import load as load_tts\n",
+        "\n",
+        "py_model = load_tts(\"prince-canuma/Kokoro-82M\")\n",
+        "print(\"Python Kokoro: ready\")\n",
+        "\n",
+        "\n",
+        "def transcribe(wav_path):\n",
+        "    return whisper_model.transcribe(wav_path, language=\"en\")[\"text\"].strip()\n",
+        "\n",
+        "\n",
+        "def python_generate(text, voice=\"af_heart\"):\n",
+        "    wav_path = tempfile.mktemp(suffix=\".wav\")\n",
+        "    for gen_result in py_model.generate(text, voice=voice, lang_code=\"a\"):\n",
+        "        audio = np.array(gen_result.audio)\n",
+        "        sf.write(wav_path, audio, gen_result.sample_rate)\n",
+        "        return wav_path\n",
+        "    return None\n",
+        "\n",
+        "\n",
+        "def rust_generate(text, voice=\"af_heart\"):\n",
+        "    wav_path = tempfile.mktemp(suffix=\".wav\")\n",
+        "    r = subprocess.run(\n",
+        "        [VOICERS_CLI, \"--text\", text, \"--voice\", voice, \"--output\", wav_path],\n",
+        "        capture_output=True,\n",
+        "        text=True,\n",
+        "        timeout=120,\n",
+        "    )\n",
+        "    phonemes = \"\"\n",
+        "    for line in r.stderr.splitlines():\n",
+        "        if line.strip().startswith(\"chunk\"):\n",
+        "            phonemes += line.split(\":\", 1)[1].strip() + \" \"\n",
+        "    return wav_path, phonemes.strip()\n",
+        "\n",
+        "\n",
+        "print(\"All ready.\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "CLI exists: True\nWhisper: ready\n"
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "ed3c713d9aad4d7eaeb668a645dde927"
+            },
+            "text/plain": "Downloading (incomplete total...): 0.00B [00:00, ?B/s]"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "e78a7146b05e4cca86ea8a388dfdbf97"
+            },
+            "text/plain": "Fetching 63 files:   0%|          | 0/63 [00:00<?, ?it/s]"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Python Kokoro: ready\nAll ready.\n"
+        }
+      ],
+      "execution_count": 1
+    },
+    {
+      "id": "cell-ad3184ae-23c5-457b-88c0-1404ad00cbf3",
+      "cell_type": "code",
+      "source": [
+        "# A/B Comparison: Python vs Rust (after iSTFT normalization fix)\n",
+        "test_phrases = [\n",
+        "    \"Hello world\",\n",
+        "    \"Good morning\",\n",
+        "    \"The quick brown fox\",\n",
+        "    \"How are you doing today?\",\n",
+        "    \"She sells seashells by the seashore.\",\n",
+        "    \"I read a book yesterday.\",\n",
+        "    \"The dog is running in the park.\",\n",
+        "]\n",
+        "\n",
+        "print(f\"{'Input':<40} {'Python Whisper':<40} {'Rust Whisper'}\")\n",
+        "print(\"=\" * 120)\n",
+        "\n",
+        "py_results = []\n",
+        "rust_results = []\n",
+        "\n",
+        "for phrase in test_phrases:\n",
+        "    py_wav = python_generate(phrase)\n",
+        "    py_heard = transcribe(py_wav) if py_wav else \"FAILED\"\n",
+        "    os.unlink(py_wav) if py_wav else None\n",
+        "\n",
+        "    rust_wav, rust_ph = rust_generate(phrase)\n",
+        "    rust_heard = transcribe(rust_wav)\n",
+        "    os.unlink(rust_wav)\n",
+        "\n",
+        "    py_results.append((phrase, py_heard))\n",
+        "    rust_results.append((phrase, rust_heard, rust_ph))\n",
+        "\n",
+        "    print(f\"{phrase:<40} {py_heard[:38]:<40} {rust_heard[:38]}\")\n",
+        "\n",
+        "\n",
+        "# Score: exact match (case-insensitive, strip trailing punct)\n",
+        "def normalize(s):\n",
+        "    return s.lower().rstrip(\".,!?;:\")\n",
+        "\n",
+        "\n",
+        "py_score = sum(1 for p, h in py_results if normalize(p) == normalize(h))\n",
+        "rust_score = sum(1 for p, h, _ in rust_results if normalize(p) == normalize(h))\n",
+        "print(\n",
+        "    f\"\\nExact match: Python {py_score}/{len(test_phrases)}   Rust {rust_score}/{len(test_phrases)}\"\n",
+        ")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python Whisper\n\u001b[0m  Rust Whisper\n================================================================================\n\u001b[0m========================================\nCreating new KokoroPipeline for language: a\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python Whisper\n\u001b[0m  Rust Whisper\n================================================================================\n\u001b[0m========================================\nCreating new KokoroPipeline for language: a\nHello world                              Hello world.\n\u001b[0m  Hello, we're told\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python Whisper\n\u001b[0m  Rust Whisper\n================================================================================\n\u001b[0m========================================\nCreating new KokoroPipeline for language: a\nHello world                              Hello world.\n\u001b[0m  Hello, we're told\nGood morning                             Good morning.\n\u001b[0m  Good. More in singing.\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python Whisper\n\u001b[0m  Rust Whisper\n================================================================================\n\u001b[0m========================================\nCreating new KokoroPipeline for language: a\nHello world                              Hello world.\n\u001b[0m  Hello, we're told\nGood morning                             Good morning.\n\u001b[0m  Good. More in singing.\nThe quick brown fox                      The quick brown fox.\n\u001b[0m  The quick brown fogs.\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python Whisper\n\u001b[0m  Rust Whisper\n================================================================================\n\u001b[0m========================================\nCreating new KokoroPipeline for language: a\nHello world                              Hello world.\n\u001b[0m  Hello, we're told\nGood morning                             Good morning.\n\u001b[0m  Good. More in singing.\nThe quick brown fox                      The quick brown fox.\n\u001b[0m  The quick brown fogs.\nHow are you doing today?                 How are you doing today?\n\u001b[0m  How are you doing to hurt Zeta?\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python Whisper\n\u001b[0m  Rust Whisper\n================================================================================\n\u001b[0m========================================\nCreating new KokoroPipeline for language: a\nHello world                              Hello world.\n\u001b[0m  Hello, we're told\nGood morning                             Good morning.\n\u001b[0m  Good. More in singing.\nThe quick brown fox                      The quick brown fox.\n\u001b[0m  The quick brown fogs.\nHow are you doing today?                 How are you doing today?\n\u001b[0m  How are you doing to hurt Zeta?\nShe sells seashells by the seashore.     She sells seashells by the seashore.\n\u001b[0m  She sells a sea she sells by a the sea\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python Whisper\n\u001b[0m  Rust Whisper\n================================================================================\n\u001b[0m========================================\nCreating new KokoroPipeline for language: a\nHello world                              Hello world.\n\u001b[0m  Hello, we're told\nGood morning                             Good morning.\n\u001b[0m  Good. More in singing.\nThe quick brown fox                      The quick brown fox.\n\u001b[0m  The quick brown fogs.\nHow are you doing today?                 How are you doing today?\n\u001b[0m  How are you doing to hurt Zeta?\nShe sells seashells by the seashore.     She sells seashells by the seashore.\n\u001b[0m  She sells a sea she sells by a the sea\nI read a book yesterday.                 I read a book yesterday.\n\u001b[0m  I read book. Yes, standard.\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                    Python Whisper\n\u001b[0m  Rust Whisper\n================================================================================\n\u001b[0m========================================\nCreating new KokoroPipeline for language: a\nHello world                              Hello world.\n\u001b[0m  Hello, we're told\nGood morning                             Good morning.\n\u001b[0m  Good. More in singing.\nThe quick brown fox                      The quick brown fox.\n\u001b[0m  The quick brown fogs.\nHow are you doing today?                 How are you doing today?\n\u001b[0m  How are you doing to hurt Zeta?\nShe sells seashells by the seashore.     She sells seashells by the seashore.\n\u001b[0m  She sells a sea she sells by a the sea\nI read a book yesterday.                 I read a book yesterday.\n\u001b[0m  I read book. Yes, standard.\nThe dog is running in the park.          The dog is running in the park.\n\u001b[0m  Did it all go get... is this running i\n\nExact match: Python 7/7   Rust 0/7\n"
+        }
+      ],
+      "execution_count": 2
+    },
+    {
+      "id": "cell-7a34403e-bc8e-44ac-be3d-e0f08b1b5f26",
+      "cell_type": "code",
+      "source": [
+        "# Compare the actual waveform statistics between Python and Rust\n",
+        "py_wav = python_generate(\"Hello world\")\n",
+        "rust_wav, _ = rust_generate(\"Hello world\")\n",
+        "\n",
+        "py_audio, py_sr = sf.read(py_wav)\n",
+        "rust_audio, rust_sr = sf.read(rust_wav)\n",
+        "\n",
+        "print(f\"Python: shape={py_audio.shape}, sr={py_sr}, dtype={py_audio.dtype}\")\n",
+        "print(\n",
+        "    f\"  min={py_audio.min():.4f}, max={py_audio.max():.4f}, mean={py_audio.mean():.6f}, std={py_audio.std():.4f}\"\n",
+        ")\n",
+        "print(f\"  samples: {len(py_audio)}, duration: {len(py_audio) / py_sr:.2f}s\")\n",
+        "print()\n",
+        "print(f\"Rust:   shape={rust_audio.shape}, sr={rust_sr}, dtype={rust_audio.dtype}\")\n",
+        "print(\n",
+        "    f\"  min={rust_audio.min():.4f}, max={rust_audio.max():.4f}, mean={rust_audio.mean():.6f}, std={rust_audio.std():.4f}\"\n",
+        ")\n",
+        "print(f\"  samples: {len(rust_audio)}, duration: {len(rust_audio) / rust_sr:.2f}s\")\n",
+        "\n",
+        "# Amplitude ratio\n",
+        "print(f\"\\nAmplitude ratio (rust_std / py_std): {rust_audio.std() / py_audio.std():.4f}\")\n",
+        "print(\n",
+        "    f\"RMS ratio: {np.sqrt(np.mean(rust_audio**2)) / np.sqrt(np.mean(py_audio**2)):.4f}\"\n",
+        ")\n",
+        "\n",
+        "os.unlink(py_wav)\n",
+        "os.unlink(rust_wav)"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Python: shape=(36600,), sr=24000, dtype=float64\n  min=-0.2066, max=0.1968, mean=-0.000065, std=0.0340\n  samples: 36600, duration: 1.52s\n\nRust:   shape=(60000,), sr=24000, dtype=float64\n  min=-0.1710, max=0.2206, mean=-0.000004, std=0.0283\n  samples: 60000, duration: 2.50s\n\nAmplitude ratio (rust_std / py_std): 0.8318\nRMS ratio: 0.8318\n"
+        }
+      ],
+      "execution_count": 3
+    },
+    {
+      "id": "cell-d077018c-f412-479a-bc83-2e9a2494b6f5",
+      "cell_type": "code",
+      "source": [
+        "# Let's look at the WAV structure more carefully\n",
+        "# The Rust output being longer could mean:\n",
+        "# 1. Duration prediction is wrong (model predicting longer durations)\n",
+        "# 2. Extra silence at start/end (padding not trimmed)\n",
+        "# 3. Wrong sample rate in WAV header\n",
+        "\n",
+        "# Check if there's a long silence tail in Rust output\n",
+        "py_wav = python_generate(\"Hello world\")\n",
+        "rust_wav, _ = rust_generate(\"Hello world\")\n",
+        "py_audio, _ = sf.read(py_wav)\n",
+        "rust_audio, _ = sf.read(rust_wav)\n",
+        "\n",
+        "\n",
+        "# Find where the audio actually starts/ends (above noise floor)\n",
+        "def find_audio_bounds(audio, threshold=0.005):\n",
+        "    abs_audio = np.abs(audio)\n",
+        "    above = abs_audio > threshold\n",
+        "    if not np.any(above):\n",
+        "        return 0, len(audio)\n",
+        "    start = np.argmax(above)\n",
+        "    end = len(audio) - np.argmax(above[::-1])\n",
+        "    return int(start), int(end)\n",
+        "\n",
+        "\n",
+        "py_start, py_end = find_audio_bounds(py_audio)\n",
+        "rust_start, rust_end = find_audio_bounds(rust_audio)\n",
+        "\n",
+        "print(f\"Python: total={len(py_audio)} samples\")\n",
+        "print(\n",
+        "    f\"  Audio region: {py_start} to {py_end} ({py_end - py_start} samples, {(py_end - py_start) / 24000:.2f}s)\"\n",
+        ")\n",
+        "print(\n",
+        "    f\"  Leading silence: {py_start / 24000:.3f}s, trailing silence: {(len(py_audio) - py_end) / 24000:.3f}s\"\n",
+        ")\n",
+        "print()\n",
+        "print(f\"Rust:   total={len(rust_audio)} samples\")\n",
+        "print(\n",
+        "    f\"  Audio region: {rust_start} to {rust_end} ({rust_end - rust_start} samples, {(rust_end - rust_start) / 24000:.2f}s)\"\n",
+        ")\n",
+        "print(\n",
+        "    f\"  Leading silence: {rust_start / 24000:.3f}s, trailing silence: {(len(rust_audio) - rust_end) / 24000:.3f}s\"\n",
+        ")\n",
+        "\n",
+        "os.unlink(py_wav)\n",
+        "os.unlink(rust_wav)"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Python: total=36600 samples\n  Audio region: 9245 to 25779 (16534 samples, 0.69s)\n  Leading silence: 0.385s, trailing silence: 0.451s\n\nRust:   total=60600 samples\n  Audio region: 11183 to 52186 (41003 samples, 1.71s)\n  Leading silence: 0.466s, trailing silence: 0.351s\n"
+        }
+      ],
+      "execution_count": 4
+    },
+    {
+      "id": "cell-41026e9a-7f0f-44ee-b3b9-bbf7c9e90be2",
+      "cell_type": "code",
+      "source": [
+        "# Let's trace the exact intermediate values.\n",
+        "# First, check what phonemes and token IDs each side uses for \"Hello world\"\n",
+        "\n",
+        "# Python side: get phonemes and token IDs\n",
+        "script = \"\"\"\n",
+        "import sys\n",
+        "sys.path.insert(0, '/Users/kylekelley/conductor/workspaces/misaki/abuja-v4')\n",
+        "from misaki.en import G2P\n",
+        "import spacy, json\n",
+        "\n",
+        "g2p = G2P(trf=False, british=False, unk='')\n",
+        "ps, tokens = g2p(\"Hello world\")\n",
+        "print(f\"phonemes: {ps}\")\n",
+        "print(f\"tokens: {[(t.text, t.phonemes, t.tag) for t in tokens]}\")\n",
+        "\n",
+        "# Show the vocab mapping\n",
+        "import json as j\n",
+        "from huggingface_hub import hf_hub_download\n",
+        "config_path = hf_hub_download('prince-canuma/Kokoro-82M', 'config.json')\n",
+        "with open(config_path) as f:\n",
+        "    config = j.load(f)\n",
+        "vocab = config['vocab']\n",
+        "ids = [vocab.get(c, -1) for c in ps]\n",
+        "print(f\"token_ids: {ids}\")\n",
+        "print(f\"phoneme_count: {len(ps)}\")\n",
+        "\"\"\"\n",
+        "r = subprocess.run(\n",
+        "    [\n",
+        "        \"uv\",\n",
+        "        \"run\",\n",
+        "        \"--with\",\n",
+        "        \"misaki[en]\",\n",
+        "        \"--with\",\n",
+        "        \"spacy\",\n",
+        "        \"--with\",\n",
+        "        \"transformers\",\n",
+        "        \"--with\",\n",
+        "        \"torch\",\n",
+        "        \"--with\",\n",
+        "        \"en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl\",\n",
+        "        \"--with\",\n",
+        "        \"huggingface-hub\",\n",
+        "        \"python\",\n",
+        "        \"-c\",\n",
+        "        script,\n",
+        "    ],\n",
+        "    capture_output=True,\n",
+        "    text=True,\n",
+        "    timeout=120,\n",
+        ")\n",
+        "print(\"=== Python misaki output ===\")\n",
+        "print(r.stdout)\n",
+        "if r.stderr:\n",
+        "    # Just show the important lines\n",
+        "    for line in r.stderr.splitlines():\n",
+        "        if not line.startswith((\" \", \"  \")) and \"WARNING\" not in line:\n",
+        "            print(f\"  stderr: {line}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "=== Python misaki output ===\nphonemes: həlˈO wˈɜɹld\ntokens: [('Hello', 'həlˈO', 'UH'), ('world', 'wˈɜɹld', 'NN')]\ntoken_ids: [50, 83, 54, 156, 31, 16, 65, 156, 87, 123, 54, 46]\nphoneme_count: 12\n\n  stderr:\n  stderr: Loading weights:   0%|                                  | 0/50 [00:00<\n\u001b[0m?, ?it/s]\n  stderr: Loading weights: 100%|██████████████████████| 50/50 [00:00<00:00, 1156\n\u001b[0m2.84it/s]\n"
+        }
+      ],
+      "execution_count": 5
+    },
+    {
+      "id": "cell-ae3d2711-d7bf-46f1-bbc3-8971067f1c54",
+      "cell_type": "code",
+      "source": [
+        "# Now check what the Rust side produces for \"Hello world\"\n",
+        "# The phonemes were: həlˈO wˈɜɹld\n",
+        "\n",
+        "# Let's check token IDs from Rust by looking at the vocab\n",
+        "import json\n",
+        "from huggingface_hub import hf_hub_download\n",
+        "\n",
+        "config_path = hf_hub_download(\"prince-canuma/Kokoro-82M\", \"config.json\")\n",
+        "with open(config_path) as f:\n",
+        "    config = json.load(f)\n",
+        "vocab = config[\"vocab\"]\n",
+        "\n",
+        "rust_phonemes = \"həlˈO wˈɜɹld\"\n",
+        "rust_ids = [vocab.get(c, -1) for c in rust_phonemes]\n",
+        "print(f\"Rust phonemes: {rust_phonemes}\")\n",
+        "print(f\"Rust token_ids: {rust_ids}\")\n",
+        "print(f\"Rust phoneme_count: {len(rust_phonemes)}\")\n",
+        "\n",
+        "py_phonemes = \"həlˈO wˈɜɹld\"\n",
+        "py_ids = [vocab.get(c, -1) for c in py_phonemes]\n",
+        "print(f\"\\nPython phonemes: {py_phonemes}\")\n",
+        "print(f\"Python token_ids: {py_ids}\")\n",
+        "print(f\"Python phoneme_count: {len(py_phonemes)}\")\n",
+        "\n",
+        "print(f\"\\nPhonemes match: {rust_phonemes == py_phonemes}\")\n",
+        "print(f\"Token IDs match: {rust_ids == py_ids}\")\n",
+        "\n",
+        "# Check vocab for space\n",
+        "print(f\"\\nSpace in vocab: {vocab.get(' ', 'NOT FOUND')}\")\n",
+        "print(f\"BOS token (0): {[k for k, v in vocab.items() if v == 0]}\")\n",
+        "\n",
+        "# Show full vocab\n",
+        "print(f\"\\nVocab size: {len(vocab)}\")\n",
+        "print(f\"Vocab: {dict(sorted(vocab.items(), key=lambda x: x[1]))}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Rust phonemes: həlˈO wˈɜɹld\nRust token_ids: [50, 83, 54, 156, 31, 16, 65, 156, 87, 123, 54, 46]\nRust phoneme_count: 12\n\nPython phonemes: həlˈO wˈɜɹld\nPython token_ids: [50, 83, 54, 156, 31, 16, 65, 156, 87, 123, 54, 46]\nPython phoneme_count: 12\n\nPhonemes match: True\nToken IDs match: True\n\nSpace in vocab: 16\nBOS token (0): []\n\nVocab size: 114\nVocab: {';': 1, ':': 2, ',': 3, '.': 4, '!': 5, '?': 6, '—': 9, '…': 10, '\"': 11\n\u001b[0m, '(': 12, ')': 13, '“': 14, '”': 15, ' ': 16, '̃': 17, 'ʣ': 18, 'ʥ': 19, 'ʦ': 20\n\u001b[0m, 'ʨ': 21, 'ᵝ': 22, 'ꭧ': 23, 'A': 24, 'I': 25, 'O': 31, 'Q': 33, 'S': 35, 'T': 3\n\u001b[0m6, 'W': 39, 'Y': 41, 'ᵊ': 42, 'a': 43, 'b': 44, 'c': 45, 'd': 46, 'e': 47, 'f':\n\u001b[0m48, 'h': 50, 'i': 51, 'j': 52, 'k': 53, 'l': 54, 'm': 55, 'n': 56, 'o': 57, 'p':\n\u001b[0m 58, 'q': 59, 'r': 60, 's': 61, 't': 62, 'u': 63, 'v': 64, 'w': 65, 'x': 66, 'y'\n\u001b[0m: 67, 'z': 68, 'ɑ': 69, 'ɐ': 70, 'ɒ': 71, 'æ': 72, 'β': 75, 'ɔ': 76, 'ɕ': 77, 'ç\n\u001b[0m': 78, 'ɖ': 80, 'ð': 81, 'ʤ': 82, 'ə': 83, 'ɚ': 85, 'ɛ': 86, 'ɜ': 87, 'ɟ': 90, '\n\u001b[0mɡ': 92, 'ɥ': 99, 'ɨ': 101, 'ɪ': 102, 'ʝ': 103, 'ɯ': 110, 'ɰ': 111, 'ŋ': 112, 'ɳ'\n\u001b[0m: 113, 'ɲ': 114, 'ɴ': 115, 'ø': 116, 'ɸ': 118, 'θ': 119, 'œ': 120, 'ɹ': 123, 'ɾ'\n\u001b[0m: 125, 'ɻ': 126, 'ʁ': 128, 'ɽ': 129, 'ʂ': 130, 'ʃ': 131, 'ʈ': 132, 'ʧ': 133, 'ʊ'\n\u001b[0m: 135, 'ʋ': 136, 'ʌ': 138, 'ɣ': 139, 'ɤ': 140, 'χ': 142, 'ʎ': 143, 'ʒ': 147, 'ʔ'\n\u001b[0m: 148, 'ˈ': 156, 'ˌ': 157, 'ː': 158, 'ʰ': 162, 'ʲ': 164, '↓': 169, '→': 171, '↗'\n\u001b[0m: 172, '↘': 173, 'ᵻ': 177}\n"
+        }
+      ],
+      "execution_count": 6
+    },
+    {
+      "id": "cell-57a5d664-b64c-4136-ac1b-f3cf897ff990",
+      "cell_type": "code",
+      "source": [
+        "# Deep dive: extract intermediate tensors from both pipelines\n",
+        "# Python: Use the model directly to get duration predictions\n",
+        "\n",
+        "script = \"\"\"\n",
+        "import sys, json, numpy as np\n",
+        "sys.path.insert(0, '/Users/kylekelley/conductor/workspaces/misaki/abuja-v4')\n",
+        "sys.path.insert(0, '/Users/kylekelley/conductor/workspaces/kokoro/montevideo')\n",
+        "\n",
+        "import torch\n",
+        "from kokoro.model import KModel\n",
+        "from huggingface_hub import hf_hub_download\n",
+        "\n",
+        "# Load model\n",
+        "config_path = hf_hub_download('prince-canuma/Kokoro-82M', 'config.json')\n",
+        "with open(config_path) as f:\n",
+        "    config = json.load(f)\n",
+        "\n",
+        "model = KModel(config)\n",
+        "weights_path = hf_hub_download('prince-canuma/Kokoro-82M', 'kokoro-v1_0.pth')\n",
+        "state = torch.load(weights_path, map_location='cpu', weights_only=True)\n",
+        "model.load_state_dict(state)\n",
+        "model.eval()\n",
+        "\n",
+        "# Load voice\n",
+        "voice_path = hf_hub_download('prince-canuma/Kokoro-82M', 'voices/af_heart.pt')\n",
+        "voice = torch.load(voice_path, map_location='cpu', weights_only=True)\n",
+        "\n",
+        "# Prepare input - same phonemes as Rust\n",
+        "phonemes = \"həlˈO wˈɜɹld\"\n",
+        "vocab = config['vocab']\n",
+        "tokens = [vocab[c] for c in phonemes]\n",
+        "input_ids = torch.tensor([[0, *tokens, 0]], dtype=torch.long)\n",
+        "ref_s = voice[len(tokens)]  # voice_pack indexed by phoneme count\n",
+        "\n",
+        "print(f\"input_ids shape: {input_ids.shape}\")\n",
+        "print(f\"input_ids: {input_ids.tolist()}\")\n",
+        "print(f\"ref_s shape: {ref_s.shape}\")\n",
+        "print(f\"ref_s[:5]: {ref_s[0,:5].tolist()}\")\n",
+        "\n",
+        "# Run the model forward pass with torch.no_grad\n",
+        "with torch.no_grad():\n",
+        "    # Get BERT output\n",
+        "    bert_out = model.bert(input_ids, attention_mask=(~(input_ids==0)).int())\n",
+        "    asr = model.bert_encoder(bert_out[0]).transpose(1, 2)\n",
+        "    print(f\"asr shape: {asr.shape}\")\n",
+        "    print(f\"asr mean: {asr.mean().item():.6f}, std: {asr.std().item():.6f}\")\n",
+        "    \n",
+        "    # Split style\n",
+        "    s_content = ref_s[:, 128:]\n",
+        "    s_ref = ref_s[:, :128]\n",
+        "    \n",
+        "    # Get durations via predictor\n",
+        "    d = model.predictor.text_encoder(asr, s_content)\n",
+        "    print(f\"duration_encoded shape: {d.shape}\")\n",
+        "    \n",
+        "    # Full forward pass to get audio\n",
+        "    audio = model(input_ids, ref_s, speed=1.0)\n",
+        "    if isinstance(audio, tuple):\n",
+        "        audio = audio[0]\n",
+        "    audio_np = audio.cpu().numpy().flatten()\n",
+        "    print(f\"audio shape: {audio_np.shape}, duration: {len(audio_np)/24000:.2f}s\")\n",
+        "    print(f\"audio stats: min={audio_np.min():.4f}, max={audio_np.max():.4f}, std={audio_np.std():.4f}\")\n",
+        "\"\"\"\n",
+        "\n",
+        "r = subprocess.run(\n",
+        "    [\n",
+        "        \"uv\",\n",
+        "        \"run\",\n",
+        "        \"--with\",\n",
+        "        \"misaki[en]\",\n",
+        "        \"--with\",\n",
+        "        \"spacy\",\n",
+        "        \"--with\",\n",
+        "        \"transformers\",\n",
+        "        \"--with\",\n",
+        "        \"torch\",\n",
+        "        \"--with\",\n",
+        "        \"huggingface-hub\",\n",
+        "        \"--with\",\n",
+        "        \"soundfile\",\n",
+        "        \"--with\",\n",
+        "        \"en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl\",\n",
+        "        \"python\",\n",
+        "        \"-c\",\n",
+        "        script,\n",
+        "    ],\n",
+        "    capture_output=True,\n",
+        "    text=True,\n",
+        "    timeout=120,\n",
+        ")\n",
+        "print(\"=== Python PyTorch model internals ===\")\n",
+        "for line in r.stdout.splitlines():\n",
+        "    print(line)\n",
+        "if r.returncode != 0:\n",
+        "    print(\"ERRORS:\")\n",
+        "    for line in r.stderr.splitlines()[-10:]:\n",
+        "        print(f\"  {line}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "=== Python PyTorch model internals ===\nERRORS:\n  Traceback (most recent call last):\n    File \"<string>\", line 7, in <module>\n    File \"/Users/kylekelley/conductor/workspaces/kokoro/montevideo/kokoro/__init\n\u001b[0m__.py\", line 3, in <module>\n      from loguru import logger\n  ModuleNotFoundError: No module named 'loguru'\n"
+        }
+      ],
+      "execution_count": 7
+    },
+    {
+      "id": "cell-cee49d61-a091-4659-8a87-d55a48b293ba",
+      "cell_type": "code",
+      "source": [
+        "# Add loguru + phonemizer deps\n",
+        "script = \"\"\"\n",
+        "import sys, json, numpy as np\n",
+        "sys.path.insert(0, '/Users/kylekelley/conductor/workspaces/kokoro/montevideo')\n",
+        "\n",
+        "import torch\n",
+        "from kokoro.model import KModel\n",
+        "from huggingface_hub import hf_hub_download\n",
+        "\n",
+        "config_path = hf_hub_download('prince-canuma/Kokoro-82M', 'config.json')\n",
+        "with open(config_path) as f:\n",
+        "    config = json.load(f)\n",
+        "\n",
+        "model = KModel(config)\n",
+        "weights_path = hf_hub_download('prince-canuma/Kokoro-82M', 'kokoro-v1_0.pth')\n",
+        "state = torch.load(weights_path, map_location='cpu', weights_only=True)\n",
+        "model.load_state_dict(state)\n",
+        "model.eval()\n",
+        "\n",
+        "voice_path = hf_hub_download('prince-canuma/Kokoro-82M', 'voices/af_heart.pt')\n",
+        "voice = torch.load(voice_path, map_location='cpu', weights_only=True)\n",
+        "\n",
+        "phonemes = \"həlˈO wˈɜɹld\"\n",
+        "vocab = config['vocab']\n",
+        "tokens = [vocab[c] for c in phonemes]\n",
+        "input_ids = torch.tensor([[0, *tokens, 0]], dtype=torch.long)\n",
+        "ref_s = voice[len(tokens)]\n",
+        "\n",
+        "print(f\"input_ids shape: {input_ids.shape}\")\n",
+        "print(f\"input_ids: {input_ids.tolist()}\")\n",
+        "print(f\"ref_s shape: {ref_s.shape}\")\n",
+        "print(f\"ref_s[0,:5]: {ref_s[0,:5].tolist()}\")\n",
+        "\n",
+        "with torch.no_grad():\n",
+        "    audio = model(input_ids, ref_s, speed=1.0)\n",
+        "    if isinstance(audio, tuple):\n",
+        "        audio = audio[0]\n",
+        "    audio_np = audio.cpu().numpy().flatten()\n",
+        "    print(f\"audio shape: {audio_np.shape}, duration: {len(audio_np)/24000:.2f}s\")\n",
+        "    print(f\"audio stats: min={audio_np.min():.4f}, max={audio_np.max():.4f}, std={audio_np.std():.4f}\")\n",
+        "\"\"\"\n",
+        "\n",
+        "r = subprocess.run(\n",
+        "    [\n",
+        "        \"uv\",\n",
+        "        \"run\",\n",
+        "        \"--with\",\n",
+        "        \"loguru\",\n",
+        "        \"--with\",\n",
+        "        \"phonemizer\",\n",
+        "        \"--with\",\n",
+        "        \"transformers\",\n",
+        "        \"--with\",\n",
+        "        \"torch\",\n",
+        "        \"--with\",\n",
+        "        \"huggingface-hub\",\n",
+        "        \"--with\",\n",
+        "        \"soundfile\",\n",
+        "        \"--with\",\n",
+        "        \"misaki[en]\",\n",
+        "        \"--with\",\n",
+        "        \"spacy\",\n",
+        "        \"--with\",\n",
+        "        \"en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl\",\n",
+        "        \"python\",\n",
+        "        \"-c\",\n",
+        "        script,\n",
+        "    ],\n",
+        "    capture_output=True,\n",
+        "    text=True,\n",
+        "    timeout=120,\n",
+        ")\n",
+        "print(\"=== PyTorch Kokoro model ===\")\n",
+        "for line in r.stdout.splitlines():\n",
+        "    print(line)\n",
+        "if r.returncode != 0:\n",
+        "    print(\"ERRORS:\")\n",
+        "    for line in r.stderr.splitlines()[-10:]:\n",
+        "        print(f\"  {line}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "=== PyTorch Kokoro model ===\nERRORS:\n  Traceback (most recent call last):\n    File \"<string>\", line 13, in <module>\n    File \"/Users/kylekelley/conductor/workspaces/kokoro/montevideo/kokoro/model.\n\u001b[0mpy\", line 46, in __init__\n      config = hf_hub_download(repo_id=repo_id, filename='config.json')\n               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    File \"/Users/kylekelley/.cache/uv/archive-v0/zEHrRvVr0g5qocUwDDoKJ/lib/pytho\n\u001b[0mn3.12/site-packages/huggingface_hub/utils/_validators.py\", line 85, in _inner_fn\n      validate_repo_id(arg_value)\n    File \"/Users/kylekelley/.cache/uv/archive-v0/zEHrRvVr0g5qocUwDDoKJ/lib/pytho\n\u001b[0mn3.12/site-packages/huggingface_hub/utils/_validators.py\", line 130, in validate\n\u001b[0m_repo_id\n      raise HFValidationError(f\"Repo id must be a string, not {type(repo_id)}: '\n\u001b[0m{repo_id}'.\")\n  huggingface_hub.errors.HFValidationError: Repo id must be a string, not <class\n\u001b[0m 'dict'>: '{'istftnet': {'upsample_kernel_sizes': [20, 12], 'upsample_rates': [1\n\u001b[0m0, 6], 'gen_istft_hop_size': 5, 'gen_istft_n_fft': 20, 'resblock_dilation_sizes'\n\u001b[0m: [[1, 3, 5], [1, 3, 5], [1, 3, 5]], 'resblock_kernel_sizes': [3, 7, 11], 'upsam\n\u001b[0mple_initial_channel': 512}, 'dim_in': 64, 'dropout': 0.2, 'hidden_dim': 512, 'ma\n\u001b[0mx_conv_dim': 512, 'max_dur': 50, 'multispeaker': True, 'n_layer': 3, 'n_mels': 8\n\u001b[0m0, 'n_token': 178, 'style_dim': 128, 'text_encoder_kernel_size': 5, 'plbert': {'\n\u001b[0mhidden_size': 768, 'num_attention_heads': 12, 'intermediate_size': 2048, 'max_po\n\u001b[0msition_embeddings': 512, 'num_hidden_layers': 12, 'dropout': 0.1}, 'vocab': {';'\n\u001b[0m: 1, ':': 2, ',': 3, '.': 4, '!': 5, '?': 6, '—': 9, '…': 10, '\"': 11, '(': 12,\n\u001b[0m')': 13, '“': 14, '”': 15, ' ': 16, '̃': 17, 'ʣ': 18, 'ʥ': 19, 'ʦ': 20, 'ʨ': 21,\n\u001b[0m'ᵝ': 22, 'ꭧ': 23, 'A': 24, 'I': 25, 'O': 31, 'Q': 33, 'S': 35, 'T': 36, 'W': 39,\n\u001b[0m 'Y': 41, 'ᵊ': 42, 'a': 43, 'b': 44, 'c': 45, 'd': 46, 'e': 47, 'f': 48, 'h': 50\n\u001b[0m, 'i': 51, 'j': 52, 'k': 53, 'l': 54, 'm': 55, 'n': 56, 'o': 57, 'p': 58, 'q': 5\n\u001b[0m9, 'r': 60, 's': 61, 't': 62, 'u': 63, 'v': 64, 'w': 65, 'x': 66, 'y': 67, 'z':\n\u001b[0m68, 'ɑ': 69, 'ɐ': 70, 'ɒ': 71, 'æ': 72, 'β': 75, 'ɔ': 76, 'ɕ': 77, 'ç': 78, 'ɖ':\n\u001b[0m 80, 'ð': 81, 'ʤ': 82, 'ə': 83, 'ɚ': 85, 'ɛ': 86, 'ɜ': 87, 'ɟ': 90, 'ɡ': 92, 'ɥ'\n\u001b[0m: 99, 'ɨ': 101, 'ɪ': 102, 'ʝ': 103, 'ɯ': 110, 'ɰ': 111, 'ŋ': 112, 'ɳ': 113, 'ɲ':\n\u001b[0m 114, 'ɴ': 115, 'ø': 116, 'ɸ': 118, 'θ': 119, 'œ': 120, 'ɹ': 123, 'ɾ': 125, 'ɻ':\n\u001b[0m 126, 'ʁ': 128, 'ɽ': 129, 'ʂ': 130, 'ʃ': 131, 'ʈ': 132, 'ʧ': 133, 'ʊ': 135, 'ʋ':\n\u001b[0m 136, 'ʌ': 138, 'ɣ': 139, 'ɤ': 140, 'χ': 142, 'ʎ': 143, 'ʒ': 147, 'ʔ': 148, 'ˈ':\n\u001b[0m 156, 'ˌ': 157, 'ː': 158, 'ʰ': 162, 'ʲ': 164, '↓': 169, '→': 171, '↗': 172, '↘':\n\u001b[0m 173, 'ᵻ': 177}}'.\n"
+        }
+      ],
+      "execution_count": 8
+    },
+    {
+      "id": "cell-3d94a832-7742-4496-b509-44abc98d3219",
+      "cell_type": "code",
+      "source": [
+        "# Use the mlx-audio Python model we already have loaded to get intermediate info\n",
+        "# The py_model is a loaded KokoroPipeline\n",
+        "\n",
+        "# Let's check the Python mlx-audio model internals\n",
+        "import mlx.core as mx\n",
+        "\n",
+        "# Get the actual model from the pipeline\n",
+        "pipeline = py_model\n",
+        "model = pipeline.model  # The underlying MLX model\n",
+        "print(f\"Model type: {type(model)}\")\n",
+        "print(f\"Model attributes: {[a for a in dir(model) if not a.startswith('_')]}\")\n",
+        "\n",
+        "# Check if we can access the forward pass components\n",
+        "vocab = model.vocab if hasattr(model, \"vocab\") else None\n",
+        "print(f\"Has vocab: {vocab is not None}\")\n",
+        "\n",
+        "# Try to trace the model's generate method\n",
+        "phonemes = \"həlˈO wˈɜɹld\"\n",
+        "if vocab:\n",
+        "    input_ids = [vocab.get(c, -1) for c in phonemes]\n",
+        "    print(f\"input_ids: {input_ids}\")\n",
+        "    print(f\"phoneme count: {len(input_ids)}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "error",
+          "ename": "AttributeError",
+          "evalue": "'Model' object has no attribute 'model'",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mAttributeError\u001b[39m                            Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[9]\u001b[39m\u001b[32m, line 9\u001b[39m\n\u001b[32m      7\u001b[39m \u001b[38;5;66;03m# Get the actual model from the pipeline\u001b[39;00m\n\u001b[32m      8\u001b[39m pipeline = py_model\n\u001b[32m----> \u001b[39m\u001b[32m9\u001b[39m model = \u001b[43mpipeline\u001b[49m\u001b[43m.\u001b[49m\u001b[43mmodel\u001b[49m  \u001b[38;5;66;03m# The underlying MLX model\u001b[39;00m\n\u001b[32m     10\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mModel type: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mtype\u001b[39m(model)\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n\u001b[32m     11\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mModel attributes: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m[a\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mfor\u001b[39;00m\u001b[38;5;250m \u001b[39ma\u001b[38;5;250m \u001b[39m\u001b[38;5;129;01min\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28mdir\u001b[39m(model)\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mif\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;129;01mnot\u001b[39;00m\u001b[38;5;250m \u001b[39ma.startswith(\u001b[33m'\u001b[39m\u001b[33m_\u001b[39m\u001b[33m'\u001b[39m)]\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.12/site-packages/mlx/nn/layers/base.py:103\u001b[39m, in \u001b[36mModule.__getattr__\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m    101\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m value\n\u001b[32m    102\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m103\u001b[39m     \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mModule\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m.\u001b[49m\u001b[34;43m__getattribute__\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m)\u001b[49m\n",
+            "\u001b[31mAttributeError\u001b[39m: 'Model' object has no attribute 'model'"
+          ]
+        }
+      ],
+      "execution_count": 9
+    },
+    {
+      "id": "cell-a163f98c-10c6-45a0-93a9-3c9c3a6c2159",
+      "cell_type": "code",
+      "source": [
+        "# py_model is the Model itself, not a pipeline wrapper\n",
+        "import mlx.core as mx\n",
+        "\n",
+        "model = py_model\n",
+        "print(f\"Model type: {type(model)}\")\n",
+        "print(f\"Model attributes: {[a for a in dir(model) if not a.startswith('_')][:30]}\")\n",
+        "\n",
+        "# Look at the generate method source\n",
+        "import inspect\n",
+        "\n",
+        "# Get the __call__ or generate method\n",
+        "print(f\"\\nHas __call__: {hasattr(model, '__call__')}\")\n",
+        "print(f\"Has generate: {hasattr(model, 'generate')}\")\n",
+        "\n",
+        "# Check key attributes\n",
+        "for attr in [\"vocab\", \"bert\", \"bert_encoder\", \"predictor\", \"text_encoder\", \"decoder\"]:\n",
+        "    print(f\"  {attr}: {hasattr(model, attr)}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Model type: <class 'mlx_audio.tts.models.kokoro.kokoro.Model'>\nModel attributes: ['Output', 'REPO_ID', 'apply', 'apply_to_modules', 'children',\n\u001b[0m 'clear', 'config', 'context_length', 'copy', 'eval', 'filter_and_map', 'freeze'\n\u001b[0m, 'fromkeys', 'generate', 'get', 'is_module', 'items', 'keys', 'leaf_modules', '\n\u001b[0mload_weights', 'modules', 'named_modules', 'parameters', 'pop', 'popitem', 'repo\n\u001b[0m_id', 'sample_rate', 'sanitize', 'save_weights', 'set_dtype']\n\nHas __call__: True\nHas generate: True\n  vocab: True\n  bert: True\n  bert_encoder: True\n  predictor: True\n  text_encoder: True\n  decoder: True\n"
+        }
+      ],
+      "execution_count": 10
+    },
+    {
+      "id": "cell-9112f9af-363c-4778-9385-97e45124b674",
+      "cell_type": "code",
+      "source": [
+        "# Now let's trace the forward pass step by step in Python MLX\n",
+        "# First, read the Python model's __call__ to understand the flow\n",
+        "import inspect\n",
+        "\n",
+        "src = inspect.getsource(model.__call__)\n",
+        "print(src[:3000])"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "    def __call__(\n        self,\n        phonemes: str,\n        ref_s: mx.array,\n        speed: Number = 1,\n        return_output: bool = False,  # MARK: BACKWARD COMPAT\n        decoder=None,\n    ) -> Union[\"KokoroModel.Output\", mx.array]:\n        input_ids = list(\n            filter(lambda i: i is not None, map(lambda p: self.vocab.get(p), pho\n\u001b[0mnemes))\n        )\n        assert len(input_ids) + 2 <= self.context_length, (\n            len(input_ids) + 2,\n            self.context_length,\n        )\n        input_ids = mx.array([[0, *input_ids, 0]])\n        input_lengths = mx.array([input_ids.shape[-1]])\n        text_mask = mx.arange(int(input_lengths.max()))[None, ...]\n        text_mask = mx.repeat(text_mask, input_lengths.shape[0], axis=0).astype(\n            input_lengths.dtype\n        )\n        text_mask = text_mask + 1 > input_lengths[:, None]\n        bert_dur, _ = self.bert(input_ids, attention_mask=(~text_mask).astype(mx\n\u001b[0m.int32))\n        d_en = self.bert_encoder(bert_dur).transpose(0, 2, 1)\n        ref_s = ref_s\n        s = ref_s[:, 128:]\n        d = self.predictor.text_encoder(d_en, s, input_lengths, text_mask)\n        x, _ = self.predictor.lstm(d)\n        duration = self.predictor.duration_proj(x)\n        duration = mx.sigmoid(duration).sum(axis=-1) / speed\n        pred_dur = mx.clip(mx.round(duration), a_min=1, a_max=None).astype(mx.in\n\u001b[0mt32)[0]\n        indices = mx.concatenate(\n            [mx.repeat(mx.array(i), int(n)) for i, n in enumerate(pred_dur)]\n        )\n        pred_aln_trg = mx.zeros((input_ids.shape[1], indices.shape[0]))\n        pred_aln_trg[indices, mx.arange(indices.shape[0])] = 1\n        pred_aln_trg = pred_aln_trg[None, :]\n        en = d.transpose(0, 2, 1) @ pred_aln_trg\n        F0_pred, N_pred = self.predictor.F0Ntrain(en, s)\n        t_en = self.text_encoder(\n            input_ids, input_lengths, text_mask\n        )  # Working fine in MLX\n        asr = t_en @ pred_aln_trg\n\n        decoder = mx.compile(decoder) if decoder is not None else self.decoder\n        audio = decoder(asr, F0_pred, N_pred, ref_s[:, :128])[0]  # Working fine\n\u001b[0m in MLX\n\n        # Evaluate the computation graph for audio and pred_dur before returning\n        mx.eval(audio, pred_dur)\n\n        return self.Output(audio=audio, pred_dur=pred_dur) if return_output else\n\u001b[0m audio\n"
+        }
+      ],
+      "execution_count": 11
+    },
+    {
+      "id": "cell-51f7dd9c-1a34-4116-bfea-bb5d3885c175",
+      "cell_type": "code",
+      "source": [
+        "# Step-by-step instrumented forward pass in Python MLX\n",
+        "import mlx.core as mx\n",
+        "import numpy as np\n",
+        "\n",
+        "phonemes = \"həlˈO wˈɜɹld\"\n",
+        "vocab = model.vocab\n",
+        "input_ids_list = [v for c in phonemes if (v := vocab.get(c)) is not None]\n",
+        "input_ids = mx.array([[0, *input_ids_list, 0]])\n",
+        "seq_len = input_ids.shape[-1]\n",
+        "input_lengths = mx.array([seq_len])\n",
+        "\n",
+        "text_mask = mx.arange(int(input_lengths.max()))[None, :]\n",
+        "text_mask = mx.repeat(text_mask, input_lengths.shape[0], axis=0).astype(\n",
+        "    input_lengths.dtype\n",
+        ")\n",
+        "text_mask = text_mask + 1 > input_lengths[:, None]\n",
+        "\n",
+        "print(f\"input_ids: {input_ids.tolist()}\")\n",
+        "print(f\"seq_len: {seq_len}\")\n",
+        "print(f\"text_mask: {text_mask.tolist()}\")\n",
+        "print(f\"text_mask shape: {text_mask.shape}\")\n",
+        "\n",
+        "# Load voice\n",
+        "from huggingface_hub import hf_hub_download\n",
+        "\n",
+        "voice_path = hf_hub_download(\"prince-canuma/Kokoro-82M\", \"voices/af_heart.pt\")\n",
+        "import torch\n",
+        "\n",
+        "voice_pt = torch.load(voice_path, map_location=\"cpu\", weights_only=True)\n",
+        "voice = mx.array(voice_pt.numpy())\n",
+        "ref_s = voice[len(input_ids_list)]\n",
+        "print(f\"\\nvoice pack shape: {voice.shape}\")\n",
+        "print(f\"ref_s shape (indexed by phoneme count {len(input_ids_list)}): {ref_s.shape}\")\n",
+        "print(f\"ref_s[0,:5]: {ref_s[0, :5].tolist()}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "input_ids: [[0, 50, 83, 54, 156, 31, 16, 65, 156, 87, 123, 54, 46, 0]]\nseq_len: 14\ntext_mask: [[False, False, False, False, False, False, False, False, False, Fals\n\u001b[0me, False, False, False, False]]\ntext_mask shape: (1, 14)\n\nvoice pack shape: (510, 1, 256)\nref_s shape (indexed by phoneme count 12): (1, 256)\nref_s[0,:5]: [-0.23354966938495636, 0.19597655534744263, -0.003190262010321021,\n\u001b[0m-0.12491673231124878, -0.23539023101329803]\n"
+        }
+      ],
+      "execution_count": 12
+    },
+    {
+      "id": "cell-4f4356cf-5e91-4979-b0a2-e356151d1065",
+      "cell_type": "code",
+      "source": [
+        "# BERT + duration prediction\n",
+        "attention_mask = (~text_mask).astype(mx.int32)\n",
+        "bert_dur, _ = model.bert(input_ids, attention_mask=attention_mask)\n",
+        "d_en = model.bert_encoder(bert_dur).transpose(0, 2, 1)\n",
+        "\n",
+        "s = ref_s[:, 128:]  # prosody style\n",
+        "\n",
+        "print(f\"bert_dur shape: {bert_dur.shape}\")\n",
+        "print(f\"d_en shape: {d_en.shape}\")\n",
+        "print(f\"s shape: {s.shape}\")\n",
+        "print(\n",
+        "    f\"d_en mean: {float(mx.mean(d_en)):.6f}, std: {float(mx.sqrt(mx.mean(d_en * d_en))):.6f}\"\n",
+        ")\n",
+        "\n",
+        "# Duration encoding\n",
+        "d = model.predictor.text_encoder(d_en, s, input_lengths, text_mask)\n",
+        "print(f\"\\nd (duration encoded) shape: {d.shape}\")\n",
+        "print(f\"d mean: {float(mx.mean(d)):.6f}\")\n",
+        "\n",
+        "# Duration LSTM\n",
+        "x, _ = model.predictor.lstm(d)\n",
+        "print(f\"lstm out shape: {x.shape}\")\n",
+        "\n",
+        "# Duration projection\n",
+        "duration = model.predictor.duration_proj(x)\n",
+        "duration = mx.sigmoid(duration).sum(axis=-1) / 1.0  # speed=1.0\n",
+        "pred_dur = mx.clip(mx.round(duration), a_min=1, a_max=None).astype(mx.int32)[0]\n",
+        "mx.eval(pred_dur)\n",
+        "\n",
+        "print(f\"\\nduration (pre-round): {duration[0].tolist()}\")\n",
+        "print(f\"pred_dur: {pred_dur.tolist()}\")\n",
+        "print(f\"total_frames: {int(mx.sum(pred_dur))}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "bert_dur shape: (1, 14, 768)\nd_en shape: (1, 512, 14)\ns shape: (1, 128)\nd_en mean: -0.016284, std: 1.045752\n\nd (duration encoded) shape: (1, 14, 640)\nd mean: -0.006935\nlstm out shape: (1, 14, 512)\n\nduration (pre-round): [17.028810501098633, 2.013627529144287, 2.0196692943573, 1\n\u001b[0m.9970686435699463, 2.0101888179779053, 2.073147773742676, 2.0227818489074707, 1.\n\u001b[0m422141671180725, 2.0004937648773193, 2.462941884994507, 4.1396098136901855, 3.19\n\u001b[0m56851482391357, 11.702914237976074, 7.928163528442383]\npred_dur: [17, 2, 2, 2, 2, 2, 2, 1, 2, 2, 4, 3, 12, 8]\ntotal_frames: 61\n"
+        }
+      ],
+      "execution_count": 13
+    },
+    {
+      "id": "cell-79452388-32da-4b6e-ae4c-384b1be46a00",
+      "cell_type": "code",
+      "source": [
+        "# Get Rust intermediate values - add a debug flag that prints durations\n",
+        "# Let's modify the CLI temporarily to dump duration info\n",
+        "\n",
+        "# Actually, easier: write a tiny Rust test that prints the intermediate values\n",
+        "# For now, let's just check the Rust output duration to compare\n",
+        "\n",
+        "rust_wav, rust_ph = rust_generate(\"Hello world\")\n",
+        "rust_audio, _ = sf.read(rust_wav)\n",
+        "\n",
+        "# From Python: total_frames=61, with hop_size=300 (upsample 10*6*5=300)\n",
+        "# expected samples = 61 * 300 = 18300 (plus padding)\n",
+        "# Python produces 36600 samples\n",
+        "# Let's check what the Rust side looks like\n",
+        "\n",
+        "# Actually the istft hop is gen_istft_hop_size=5, and upsample is 10*6=60\n",
+        "# So effective hop = 60 * 5 = 300 samples per frame\n",
+        "# 61 frames * 300 = 18300\n",
+        "\n",
+        "print(f\"Python: 61 frames * 300 hop = 18300 expected samples\")\n",
+        "print(f\"Python actual: 36600 samples (2x expected - likely due to center padding)\")\n",
+        "print(f\"Rust actual: {len(rust_audio)} samples\")\n",
+        "print(f\"Rust / Python ratio: {len(rust_audio) / 36600:.2f}\")\n",
+        "\n",
+        "# If Rust is 60000 samples and Python is 36600, and Python has 61 frames...\n",
+        "# Rust would have about 61 * (60000/36600) = ~100 frames\n",
+        "# That suggests durations are ~1.64x too long\n",
+        "print(f\"\\nIf proportional, Rust frames ~ {61 * len(rust_audio) / 36600:.0f}\")\n",
+        "os.unlink(rust_wav)"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Python: 61 frames * 300 hop = 18300 expected samples\nPython actual: 36600 samples (2x expected - likely due to center padding)\nRust actual: 58800 samples\nRust / Python ratio: 1.61\n\nIf proportional, Rust frames ~ 98\n"
+        }
+      ],
+      "execution_count": 14
+    },
+    {
+      "id": "cell-344e6d79-35f5-4bee-9791-95aa6b86aa9c",
+      "cell_type": "code",
+      "source": [
+        "# Compare intermediate values between Python and Rust\n",
+        "\n",
+        "print(\"=== d_en (BERT encoder output) ===\")\n",
+        "print(f\"  Python: shape (1,512,14), mean: -0.016284, rms: 1.045752\")\n",
+        "print(f\"  Rust:   shape [1,512,14], mean:  0.000983, rms: 1.073082\")\n",
+        "print(f\"  -> Mean is different sign! RMS similar. BERT output diverges slightly.\")\n",
+        "\n",
+        "print(\"\\n=== ref_s (voice embedding) ===\")\n",
+        "print(f\"  Python first5: [-0.2335, 0.1960, -0.0032, -0.1249, -0.2354]\")\n",
+        "print(f\"  Rust   first5: [-0.2342, 0.1981, -0.0026, -0.1251, -0.2329]\")\n",
+        "print(f\"  -> Very close! Voice loading is correct.\")\n",
+        "\n",
+        "print(\"\\n=== s (prosody style, ref_s[:, 128:]) ===\")\n",
+        "print(f\"  Python: (checked via ref_s[0,128:133])\")\n",
+        "\n",
+        "# Actually let me get the Python s values\n",
+        "s_vals = ref_s[0, 128:133].tolist()\n",
+        "print(f\"  Python first5: {s_vals}\")\n",
+        "print(f\"  Rust   first5: [-0.0819, 0.3838, 0.8232, 0.2056, -0.0507]\")\n",
+        "print(f\"  -> Very close! Style extraction correct.\")\n",
+        "\n",
+        "print(\"\\n=== d (duration encoder output) ===\")\n",
+        "print(f\"  Python: shape (1,14,640), mean: -0.006935\")\n",
+        "print(f\"  Rust:   shape [1,14,640], mean: -0.002426\")\n",
+        "print(f\"  -> Starting to diverge (different d_en inputs -> different d)\")\n",
+        "\n",
+        "print(\"\\n=== duration (pre-round) ===\")\n",
+        "py_dur = [\n",
+        "    17.03,\n",
+        "    2.01,\n",
+        "    2.02,\n",
+        "    2.00,\n",
+        "    2.01,\n",
+        "    2.07,\n",
+        "    2.02,\n",
+        "    1.42,\n",
+        "    2.00,\n",
+        "    2.46,\n",
+        "    4.14,\n",
+        "    3.20,\n",
+        "    11.70,\n",
+        "    7.93,\n",
+        "]\n",
+        "rust_dur = [\n",
+        "    17.66,\n",
+        "    3.48,\n",
+        "    3.06,\n",
+        "    2.27,\n",
+        "    3.25,\n",
+        "    8.04,\n",
+        "    17.69,\n",
+        "    2.30,\n",
+        "    3.39,\n",
+        "    14.92,\n",
+        "    3.43,\n",
+        "    2.17,\n",
+        "    6.06,\n",
+        "    13.86,\n",
+        "]\n",
+        "\n",
+        "print(f\"  Python: {py_dur}\")\n",
+        "print(f\"  Rust:   {rust_dur}\")\n",
+        "print(f\"  Ratios: {[f'{r / p:.2f}' for p, r in zip(py_dur, rust_dur)]}\")\n",
+        "print(f\"  -> WILDLY different! Esp: space(2->18), ɜ(2.5->15), d(12->6), EOS(8->14)\")\n",
+        "print(\n",
+        "    f\"  -> The BERT d_en difference cascades through duration encoder -> LSTM -> projection\"\n",
+        ")\n",
+        "\n",
+        "print(\"\\n=== pred_dur ===\")\n",
+        "py_pred = [17, 2, 2, 2, 2, 2, 2, 1, 2, 2, 4, 3, 12, 8]\n",
+        "rust_pred = [18, 3, 3, 2, 3, 8, 18, 2, 3, 15, 3, 2, 6, 14]\n",
+        "print(f\"  Python: {py_pred} -> total {sum(py_pred)}\")\n",
+        "print(f\"  Rust:   {rust_pred} -> total {sum(rust_pred)}\")\n",
+        "\n",
+        "print(\"\\n=== ROOT CAUSE ===\")\n",
+        "print(\"The BERT (ALBERT) encoder produces different output in Rust vs Python.\")\n",
+        "print(\n",
+        "    \"Small differences in d_en get amplified by the duration encoder + LSTM pipeline.\"\n",
+        ")\n",
+        "print(\"Need to investigate the CustomAlbert implementation.\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "=== d_en (BERT encoder output) ===\n  Python: shape (1,512,14), mean: -0.016284, rms: 1.045752\n  Rust:   shape [1,512,14], mean:  0.000983, rms: 1.073082\n  -> Mean is different sign! RMS similar. BERT output diverges slightly.\n\n=== ref_s (voice embedding) ===\n  Python first5: [-0.2335, 0.1960, -0.0032, -0.1249, -0.2354]\n  Rust   first5: [-0.2342, 0.1981, -0.0026, -0.1251, -0.2329]\n  -> Very close! Voice loading is correct.\n\n=== s (prosody style, ref_s[:, 128:]) ===\n  Python: (checked via ref_s[0,128:133])\n  Python first5: [-0.07459218055009842, 0.3677627742290497, 0.7973013520240784,\n\u001b[0m0.20154288411140442, -0.05479338392615318]\n  Rust   first5: [-0.0819, 0.3838, 0.8232, 0.2056, -0.0507]\n  -> Very close! Style extraction correct.\n\n=== d (duration encoder output) ===\n  Python: shape (1,14,640), mean: -0.006935\n  Rust:   shape [1,14,640], mean: -0.002426\n  -> Starting to diverge (different d_en inputs -> different d)\n\n=== duration (pre-round) ===\n  Python: [17.03, 2.01, 2.02, 2.0, 2.01, 2.07, 2.02, 1.42, 2.0, 2.46, 4.14, 3.2,\n\u001b[0m 11.7, 7.93]\n  Rust:   [17.66, 3.48, 3.06, 2.27, 3.25, 8.04, 17.69, 2.3, 3.39, 14.92, 3.43, 2\n\u001b[0m.17, 6.06, 13.86]\n  Ratios: ['1.04', '1.73', '1.51', '1.14', '1.62', '3.88', '8.76', '1.62', '1.70\n\u001b[0m', '6.07', '0.83', '0.68', '0.52', '1.75']\n  -> WILDLY different! Esp: space(2->18), ɜ(2.5->15), d(12->6), EOS(8->14)\n  -> The BERT d_en difference cascades through duration encoder -> LSTM -> proje\n\u001b[0mction\n\n=== pred_dur ===\n  Python: [17, 2, 2, 2, 2, 2, 2, 1, 2, 2, 4, 3, 12, 8] -> total 61\n  Rust:   [18, 3, 3, 2, 3, 8, 18, 2, 3, 15, 3, 2, 6, 14] -> total 100\n\n=== ROOT CAUSE ===\nThe BERT (ALBERT) encoder produces different output in Rust vs Python.\nSmall differences in d_en get amplified by the duration encoder + LSTM pipeline.\nNeed to investigate the CustomAlbert implementation.\n"
+        }
+      ],
+      "execution_count": 15
+    },
+    {
+      "id": "cell-fe6b794e-6916-42dd-be39-977e80c538b2",
+      "cell_type": "code",
+      "source": [
+        "# Check weight keys for the duration encoder\n",
+        "from safetensors.numpy import load_file\n",
+        "from huggingface_hub import hf_hub_download\n",
+        "\n",
+        "path = hf_hub_download(\"prince-canuma/Kokoro-82M\", \"model.safetensors\")\n",
+        "weights = load_file(path)\n",
+        "print(\"=== predictor.text_encoder weights ===\")\n",
+        "for k in sorted(weights.keys()):\n",
+        "    if \"predictor.text_encoder\" in k:\n",
+        "        print(f\"  {k}: {weights[k].shape}\")\n",
+        "\n",
+        "print(\"\\n=== predictor.lstm weights ===\")\n",
+        "for k in sorted(weights.keys()):\n",
+        "    if k.startswith(\"predictor.lstm\"):\n",
+        "        print(f\"  {k}: {weights[k].shape}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "error",
+          "ename": "RemoteEntryNotFoundError",
+          "evalue": "404 Client Error. (Request ID: Root=1-69ba1dfe-55c9f7b132c9d7d8635e5dd6;740c0d2e-3e56-4985-9ddd-844fd55c68c4)\n\nEntry Not Found for url: https://huggingface.co/prince-canuma/Kokoro-82M/resolve/main/model.safetensors.",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mHTTPStatusError\u001b[39m                           Traceback (most recent call last)",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.12/site-packages/huggingface_hub/utils/_http.py:761\u001b[39m, in \u001b[36mhf_raise_for_status\u001b[39m\u001b[34m(response, endpoint_name)\u001b[39m\n\u001b[32m    760\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m761\u001b[39m     \u001b[43mresponse\u001b[49m\u001b[43m.\u001b[49m\u001b[43mraise_for_status\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    762\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m httpx.HTTPStatusError \u001b[38;5;28;01mas\u001b[39;00m e:\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.12/site-packages/httpx/_models.py:829\u001b[39m, in \u001b[36mResponse.raise_for_status\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m    828\u001b[39m message = message.format(\u001b[38;5;28mself\u001b[39m, error_type=error_type)\n\u001b[32m--> \u001b[39m\u001b[32m829\u001b[39m \u001b[38;5;28;01mraise\u001b[39;00m HTTPStatusError(message, request=request, response=\u001b[38;5;28mself\u001b[39m)\n",
+            "\u001b[31mHTTPStatusError\u001b[39m: Client error '404 Not Found' for url 'https://huggingface.co/prince-canuma/Kokoro-82M/resolve/main/model.safetensors'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404",
+            "\nThe above exception was the direct cause of the following exception:\n",
+            "\u001b[31mRemoteEntryNotFoundError\u001b[39m                  Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[16]\u001b[39m\u001b[32m, line 5\u001b[39m\n\u001b[32m      2\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01msafetensors\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mnumpy\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m load_file\n\u001b[32m      3\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mhuggingface_hub\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m hf_hub_download\n\u001b[32m----> \u001b[39m\u001b[32m5\u001b[39m path = \u001b[43mhf_hub_download\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mprince-canuma/Kokoro-82M\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mmodel.safetensors\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[32m      6\u001b[39m weights = load_file(path)\n\u001b[32m      7\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33m\"\u001b[39m\u001b[33m=== predictor.text_encoder weights ===\u001b[39m\u001b[33m\"\u001b[39m)\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.12/site-packages/huggingface_hub/utils/_validators.py:89\u001b[39m, in \u001b[36mvalidate_hf_hub_args.<locals>._inner_fn\u001b[39m\u001b[34m(*args, **kwargs)\u001b[39m\n\u001b[32m     85\u001b[39m         validate_repo_id(arg_value)\n\u001b[32m     87\u001b[39m kwargs = smoothly_deprecate_legacy_arguments(fn_name=fn.\u001b[34m__name__\u001b[39m, kwargs=kwargs)\n\u001b[32m---> \u001b[39m\u001b[32m89\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfn\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.12/site-packages/huggingface_hub/file_download.py:986\u001b[39m, in \u001b[36mhf_hub_download\u001b[39m\u001b[34m(repo_id, filename, subfolder, repo_type, revision, library_name, library_version, cache_dir, local_dir, user_agent, force_download, etag_timeout, token, local_files_only, headers, endpoint, tqdm_class, dry_run)\u001b[39m\n\u001b[32m    965\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m _hf_hub_download_to_local_dir(\n\u001b[32m    966\u001b[39m         \u001b[38;5;66;03m# Destination\u001b[39;00m\n\u001b[32m    967\u001b[39m         local_dir=local_dir,\n\u001b[32m   (...)\u001b[39m\u001b[32m    983\u001b[39m         dry_run=dry_run,\n\u001b[32m    984\u001b[39m     )\n\u001b[32m    985\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m986\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43m_hf_hub_download_to_cache_dir\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m    987\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;66;43;03m# Destination\u001b[39;49;00m\n\u001b[32m    988\u001b[39m \u001b[43m        \u001b[49m\u001b[43mcache_dir\u001b[49m\u001b[43m=\u001b[49m\u001b[43mcache_dir\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    989\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;66;43;03m# File info\u001b[39;49;00m\n\u001b[32m    990\u001b[39m \u001b[43m        \u001b[49m\u001b[43mrepo_id\u001b[49m\u001b[43m=\u001b[49m\u001b[43mrepo_id\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    991\u001b[39m \u001b[43m        \u001b[49m\u001b[43mfilename\u001b[49m\u001b[43m=\u001b[49m\u001b[43mfilename\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    992\u001b[39m \u001b[43m        \u001b[49m\u001b[43mrepo_type\u001b[49m\u001b[43m=\u001b[49m\u001b[43mrepo_type\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    993\u001b[39m \u001b[43m        \u001b[49m\u001b[43mrevision\u001b[49m\u001b[43m=\u001b[49m\u001b[43mrevision\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    994\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;66;43;03m# HTTP info\u001b[39;49;00m\n\u001b[32m    995\u001b[39m \u001b[43m        \u001b[49m\u001b[43mendpoint\u001b[49m\u001b[43m=\u001b[49m\u001b[43mendpoint\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    996\u001b[39m \u001b[43m        \u001b[49m\u001b[43metag_timeout\u001b[49m\u001b[43m=\u001b[49m\u001b[43metag_timeout\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    997\u001b[39m \u001b[43m        \u001b[49m\u001b[43mheaders\u001b[49m\u001b[43m=\u001b[49m\u001b[43mhf_headers\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    998\u001b[39m \u001b[43m        \u001b[49m\u001b[43mtoken\u001b[49m\u001b[43m=\u001b[49m\u001b[43mtoken\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    999\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;66;43;03m# Additional options\u001b[39;49;00m\n\u001b[32m   1000\u001b[39m \u001b[43m        \u001b[49m\u001b[43mlocal_files_only\u001b[49m\u001b[43m=\u001b[49m\u001b[43mlocal_files_only\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1001\u001b[39m \u001b[43m        \u001b[49m\u001b[43mforce_download\u001b[49m\u001b[43m=\u001b[49m\u001b[43mforce_download\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1002\u001b[39m \u001b[43m        \u001b[49m\u001b[43mtqdm_class\u001b[49m\u001b[43m=\u001b[49m\u001b[43mtqdm_class\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1003\u001b[39m \u001b[43m        \u001b[49m\u001b[43mdry_run\u001b[49m\u001b[43m=\u001b[49m\u001b[43mdry_run\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1004\u001b[39m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.12/site-packages/huggingface_hub/file_download.py:1061\u001b[39m, in \u001b[36m_hf_hub_download_to_cache_dir\u001b[39m\u001b[34m(cache_dir, repo_id, filename, repo_type, revision, endpoint, etag_timeout, headers, token, local_files_only, force_download, tqdm_class, dry_run)\u001b[39m\n\u001b[32m   1057\u001b[39m             \u001b[38;5;28;01mreturn\u001b[39;00m pointer_path\n\u001b[32m   1059\u001b[39m \u001b[38;5;66;03m# Try to get metadata (etag, commit_hash, url, size) from the server.\u001b[39;00m\n\u001b[32m   1060\u001b[39m \u001b[38;5;66;03m# If we can't, a HEAD request error is returned.\u001b[39;00m\n\u001b[32m-> \u001b[39m\u001b[32m1061\u001b[39m (url_to_download, etag, commit_hash, expected_size, xet_file_data, head_call_error) = \u001b[43m_get_metadata_or_catch_error\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m   1062\u001b[39m \u001b[43m    \u001b[49m\u001b[43mrepo_id\u001b[49m\u001b[43m=\u001b[49m\u001b[43mrepo_id\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1063\u001b[39m \u001b[43m    \u001b[49m\u001b[43mfilename\u001b[49m\u001b[43m=\u001b[49m\u001b[43mfilename\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1064\u001b[39m \u001b[43m    \u001b[49m\u001b[43mrepo_type\u001b[49m\u001b[43m=\u001b[49m\u001b[43mrepo_type\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1065\u001b[39m \u001b[43m    \u001b[49m\u001b[43mrevision\u001b[49m\u001b[43m=\u001b[49m\u001b[43mrevision\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1066\u001b[39m \u001b[43m    \u001b[49m\u001b[43mendpoint\u001b[49m\u001b[43m=\u001b[49m\u001b[43mendpoint\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1067\u001b[39m \u001b[43m    \u001b[49m\u001b[43metag_timeout\u001b[49m\u001b[43m=\u001b[49m\u001b[43metag_timeout\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1068\u001b[39m \u001b[43m    \u001b[49m\u001b[43mheaders\u001b[49m\u001b[43m=\u001b[49m\u001b[43mheaders\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1069\u001b[39m \u001b[43m    \u001b[49m\u001b[43mtoken\u001b[49m\u001b[43m=\u001b[49m\u001b[43mtoken\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1070\u001b[39m \u001b[43m    \u001b[49m\u001b[43mlocal_files_only\u001b[49m\u001b[43m=\u001b[49m\u001b[43mlocal_files_only\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1071\u001b[39m \u001b[43m    \u001b[49m\u001b[43mstorage_folder\u001b[49m\u001b[43m=\u001b[49m\u001b[43mstorage_folder\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1072\u001b[39m \u001b[43m    \u001b[49m\u001b[43mrelative_filename\u001b[49m\u001b[43m=\u001b[49m\u001b[43mrelative_filename\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1073\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1075\u001b[39m \u001b[38;5;66;03m# etag can be None for several reasons:\u001b[39;00m\n\u001b[32m   1076\u001b[39m \u001b[38;5;66;03m# 1. we passed local_files_only.\u001b[39;00m\n\u001b[32m   1077\u001b[39m \u001b[38;5;66;03m# 2. we don't have a connection\u001b[39;00m\n\u001b[32m   (...)\u001b[39m\u001b[32m   1083\u001b[39m \u001b[38;5;66;03m# If the specified revision is a commit hash, look inside \"snapshots\".\u001b[39;00m\n\u001b[32m   1084\u001b[39m \u001b[38;5;66;03m# If the specified revision is a branch or tag, look inside \"refs\".\u001b[39;00m\n\u001b[32m   1085\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m head_call_error \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m   1086\u001b[39m     \u001b[38;5;66;03m# Couldn't make a HEAD call => let's try to find a local file\u001b[39;00m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.12/site-packages/huggingface_hub/file_download.py:1653\u001b[39m, in \u001b[36m_get_metadata_or_catch_error\u001b[39m\u001b[34m(repo_id, filename, repo_type, revision, endpoint, etag_timeout, headers, token, local_files_only, relative_filename, storage_folder, retry_on_errors)\u001b[39m\n\u001b[32m   1651\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m   1652\u001b[39m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m-> \u001b[39m\u001b[32m1653\u001b[39m         metadata = \u001b[43mget_hf_file_metadata\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m   1654\u001b[39m \u001b[43m            \u001b[49m\u001b[43murl\u001b[49m\u001b[43m=\u001b[49m\u001b[43murl\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1655\u001b[39m \u001b[43m            \u001b[49m\u001b[43mtimeout\u001b[49m\u001b[43m=\u001b[49m\u001b[43metag_timeout\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1656\u001b[39m \u001b[43m            \u001b[49m\u001b[43mheaders\u001b[49m\u001b[43m=\u001b[49m\u001b[43mheaders\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1657\u001b[39m \u001b[43m            \u001b[49m\u001b[43mtoken\u001b[49m\u001b[43m=\u001b[49m\u001b[43mtoken\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1658\u001b[39m \u001b[43m            \u001b[49m\u001b[43mendpoint\u001b[49m\u001b[43m=\u001b[49m\u001b[43mendpoint\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1659\u001b[39m \u001b[43m            \u001b[49m\u001b[43mretry_on_errors\u001b[49m\u001b[43m=\u001b[49m\u001b[43mretry_on_errors\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1660\u001b[39m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1661\u001b[39m     \u001b[38;5;28;01mexcept\u001b[39;00m RemoteEntryNotFoundError \u001b[38;5;28;01mas\u001b[39;00m http_error:\n\u001b[32m   1662\u001b[39m         \u001b[38;5;28;01mif\u001b[39;00m storage_folder \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mand\u001b[39;00m relative_filename \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m   1663\u001b[39m             \u001b[38;5;66;03m# Cache the non-existence of the file\u001b[39;00m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.12/site-packages/huggingface_hub/utils/_validators.py:89\u001b[39m, in \u001b[36mvalidate_hf_hub_args.<locals>._inner_fn\u001b[39m\u001b[34m(*args, **kwargs)\u001b[39m\n\u001b[32m     85\u001b[39m         validate_repo_id(arg_value)\n\u001b[32m     87\u001b[39m kwargs = smoothly_deprecate_legacy_arguments(fn_name=fn.\u001b[34m__name__\u001b[39m, kwargs=kwargs)\n\u001b[32m---> \u001b[39m\u001b[32m89\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfn\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.12/site-packages/huggingface_hub/file_download.py:1576\u001b[39m, in \u001b[36mget_hf_file_metadata\u001b[39m\u001b[34m(url, token, timeout, library_name, library_version, user_agent, headers, endpoint, retry_on_errors)\u001b[39m\n\u001b[32m   1573\u001b[39m hf_headers[\u001b[33m\"\u001b[39m\u001b[33mAccept-Encoding\u001b[39m\u001b[33m\"\u001b[39m] = \u001b[33m\"\u001b[39m\u001b[33midentity\u001b[39m\u001b[33m\"\u001b[39m  \u001b[38;5;66;03m# prevent any compression => we want to know the real size of the file\u001b[39;00m\n\u001b[32m   1575\u001b[39m \u001b[38;5;66;03m# Retrieve metadata\u001b[39;00m\n\u001b[32m-> \u001b[39m\u001b[32m1576\u001b[39m response = \u001b[43m_httpx_follow_relative_redirects_with_backoff\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m   1577\u001b[39m \u001b[43m    \u001b[49m\u001b[43mmethod\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mHEAD\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43murl\u001b[49m\u001b[43m=\u001b[49m\u001b[43murl\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mheaders\u001b[49m\u001b[43m=\u001b[49m\u001b[43mhf_headers\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtimeout\u001b[49m\u001b[43m=\u001b[49m\u001b[43mtimeout\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mretry_on_errors\u001b[49m\u001b[43m=\u001b[49m\u001b[43mretry_on_errors\u001b[49m\n\u001b[32m   1578\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1579\u001b[39m hf_raise_for_status(response)\n\u001b[32m   1581\u001b[39m \u001b[38;5;66;03m# Return\u001b[39;00m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.12/site-packages/huggingface_hub/utils/_http.py:692\u001b[39m, in \u001b[36m_httpx_follow_relative_redirects_with_backoff\u001b[39m\u001b[34m(method, url, retry_on_errors, **httpx_kwargs)\u001b[39m\n\u001b[32m    684\u001b[39m \u001b[38;5;28;01mwhile\u001b[39;00m \u001b[38;5;28;01mTrue\u001b[39;00m:\n\u001b[32m    685\u001b[39m     response = http_backoff(\n\u001b[32m    686\u001b[39m         method=method,\n\u001b[32m    687\u001b[39m         url=url,\n\u001b[32m   (...)\u001b[39m\u001b[32m    690\u001b[39m         **no_retry_kwargs,\n\u001b[32m    691\u001b[39m     )\n\u001b[32m--> \u001b[39m\u001b[32m692\u001b[39m     \u001b[43mhf_raise_for_status\u001b[49m\u001b[43m(\u001b[49m\u001b[43mresponse\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    694\u001b[39m     \u001b[38;5;66;03m# Check if response is a relative redirect\u001b[39;00m\n\u001b[32m    695\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[32m300\u001b[39m <= response.status_code <= \u001b[32m399\u001b[39m:\n",
+            "\u001b[36mFile \u001b[39m\u001b[32m~/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.12/site-packages/huggingface_hub/utils/_http.py:787\u001b[39m, in \u001b[36mhf_raise_for_status\u001b[39m\u001b[34m(response, endpoint_name)\u001b[39m\n\u001b[32m    785\u001b[39m     entry_err.repo_type = repo_type\n\u001b[32m    786\u001b[39m     entry_err.repo_id = repo_id\n\u001b[32m--> \u001b[39m\u001b[32m787\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m entry_err \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01me\u001b[39;00m\n\u001b[32m    789\u001b[39m \u001b[38;5;28;01melif\u001b[39;00m error_code == \u001b[33m\"\u001b[39m\u001b[33mGatedRepo\u001b[39m\u001b[33m\"\u001b[39m:\n\u001b[32m    790\u001b[39m     message = (\n\u001b[32m    791\u001b[39m         \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mresponse.status_code\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m Client Error.\u001b[39m\u001b[33m\"\u001b[39m + \u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33m\"\u001b[39m + \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mCannot access gated repo for url \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mresponse.url\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    792\u001b[39m     )\n",
+            "\u001b[31mRemoteEntryNotFoundError\u001b[39m: 404 Client Error. (Request ID: Root=1-69ba1dfe-55c9f7b132c9d7d8635e5dd6;740c0d2e-3e56-4985-9ddd-844fd55c68c4)\n\nEntry Not Found for url: https://huggingface.co/prince-canuma/Kokoro-82M/resolve/main/model.safetensors."
+          ]
+        }
+      ],
+      "execution_count": 16
+    },
+    {
+      "id": "cell-0b679825-3a44-45ee-bae3-e58de188c587",
+      "cell_type": "code",
+      "source": [
+        "# Check weight keys using the local cache\n",
+        "from safetensors.numpy import load_file\n",
+        "import os\n",
+        "\n",
+        "SNAPSHOT = os.path.expanduser(\n",
+        "    \"~/.cache/huggingface/hub/models--prince-canuma--Kokoro-82M/snapshots/e02c9eada7ce7416798af36b190a8a2dd2ecd566\"\n",
+        ")\n",
+        "weights = load_file(os.path.join(SNAPSHOT, \"kokoro-v1_0.safetensors\"))\n",
+        "\n",
+        "print(\"=== predictor.text_encoder weights ===\")\n",
+        "for k in sorted(weights.keys()):\n",
+        "    if \"predictor.text_encoder\" in k:\n",
+        "        print(f\"  {k}: {weights[k].shape}\")\n",
+        "\n",
+        "print(\"\\n=== predictor.lstm weights ===\")\n",
+        "for k in sorted(weights.keys()):\n",
+        "    if k.startswith(\"predictor.lstm\"):\n",
+        "        print(f\"  {k}: {weights[k].shape}\")\n",
+        "\n",
+        "print(\"\\n=== predictor.duration_proj ===\")\n",
+        "for k in sorted(weights.keys()):\n",
+        "    if \"duration_proj\" in k:\n",
+        "        print(f\"  {k}: {weights[k].shape}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "=== predictor.text_encoder weights ===\n  predictor.text_encoder.lstms.0.bias_hh_l0: (1024,)\n  predictor.text_encoder.lstms.0.bias_hh_l0_reverse: (1024,)\n  predictor.text_encoder.lstms.0.bias_ih_l0: (1024,)\n  predictor.text_encoder.lstms.0.bias_ih_l0_reverse: (1024,)\n  predictor.text_encoder.lstms.0.weight_hh_l0: (1024, 256)\n  predictor.text_encoder.lstms.0.weight_hh_l0_reverse: (1024, 256)\n  predictor.text_encoder.lstms.0.weight_ih_l0: (1024, 640)\n  predictor.text_encoder.lstms.0.weight_ih_l0_reverse: (1024, 640)\n  predictor.text_encoder.lstms.1.fc.bias: (1024,)\n  predictor.text_encoder.lstms.1.fc.weight: (1024, 128)\n  predictor.text_encoder.lstms.2.bias_hh_l0: (1024,)\n  predictor.text_encoder.lstms.2.bias_hh_l0_reverse: (1024,)\n  predictor.text_encoder.lstms.2.bias_ih_l0: (1024,)\n  predictor.text_encoder.lstms.2.bias_ih_l0_reverse: (1024,)\n  predictor.text_encoder.lstms.2.weight_hh_l0: (1024, 256)\n  predictor.text_encoder.lstms.2.weight_hh_l0_reverse: (1024, 256)\n  predictor.text_encoder.lstms.2.weight_ih_l0: (1024, 640)\n  predictor.text_encoder.lstms.2.weight_ih_l0_reverse: (1024, 640)\n  predictor.text_encoder.lstms.3.fc.bias: (1024,)\n  predictor.text_encoder.lstms.3.fc.weight: (1024, 128)\n  predictor.text_encoder.lstms.4.bias_hh_l0: (1024,)\n  predictor.text_encoder.lstms.4.bias_hh_l0_reverse: (1024,)\n  predictor.text_encoder.lstms.4.bias_ih_l0: (1024,)\n  predictor.text_encoder.lstms.4.bias_ih_l0_reverse: (1024,)\n  predictor.text_encoder.lstms.4.weight_hh_l0: (1024, 256)\n  predictor.text_encoder.lstms.4.weight_hh_l0_reverse: (1024, 256)\n  predictor.text_encoder.lstms.4.weight_ih_l0: (1024, 640)\n  predictor.text_encoder.lstms.4.weight_ih_l0_reverse: (1024, 640)\n  predictor.text_encoder.lstms.5.fc.bias: (1024,)\n  predictor.text_encoder.lstms.5.fc.weight: (1024, 128)\n\n=== predictor.lstm weights ===\n  predictor.lstm.bias_hh_l0: (1024,)\n  predictor.lstm.bias_hh_l0_reverse: (1024,)\n  predictor.lstm.bias_ih_l0: (1024,)\n  predictor.lstm.bias_ih_l0_reverse: (1024,)\n  predictor.lstm.weight_hh_l0: (1024, 256)\n  predictor.lstm.weight_hh_l0_reverse: (1024, 256)\n  predictor.lstm.weight_ih_l0: (1024, 640)\n  predictor.lstm.weight_ih_l0_reverse: (1024, 640)\n\n=== predictor.duration_proj ===\n  predictor.duration_proj.linear_layer.bias: (50,)\n  predictor.duration_proj.linear_layer.weight: (50, 512)\n"
+        }
+      ],
+      "execution_count": 17
+    },
+    {
+      "id": "cell-9abba0d2-06a4-44fe-9bd7-a2f4d4b518a6",
+      "cell_type": "code",
+      "source": [
+        "# Instrument Python DurationEncoder step by step\n",
+        "import mlx.core as mx\n",
+        "\n",
+        "# Re-use the already-computed values from earlier cells\n",
+        "# d_en, s, input_lengths, text_mask are all still in scope\n",
+        "\n",
+        "# Manually run DurationEncoder\n",
+        "dur_enc = model.predictor.text_encoder\n",
+        "\n",
+        "x = d_en  # (1, 512, 14)\n",
+        "style = s  # (1, 128)\n",
+        "m = text_mask  # (1, 14)\n",
+        "\n",
+        "x = x.transpose(2, 0, 1)  # (14, 1, 512)\n",
+        "s_broad = mx.broadcast_to(style, (x.shape[0], x.shape[1], style.shape[-1]))\n",
+        "x = mx.concatenate([x, s_broad], axis=-1)  # (14, 1, 640)\n",
+        "x = mx.where(m[..., None].transpose(1, 0, 2), 0.0, x)\n",
+        "x = x.transpose(1, 2, 0)  # (1, 640, 14)\n",
+        "\n",
+        "print(f\"Initial: shape={x.shape}, mean={float(mx.mean(x)):.6f}\")\n",
+        "\n",
+        "for bi, block in enumerate(dur_enc.lstms):\n",
+        "    mx.eval(x)\n",
+        "    print(f\"  Block {bi} input: shape={x.shape}, mean={float(mx.mean(x)):.6f}\")\n",
+        "\n",
+        "    if hasattr(block, \"fc\"):  # AdaLayerNorm\n",
+        "        x = block(x.transpose(0, 2, 1), style).transpose(0, 2, 1)\n",
+        "        x = mx.concatenate([x, s_broad.transpose(1, 2, 0)], axis=1)\n",
+        "        x = mx.where(m[..., None].transpose(0, 2, 1), 0.0, x)\n",
+        "    else:  # LSTM\n",
+        "        x_for_lstm = x.transpose(0, 2, 1)[0]  # (14, 640)\n",
+        "        x_lstm_out, _ = block(x_for_lstm)\n",
+        "        x = x_lstm_out.transpose(0, 2, 1)\n",
+        "        x_pad = mx.zeros([x.shape[0], x.shape[1], m.shape[-1]])\n",
+        "        x_pad[:, :, : x.shape[-1]] = x\n",
+        "        x = x_pad\n",
+        "\n",
+        "mx.eval(x)\n",
+        "x_final = x.transpose(0, 2, 1)\n",
+        "print(f\"\\nFinal: shape={x_final.shape}, mean={float(mx.mean(x_final)):.6f}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Initial: shape=(1, 640, 14), mean=-0.005801\n  Block 0 input: shape=(1, 640, 14), mean=-0.005801\n  Block 1 input: shape=(1, 512, 14), mean=-0.005467\n  Block 2 input: shape=(1, 640, 14), mean=0.024576\n  Block 3 input: shape=(1, 512, 14), mean=0.001655\n  Block 4 input: shape=(1, 640, 14), mean=-0.001214\n  Block 5 input: shape=(1, 512, 14), mean=-0.007109\n\nFinal: shape=(1, 14, 640), mean=-0.006935\n"
+        }
+      ],
+      "execution_count": 18
+    },
+    {
+      "id": "cell-6b2b57ab-59e7-4f75-8a89-1ce19e35dc14",
+      "cell_type": "code",
+      "source": [
+        "# Check the actual weight values for the first DurationEncoder LSTM\n",
+        "lstm0 = dur_enc.lstms[0]\n",
+        "print(f\"Type: {type(lstm0)}\")\n",
+        "print(f\"Wx_forward shape: {lstm0.Wx_forward.shape}\")\n",
+        "print(f\"Wh_forward shape: {lstm0.Wh_forward.shape}\")\n",
+        "print(\n",
+        "    f\"bias_ih_forward: {lstm0.bias_ih_forward.shape if lstm0.bias_ih_forward is not None else None}\"\n",
+        ")\n",
+        "print(\n",
+        "    f\"bias_hh_forward: {lstm0.bias_hh_forward.shape if lstm0.bias_hh_forward is not None else None}\"\n",
+        ")\n",
+        "\n",
+        "# Get first few values of Wx_forward\n",
+        "wx_fwd = lstm0.Wx_forward\n",
+        "mx.eval(wx_fwd)\n",
+        "print(f\"\\nWx_forward[0,:5]: {wx_fwd[0, :5].tolist()}\")\n",
+        "\n",
+        "# Combined bias\n",
+        "bias_combined = lstm0.bias_ih_forward + lstm0.bias_hh_forward\n",
+        "mx.eval(bias_combined)\n",
+        "print(f\"Combined bias[:5]: {bias_combined[:5].tolist()}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Type: <class 'mlx_audio.tts.models.kokoro.modules.LSTM'>\nWx_forward shape: (1024, 640)\nWh_forward shape: (1024, 256)\nbias_ih_forward: (1024,)\nbias_hh_forward: (1024,)\n\nWx_forward[0,:5]: [0.0005577385309152305, -0.041339144110679626, 0.1754166036844\n\u001b[0m2535, -0.10248763114213943, 0.06687430292367935]\nCombined bias[:5]: [0.004875728860497475, -0.17237330973148346, 0.09251148998737\n\u001b[0m335, -0.01823487877845764, 0.2256598174571991]\n"
+        }
+      ],
+      "execution_count": 19
+    },
+    {
+      "id": "cell-52ae9ebf-7d46-4ec1-9d9d-6b2dd63cad30",
+      "cell_type": "code",
+      "source": [
+        "# Trace exact shapes through the Python DurationEncoder\n",
+        "x = d_en  # (1, 512, 14)\n",
+        "style_in = s\n",
+        "m = text_mask\n",
+        "\n",
+        "x = x.transpose(2, 0, 1)  # (14, 1, 512)\n",
+        "s_broad = mx.broadcast_to(style_in, (x.shape[0], x.shape[1], style_in.shape[-1]))\n",
+        "x = mx.concatenate([x, s_broad], axis=-1)  # (14, 1, 640)\n",
+        "x = mx.where(m[..., None].transpose(1, 0, 2), 0.0, x)\n",
+        "x = x.transpose(1, 2, 0)  # (1, 640, 14)\n",
+        "print(f\"After init: {x.shape}\")\n",
+        "\n",
+        "for bi, block in enumerate(dur_enc.lstms):\n",
+        "    if hasattr(block, \"fc\"):  # AdaLayerNorm\n",
+        "        xt = x.transpose(0, 2, 1)\n",
+        "        print(f\"  Block {bi} (Norm): input shape {xt.shape}\")\n",
+        "        x = block(xt, style_in).transpose(0, 2, 1)\n",
+        "        print(f\"    after norm: {x.shape}\")\n",
+        "        x = mx.concatenate([x, s_broad.transpose(1, 2, 0)], axis=1)\n",
+        "        print(f\"    after concat: {x.shape}\")\n",
+        "        x = mx.where(m[..., None].transpose(0, 2, 1), 0.0, x)\n",
+        "    else:  # LSTM\n",
+        "        xt = x.transpose(0, 2, 1)\n",
+        "        print(f\"  Block {bi} (LSTM): pre-transpose shape {xt.shape}\")\n",
+        "        xt0 = xt[0]\n",
+        "        print(f\"    after [0]: {xt0.shape}\")\n",
+        "        h, _ = block(xt0)\n",
+        "        print(f\"    LSTM output: {h.shape}\")\n",
+        "        x = h.transpose(0, 2, 1) if h.ndim == 3 else h.T\n",
+        "        print(f\"    after transpose: {x.shape}\")\n",
+        "        x_pad = mx.zeros([x.shape[0], x.shape[1], m.shape[-1]])\n",
+        "        x_pad = x_pad.at[:, :, : x.shape[-1]].add(x)\n",
+        "        x = x_pad\n",
+        "        print(f\"    after pad: {x.shape}\")\n",
+        "\n",
+        "print(f\"\\nFinal: {x.transpose(0, 2, 1).shape}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "After init: (1, 640, 14)\n  Block 0 (LSTM): pre-transpose shape (1, 14, 640)\n    after [0]: (14, 640)\n    LSTM output: (1, 14, 512)\n    after transpose: (1, 512, 14)\n    after pad: (1, 512, 14)\n  Block 1 (Norm): input shape (1, 14, 512)\n    after norm: (1, 512, 14)\n    after concat: (1, 640, 14)\n  Block 2 (LSTM): pre-transpose shape (1, 14, 640)\n    after [0]: (14, 640)\n    LSTM output: (1, 14, 512)\n    after transpose: (1, 512, 14)\n    after pad: (1, 512, 14)\n  Block 3 (Norm): input shape (1, 14, 512)\n    after norm: (1, 512, 14)\n    after concat: (1, 640, 14)\n  Block 4 (LSTM): pre-transpose shape (1, 14, 640)\n    after [0]: (14, 640)\n    LSTM output: (1, 14, 512)\n    after transpose: (1, 512, 14)\n    after pad: (1, 512, 14)\n  Block 5 (Norm): input shape (1, 14, 512)\n    after norm: (1, 512, 14)\n    after concat: (1, 640, 14)\n\nFinal: (1, 14, 640)\n"
+        }
+      ],
+      "execution_count": 20
+    },
+    {
+      "id": "cell-bdcb5823-0cab-4bce-b4ce-2b083521f3b2",
+      "cell_type": "code",
+      "source": [
+        "# Check backward weights\n",
+        "lstm0 = dur_enc.lstms[0]\n",
+        "wx_bwd = lstm0.Wx_backward\n",
+        "mx.eval(wx_bwd)\n",
+        "print(f\"Wx_backward[0,:5]: {wx_bwd[0, :5].tolist()}\")\n",
+        "\n",
+        "bias_bwd = lstm0.bias_ih_backward + lstm0.bias_hh_backward\n",
+        "mx.eval(bias_bwd)\n",
+        "print(f\"Combined backward bias[:5]: {bias_bwd[:5].tolist()}\")\n",
+        "\n",
+        "wh_fwd = lstm0.Wh_forward\n",
+        "mx.eval(wh_fwd)\n",
+        "print(f\"Wh_forward[0,:5]: {wh_fwd[0, :5].tolist()}\")\n",
+        "\n",
+        "wh_bwd = lstm0.Wh_backward\n",
+        "mx.eval(wh_bwd)\n",
+        "print(f\"Wh_backward[0,:5]: {wh_bwd[0, :5].tolist()}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Wx_backward[0,:5]: [0.07535813003778458, 0.015768224373459816, 0.038377407938241\n\u001b[0m96, -0.05646621435880661, 0.059998419135808945]\nCombined backward bias[:5]: [0.008811943233013153, 0.07471653074026108, 0.241935\n\u001b[0m8789920807, -0.18136098980903625, 0.07517142593860626]\nWh_forward[0,:5]: [-0.00253816950134933, -0.05682491883635521, -0.08022928237915\n\u001b[0m039, 0.1669272631406784, -0.04581911861896515]\nWh_backward[0,:5]: [0.023976480588316917, -0.13653622567653656, -0.0113054495304\n\u001b[0m82292, -0.0346134789288044, -0.08951855450868607]\n"
+        }
+      ],
+      "execution_count": 21
+    },
+    {
+      "id": "cell-c3903902-94cc-41e7-a4a6-e1069f6639bc",
+      "cell_type": "code",
+      "source": [
+        "# Quick A/B test with the LSTM recurrence fix\n",
+        "import subprocess, os, tempfile\n",
+        "import soundfile as sf\n",
+        "\n",
+        "REPO_ROOT = os.path.dirname(os.getcwd())\n",
+        "VOICERS_CLI = os.path.join(REPO_ROOT, \"target/release/voicers-cli\")\n",
+        "\n",
+        "\n",
+        "def rust_gen(text, voice=\"af_heart\"):\n",
+        "    wav = tempfile.mktemp(suffix=\".wav\")\n",
+        "    subprocess.run(\n",
+        "        [VOICERS_CLI, \"--text\", text, \"--voice\", voice, \"--output\", wav],\n",
+        "        capture_output=True,\n",
+        "        text=True,\n",
+        "        timeout=120,\n",
+        "    )\n",
+        "    return wav\n",
+        "\n",
+        "\n",
+        "test_phrases = [\n",
+        "    \"Hello world\",\n",
+        "    \"Good morning\",\n",
+        "    \"The quick brown fox\",\n",
+        "    \"How are you doing today?\",\n",
+        "    \"She sells seashells by the seashore.\",\n",
+        "    \"I read a book yesterday.\",\n",
+        "    \"The dog is running in the park.\",\n",
+        "]\n",
+        "\n",
+        "print(f\"{'Input':<45} {'Python Whisper':<40} {'Rust Whisper'}\")\n",
+        "print(\"=\" * 125)\n",
+        "\n",
+        "for phrase in test_phrases:\n",
+        "    py_wav = python_generate(phrase)\n",
+        "    py_heard = transcribe(py_wav) if py_wav else \"FAILED\"\n",
+        "    os.unlink(py_wav) if py_wav else None\n",
+        "\n",
+        "    rust_wav = rust_gen(phrase)\n",
+        "    rust_heard = transcribe(rust_wav)\n",
+        "    os.unlink(rust_wav)\n",
+        "\n",
+        "    print(f\"{phrase:<45} {py_heard[:38]:<40} {rust_heard[:38]}\")\n",
+        "\n",
+        "print(\"\\nDone!\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Python Whisper\n\u001b[0m       Rust Whisper\n================================================================================\n\u001b[0m=============================================\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Python Whisper\n\u001b[0m       Rust Whisper\n================================================================================\n\u001b[0m=============================================\nHello world                                   Hello world.\n\u001b[0m       Hello world.\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Python Whisper\n\u001b[0m       Rust Whisper\n================================================================================\n\u001b[0m=============================================\nHello world                                   Hello world.\n\u001b[0m       Hello world.\nGood morning                                  Good morning.\n\u001b[0m       Good morning.\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Python Whisper\n\u001b[0m       Rust Whisper\n================================================================================\n\u001b[0m=============================================\nHello world                                   Hello world.\n\u001b[0m       Hello world.\nGood morning                                  Good morning.\n\u001b[0m       Good morning.\nThe quick brown fox                           The quick brown fox.\n\u001b[0m       The quick brown fox.\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Python Whisper\n\u001b[0m       Rust Whisper\n================================================================================\n\u001b[0m=============================================\nHello world                                   Hello world.\n\u001b[0m       Hello world.\nGood morning                                  Good morning.\n\u001b[0m       Good morning.\nThe quick brown fox                           The quick brown fox.\n\u001b[0m       The quick brown fox.\nHow are you doing today?                      How are you doing today?\n\u001b[0m       How are you doing today?\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Python Whisper\n\u001b[0m       Rust Whisper\n================================================================================\n\u001b[0m=============================================\nHello world                                   Hello world.\n\u001b[0m       Hello world.\nGood morning                                  Good morning.\n\u001b[0m       Good morning.\nThe quick brown fox                           The quick brown fox.\n\u001b[0m       The quick brown fox.\nHow are you doing today?                      How are you doing today?\n\u001b[0m       How are you doing today?\nShe sells seashells by the seashore.          She sells seashells by the seashor\n\u001b[0me.     She sells seashells by the seashore.\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Python Whisper\n\u001b[0m       Rust Whisper\n================================================================================\n\u001b[0m=============================================\nHello world                                   Hello world.\n\u001b[0m       Hello world.\nGood morning                                  Good morning.\n\u001b[0m       Good morning.\nThe quick brown fox                           The quick brown fox.\n\u001b[0m       The quick brown fox.\nHow are you doing today?                      How are you doing today?\n\u001b[0m       How are you doing today?\nShe sells seashells by the seashore.          She sells seashells by the seashor\n\u001b[0me.     She sells seashells by the seashore.\nI read a book yesterday.                      I read a book yesterday.\n\u001b[0m       I read a book yesterday.\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Input                                         Python Whisper\n\u001b[0m       Rust Whisper\n================================================================================\n\u001b[0m=============================================\nHello world                                   Hello world.\n\u001b[0m       Hello world.\nGood morning                                  Good morning.\n\u001b[0m       Good morning.\nThe quick brown fox                           The quick brown fox.\n\u001b[0m       The quick brown fox.\nHow are you doing today?                      How are you doing today?\n\u001b[0m       How are you doing today?\nShe sells seashells by the seashore.          She sells seashells by the seashor\n\u001b[0me.     She sells seashells by the seashore.\nI read a book yesterday.                      I read a book yesterday.\n\u001b[0m       I read a book yesterday.\nThe dog is running in the park.               The dog is running in the park.\n\u001b[0m       The dog is running in the park.\n\nDone!\n"
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": "/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n/Users/kylekelley/Library/Caches/runt/inline-envs/da6ba3ffe24a2e47/lib/python3.1\n\u001b[0m2/site-packages/whisper/transcribe.py:132: UserWarning: FP16 is not supported on\n\u001b[0m CPU; using FP32 instead\n  warnings.warn(\"FP16 is not supported on CPU; using FP32 instead\")\n"
+        }
+      ],
+      "execution_count": 22
     }
   ]
 }


### PR DESCRIPTION
## Two critical bugs found via A/B comparison (Whisper STT: 0/7 → 7/7)

### 1. ALBERT dropout active during inference
mlx-rs `Dropout` defaults to `training=true`, but Python MLX modules default to eval mode where `nn.Dropout` is a no-op. Without `training_mode(false)`, ALBERT's dropout randomly zeroed 10% of activations during inference, causing different encoder outputs every run.

### 2. LSTM missing hidden state recurrence  
mlx-rs `Lstm::step` doesn't propagate hidden/cell state between timesteps — each step uses the initial `hidden=None`. This is a Rust scoping issue where `let hidden = ...;` shadows the function parameter but doesn't feed back. Implemented `lstm_forward_recurrent()` that properly propagates hidden/cell state.

### Impact
- Duration predictions now match Python exactly (e.g. 'Hello world': 61 frames vs 102 before)
- Whisper STT correctly transcribes all 7 test phrases
- Audio quality matches Python mlx-audio reference

### Test
```
cargo run --release -p voicers-cli -- --text "Hello world" --voice af_heart --play
```