### PR TITLE
Fix punct edge cases: brackets, quotes, ellipsis, numbers + spaCy test harness

### DIFF
--- a/crates/voice-g2p/src/tokenizer.rs
+++ b/crates/voice-g2p/src/tokenizer.rs
@@ -14,21 +14,38 @@ use crate::tagger;
 use crate::token::MToken;
 
 /// Characters that should be split off the **end** of a word token.
-const TRAILING_PUNCT: &str = ".!?…,;:)—\u{201D}\u{201E}\u{2019}";
+const TRAILING_PUNCT: &str = ".!?…,;:)—\"\u{201D}\u{201E}\u{2019}";
 
 /// Characters that should be split off the **start** of a word token.
-const LEADING_PUNCT: &str = "($£€¥\u{201C}\u{2018}";
+const LEADING_PUNCT: &str = "($£€¥\"\u{201C}\u{2018}";
 
 /// Returns true if every character in `s` is a punctuation character from PUNCTS.
 fn is_all_puncts(s: &str) -> bool {
     !s.is_empty() && s.chars().all(|c| PUNCTS.contains(c))
 }
 
-/// Returns true if every character in `s` is a digit, comma, or dot.
+/// Returns true if `s` looks like a number (digits with optional commas/dots).
+///
+/// A trailing dot with no digit after it is NOT number-like — that's a
+/// sentence-ending period (e.g. `"3."` → `["3", "."]`), matching spaCy's
+/// behaviour. Internal dots with digits on both sides are fine (`"3.14"`).
 fn is_number_like(s: &str) -> bool {
-    !s.is_empty()
-        && s.chars()
-            .all(|c| c.is_ascii_digit() || c == ',' || c == '.')
+    if s.is_empty() {
+        return false;
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_digit() || c == ',' || c == '.')
+    {
+        return false;
+    }
+    // Must contain at least one digit
+    if !s.chars().any(|c| c.is_ascii_digit()) {
+        return false;
+    }
+    // Trailing dot/comma without a following digit → not a number
+    // (e.g. "3." is sentence-ending, "3," is a list)
+    !s.ends_with('.') && !s.ends_with(',')
 }
 
 /// Returns true if every character in `s` is a currency symbol.
@@ -40,6 +57,10 @@ fn is_currency(s: &str) -> bool {
 fn simple_tag(text: &str) -> &'static str {
     if is_currency(text) {
         "$"
+    } else if text == "(" {
+        "-LRB-"
+    } else if text == ")" {
+        "-RRB-"
     } else if is_all_puncts(text) {
         // Classify punctuation
         let first = text.chars().next().unwrap();
@@ -59,21 +80,68 @@ fn simple_tag(text: &str) -> &'static str {
     }
 }
 
+/// Assign a POS tag for a leading (opening) punctuation character.
+///
+/// Matches spaCy's tagging: `(` → `-LRB-`, `"` → ` `` `, etc.
+fn leading_punct_tag(text: &str) -> &'static str {
+    match text {
+        "(" => "-LRB-",
+        "\"" | "\u{201C}" | "\u{2018}" => "``",
+        _ => simple_tag(text),
+    }
+}
+
+/// Assign a POS tag for a trailing (closing) punctuation character.
+///
+/// Matches spaCy's tagging: `)` → `-RRB-`, `"` → `''`, etc.
+fn trailing_punct_tag(text: &str) -> &'static str {
+    match text {
+        ")" => "-RRB-",
+        "\"" | "\u{201D}" | "\u{201E}" | "\u{2019}" => "''",
+        _ => simple_tag(text),
+    }
+}
+
 /// Split leading and trailing punctuation from a word token into separate tokens.
 ///
 /// For example, `"Hello,"` (with whitespace `" "`) becomes:
 ///   - `MToken { text: "Hello", whitespace: "", tag: "DEFAULT" }`
 ///   - `MToken { text: ",",     whitespace: " ", tag: "," }`
 ///
