### PR TITLE
Detect LFS pointers at build time, clean up install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,22 @@ Faster time-to-first-speech than macOS `say`, with dramatically better audio qua
 
 ## Install
 
-### From source (recommended)
+Build from source (requires Git LFS for embedded voice/model data):
 
 ```bash
+# Install git-lfs if you don't have it
+brew install git-lfs
+git lfs install
+
+# Clone and build
 git clone https://github.com/rgbkrk/voicers.git
 cd voicers
 cargo install --path crates/voice-cli
 ```
 
-### From crates.io
+> **Why not `cargo install voice`?** The Metal shader library path is baked in at compile time by mlx-sys and points to a temp directory that gets cleaned up after install. This is an [upstream mlx-rs issue](https://github.com/oxiglade/mlx-rs/issues/327). Building from source avoids this entirely.
 
-```bash
-cargo install voice
-```
-
-> **Note:** `cargo install voice` may fail at runtime with `Failed to load the default metallib` on Apple Silicon. This is an [upstream mlx-sys issue](https://github.com/oxiglade/mlx-rs/issues/327) — the Metal shader library path is baked in at compile time and points to a temp directory that gets cleaned up. Building from source (above) avoids this. If you hit the error, copy the metallib next to the binary:
->
-> ```bash
-> cp target/release/build/mlx-sys-*/out/build/_deps/mlx-build/mlx/backend/metal/kernels/mlx.metallib ~/.cargo/bin/
-> ```
+> **Why git-lfs?** Voice data (`.safetensors`) and tagger weights are stored with Git LFS. Without it, those files are tiny pointers instead of actual data — the build will catch this and tell you what to do.
 
 This puts the `voice` binary on your `$PATH`. Model weights (~312MB) are downloaded from HuggingFace Hub on first run and cached in `~/.cache/huggingface/hub/`. Seven popular voices and the model config are embedded in the binary — no network needed for common use.
 
@@ -54,12 +51,6 @@ voice --markdown -f blog-post.mdx
 
 # Raw phoneme input
 voice --phonemes "həlˈO wˈɜɹld"
-```
-
-### From source
-
-```bash
-cargo install --path crates/voice-cli
 ```
 
 ## CLI options
@@ -243,18 +234,16 @@ Model loading runs in a background thread while text resolution, G2P, and voice 
 
 - macOS with Apple Silicon (MLX requirement)
 - Rust 1.85+
+- Git LFS (`brew install git-lfs && git lfs install`)
 - Xcode command line tools (for MLX Metal compilation)
 - Xcode license accepted: `sudo xcodebuild -license`
 - Metal Toolchain (Xcode 17+): `xcodebuild -downloadComponent MetalToolchain`
 - espeak-ng (optional, for G2P fallback on unknown words): `brew install espeak-ng`
-- git-lfs when building from source: `brew install git-lfs; git lfs install; git lfs install --system`
 
-> **Fresh Mac?** If `cargo install voice` fails with linker errors mentioning
-> "You have not agreed to the Xcode license agreements", run
-> `sudo xcodebuild -license`. If it fails with "cannot execute tool 'metal'
-> due to missing Metal Toolchain", run
-> `xcodebuild -downloadComponent MetalToolchain`. Then retry the install.
-> Also, when compiling from source, a "Failed to parse tagger weights.json" error indicates git-lfs was not installed before the repo was cloned (several large files in the repo will only have internal git-lfs references rather than the full file contents).
+> **Fresh Mac?** If the build fails with linker errors mentioning "You have not
+> agreed to the Xcode license agreements", run `sudo xcodebuild -license`.
+> If it fails with "cannot execute tool 'metal' due to missing Metal Toolchain",
+> run `xcodebuild -downloadComponent MetalToolchain`. Then retry the build.
 
 ## License
 

--- a/crates/voice-g2p/build.rs
+++ b/crates/voice-g2p/build.rs
@@ -1,0 +1,64 @@
+//! Build-time check for Git LFS data.
+//!
+//! The tagger weights file (`data/tagger/weights.json`) is tracked by Git LFS.
+//! If `git lfs` wasn't installed before cloning, the file will contain a tiny
+//! LFS pointer instead of the actual JSON weights. The build will succeed
+//! (it's valid UTF-8, so `include_str!` is happy), but the binary will panic
+//! at runtime when it tries to parse the pointer as JSON.
+//!
+//! This script catches that at build time with a clear error message.
+
+use std::path::Path;
+
+/// LFS pointer files always start with this line.
+const LFS_SIGNATURE: &str = "version https://git-lfs.github.com/spec/v1";
+
+fn main() {
+    let lfs_files: &[&str] = &["data/tagger/weights.json"];
+
+    for rel_path in lfs_files {
+        let path = Path::new(rel_path);
+
+        // Re-run this check if the file changes (e.g. after `git lfs pull`).
+        println!("cargo:rerun-if-changed={}", rel_path);
+
+        let contents = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(e) => {
+                println!(
+                    "cargo:warning=Could not read {}: {}. \
+                     Build may fail if the file is missing.",
+                    rel_path, e
+                );
+                continue;
+            }
+        };
+
+        if contents.starts_with(LFS_SIGNATURE) {
+            eprintln!();
+            eprintln!(
+                "error: {} is a Git LFS pointer, not the actual data.",
+                rel_path
+            );
+            eprintln!();
+            eprintln!("  Git Large File Storage (git-lfs) was not installed when you");
+            eprintln!("  cloned this repository. The file contains:");
+            eprintln!();
+            for line in contents.lines().take(3) {
+                eprintln!("    {}", line);
+            }
+            eprintln!();
+            eprintln!("  To fix this, install git-lfs and re-fetch the data:");
+            eprintln!();
+            eprintln!("    brew install git-lfs");
+            eprintln!("    git lfs install");
+            eprintln!("    git lfs pull");
+            eprintln!();
+            eprintln!("  Then rebuild:");
+            eprintln!();
+            eprintln!("    cargo install --path crates/voice-cli");
+            eprintln!();
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/voice-tts/build.rs
+++ b/crates/voice-tts/build.rs
@@ -1,0 +1,74 @@
+//! Build-time check for Git LFS data.
+//!
+//! The embedded voice files (`data/voices/*.safetensors`) are tracked by Git
+//! LFS. If `git lfs` wasn't installed before cloning, these files will contain
+//! tiny LFS pointers instead of actual safetensor weights. The build will
+//! succeed (the bytes are valid for `include_bytes!`), but the binary will
+//! fail at runtime when it tries to deserialize the pointers as safetensors.
+//!
+//! This script catches that at build time with a clear error message.
+
+use std::path::Path;
+
+/// LFS pointer files always start with this line.
+const LFS_SIGNATURE: &[u8] = b"version https://git-lfs.github.com/spec/v1";
+
+fn main() {
+    let lfs_files: &[&str] = &[
+        "data/voices/af_heart.safetensors",
+        "data/voices/af_bella.safetensors",
+        "data/voices/af_sarah.safetensors",
+        "data/voices/af_sky.safetensors",
+        "data/voices/am_michael.safetensors",
+        "data/voices/am_adam.safetensors",
+        "data/voices/bf_emma.safetensors",
+    ];
+
+    for rel_path in lfs_files {
+        let path = Path::new(rel_path);
+
+        // Re-run this check if the file changes (e.g. after `git lfs pull`).
+        println!("cargo:rerun-if-changed={}", rel_path);
+
+        let contents = match std::fs::read(path) {
+            Ok(c) => c,
+            Err(e) => {
+                println!(
+                    "cargo:warning=Could not read {}: {}. \
+                     Build may fail if the file is missing.",
+                    rel_path, e
+                );
+                continue;
+            }
+        };
+
+        if contents.starts_with(LFS_SIGNATURE) {
+            eprintln!();
+            eprintln!(
+                "error: {} is a Git LFS pointer, not the actual data.",
+                rel_path
+            );
+            eprintln!();
+            eprintln!("  Git Large File Storage (git-lfs) was not installed when you");
+            eprintln!("  cloned this repository. The file contains:");
+            eprintln!();
+            // LFS pointers are small text — safe to display as UTF-8.
+            let text = String::from_utf8_lossy(&contents);
+            for line in text.lines().take(3) {
+                eprintln!("    {}", line);
+            }
+            eprintln!();
+            eprintln!("  To fix this, install git-lfs and re-fetch the data:");
+            eprintln!();
+            eprintln!("    brew install git-lfs");
+            eprintln!("    git lfs install");
+            eprintln!("    git lfs pull");
+            eprintln!();
+            eprintln!("  Then rebuild:");
+            eprintln!();
+            eprintln!("    cargo install --path crates/voice-cli");
+            eprintln!();
+            std::process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
Two things that came up from [#16](https://github.com/rgbkrk/voicers/pull/16):

### Build-time LFS detection

`voice-g2p` and `voice-tts` now have `build.rs` scripts that check if embedded data files are Git LFS pointers instead of actual data. If someone clones without `git lfs`, the build fails immediately with:

```
error: data/tagger/weights.json is a Git LFS pointer, not the actual data.

  Git Large File Storage (git-lfs) was not installed when you
  cloned this repository. The file contains:

    version https://git-lfs.github.com/spec/v1
    oid sha256:789e8e35...
    size 5677744

  To fix this, install git-lfs and re-fetch the data:

    brew install git-lfs
    git lfs install
    git lfs pull
```

Previously this would compile fine but panic at runtime with a cryptic JSON parse error.

### README cleanup

- Removed `cargo install voice` as an install option (broken due to [mlx-rs #327](https://github.com/oxiglade/mlx-rs/issues/327))
- Made build-from-source the only documented path
- Added `git-lfs` to the install instructions and requirements
- Removed duplicate "From source" section
