### PR TITLE
Bump versions: voice-g2p 0.2.1, voice-tts 0.2.1, voice 0.3.0

### DIFF
--- a/crates/voice-cli/Cargo.toml
+++ b/crates/voice-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voice"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.85.0"
 description = "CLI for voice TTS — like say, but with Kokoro"

--- a/crates/voice-g2p/Cargo.toml
+++ b/crates/voice-g2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voice-g2p"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.85.0"
 description = "Grapheme-to-phoneme conversion: misaki dictionary + espeak-ng fallback"

--- a/crates/voice-tts/Cargo.toml
+++ b/crates/voice-tts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voice-tts"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.85.0"
 description = "Rust TTS library backed by MLX, starting with Kokoro"


### PR DESCRIPTION
| Crate | Old | New | What changed |
|-------|-----|-----|-------------|
| `voice-g2p` | 0.2.0 | 0.2.1 | Build-time LFS pointer detection |
| `voice-tts` | 0.2.0 | 0.2.1 | Build-time LFS pointer detection |
| `voice` (CLI) | 0.2.3 | 0.3.0 | JSON-RPC stdio server, cancel, progress notifications |
| `voice-nn` | 0.2.0 | — | No changes |
| `voice-dsp` | 0.2.0 | — | No changes |