### PR TITLE
Detect missing Xcode license and Metal Toolchain on fresh Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,15 @@ Model loading runs in a background thread while text resolution, G2P, and voice 
 - macOS with Apple Silicon (MLX requirement)
 - Rust 1.85+
 - Xcode command line tools (for MLX Metal compilation)
+- Xcode license accepted: `sudo xcodebuild -license`
+- Metal Toolchain (Xcode 17+): `xcodebuild -downloadComponent MetalToolchain`
 - espeak-ng (optional, for G2P fallback on unknown words): `brew install espeak-ng`
+
+> **Fresh Mac?** If `cargo install voice` fails with linker errors mentioning
+> "You have not agreed to the Xcode license agreements", run
+> `sudo xcodebuild -license`. If it fails with "cannot execute tool 'metal'
+> due to missing Metal Toolchain", run
+> `xcodebuild -downloadComponent MetalToolchain`. Then retry the install.
 
 ## License
 

--- a/crates/voice-cli/build.rs
+++ b/crates/voice-cli/build.rs
@@ -9,7 +9,53 @@
 //! falling back to the (potentially broken) compile-time `METAL_PATH`.
 
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::{env, fs};
+
+/// Check that the Xcode license has been accepted and the Metal toolchain is
+/// installed.  These are required by `mlx-sys` (which compiles Metal shaders
+/// via CMake).  When building from source the voice-cli build script may run
+/// before or in parallel with mlx-sys, so an early warning here can save the
+/// user from digging through pages of CMake output.
+fn preflight_checks() {
+    // 1. Xcode license — `xcrun --find cc` exits 69 when the license hasn't
+    //    been accepted.
+    if let Ok(output) = Command::new("xcrun").args(["--find", "cc"]).output() {
+        if output.status.code() == Some(69) {
+            println!(
+                "cargo:warning=Xcode license has not been accepted. \
+                 Run `sudo xcodebuild -license` and retry the build."
+            );
+        }
+    }
+
+    // 2. Metal toolchain — Xcode 17+ ships the Metal compiler as a separate
+    //    downloadable component.  `xcrun -sdk macosx metal -v` will fail if
+    //    it isn't installed.
+    match Command::new("xcrun")
+        .args(["-sdk", "macosx", "--find", "metal"])
+        .output()
+    {
+        Ok(output) if !output.status.success() => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if stderr.contains("missing Metal Toolchain")
+                || stderr.contains("unable to find utility")
+            {
+                println!(
+                    "cargo:warning=Metal Toolchain is not installed. \
+                     Run `xcodebuild -downloadComponent MetalToolchain` and retry the build."
+                );
+            }
+        }
+        Err(_) => {
+            println!(
+                "cargo:warning=Could not run `xcrun` — is Xcode or the \
+                 Command Line Tools installed?"
+            );
+        }
+        _ => {} // success — nothing to report
+    }
+}
 
 /// Walk up from a starting directory looking for `mlx-sys-*/out/build/lib/mlx.metallib`.
 fn find_metallib(build_dir: &Path) -> Option<PathBuf> {
@@ -49,6 +95,8 @@ fn stable_metallib_dir() -> Option<PathBuf> {
 }
 
 fn main() {
+    preflight_checks();
+
     let out_dir = match env::var("OUT_DIR") {
         Ok(d) => PathBuf::from(d),
         Err(_) => return,


### PR DESCRIPTION
Addresses the fresh Mac install experience where `cargo install voice` fails with obscure errors.

## Changes

**`crates/voice-cli/build.rs`** — preflight checks that run early in the build:
- Detects unaccepted Xcode license (`xcrun --find cc` exit code 69) and prints a clear `cargo:warning`
- Detects missing Metal Toolchain (`xcrun -sdk macosx --find metal`) and prints a clear `cargo:warning`
- Detects missing `xcrun` entirely

Note: these checks won't prevent `mlx-sys` from failing (it builds before voice-cli's build.rs runs), but they help for from-source builds and document the requirements in code.

**`README.md`** — updated requirements section:
- Lists `sudo xcodebuild -license` and `xcodebuild -downloadComponent MetalToolchain` as explicit steps
- Adds a "Fresh Mac?" troubleshooting callout

## Context

Tested on a separate Mac where `cargo install voice` hit both issues sequentially:
1. Xcode license not accepted → linker exit code 69
2. Metal Toolchain not installed → `cannot execute tool 'metal' due to missing Metal Toolchain`