-/// Tokens that are already pure punctuation, pure numbers, or pure currency
-/// are returned as-is (no splitting).
+/// Pure-punctuation tokens like `"!?!?"` or `"..."` are split into individual
+/// characters so each one maps to its own model pause token.
+///
+/// Number-like and currency tokens are returned as-is.
 fn split_punct(word: &str, whitespace: &str) -> Vec<MToken> {
-    // Don't split tokens that are already classified as non-word
-    if is_all_puncts(word) || is_number_like(word) || is_currency(word) || word.is_empty() {
+    if word.is_empty() || is_number_like(word) || is_currency(word) {
         let tag = simple_tag(word);
         let mut tok = MToken::new(word, tag, whitespace);
         tok.underscore.is_head = true;
         return vec![tok];
+    }
+
+    // Pure-punctuation tokens: split into individual characters so each maps
+    // to its own model vocab entry (e.g. "!?!?" → ["!", "?", "!", "?"],
+    // "..." → [".", ".", "."]). Single-char punct passes through as-is.
+    if is_all_puncts(word) {
+        let chars: Vec<char> = word.chars().collect();
+        if chars.len() == 1 {
+            let tag = simple_tag(word);
+            let mut tok = MToken::new(word, tag, whitespace);
+            tok.underscore.is_head = true;
+            return vec![tok];
+        }
+        let mut result = Vec::new();
+        for (i, ch) in chars.iter().enumerate() {
+            let s: String = std::iter::once(*ch).collect();
+            let is_last = i == chars.len() - 1;
+            let tok_ws = if is_last { whitespace } else { "" };
+            let tag = simple_tag(&s);
+            let mut tok = MToken::new(&s, tag, tok_ws);
+            tok.underscore.is_head = true;
+            result.push(tok);
+        }
+        return result;
     }
 
     let chars: Vec<char> = word.chars().collect();
@@ -92,12 +160,25 @@ fn split_punct(word: &str, whitespace: &str) -> Vec<MToken> {
         .take_while(|c| TRAILING_PUNCT.contains(**c))
         .count();
 
-    // If splitting would consume the entire token, don't split
+    // If leading + trailing consume the entire token (e.g. "()", "\"\""),
+    // emit each character individually with positional tags rather than
+    // returning the whole thing as one opaque token.
     if leading + trailing >= len {
-        let tag = simple_tag(word);
-        let mut tok = MToken::new(word, tag, whitespace);
-        tok.underscore.is_head = true;
-        return vec![tok];
+        let mut result = Vec::new();
+        for (i, ch) in chars.iter().enumerate() {
+            let s: String = std::iter::once(*ch).collect();
+            let is_last = i == chars.len() - 1;
+            let tok_ws = if is_last { whitespace } else { "" };
+            let tag = if LEADING_PUNCT.contains(*ch) {
+                leading_punct_tag(&s)
+            } else {
+                trailing_punct_tag(&s)
+            };
+            let mut tok = MToken::new(&s, tag, tok_ws);
+            tok.underscore.is_head = true;
+            result.push(tok);
+        }
+        return result;
     }
 
     let mut result = Vec::new();
@@ -105,7 +186,7 @@ fn split_punct(word: &str, whitespace: &str) -> Vec<MToken> {
     // Emit leading punct tokens (one per character, like spaCy)
     for i in 0..leading {
         let ch: String = chars[i..=i].iter().collect();
-        let tag = simple_tag(&ch);
+        let tag = leading_punct_tag(&ch);
         let mut tok = MToken::new(&ch, tag, "");
         tok.underscore.is_head = true;
         result.push(tok);
@@ -126,7 +207,7 @@ fn split_punct(word: &str, whitespace: &str) -> Vec<MToken> {
             .collect();
         let is_last = i == trailing - 1;
         let tok_ws = if is_last { whitespace } else { "" };
-        let tag = simple_tag(&ch);
+        let tag = trailing_punct_tag(&ch);
         let mut tok = MToken::new(&ch, tag, tok_ws);
         tok.underscore.is_head = true;
         result.push(tok);
@@ -571,12 +652,99 @@ mod tests {
     }
 
     #[test]
-    fn pure_punct_not_split() {
+    fn pure_punct_split_into_chars() {
+        // "..." → three separate "." tokens
         let tokens = tokenize_simple("...");
+        assert_eq!(tokens.len(), 3);
+        assert_eq!(tokens[0].text, ".");
+        assert_eq!(tokens[1].text, ".");
+        assert_eq!(tokens[2].text, ".");
+    }
+
+    #[test]
+    fn pure_mixed_punct_split() {
+        let tokens = tokenize_simple("!?!?");
+        assert_eq!(tokens.len(), 4);
+        assert_eq!(tokens[0].text, "!");
+        assert_eq!(tokens[1].text, "?");
+        assert_eq!(tokens[2].text, "!");
+        assert_eq!(tokens[3].text, "?");
+    }
+
+    #[test]
+    fn single_punct_not_split_further() {
+        let tokens = tokenize_simple(".");
         assert_eq!(tokens.len(), 1);
-        assert_eq!(tokens[0].text, "...");
+        assert_eq!(tokens[0].text, ".");
         assert_eq!(tokens[0].tag, ".");
     }
+
+    #[test]
+    fn split_parens_with_tags() {
+        let tokens = tokenize_simple("(Hello)");
+        assert_eq!(tokens[0].text, "(");
+        assert_eq!(tokens[0].tag, "-LRB-");
+        assert_eq!(tokens[2].text, ")");
+        assert_eq!(tokens[2].tag, "-RRB-");
+    }
+
+    #[test]
+    fn split_ascii_quotes() {
+        let tokens = tokenize_simple("\"Hello\"");
+        assert_eq!(tokens.len(), 3);
+        assert_eq!(tokens[0].text, "\"");
+        assert_eq!(tokens[0].tag, "``"); // opening
+        assert_eq!(tokens[2].text, "\"");
+        assert_eq!(tokens[2].tag, "''"); // closing
+    }
+
+    #[test]
+    fn split_quoted_sentence_with_period() {
+        // She said, "hello." → She | said | , | " | hello | . | "
+        let tokens = tokenize_simple("She said, \"hello.\"");
+        let texts: Vec<&str> = tokens.iter().map(|t| t.text.as_str()).collect();
+        assert!(texts.contains(&","), "comma should be split: {texts:?}");
+        assert!(texts.contains(&"."), "period should be split: {texts:?}");
+        assert!(
+            texts.iter().filter(|t| **t == "\"").count() == 2,
+            "two quotes should be split: {texts:?}"
+        );
+    }
+
+    #[test]
+    fn split_number_trailing_period() {
+        // "3." at end of sentence → ["3", "."] (period is sentence-ending, not decimal)
+        // Matches spaCy: "I have 3." → [I, have, 3, .]
+        let tokens = tokenize_simple("I have 3.");
+        let texts: Vec<&str> = tokens.iter().map(|t| t.text.as_str()).collect();
+        assert!(texts.contains(&"3"), "number should be separate: {texts:?}");
+        assert!(texts.contains(&"."), "period should be split: {texts:?}");
+    }
+
+    #[test]
+    fn no_split_decimal_number() {
+        // "3.14" stays together — dot has digits on both sides
+        let tokens = tokenize_simple("He scored 3.14 points.");
+        let texts: Vec<&str> = tokens.iter().map(|t| t.text.as_str()).collect();
+        assert!(
+            texts.contains(&"3.14"),
+            "decimal should stay together: {texts:?}"
+        );
+    }
+
+    #[test]
+    fn split_number_trailing_comma() {
+        // "Buy 3, get 1" → "3" and "," split
+        let tokens = tokenize_simple("Buy 3, get 1.");
+        let texts: Vec<&str> = tokens.iter().map(|t| t.text.as_str()).collect();
+        assert!(texts.contains(&"3"), "number should be separate: {texts:?}");
+        assert!(texts.contains(&","), "comma should be split: {texts:?}");
+    }
+
+    // Known edge cases: pure-punctuation inputs like "...", "()", "!?!?" are
+    // degenerate (no words). They pass through as single tokens via
+    // is_all_puncts/simple_tag but may produce empty or unexpected phonemes
+    // downstream. This is acceptable — these inputs don't occur in real speech.
 
     #[test]
     fn simple_currency() {

--- a/tests/spacy_compare.py
+++ b/tests/spacy_compare.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Compare our Rust tokenizer's punctuation output against spaCy's tokenization.
+
+Usage:
+    python3 .context/spacy_compare.py
+    python3 .context/spacy_compare.py --verbose
+    python3 .context/spacy_compare.py --only-failures
+
+Requires:
+    pip install spacy
+    python -m spacy download en_core_web_sm
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+
+try:
+    import spacy
+except ImportError:
+    print("spacy is required: pip install spacy", file=sys.stderr)
+    print("Then: python -m spacy download en_core_web_sm", file=sys.stderr)
+    sys.exit(1)
+
+
+PUNCT_CHARS = set('.,!?;:—…()\u201c\u201d"')
+
+# For comparison purposes, treat ASCII " and curly quotes as equivalent.
+# Our pipeline may normalize " → " or " depending on position.
+QUOTE_EQUIVALENTS = {'"', "\u201c", "\u201d"}
+
+TEST_CASES = [
+    # Basic sentence-ending punctuation
+    "Hello.",
+    "Hello!",
+    "Hello?",
+    # Comma
+    "Hello, world.",
+    # Multiple sentence-ending
+    "Hello. World.",
+    "Wait! What?",
+    "Wait! What? Really.",
+    # Multiple trailing punct
+    "Really?!",
+    "No way!?",
+    # Ellipsis
+    "Hmm...",
+    "Wait... what?",
+    # Brackets
+    "(Hello)",
+    "(yes) and (no)",
+    # Quotes
+    '"Hello"',
+    'She said, "hello."',
+    '"Wait," he said.',
+    # Currency
+    "$100",
+    "$3.50",
+    # Contractions — should NOT split the apostrophe
+    "don't",
+    "I'm fine.",
+    "it's great.",
+    "can't stop, won't stop.",
+    # Numbers — should NOT split internal punct
+    "3.14",
+    "1,000",
+    "3.14 is pi.",
+    # Abbreviations
+    "Mr. Smith",
+    "U.S.A.",
+    "Dr. Jones said hello.",
+    # Semicolons and colons
+    "Hello; world.",
+    "Note: this works.",
+    # Em-dash
+    "Hello — world.",
+    # Complex
+    "Hello, world. How are you? I'm fine!",
+    "First sentence. Second sentence. Third sentence.",
+    "It's amazing how fast voice is. We should build more.",
+    # Edge cases
+    "",
+    "hello",
+    "...",
+    "()",
+    "!?!?",
+    "42",
+]
+
+
+@dataclass
+class TokenInfo:
+    text: str
+    tag: str
+
+
+@dataclass
+class ComparisonResult:
+    input_text: str
+    spacy_tokens: list[TokenInfo]
+    our_phonemes: str
+    spacy_punct_chars: set[str]
+    our_punct_chars: set[str]
+    missing: set[str]
+    extra: set[str]
+
+    @property
+    def ok(self) -> bool:
+        return len(self.missing) == 0
+
+
+def get_spacy_tokens(nlp, text: str) -> list[TokenInfo]:
+    doc = nlp(text)
+    return [TokenInfo(text=tk.text, tag=tk.tag_) for tk in doc]
+
+
+def normalize_punct_set(chars: set[str]) -> set[str]:
+    """Normalize a set of punct characters so that all quote variants collapse to a single canonical form."""
+    result = set()
+    for c in chars:
+        if c in QUOTE_EQUIVALENTS:
+            result.add('"')  # canonical form
+        else:
+            result.add(c)
+    return result
+
+
+def extract_punct_from_spacy(tokens: list[TokenInfo]) -> set[str]:
+    """Extract the set of punctuation characters that spaCy produced as separate tokens."""
+    punct_tags = {".", ",", ":", "-LRB-", "-RRB-", "``", '""', "''", "#", "NFP"}
+    chars = set()
+    for tk in tokens:
+        if tk.tag in punct_tags:
+            for c in tk.text:
+                if c in PUNCT_CHARS:
+                    chars.add(c)
+    return normalize_punct_set(chars)
+
+
+def extract_punct_from_phonemes(phonemes: str) -> set[str]:
+    """Extract the set of punctuation characters present in our phoneme output."""
+    return normalize_punct_set({c for c in phonemes if c in PUNCT_CHARS})
+
+
+def run_comparison(
+    voice_binary: str, nlp, verbose: bool = False
+) -> list[ComparisonResult]:
+    p = subprocess.Popen(
+        [voice_binary, "--jsonrpc", "-q"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        bufsize=1,
+    )
+
+    req_id = 0
+
+    def rpc(method, params=None):
+        nonlocal req_id
+        req_id += 1
+        msg = {"jsonrpc": "2.0", "method": method, "id": req_id}
+        if params:
+            msg["params"] = params
+        p.stdin.write(json.dumps(msg) + "\n")
+        p.stdin.flush()
+        while True:
+            line = p.stdout.readline()
+            if not line:
+                return None
+            obj = json.loads(line)
+            if "id" in obj and obj["id"] is not None:
+                return obj
+
+    rpc("ping")
+
+    results = []
+
+    for text in TEST_CASES:
+        if not text:
+            continue
+
+        spacy_tokens = get_spacy_tokens(nlp, text)
+        spacy_puncts = extract_punct_from_spacy(spacy_tokens)
+
+        resp = rpc("speak", {"text": text, "detail": "full"})
+        if resp and "result" in resp:
+            phonemes = " | ".join(resp["result"]["phonemes"])
+        elif resp and "error" in resp:
+            phonemes = f"ERROR: {resp['error']['message']}"
+        else:
+            phonemes = "ERROR: no response"
+
+        our_puncts = extract_punct_from_phonemes(phonemes)
+        missing = spacy_puncts - our_puncts
+        extra = our_puncts - spacy_puncts
+
+        results.append(
+            ComparisonResult(
+                input_text=text,
+                spacy_tokens=spacy_tokens,
+                our_phonemes=phonemes,
+                spacy_punct_chars=spacy_puncts,
+                our_punct_chars=our_puncts,
+                missing=missing,
+                extra=extra,
+            )
+        )
+
+    p.stdin.close()
+    p.wait()
+    return results
+
+
+def print_results(results: list[ComparisonResult], verbose: bool, only_failures: bool):
+    passed = sum(1 for r in results if r.ok)
+    failed = sum(1 for r in results if not r.ok)
+    total = len(results)
+
+    header = f"{'Input':<40} {'spaCy punct':<15} {'Our punct':<15} {'Status'}"
+    print(header)
+    print("-" * len(header))
+
+    for r in results:
+        if only_failures and r.ok:
+            continue
+
+        spacy_str = "".join(sorted(r.spacy_punct_chars)) or "(none)"
+        our_str = "".join(sorted(r.our_punct_chars)) or "(none)"
+        status = (
+            "\033[32m✓\033[0m"
+            if r.ok
+            else f"\033[31m✗ missing: {''.join(sorted(r.missing))}\033[0m"
+        )
+
+        print(f"{r.input_text:<40} {spacy_str:<15} {our_str:<15} {status}")
+
+        if verbose and not r.ok:
+            spacy_tok_str = " ".join(f"{t.text}|{t.tag}" for t in r.spacy_tokens)
+            print(f"  spaCy: {spacy_tok_str}")
+            print(f"  phon:  {r.our_phonemes}")
+            if r.extra:
+                print(f"  extra: {''.join(sorted(r.extra))}")
+            print()
+
+    print()
+    print(f"Results: {passed}/{total} passed, {failed} failed")
+
+    if failed == 0:
+        print(
+            "\033[32m✅ All punctuation from spaCy appears in our phoneme output.\033[0m"
+        )
+    else:
+        print(
+            f"\033[33m⚠️  {failed} input(s) have punctuation that spaCy produces but we don't.\033[0m"
+        )
+
+    return failed
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare voice G2P punctuation against spaCy"
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Show details for failures"
+    )
+    parser.add_argument(
+        "--only-failures", "-f", action="store_true", help="Only show failures"
+    )
+    parser.add_argument(
+        "--binary",
+        default="voice",
+        help="Path to voice binary (default: voice from PATH)",
+    )
+    args = parser.parse_args()
+
+    print("Loading spaCy model...", file=sys.stderr)
+    nlp = spacy.load("en_core_web_sm")
+
+    print("Running comparison...\n", file=sys.stderr)
+    results = run_comparison(args.binary, nlp, verbose=args.verbose)
+    failed = print_results(
+        results, verbose=args.verbose, only_failures=args.only_failures
+    )
+
+    sys.exit(1 if failed > 0 else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follow-up to #20 — fixes the remaining edge cases found by comparing against spaCy's tokenization.

### Fixes

- **Brackets**: `(Hello)` now properly splits into `(` / `Hello` / `)` with `-LRB-`/`-RRB-` tags
- **Quotes**: ASCII `"` gets positional tags (leading → ` `` `, trailing → `''`) matching spaCy
- **Ellipsis**: `...` splits into three `.` tokens → three pause beats instead of audio garbage
- **Multi-punct**: `!?!?` splits into `!` `?` `!` `?` → proper pause tokens instead of being phonemized as "exclamation"
- **Trailing dot on numbers**: `"I have 3."` now splits `3` and `.` (sentence-ending period, not decimal) — matches spaCy's behaviour

### spaCy comparison harness

Added `tests/spacy_compare.py` — runs 39 test inputs through both spaCy `en_core_web_sm` and our voice G2P, verifying punctuation token coverage matches:

```
python3 tests/spacy_compare.py --binary ./target/release/voice
```

```
Results: 39/39 passed, 0 failed
✅ All punctuation from spaCy appears in our phoneme output.
```

### Tests added

- 8 new tokenizer unit tests (bracket tags, quote tags, quoted sentences, number+period splitting, pure-punct splitting)
- 139 total tests passing in voice-g2p