### PR TITLE
Add G2PConfig for custom uv and espeak-ng binary paths

### DIFF
--- a/crates/voicers-g2p/src/espeak.rs
+++ b/crates/voicers-g2p/src/espeak.rs
@@ -40,23 +40,23 @@ const E2M: &[(&str, &str)] = &[
 /// Per-word espeak-ng fallback, ported from misaki's `EspeakFallback`.
 pub struct EspeakFallback {
     british: bool,
+    espeak_path: String,
 }
 
 impl EspeakFallback {
-    /// Create a new fallback with US English (british=false).
+    /// Create a new fallback with US English and default PATH lookup.
     pub fn new() -> Self {
-        Self { british: false }
+        Self { british: false, espeak_path: "espeak-ng".to_string() }
     }
 
-    /// Create a new fallback specifying British or American English.
-    #[allow(dead_code)]
-    pub fn with_british(british: bool) -> Self {
-        Self { british }
+    /// Create a new fallback with a custom espeak-ng binary path.
+    pub fn with_path(espeak_path: String) -> Self {
+        Self { british: false, espeak_path }
     }
 
     /// Check if espeak-ng is available on the system.
-    pub fn is_available() -> bool {
-        Command::new("espeak-ng")
+    pub fn is_available(&self) -> bool {
+        Command::new(&self.espeak_path)
             .arg("--version")
             .output()
             .map(|o| o.status.success())
@@ -70,7 +70,7 @@ impl EspeakFallback {
     pub fn convert_word(&self, word: &str) -> Option<(String, u8)> {
         let lang = if self.british { "en-gb" } else { "en-us" };
 
-        let output = Command::new("espeak-ng")
+        let output = Command::new(&self.espeak_path)
             .args(["--ipa", "-q", "-v", lang, "--tie=^", word])
             .output()
             .ok()?;
@@ -156,8 +156,8 @@ fn replace_syllabic_mark(input: &str) -> String {
 ///
 /// This wraps the same espeak-ng subprocess call used by `english_to_phonemes`
 /// in `lib.rs`, but returns `Option<String>` for convenience in fallback chains.
-pub fn espeak_sentence(text: &str) -> Option<String> {
-    let output = Command::new("espeak-ng")
+pub fn espeak_sentence(text: &str, espeak_path: &str) -> Option<String> {
+    let output = Command::new(espeak_path)
         .args(["--ipa", "-q", "-v", "en-us", text])
         .output()
         .ok()?;
@@ -222,12 +222,11 @@ mod tests {
 
     #[test]
     fn test_convert_word_available() {
-        if !EspeakFallback::is_available() {
+        let fb = EspeakFallback::new();
+        if !fb.is_available() {
             eprintln!("Skipping test: espeak-ng not installed");
             return;
         }
-
-        let fb = EspeakFallback::new();
         let result = fb.convert_word("hello");
         assert!(result.is_some(), "espeak-ng should produce output for 'hello'");
         let (ps, rating) = result.unwrap();
@@ -243,12 +242,13 @@ mod tests {
 
     #[test]
     fn test_espeak_sentence_available() {
-        if !EspeakFallback::is_available() {
+        let fb = EspeakFallback::new();
+        if !fb.is_available() {
             eprintln!("Skipping test: espeak-ng not installed");
             return;
         }
 
-        let result = espeak_sentence("Hello world");
+        let result = espeak_sentence("Hello world", "espeak-ng");
         assert!(result.is_some());
         let ps = result.unwrap();
         assert!(!ps.is_empty());

--- a/crates/voicers-g2p/src/lib.rs
+++ b/crates/voicers-g2p/src/lib.rs
@@ -25,11 +25,32 @@ pub enum G2pError {
     Io(#[from] std::io::Error),
 }
 
+/// Configuration for external tool paths used by the G2P pipeline.
+#[derive(Debug, Clone)]
+pub struct G2PConfig {
+    /// Path to the `uv` binary for spaCy POS tagging.
+    /// Defaults to `"uv"` (PATH lookup).
+    pub uv_path: String,
+    /// Path to the `espeak-ng` binary for fallback pronunciation.
+    /// Defaults to `"espeak-ng"` (PATH lookup).
+    pub espeak_path: String,
+}
+
+impl Default for G2PConfig {
+    fn default() -> Self {
+        Self {
+            uv_path: "uv".to_string(),
+            espeak_path: "espeak-ng".to_string(),
+        }
+    }
+}
+
 /// The main G2P pipeline, ported from misaki's `en.G2P.__call__()`.
 pub struct G2P {
     lexicon: Lexicon,
     fallback: EspeakFallback,
     unk: String,
+    config: G2PConfig,
 }
 
 fn global_g2p() -> &'static G2P {
@@ -39,10 +60,15 @@ fn global_g2p() -> &'static G2P {
 
 impl G2P {
     pub fn new() -> Self {
+        Self::with_config(G2PConfig::default())
+    }
+
+    pub fn with_config(config: G2PConfig) -> Self {
         Self {
             lexicon: Lexicon::new(),
-            fallback: EspeakFallback::new(),
+            fallback: EspeakFallback::with_path(config.espeak_path.clone()),
             unk: String::new(),
+            config,
         }
     }
 
@@ -51,7 +77,7 @@ impl G2P {
     /// Mirrors misaki `G2P.__call__()` from en.py:679-738.
     pub fn convert(&self, text: &str) -> Result<String, G2pError> {
         // 1. Tokenize (spaCy preferred, simple fallback)
-        let tokens = tokenizer::tokenize(text);
+        let tokens = tokenizer::tokenize(text, &self.config.uv_path);
 
         // 2. fold_left: merge non-head tokens
         let tokens = tokenizer::fold_left(tokens);

--- a/crates/voicers-g2p/src/tokenizer.rs
+++ b/crates/voicers-g2p/src/tokenizer.rs
@@ -40,8 +40,8 @@ const EN_CORE_WEB_SM_URL: &str = "https://github.com/explosion/spacy-models/rele
 /// Uses `uv run --with spacy --with <en_core_web_sm whl URL>` so no
 /// pre-installed Python environment is needed — just `uv`.
 /// Falls back to `None` if `uv` is not available.
-pub fn tokenize_with_spacy(text: &str) -> Option<Vec<MToken>> {
-    let output = Command::new("uv")
+pub fn tokenize_with_spacy(text: &str, uv_path: &str) -> Option<Vec<MToken>> {
+    let output = Command::new(uv_path)
         .args([
             "run",
             "--with", "spacy",
@@ -172,8 +172,8 @@ pub fn tokenize_simple(text: &str) -> Vec<MToken> {
 // ---------------------------------------------------------------------------
 
 /// Tokenize text, trying spaCy first and falling back to the simple tokenizer.
-pub fn tokenize(text: &str) -> Vec<MToken> {
-    tokenize_with_spacy(text).unwrap_or_else(|| tokenize_simple(text))
+pub fn tokenize(text: &str, uv_path: &str) -> Vec<MToken> {
+    tokenize_with_spacy(text, uv_path).unwrap_or_else(|| tokenize_simple(text))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Library users can now configure paths to external tools instead of relying on PATH lookup:

```rust
let config = voicers_g2p::G2PConfig {
    uv_path: "/opt/homebrew/bin/uv".to_string(),
    espeak_path: "/usr/local/bin/espeak-ng".to_string(),
};
let g2p = voicers_g2p::G2P::with_config(config);
```

Defaults to PATH lookup for backward compatibility.