### PR TITLE
reminder to install git-lfs when compiling from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,12 +247,14 @@ Model loading runs in a background thread while text resolution, G2P, and voice 
 - Xcode license accepted: `sudo xcodebuild -license`
 - Metal Toolchain (Xcode 17+): `xcodebuild -downloadComponent MetalToolchain`
 - espeak-ng (optional, for G2P fallback on unknown words): `brew install espeak-ng`
+- git-lfs when building from source: `brew install git-lfs; git lfs install; git lfs install --system`
 
 > **Fresh Mac?** If `cargo install voice` fails with linker errors mentioning
 > "You have not agreed to the Xcode license agreements", run
 > `sudo xcodebuild -license`. If it fails with "cannot execute tool 'metal'
 > due to missing Metal Toolchain", run
 > `xcodebuild -downloadComponent MetalToolchain`. Then retry the install.
+> Also, when compiling from source, a "Failed to parse tagger weights.json" error indicates git-lfs was not installed before the repo was cloned (several large files in the repo will only have internal git-lfs references rather than the full file contents).
 
 ## License
 


### PR DESCRIPTION
When installing from source, if [Git Large File Storage, git-lfs](https://git-lfs.com) is not installed then several of the files in the repo will only contain metadata and git-lfs references to the file contents rather than the appropriate file contents (e.g. "version https://git-lfs.github.com/spec/v1 ").

`README.md` updated to require an install of Git LFS when installing from source.

If git-lfs is not installed:

`voice test`

returns

```
Converting text to phonemes...

thread 'main' (3991666) panicked at crates/voice-g2p/src/tagger.rs:48:48:
Failed to parse tagger weights.json: Error("expected value", line: 1, column: 1)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace```
```

and `weights.json` would look like this rather than actual json content

```
version https://git-lfs.github.com/spec/v1
oid sha256:789e8e35f6fac656d9b7eccea29ba4e8a137cbb5b525dd31f39e4291a9e80832
size 5677744
```


