### PR TITLE
Add JSON-RPC 2.0 stdio server (`--jsonrpc`)

### DIFF
--- a/crates/voice-cli/Cargo.toml
+++ b/crates/voice-cli/Cargo.toml
@@ -20,3 +20,5 @@ rodio = "0.22"
 hound = "3"
 pulldown-cmark = "0.13.1"
 ctrlc = "3.5.2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/voice-cli/src/jsonrpc.rs
+++ b/crates/voice-cli/src/jsonrpc.rs
@@ -1,0 +1,445 @@
+//! JSON-RPC 2.0 stdio server for voice TTS.
+//!
+//! Reads newline-delimited JSON-RPC requests from stdin, writes responses to
+//! stdout. The model and a default voice are loaded once at startup; callers
+//! can switch voices mid-session.
+//!
+//! ## Methods
+//!
+//! - `speak`        — Generate and play audio from text or phonemes.
+//! - `set_voice`    — Change the session's default voice.
+//! - `set_speed`    — Change the session's default speed.
+//! - `list_voices`  — Return the list of builtin voice names.
+//! - `ping`         — Health check, returns `"pong"`.
+//!
+//! ## Example session (stdin → stdout)
+//!
+//! ```jsonl
+//! → {"jsonrpc":"2.0","method":"speak","params":{"text":"Hello world"},"id":1}
+//! ← {"jsonrpc":"2.0","result":{"duration_ms":1840},"id":1}
+//!
+//! → {"jsonrpc":"2.0","method":"set_voice","params":{"voice":"am_michael"},"id":2}
+//! ← {"jsonrpc":"2.0","result":{"voice":"am_michael"},"id":2}
+//!
+//! → {"jsonrpc":"2.0","method":"speak","params":{"text":"Now in a different voice"},"id":3}
+//! ← {"jsonrpc":"2.0","result":{"duration_ms":2100},"id":3}
+//!
+//! → {"jsonrpc":"2.0","method":"list_voices","id":4}
+//! ← {"jsonrpc":"2.0","result":{"voices":["af_heart","af_bella","af_sarah","af_sky","am_michael","am_adam","bf_emma"]},"id":4}
+//! ```
+//!
+//! Notifications (requests without `id`) are executed but produce no response.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::io::{self, BufRead, Write};
+use std::num::NonZero;
+use std::sync::atomic::Ordering;
+use std::time::Instant;
+
+use crate::{apply_substitutions, apply_tech_subs, collect_subs, interrupted, INTERRUPTED, QUIET};
+
+// ── JSON-RPC 2.0 types ────────────────────────────────────────────────
+
+const JSONRPC_VERSION: &str = "2.0";
+
+#[derive(Debug, Deserialize)]
+struct Request {
+    #[allow(dead_code)]
+    jsonrpc: Option<String>,
+    method: String,
+    #[serde(default)]
+    params: Value,
+    id: Option<Value>,
+}
+
+#[derive(Debug, Serialize)]
+struct Response {
+    jsonrpc: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<RpcError>,
+    id: Value,
+}
+
+#[derive(Debug, Serialize)]
+struct RpcError {
+    code: i64,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<Value>,
+}
+
+// Standard JSON-RPC error codes
+const PARSE_ERROR: i64 = -32700;
+#[allow(dead_code)]
+const INVALID_REQUEST: i64 = -32600;
+const METHOD_NOT_FOUND: i64 = -32601;
+const INVALID_PARAMS: i64 = -32602;
+const INTERNAL_ERROR: i64 = -32603;
+
+impl Response {
+    fn success(id: Value, result: Value) -> Self {
+        Self {
+            jsonrpc: JSONRPC_VERSION,
+            result: Some(result),
+            error: None,
+            id,
+        }
+    }
+
+    fn error(id: Value, code: i64, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: JSONRPC_VERSION,
+            result: None,
+            error: Some(RpcError {
+                code,
+                message: message.into(),
+                data: None,
+            }),
+            id,
+        }
+    }
+}
+
+// ── Method params ──────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct SpeakParams {
+    /// Text to speak (mutually exclusive with `phonemes`).
+    text: Option<String>,
+    /// Raw phoneme string, bypasses G2P.
+    phonemes: Option<String>,
+    /// Override voice for this utterance only.
+    voice: Option<String>,
+    /// Override speed for this utterance only.
+    speed: Option<f32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SetVoiceParams {
+    voice: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SetSpeedParams {
+    speed: f32,
+}
+
+// ── Session state ──────────────────────────────────────────────────────
+
+struct Session {
+    model: voice_tts::KokoroModel,
+    voice: voice_tts::Array,
+    voice_name: String,
+    speed: f32,
+    sample_rate: u32,
+    repo_id: String,
+    subs: Vec<(String, String)>,
+    phoneme_overrides: HashMap<String, String>,
+    /// Cache of loaded voices so we don't re-load on every `speak`.
+    voice_cache: HashMap<String, voice_tts::Array>,
+}
+
+impl Session {
+    fn get_voice(&mut self, name: &str) -> Result<&voice_tts::Array, String> {
+        if !self.voice_cache.contains_key(name) {
+            let v = voice_tts::load_voice(name, Some(&self.repo_id))
+                .map_err(|e| format!("Failed to load voice '{name}': {e}"))?;
+            self.voice_cache.insert(name.to_string(), v);
+        }
+        Ok(&self.voice_cache[name])
+    }
+}
+
+// ── Public entry point ─────────────────────────────────────────────────
+
+/// Run the JSON-RPC stdio server. Blocks until stdin is closed or interrupted.
+pub fn run(
+    model: voice_tts::KokoroModel,
+    voice: voice_tts::Array,
+    voice_name: String,
+    speed: f32,
+    sample_rate: u32,
+    repo_id: &str,
+    cli_subs: &[String],
+    sub_file_path: Option<&std::path::Path>,
+) {
+    let (subs, phoneme_overrides) = collect_subs(cli_subs, sub_file_path);
+
+    let mut voice_cache = HashMap::new();
+    voice_cache.insert(voice_name.clone(), voice.clone());
+
+    let mut session = Session {
+        model,
+        voice,
+        voice_name,
+        speed,
+        sample_rate,
+        repo_id: repo_id.to_string(),
+        subs,
+        phoneme_overrides,
+        voice_cache,
+    };
+
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+
+    if !QUIET.load(Ordering::Relaxed) {
+        eprintln!("voice jsonrpc server ready");
+    }
+
+    for line in stdin.lock().lines() {
+        if interrupted() {
+            break;
+        }
+
+        let line = match line {
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!("stdin read error: {e}");
+                break;
+            }
+        };
+
+        let line = line.trim().to_string();
+        if line.is_empty() {
+            continue;
+        }
+
+        // Parse JSON
+        let req: Request = match serde_json::from_str(&line) {
+            Ok(r) => r,
+            Err(e) => {
+                let resp = Response::error(Value::Null, PARSE_ERROR, format!("Parse error: {e}"));
+                write_response(&mut stdout, &resp);
+                continue;
+            }
+        };
+
+        let is_notification = req.id.is_none();
+        let id = req.id.clone().unwrap_or(Value::Null);
+
+        let resp = dispatch(&mut session, &req.method, req.params, id);
+
+        // Notifications don't get responses per JSON-RPC 2.0
+        if !is_notification {
+            if let Some(resp) = resp {
+                write_response(&mut stdout, &resp);
+            }
+        }
+
+        // Reset interrupt flag so Ctrl+C during playback only cancels the
+        // current utterance, not the whole server.
+        INTERRUPTED.store(false, Ordering::Relaxed);
+    }
+}
+
+// ── Dispatch ───────────────────────────────────────────────────────────
+
+fn dispatch(session: &mut Session, method: &str, params: Value, id: Value) -> Option<Response> {
+    let result = match method {
+        "speak" => handle_speak(session, params),
+        "set_voice" => handle_set_voice(session, params),
+        "set_speed" => handle_set_speed(session, params),
+        "list_voices" => handle_list_voices(),
+        "ping" => Ok(serde_json::json!("pong")),
+        _ => {
+            return Some(Response::error(
+                id,
+                METHOD_NOT_FOUND,
+                format!("Unknown method: {method}"),
+            ));
+        }
+    };
+
+    Some(match result {
+        Ok(value) => Response::success(id, value),
+        Err(e) => e.into_response(id),
+    })
+}
+
+// ── Error helper ───────────────────────────────────────────────────────
+
+struct RpcErr {
+    code: i64,
+    message: String,
+}
+
+impl RpcErr {
+    fn invalid_params(msg: impl Into<String>) -> Self {
+        Self {
+            code: INVALID_PARAMS,
+            message: msg.into(),
+        }
+    }
+
+    fn internal(msg: impl Into<String>) -> Self {
+        Self {
+            code: INTERNAL_ERROR,
+            message: msg.into(),
+        }
+    }
+
+    fn into_response(self, id: Value) -> Response {
+        Response::error(id, self.code, self.message)
+    }
+}
+
+// ── Method handlers ────────────────────────────────────────────────────
+
+fn handle_speak(session: &mut Session, params: Value) -> Result<Value, RpcErr> {
+    let p: SpeakParams =
+        serde_json::from_value(params).map_err(|e| RpcErr::invalid_params(e.to_string()))?;
+
+    let speed = p.speed.unwrap_or(session.speed);
+
+    // Determine which voice to use
+    let voice_ref: *const voice_tts::Array = if let Some(ref name) = p.voice {
+        session
+            .get_voice(name)
+            .map_err(|e| RpcErr::invalid_params(e))? as *const _
+    } else {
+        &session.voice as *const _
+    };
+    // SAFETY: voice_ref points into session.voice or session.voice_cache,
+    // both of which live for the duration of this call. We use a raw pointer
+    // to avoid borrow-checker conflicts with the mutable session borrow for
+    // the model below.
+    let voice = unsafe { &*voice_ref };
+
+    // Resolve phoneme chunks
+    let chunks: Vec<String> = if let Some(ref phonemes) = p.phonemes {
+        vec![phonemes.clone()]
+    } else if let Some(ref text) = p.text {
+        let text = apply_tech_subs(text);
+        let text = if session.subs.is_empty() {
+            text
+        } else {
+            apply_substitutions(&text, &session.subs)
+        };
+        let result = if session.phoneme_overrides.is_empty() {
+            voice_g2p::text_to_phoneme_chunks(&text)
+        } else {
+            voice_g2p::text_to_phoneme_chunks_with_overrides(&text, &session.phoneme_overrides)
+        };
+        result.map_err(|e| RpcErr::internal(format!("G2P error: {e}")))?
+    } else {
+        return Err(RpcErr::invalid_params(
+            "Either 'text' or 'phonemes' is required",
+        ));
+    };
+
+    // Generate and play
+    let started = Instant::now();
+    stream_chunks(session, voice, &chunks, speed)?;
+    let duration_ms = started.elapsed().as_millis() as u64;
+
+    Ok(serde_json::json!({
+        "duration_ms": duration_ms,
+        "chunks": chunks.len(),
+    }))
+}
+
+fn handle_set_voice(session: &mut Session, params: Value) -> Result<Value, RpcErr> {
+    let p: SetVoiceParams =
+        serde_json::from_value(params).map_err(|e| RpcErr::invalid_params(e.to_string()))?;
+
+    // Pre-load to validate the voice exists
+    let voice = session
+        .get_voice(&p.voice)
+        .map_err(|e| RpcErr::invalid_params(e))?
+        .clone();
+
+    session.voice = voice;
+    session.voice_name = p.voice.clone();
+
+    Ok(serde_json::json!({ "voice": p.voice }))
+}
+
+fn handle_set_speed(session: &mut Session, params: Value) -> Result<Value, RpcErr> {
+    let p: SetSpeedParams =
+        serde_json::from_value(params).map_err(|e| RpcErr::invalid_params(e.to_string()))?;
+
+    if p.speed <= 0.0 || p.speed > 5.0 {
+        return Err(RpcErr::invalid_params(
+            "Speed must be between 0.0 (exclusive) and 5.0 (inclusive)",
+        ));
+    }
+
+    session.speed = p.speed;
+
+    Ok(serde_json::json!({ "speed": p.speed }))
+}
+
+fn handle_list_voices() -> Result<Value, RpcErr> {
+    Ok(serde_json::json!({
+        "voices": voice_tts::builtin::BUILTIN_VOICES,
+    }))
+}
+
+// ── Audio playback ─────────────────────────────────────────────────────
+
+fn stream_chunks(
+    session: &mut Session,
+    voice: &voice_tts::Array,
+    chunks: &[String],
+    speed: f32,
+) -> Result<(), RpcErr> {
+    use rodio::{buffer::SamplesBuffer, DeviceSinkBuilder, Player};
+
+    let mut stream =
+        DeviceSinkBuilder::open_default_sink().map_err(|e| RpcErr::internal(e.to_string()))?;
+    stream.log_on_drop(false);
+    let player = Player::connect_new(stream.mixer());
+
+    let channels = NonZero::new(1u16).unwrap();
+    let rate = NonZero::new(session.sample_rate).unwrap();
+
+    for (i, phonemes) in chunks.iter().enumerate() {
+        if interrupted() {
+            break;
+        }
+        if phonemes.is_empty() {
+            continue;
+        }
+        if chunks.len() > 1 && !QUIET.load(Ordering::Relaxed) {
+            eprintln!("  generating chunk {}/{}...", i + 1, chunks.len());
+        }
+        match voice_tts::generate(&mut session.model, phonemes, voice, speed) {
+            Ok(audio) => {
+                let samples: Vec<f32> = audio.as_slice().to_vec();
+                let source = SamplesBuffer::new(channels, rate, samples);
+                player.append(source);
+            }
+            Err(e) => {
+                return Err(RpcErr::internal(format!(
+                    "Generation failed on chunk {}: {e}",
+                    i + 1
+                )));
+            }
+        }
+    }
+
+    // Wait for playback, checking for Ctrl+C
+    while !player.empty() {
+        if interrupted() {
+            player.stop();
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    Ok(())
+}
+
+// ── IO ─────────────────────────────────────────────────────────────────
+
+fn write_response(stdout: &mut io::Stdout, resp: &Response) {
+    // Unwrap is fine — our Response type is always serializable.
+    let json = serde_json::to_string(resp).unwrap();
+    let _ = writeln!(stdout, "{json}");
+    let _ = stdout.flush();
+}

--- a/crates/voice-cli/src/jsonrpc.rs
+++ b/crates/voice-cli/src/jsonrpc.rs
@@ -7,6 +7,7 @@
 //! ## Methods
 //!
 //! - `speak`        — Generate and play audio from text or phonemes.
+//! - `cancel`       — Interrupt the current utterance's playback.
 //! - `set_voice`    — Change the session's default voice.
 //! - `set_speed`    — Change the session's default speed.
 //! - `list_voices`  — Return the list of builtin voice names.
@@ -36,6 +37,7 @@ use std::collections::HashMap;
 use std::io::{self, BufRead, Write};
 use std::num::NonZero;
 use std::sync::atomic::Ordering;
+use std::sync::mpsc;
 use std::time::Instant;
 
 use crate::{
@@ -186,7 +188,18 @@ pub struct ServerConfig {
     pub sub_file_path: Option<std::path::PathBuf>,
 }
 
+/// Parsed message from the stdin reader thread.
+enum StdinMsg {
+    Request(Request),
+    ParseError(String),
+    Closed,
+}
+
 /// Run the JSON-RPC stdio server. Blocks until stdin is closed or interrupted.
+///
+/// Stdin is read on a dedicated thread so that `cancel` requests can arrive
+/// while a `speak` call is still generating/playing audio. The main loop
+/// pulls parsed messages from an mpsc channel.
 pub fn run(config: ServerConfig) {
     let (subs, phoneme_overrides) = collect_subs(&config.cli_subs, config.sub_file_path.as_deref());
 
@@ -205,56 +218,102 @@ pub fn run(config: ServerConfig) {
         voice_cache,
     };
 
-    let stdin = io::stdin();
     let mut stdout = io::stdout();
 
     if !QUIET.load(Ordering::Relaxed) {
         eprintln!("voice jsonrpc server ready");
     }
 
-    for line in stdin.lock().lines() {
-        if interrupted() {
-            break;
-        }
-
-        let line = match line {
-            Ok(l) => l,
-            Err(e) => {
-                eprintln!("stdin read error: {e}");
+    // Spawn a reader thread so stdin isn't blocked while speak is running.
+    // This lets `cancel` arrive mid-playback.
+    let (tx, rx) = mpsc::channel::<StdinMsg>();
+    std::thread::spawn(move || {
+        let stdin = io::stdin();
+        for line in stdin.lock().lines() {
+            let msg = match line {
+                Ok(l) => {
+                    let l = l.trim().to_string();
+                    if l.is_empty() {
+                        continue;
+                    }
+                    match serde_json::from_str::<Request>(&l) {
+                        Ok(req) => {
+                            // Set the interrupt flag immediately on the reader
+                            // thread so it takes effect while speak is blocked
+                            // on the main thread.
+                            if req.method == "cancel" {
+                                INTERRUPTED.store(true, Ordering::SeqCst);
+                            }
+                            StdinMsg::Request(req)
+                        }
+                        Err(e) => StdinMsg::ParseError(format!("Parse error: {e}")),
+                    }
+                }
+                Err(_) => StdinMsg::Closed,
+            };
+            let is_closed = matches!(msg, StdinMsg::Closed);
+            if tx.send(msg).is_err() || is_closed {
                 break;
             }
-        };
-
-        let line = line.trim().to_string();
-        if line.is_empty() {
-            continue;
         }
+        // EOF — signal the main loop
+        let _ = tx.send(StdinMsg::Closed);
+    });
 
-        // Parse JSON
-        let req: Request = match serde_json::from_str(&line) {
-            Ok(r) => r,
-            Err(e) => {
-                let resp = Response::error(Value::Null, PARSE_ERROR, format!("Parse error: {e}"));
-                write_response(&mut stdout, &resp);
-                continue;
-            }
-        };
-
-        let is_notification = req.id.is_none();
-        let id = req.id.clone().unwrap_or(Value::Null);
-
-        let resp = dispatch(&mut session, &req.method, req.params, id);
-
-        // Notifications don't get responses per JSON-RPC 2.0
-        if !is_notification {
-            if let Some(resp) = resp {
+    // Main dispatch loop — drains the channel, handles requests.
+    // Between speak chunks we also drain any queued cancel requests
+    // via the interrupted() flag (set by handle_cancel or Ctrl+C).
+    while let Ok(msg) = rx.recv() {
+        match msg {
+            StdinMsg::Closed => break,
+            StdinMsg::ParseError(e) => {
+                let resp = Response::error(Value::Null, PARSE_ERROR, e);
                 write_response(&mut stdout, &resp);
             }
-        }
+            StdinMsg::Request(req) => {
+                let is_notification = req.id.is_none();
+                let id = req.id.clone().unwrap_or(Value::Null);
 
-        // Reset interrupt flag so Ctrl+C during playback only cancels the
-        // current utterance, not the whole server.
-        INTERRUPTED.store(false, Ordering::Relaxed);
+                let resp = dispatch(&mut session, &req.method, req.params, id);
+
+                if !is_notification {
+                    if let Some(resp) = resp {
+                        write_response(&mut stdout, &resp);
+                    }
+                }
+
+                // Reset so the next speak isn't pre-cancelled.
+                INTERRUPTED.store(false, Ordering::Relaxed);
+
+                // Drain any requests that arrived while we were busy (e.g.
+                // a cancel that came in right at the tail end of playback).
+                drain_pending(&rx, &mut session, &mut stdout);
+            }
+        }
+    }
+}
+
+/// Process any already-queued messages without blocking.
+fn drain_pending(rx: &mpsc::Receiver<StdinMsg>, session: &mut Session, stdout: &mut io::Stdout) {
+    loop {
+        match rx.try_recv() {
+            Ok(StdinMsg::Request(req)) => {
+                let is_notification = req.id.is_none();
+                let id = req.id.clone().unwrap_or(Value::Null);
+                let resp = dispatch(session, &req.method, req.params, id);
+                if !is_notification {
+                    if let Some(resp) = resp {
+                        write_response(stdout, &resp);
+                    }
+                }
+                INTERRUPTED.store(false, Ordering::Relaxed);
+            }
+            Ok(StdinMsg::ParseError(e)) => {
+                let resp = Response::error(Value::Null, PARSE_ERROR, e);
+                write_response(stdout, &resp);
+            }
+            _ => break, // empty or closed
+        }
     }
 }
 
@@ -263,6 +322,7 @@ pub fn run(config: ServerConfig) {
 fn dispatch(session: &mut Session, method: &str, params: Value, id: Value) -> Option<Response> {
     let result = match method {
         "speak" => handle_speak(session, params),
+        "cancel" => handle_cancel(),
         "set_voice" => handle_set_voice(session, params),
         "set_speed" => handle_set_speed(session, params),
         "list_voices" => handle_list_voices(),
@@ -310,6 +370,11 @@ impl RpcErr {
 }
 
 // ── Method handlers ────────────────────────────────────────────────────
+
+fn handle_cancel() -> Result<Value, RpcErr> {
+    INTERRUPTED.store(true, Ordering::SeqCst);
+    Ok(serde_json::json!({"cancelled": true}))
+}
 
 fn handle_speak(session: &mut Session, params: Value) -> Result<Value, RpcErr> {
     let p: SpeakParams =

--- a/crates/voice-cli/src/jsonrpc.rs
+++ b/crates/voice-cli/src/jsonrpc.rs
@@ -19,8 +19,10 @@
 //! → {"jsonrpc":"2.0","method":"speak","params":{"text":"Hello world"},"id":1}
 //! ← {"jsonrpc":"2.0","result":{"duration_ms":1840,"chunks":1},"id":1}
 //!
-//! → {"jsonrpc":"2.0","method":"speak","params":{"text":"# Heading\n\nSome *bold* text","markdown":true,"detail":"full"},"id":2}
-//! ← {"jsonrpc":"2.0","result":{"duration_ms":2100,"chunks":1,"phonemes":["..."]},"id":2}
+//! → {"jsonrpc":"2.0","method":"speak","params":{"text":"Hello. How are you?","detail":"full"},"id":2}
+//! ← {"jsonrpc":"2.0","method":"speak.progress","params":{"chunk":1,"total":2,"phonemes":"həlˈO."}}
+//! ← {"jsonrpc":"2.0","method":"speak.progress","params":{"chunk":2,"total":2,"phonemes":"hˌaʊ ɑːɹ ɪU?"}}
+//! ← {"jsonrpc":"2.0","result":{"duration_ms":2100,"chunks":2,"phonemes":["həlˈO.","hˌaʊ ɑːɹ ɪU?"]},"id":2}
 //!
 //! → {"jsonrpc":"2.0","method":"set_voice","params":{"voice":"am_michael"},"id":3}
 //! ← {"jsonrpc":"2.0","result":{"voice":"am_michael"},"id":3}
@@ -274,7 +276,7 @@ pub fn run(config: ServerConfig) {
                 let is_notification = req.id.is_none();
                 let id = req.id.clone().unwrap_or(Value::Null);
 
-                let resp = dispatch(&mut session, &req.method, req.params, id);
+                let resp = dispatch(&mut session, &mut stdout, &req.method, req.params, id);
 
                 if !is_notification {
                     if let Some(resp) = resp {
@@ -300,7 +302,7 @@ fn drain_pending(rx: &mpsc::Receiver<StdinMsg>, session: &mut Session, stdout: &
             Ok(StdinMsg::Request(req)) => {
                 let is_notification = req.id.is_none();
                 let id = req.id.clone().unwrap_or(Value::Null);
-                let resp = dispatch(session, &req.method, req.params, id);
+                let resp = dispatch(session, stdout, &req.method, req.params, id);
                 if !is_notification {
                     if let Some(resp) = resp {
                         write_response(stdout, &resp);
@@ -319,9 +321,15 @@ fn drain_pending(rx: &mpsc::Receiver<StdinMsg>, session: &mut Session, stdout: &
 
 // ── Dispatch ───────────────────────────────────────────────────────────
 
-fn dispatch(session: &mut Session, method: &str, params: Value, id: Value) -> Option<Response> {
+fn dispatch(
+    session: &mut Session,
+    stdout: &mut io::Stdout,
+    method: &str,
+    params: Value,
+    id: Value,
+) -> Option<Response> {
     let result = match method {
-        "speak" => handle_speak(session, params),
+        "speak" => handle_speak(session, stdout, params),
         "cancel" => handle_cancel(),
         "set_voice" => handle_set_voice(session, params),
         "set_speed" => handle_set_speed(session, params),
@@ -376,7 +384,11 @@ fn handle_cancel() -> Result<Value, RpcErr> {
     Ok(serde_json::json!({"cancelled": true}))
 }
 
-fn handle_speak(session: &mut Session, params: Value) -> Result<Value, RpcErr> {
+fn handle_speak(
+    session: &mut Session,
+    stdout: &mut io::Stdout,
+    params: Value,
+) -> Result<Value, RpcErr> {
     let p: SpeakParams =
         serde_json::from_value(params).map_err(|e| RpcErr::invalid_params(e.to_string()))?;
 
@@ -422,8 +434,9 @@ fn handle_speak(session: &mut Session, params: Value) -> Result<Value, RpcErr> {
     };
 
     // Generate and play
+    let detail_full = p.detail == Detail::Full;
     let started = Instant::now();
-    stream_chunks(session, voice, &chunks, speed)?;
+    stream_chunks(session, stdout, voice, &chunks, speed, detail_full)?;
     let duration_ms = started.elapsed().as_millis() as u64;
 
     let mut result = serde_json::json!({
@@ -479,9 +492,11 @@ fn handle_list_voices() -> Result<Value, RpcErr> {
 
 fn stream_chunks(
     session: &mut Session,
+    stdout: &mut io::Stdout,
     voice: &voice_tts::Array,
     chunks: &[String],
     speed: f32,
+    progress: bool,
 ) -> Result<(), RpcErr> {
     use rodio::{buffer::SamplesBuffer, DeviceSinkBuilder, Player};
 
@@ -502,6 +517,17 @@ fn stream_chunks(
         }
         if chunks.len() > 1 && !QUIET.load(Ordering::Relaxed) {
             eprintln!("  generating chunk {}/{}...", i + 1, chunks.len());
+        }
+        if progress {
+            write_notification(
+                stdout,
+                "speak.progress",
+                serde_json::json!({
+                    "chunk": i + 1,
+                    "total": chunks.len(),
+                    "phonemes": phonemes,
+                }),
+            );
         }
         match voice_tts::generate(&mut session.model, phonemes, voice, speed) {
             Ok(audio) => {
@@ -535,6 +561,18 @@ fn stream_chunks(
 fn write_response(stdout: &mut io::Stdout, resp: &Response) {
     // Unwrap is fine — our Response type is always serializable.
     let json = serde_json::to_string(resp).unwrap();
+    let _ = writeln!(stdout, "{json}");
+    let _ = stdout.flush();
+}
+
+/// Emit a server-initiated notification (no `id`).
+fn write_notification(stdout: &mut io::Stdout, method: &str, params: Value) {
+    let msg = serde_json::json!({
+        "jsonrpc": JSONRPC_VERSION,
+        "method": method,
+        "params": params,
+    });
+    let json = serde_json::to_string(&msg).unwrap();
     let _ = writeln!(stdout, "{json}");
     let _ = stdout.flush();
 }

--- a/crates/voice-cli/src/jsonrpc.rs
+++ b/crates/voice-cli/src/jsonrpc.rs
@@ -18,7 +18,7 @@
 //! → {"jsonrpc":"2.0","method":"speak","params":{"text":"Hello world"},"id":1}
 //! ← {"jsonrpc":"2.0","result":{"duration_ms":1840,"chunks":1},"id":1}
 //!
-//! → {"jsonrpc":"2.0","method":"speak","params":{"text":"# Heading\n\nSome *bold* text","markdown":true,"return_phonemes":true},"id":2}
+//! → {"jsonrpc":"2.0","method":"speak","params":{"text":"# Heading\n\nSome *bold* text","markdown":true,"detail":"full"},"id":2}
 //! ← {"jsonrpc":"2.0","result":{"duration_ms":2100,"chunks":1,"phonemes":["..."]},"id":2}
 //!
 //! → {"jsonrpc":"2.0","method":"set_voice","params":{"voice":"am_michael"},"id":3}
@@ -122,9 +122,17 @@ struct SpeakParams {
     /// Strip markdown/MDX formatting before G2P conversion.
     #[serde(default)]
     markdown: bool,
-    /// Include the phoneme chunks in the response.
+    /// Response detail level: "normal" (default) or "full" (includes phonemes).
     #[serde(default)]
-    return_phonemes: bool,
+    detail: Detail,
+}
+
+#[derive(Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum Detail {
+    #[default]
+    Normal,
+    Full,
 }
 
 #[derive(Debug, Deserialize)]
@@ -358,7 +366,7 @@ fn handle_speak(session: &mut Session, params: Value) -> Result<Value, RpcErr> {
         "chunks": chunks.len(),
     });
 
-    if p.return_phonemes {
+    if p.detail == Detail::Full {
         result["phonemes"] = serde_json::json!(chunks);
     }
 

--- a/crates/voice-cli/src/jsonrpc.rs
+++ b/crates/voice-cli/src/jsonrpc.rs
@@ -16,13 +16,13 @@
 //!
 //! ```jsonl
 //! → {"jsonrpc":"2.0","method":"speak","params":{"text":"Hello world"},"id":1}
-//! ← {"jsonrpc":"2.0","result":{"duration_ms":1840},"id":1}
+//! ← {"jsonrpc":"2.0","result":{"duration_ms":1840,"chunks":1},"id":1}
 //!
-//! → {"jsonrpc":"2.0","method":"set_voice","params":{"voice":"am_michael"},"id":2}
-//! ← {"jsonrpc":"2.0","result":{"voice":"am_michael"},"id":2}
+//! → {"jsonrpc":"2.0","method":"speak","params":{"text":"# Heading\n\nSome *bold* text","markdown":true,"return_phonemes":true},"id":2}
+//! ← {"jsonrpc":"2.0","result":{"duration_ms":2100,"chunks":1,"phonemes":["..."]},"id":2}
 //!
-//! → {"jsonrpc":"2.0","method":"speak","params":{"text":"Now in a different voice"},"id":3}
-//! ← {"jsonrpc":"2.0","result":{"duration_ms":2100},"id":3}
+//! → {"jsonrpc":"2.0","method":"set_voice","params":{"voice":"am_michael"},"id":3}
+//! ← {"jsonrpc":"2.0","result":{"voice":"am_michael"},"id":3}
 //!
 //! → {"jsonrpc":"2.0","method":"list_voices","id":4}
 //! ← {"jsonrpc":"2.0","result":{"voices":["af_heart","af_bella","af_sarah","af_sky","am_michael","am_adam","bf_emma"]},"id":4}
@@ -38,7 +38,10 @@ use std::num::NonZero;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
 
-use crate::{apply_substitutions, apply_tech_subs, collect_subs, interrupted, INTERRUPTED, QUIET};
+use crate::{
+    apply_substitutions, apply_tech_subs, collect_subs, interrupted, strip_markdown, INTERRUPTED,
+    QUIET,
+};
 
 // ── JSON-RPC 2.0 types ────────────────────────────────────────────────
 
@@ -116,6 +119,12 @@ struct SpeakParams {
     voice: Option<String>,
     /// Override speed for this utterance only.
     speed: Option<f32>,
+    /// Strip markdown/MDX formatting before G2P conversion.
+    #[serde(default)]
+    markdown: bool,
+    /// Include the phoneme chunks in the response.
+    #[serde(default)]
+    return_phonemes: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -156,29 +165,33 @@ impl Session {
 
 // ── Public entry point ─────────────────────────────────────────────────
 
+/// Configuration for starting the JSON-RPC server, bundled to avoid
+/// passing too many positional arguments.
+pub struct ServerConfig {
+    pub model: voice_tts::KokoroModel,
+    pub voice: voice_tts::Array,
+    pub voice_name: String,
+    pub speed: f32,
+    pub sample_rate: u32,
+    pub repo_id: String,
+    pub cli_subs: Vec<String>,
+    pub sub_file_path: Option<std::path::PathBuf>,
+}
+
 /// Run the JSON-RPC stdio server. Blocks until stdin is closed or interrupted.
-pub fn run(
-    model: voice_tts::KokoroModel,
-    voice: voice_tts::Array,
-    voice_name: String,
-    speed: f32,
-    sample_rate: u32,
-    repo_id: &str,
-    cli_subs: &[String],
-    sub_file_path: Option<&std::path::Path>,
-) {
-    let (subs, phoneme_overrides) = collect_subs(cli_subs, sub_file_path);
+pub fn run(config: ServerConfig) {
+    let (subs, phoneme_overrides) = collect_subs(&config.cli_subs, config.sub_file_path.as_deref());
 
     let mut voice_cache = HashMap::new();
-    voice_cache.insert(voice_name.clone(), voice.clone());
+    voice_cache.insert(config.voice_name.clone(), config.voice.clone());
 
     let mut session = Session {
-        model,
-        voice,
-        voice_name,
-        speed,
-        sample_rate,
-        repo_id: repo_id.to_string(),
+        model: config.model,
+        voice: config.voice,
+        voice_name: config.voice_name,
+        speed: config.speed,
+        sample_rate: config.sample_rate,
+        repo_id: config.repo_id,
         subs,
         phoneme_overrides,
         voice_cache,
@@ -298,9 +311,7 @@ fn handle_speak(session: &mut Session, params: Value) -> Result<Value, RpcErr> {
 
     // Determine which voice to use
     let voice_ref: *const voice_tts::Array = if let Some(ref name) = p.voice {
-        session
-            .get_voice(name)
-            .map_err(|e| RpcErr::invalid_params(e))? as *const _
+        session.get_voice(name).map_err(RpcErr::invalid_params)? as *const _
     } else {
         &session.voice as *const _
     };
@@ -314,7 +325,12 @@ fn handle_speak(session: &mut Session, params: Value) -> Result<Value, RpcErr> {
     let chunks: Vec<String> = if let Some(ref phonemes) = p.phonemes {
         vec![phonemes.clone()]
     } else if let Some(ref text) = p.text {
-        let text = apply_tech_subs(text);
+        let text = if p.markdown {
+            strip_markdown(text)
+        } else {
+            text.clone()
+        };
+        let text = apply_tech_subs(&text);
         let text = if session.subs.is_empty() {
             text
         } else {
@@ -337,10 +353,16 @@ fn handle_speak(session: &mut Session, params: Value) -> Result<Value, RpcErr> {
     stream_chunks(session, voice, &chunks, speed)?;
     let duration_ms = started.elapsed().as_millis() as u64;
 
-    Ok(serde_json::json!({
+    let mut result = serde_json::json!({
         "duration_ms": duration_ms,
         "chunks": chunks.len(),
-    }))
+    });
+
+    if p.return_phonemes {
+        result["phonemes"] = serde_json::json!(chunks);
+    }
+
+    Ok(result)
 }
 
 fn handle_set_voice(session: &mut Session, params: Value) -> Result<Value, RpcErr> {
@@ -350,7 +372,7 @@ fn handle_set_voice(session: &mut Session, params: Value) -> Result<Value, RpcEr
     // Pre-load to validate the voice exists
     let voice = session
         .get_voice(&p.voice)
-        .map_err(|e| RpcErr::invalid_params(e))?
+        .map_err(RpcErr::invalid_params)?
         .clone();
 
     session.voice = voice;

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -141,7 +141,7 @@ fn resolve_text(args: &Args) -> Result<String, String> {
 /// Keeps text content from paragraphs, headings, list items, and block quotes.
 /// Drops code blocks, inline code, images, HTML, and link URLs (keeps link text).
 /// Handles YAML frontmatter (--- delimited) by skipping it before parsing.
-fn strip_markdown(text: &str) -> String {
+pub(crate) fn strip_markdown(text: &str) -> String {
     // Strip YAML frontmatter before passing to pulldown-cmark
     let text = strip_frontmatter(text);
 
@@ -510,16 +510,16 @@ fn main() {
 
     if args.jsonrpc {
         let sub_file = args.sub_file.clone().or_else(find_sub_file);
-        jsonrpc::run(
+        jsonrpc::run(jsonrpc::ServerConfig {
             model,
             voice,
-            args.voice.clone(),
-            args.speed,
+            voice_name: args.voice.clone(),
+            speed: args.speed,
             sample_rate,
-            MODEL_REPO,
-            &args.subs,
-            sub_file.as_deref(),
-        );
+            repo_id: MODEL_REPO.to_string(),
+            cli_subs: args.subs.clone(),
+            sub_file_path: sub_file,
+        });
         return;
     }
 

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -1,3 +1,5 @@
+mod jsonrpc;
+
 use clap::Parser;
 use pulldown_cmark::{Event, Options, Parser as MdParser, Tag, TagEnd};
 use std::collections::HashMap;
@@ -82,6 +84,10 @@ struct Args {
     /// Errors are always printed.
     #[arg(short, long)]
     quiet: bool,
+
+    /// Run as a JSON-RPC 2.0 server on stdin/stdout.
+    #[arg(long)]
+    jsonrpc: bool,
 }
 
 fn resolve_text(args: &Args) -> Result<String, String> {
@@ -408,7 +414,10 @@ fn main() {
 
     // Resolve phoneme chunks (text resolution + G2P are fast with the
     // embedded perceptron tagger, ~1-2ms total).
-    let phoneme_chunks: Vec<String> = if let Some(phonemes) = &args.phonemes {
+    // In JSON-RPC mode, text is resolved per-request.
+    let phoneme_chunks: Vec<String> = if args.jsonrpc {
+        Vec::new()
+    } else if let Some(phonemes) = &args.phonemes {
         vec![phonemes.clone()]
     } else {
         match resolve_text(&args) {
@@ -498,6 +507,21 @@ fn main() {
     };
 
     let sample_rate = model.sample_rate as u32;
+
+    if args.jsonrpc {
+        let sub_file = args.sub_file.clone().or_else(find_sub_file);
+        jsonrpc::run(
+            model,
+            voice,
+            args.voice.clone(),
+            args.speed,
+            sample_rate,
+            MODEL_REPO,
+            &args.subs,
+            sub_file.as_deref(),
+        );
+        return;
+    }
 
     if let Some(output_path) = &args.output {
         // File output: batch generate all chunks, then write WAV


### PR DESCRIPTION
Run voice as a long-lived process that other programs can talk to over stdin/stdout.

```
voice -v am_michael --jsonrpc
```

**Methods:** `speak`, `cancel`, `set_voice`, `set_speed`, `list_voices`, `ping`

```
→ {"jsonrpc":"2.0","method":"speak","params":{"text":"Hello world"},"id":1}
← {"jsonrpc":"2.0","result":{"duration_ms":1840,"chunks":1},"id":1}

→ {"jsonrpc":"2.0","method":"speak","params":{"text":"# Heading\n\nProse here","markdown":true,"detail":"full"},"id":2}
← {"jsonrpc":"2.0","result":{"duration_ms":2100,"chunks":1,"phonemes":["..."]},"id":2}

→ {"jsonrpc":"2.0","method":"cancel","id":3}
← {"jsonrpc":"2.0","result":{"cancelled":true},"id":3}

→ {"jsonrpc":"2.0","method":"set_voice","params":{"voice":"af_heart"},"id":4}
← {"jsonrpc":"2.0","result":{"voice":"af_heart"},"id":4}
```

- Model loads once, voices cached per-session
- `speak` supports per-request `voice`/`speed` overrides, `markdown` stripping, and `detail: "full"` to include phonemes
- `cancel` interrupts the current utterance mid-playback — stdin is read on a separate thread so cancel arrives while speak is blocked
- Ctrl+C also cancels the current utterance without killing the server

_PR submitted by @rgbkrk's agent Quill, via Zed_