### PR TITLE
Add speech-to-text: voice-stt crate, voice listen, JSON-RPC listen method

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 crates/voice-g2p/data/tagger/weights.json filter=lfs diff=lfs merge=lfs -text
 crates/voice-tts/data/voices/*.safetensors filter=lfs diff=lfs merge=lfs -text
+crates/voice-stt/data/moonshine_tiny_tokenizer.json filter=lfs diff=lfs merge=lfs -text

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,9 +33,21 @@ dependencies = [
 
 [[package]]
 name = "alsa"
-version = "0.11.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.11.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c88dbbce13b232b26250e1e2e6ac18b6a891a646b8148285036ebce260ac5c3"
 dependencies = [
  "alsa-sys",
  "bitflags 2.11.0",
@@ -31,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "alsa-sys"
-version = "0.4.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
 dependencies = [
  "libc",
  "pkg-config",
@@ -115,6 +141,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -140,7 +172,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn",
 ]
@@ -206,12 +256,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -330,6 +391,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,11 +487,22 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.14.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15c3c3cee7c087938f7ad1c3098840b3ef1f1bdc7f6e496336c3b1e7a6f3914"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-rs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aae284fbaf7d27aa0e292f7677dfbe26503b0d555026f702940805a630eac17"
+dependencies = [
+ "bitflags 1.3.2",
  "libc",
  "objc2-audio-toolbox",
  "objc2-core-audio",
@@ -411,19 +511,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpal"
-version = "0.17.3"
+name = "coreaudio-sys"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
+checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
 dependencies = [
- "alsa",
- "coreaudio-rs",
+ "bindgen 0.72.1",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa 0.9.1",
+ "core-foundation-sys",
+ "coreaudio-rs 0.11.3",
  "dasp_sample",
  "jni",
  "js-sys",
  "libc",
- "mach2",
- "ndk",
+ "mach2 0.4.3",
+ "ndk 0.8.0",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
+]
+
+[[package]]
+name = "cpal"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b1f9c7312f19fc2fa12fd7acaf38de54e8320ba10d1a02dcbe21038def51ccb"
+dependencies = [
+ "alsa 0.10.0",
+ "coreaudio-rs 0.13.0",
+ "dasp_sample",
+ "jni",
+ "js-sys",
+ "libc",
+ "mach2 0.5.0",
+ "ndk 0.9.0",
  "ndk-context",
  "num-derive",
  "num-traits",
@@ -437,7 +569,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -459,6 +591,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,12 +634,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -501,13 +682,33 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -533,6 +734,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -629,6 +861,15 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -912,7 +1153,7 @@ dependencies = [
  "dirs",
  "futures",
  "http",
- "indicatif",
+ "indicatif 0.18.4",
  "libc",
  "log",
  "native-tls",
@@ -1032,7 +1273,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1179,11 +1420,24 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console 0.15.11",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console",
+ "console 0.16.3",
  "portable-atomic",
  "unicode-width",
  "unit-prefix",
@@ -1257,6 +1511,16 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1355,12 +1619,37 @@ dependencies = [
 
 [[package]]
 name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
 name = "memchr"
@@ -1407,7 +1696,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a7c4444d624bf6b93db5cc22ebff4fdfa13593fd56154fe33b1f302a557c2c6"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
@@ -1420,7 +1709,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a819ee8b4434690572b6feb9c3ef0b6e90137e4190b340cf00150703b410aaf9"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -1458,9 +1747,31 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e3bc3880111918b2d5018f845d48fd995f9901f16efc81d1fcfd2f4210b8219"
 dependencies = [
- "bindgen",
+ "bindgen 0.70.1",
  "cc",
  "cmake",
+]
+
+[[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1482,6 +1793,20 @@ dependencies = [
 
 [[package]]
 name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.11.0",
+ "jni-sys",
+ "log",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
@@ -1489,7 +1814,7 @@ dependencies = [
  "bitflags 2.11.0",
  "jni-sys",
  "log",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "thiserror 1.0.69",
 ]
@@ -1499,6 +1824,15 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys",
+]
 
 [[package]]
 name = "ndk-sys"
@@ -1630,6 +1964,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,6 +2059,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni",
+ "ndk 0.8.0",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,6 +2092,28 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "openssl"
@@ -1997,6 +2382,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools 0.14.0",
+ "rayon",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2051,7 +2467,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2108,7 +2524,7 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a536bb79db59098ef71a4dd4246c02eb87b316deceb1b68e0cde7167ec01eb"
 dependencies = [
- "cpal",
+ "cpal 0.17.1",
  "dasp_sample",
  "num-rational",
  "rand 0.10.0",
@@ -2129,6 +2545,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -2354,10 +2776,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -2701,6 +3141,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokenizers"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "indicatif 0.17.11",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.2",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2881,6 +3355,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2891,6 +3380,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unit-prefix"
@@ -2910,7 +3405,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "cookie_store",
  "der",
  "flate2",
@@ -2934,7 +3429,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "httparse",
  "log",
@@ -2984,9 +3479,10 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voice"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
+ "cpal 0.15.3",
  "ctrlc",
  "hound",
  "pulldown-cmark",
@@ -2994,6 +3490,7 @@ dependencies = [
  "serde",
  "serde_json",
  "voice-g2p",
+ "voice-stt",
  "voice-tts",
 ]
 
@@ -3006,7 +3503,7 @@ dependencies = [
 
 [[package]]
 name = "voice-g2p"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "fancy-regex",
  "serde",
@@ -3023,6 +3520,20 @@ dependencies = [
  "mlx-rs",
  "serde",
  "voice-dsp",
+]
+
+[[package]]
+name = "voice-stt"
+version = "0.1.0"
+dependencies = [
+ "hf-hub",
+ "hound",
+ "mlx-macros",
+ "mlx-rs",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokenizers",
 ]
 
 [[package]]
@@ -3260,12 +3771,22 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.62.2",
  "windows-future",
  "windows-numerics",
 ]
@@ -3276,7 +3797,17 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3288,7 +3819,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
 ]
 
@@ -3298,7 +3829,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
  "windows-threading",
 ]
@@ -3337,7 +3868,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
 ]
 
@@ -3348,8 +3879,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3384,6 +3924,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/crates/voice-cli/Cargo.toml
+++ b/crates/voice-cli/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 [dependencies]
 voice-tts = { version = "0.2.0", path = "../voice-tts" }
 voice-g2p = { version = "0.2.0", path = "../voice-g2p" }
+voice-stt = { version = "0.1.0", path = "../voice-stt" }
 clap = { version = "4", features = ["derive"] }
 rodio = "0.22"
 hound = "3"
@@ -22,3 +23,4 @@ pulldown-cmark = "0.13.1"
 ctrlc = "3.5.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+cpal = "0.15"

--- a/crates/voice-cli/src/jsonrpc.rs
+++ b/crates/voice-cli/src/jsonrpc.rs
@@ -7,7 +7,8 @@
 //! ## Methods
 //!
 //! - `speak`        — Generate and play audio from text or phonemes.
-//! - `cancel`       — Interrupt the current utterance's playback.
+//! - `listen`       — Record from mic (VAD auto-stop), transcribe, return text.
+//! - `cancel`       — Interrupt the current utterance's playback or recording.
 //! - `set_voice`    — Change the session's default voice.
 //! - `set_speed`    — Change the session's default speed.
 //! - `list_voices`  — Return the list of builtin voice names.
@@ -43,8 +44,8 @@ use std::sync::mpsc;
 use std::time::Instant;
 
 use crate::{
-    apply_substitutions, apply_tech_subs, collect_subs, interrupted, strip_markdown, INTERRUPTED,
-    QUIET,
+    apply_substitutions, apply_tech_subs, collect_subs, interrupted, listen, strip_markdown,
+    INTERRUPTED, QUIET,
 };
 
 // ── JSON-RPC 2.0 types ────────────────────────────────────────────────
@@ -149,6 +150,16 @@ struct SetSpeedParams {
     speed: f32,
 }
 
+#[derive(Debug, Deserialize)]
+struct ListenParams {
+    /// Maximum recording duration in milliseconds (default: 30000).
+    max_duration_ms: Option<u64>,
+    /// Stop after this many ms of silence following speech (default: 2000).
+    silence_timeout_ms: Option<u64>,
+    /// Amplitude threshold for voice activity detection (default: 0.01).
+    silence_threshold: Option<f32>,
+}
+
 // ── Session state ──────────────────────────────────────────────────────
 
 struct Session {
@@ -162,6 +173,10 @@ struct Session {
     phoneme_overrides: HashMap<String, String>,
     /// Cache of loaded voices so we don't re-load on every `speak`.
     voice_cache: HashMap<String, voice_tts::Array>,
+    /// Lazily-loaded STT model (only initialized on first `listen` call).
+    stt_model: Option<voice_stt::MoonshineModel>,
+    /// Lazily-loaded STT tokenizer.
+    stt_tokenizer: Option<voice_stt::tokenizers::Tokenizer>,
 }
 
 impl Session {
@@ -218,6 +233,8 @@ pub fn run(config: ServerConfig) {
         subs,
         phoneme_overrides,
         voice_cache,
+        stt_model: None,
+        stt_tokenizer: None,
     };
 
     let mut stdout = io::stdout();
@@ -330,6 +347,7 @@ fn dispatch(
 ) -> Option<Response> {
     let result = match method {
         "speak" => handle_speak(session, stdout, params),
+        "listen" => handle_listen(session, params),
         "cancel" => handle_cancel(),
         "set_voice" => handle_set_voice(session, params),
         "set_speed" => handle_set_speed(session, params),
@@ -382,6 +400,71 @@ impl RpcErr {
 fn handle_cancel() -> Result<Value, RpcErr> {
     INTERRUPTED.store(true, Ordering::SeqCst);
     Ok(serde_json::json!({"cancelled": true}))
+}
+
+fn handle_listen(session: &mut Session, params: Value) -> Result<Value, RpcErr> {
+    let p: ListenParams = serde_json::from_value(params).unwrap_or(ListenParams {
+        max_duration_ms: None,
+        silence_timeout_ms: None,
+        silence_threshold: None,
+    });
+
+    let max_duration = p.max_duration_ms.unwrap_or(30_000);
+    let silence_timeout = p.silence_timeout_ms.unwrap_or(2_000);
+    let threshold = p.silence_threshold.unwrap_or(0.01);
+
+    // Lazily load STT model on first listen call
+    if session.stt_model.is_none() {
+        let repo = std::env::var("STT_MODEL")
+            .unwrap_or_else(|_| "UsefulSensors/moonshine-base".to_string());
+
+        if !QUIET.load(Ordering::Relaxed) {
+            eprintln!("Loading STT model ({repo})...");
+        }
+
+        let model = voice_stt::load_model(&repo)
+            .map_err(|e| RpcErr::internal(format!("Failed to load STT model: {e}")))?;
+        let tokenizer = voice_stt::load_tokenizer(&repo)
+            .map_err(|e| RpcErr::internal(format!("Failed to load tokenizer: {e}")))?;
+
+        session.stt_model = Some(model);
+        session.stt_tokenizer = Some(tokenizer);
+
+        if !QUIET.load(Ordering::Relaxed) {
+            eprintln!("STT model loaded.");
+        }
+    }
+
+    let stt_model = session.stt_model.as_mut().unwrap();
+    let stt_tokenizer = session.stt_tokenizer.as_ref().unwrap();
+
+    let started = Instant::now();
+
+    let result = listen::listen_and_transcribe_vad(
+        stt_model,
+        stt_tokenizer,
+        max_duration,
+        silence_timeout,
+        threshold,
+    );
+
+    let duration_ms = started.elapsed().as_millis() as u64;
+
+    // Reset interrupt flag after listen completes
+    INTERRUPTED.store(false, Ordering::Relaxed);
+
+    match result {
+        Some(r) => Ok(serde_json::json!({
+            "text": r.text,
+            "tokens": r.tokens.len(),
+            "duration_ms": duration_ms,
+        })),
+        None => Ok(serde_json::json!({
+            "text": "",
+            "tokens": 0,
+            "duration_ms": duration_ms,
+        })),
+    }
 }
 
 fn handle_speak(

--- a/crates/voice-cli/src/jsonrpc.rs
+++ b/crates/voice-cli/src/jsonrpc.rs
@@ -403,11 +403,16 @@ fn handle_cancel() -> Result<Value, RpcErr> {
 }
 
 fn handle_listen(session: &mut Session, params: Value) -> Result<Value, RpcErr> {
-    let p: ListenParams = serde_json::from_value(params).unwrap_or(ListenParams {
-        max_duration_ms: None,
-        silence_timeout_ms: None,
-        silence_threshold: None,
-    });
+    let p: ListenParams = if params.is_null() {
+        ListenParams {
+            max_duration_ms: None,
+            silence_timeout_ms: None,
+            silence_threshold: None,
+        }
+    } else {
+        serde_json::from_value(params)
+            .map_err(|e| RpcErr::invalid_params(format!("bad listen params: {e}")))?
+    };
 
     let max_duration = p.max_duration_ms.unwrap_or(30_000);
     let silence_timeout = p.silence_timeout_ms.unwrap_or(2_000);

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -1,122 +1,237 @@
 //! Microphone recording and speech-to-text transcription.
 //!
-//! Debug: set `VOICE_SAVE_RECORDING=1` to save mic audio to `/tmp/voice_recording.wav`.
+//! Debug: set `VOICE_SAVE_RECORDING=1` to save mic audio to `/tmp/voice_recording_<timestamp>.wav`.
 //!
 //! Leading silence is automatically trimmed to handle Bluetooth mic latency
 //! (AirPods can take ~0.5-1s before the mic starts capturing real audio).
 //!
-//! Captures audio from the default input device, then runs Moonshine STT
-//! to produce a transcription. Two modes:
+//! A pleasant ding sound plays when the mic is ready to record, so you know
+//! when to start speaking (especially helpful with Bluetooth mic latency).
 //!
-//! - **Single-shot** (`voice listen`): Records until Enter or Ctrl+C,
-//!   transcribes, prints the result.
-//! - **Continuous** (`voice listen --continuous`): Records in segments
-//!   separated by pauses, transcribes each segment as it completes.
+//! Two recording modes:
+//!
+//! - **Manual stop** (`voice listen`): Records until Enter or Ctrl+C.
+//! - **VAD auto-stop** (`record_with_vad`): Records until speech is detected
+//!   and then silence follows for a configurable timeout. Used by the JSON-RPC
+//!   `listen` method so agents don't need to send a signal to stop recording.
 
 use std::io::{self, Write};
+use std::num::NonZero;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::SampleFormat;
+use rodio::{buffer::SamplesBuffer, DeviceSinkBuilder, Player};
 
 use crate::{INTERRUPTED, QUIET};
 
-/// Record audio from the default input device until interrupted.
+// ── Ding sound ─────────────────────────────────────────────────────────
+
+/// Play a short pleasant ding to signal that recording has started.
 ///
-/// Returns mono f32 samples at the device's native sample rate, plus the rate.
-/// Recording stops when `INTERRUPTED` is set (Ctrl+C) or when `stop` is called.
-pub fn record_until_interrupt() -> Result<(Vec<f32>, u32), String> {
+/// Synthesizes a 880Hz (A5) sine tone with a gentle exponential decay
+/// over ~200ms. Quick enough to not be annoying, clear enough to hear.
+fn play_ding() {
+    let sample_rate = 44100u32;
+    let duration_ms = 200;
+    let num_samples = sample_rate as usize * duration_ms / 1000;
+    let freq = 880.0f32; // A5 — bright but not shrill
+
+    let mut samples = Vec::with_capacity(num_samples);
+    for i in 0..num_samples {
+        let t = i as f32 / sample_rate as f32;
+        // Sine wave with exponential decay (τ ≈ 60ms)
+        let envelope = (-t / 0.06).exp() * 0.3; // 0.3 peak volume
+        let sample = (2.0 * std::f32::consts::PI * freq * t).sin() * envelope;
+        samples.push(sample);
+    }
+
+    let Ok(mut stream) = DeviceSinkBuilder::open_default_sink() else {
+        return; // Silent failure — ding is optional
+    };
+    stream.log_on_drop(false);
+    let player = Player::connect_new(stream.mixer());
+
+    let channels = NonZero::new(1u16).unwrap();
+    let rate = NonZero::new(sample_rate).unwrap();
+    let source = SamplesBuffer::new(channels, rate, samples);
+    player.append(source);
+
+    // Wait for the ding to finish before returning
+    while !player.empty() {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    // Brief pause so the ding decays fully before mic picks it up
+    std::thread::sleep(std::time::Duration::from_millis(50));
+}
+
+// ── Mic input helpers ──────────────────────────────────────────────────
+
+/// Open the default input device and return its config.
+fn open_input_device() -> Result<(cpal::Device, cpal::SupportedStreamConfig), String> {
     let host = cpal::default_host();
     let device = host
         .default_input_device()
         .ok_or("No input device available")?;
-
     let config = device
         .default_input_config()
         .map_err(|e| format!("Failed to get input config: {e}"))?;
+    Ok((device, config))
+}
 
-    let sample_rate = config.sample_rate().0;
+/// Build an input stream that writes mono f32 samples into `buffer`.
+///
+/// If `peak_out` is `Some`, each callback also writes the chunk's peak
+/// amplitude (as `f32::to_bits()`) into the atomic for VAD polling.
+fn build_input_stream(
+    device: &cpal::Device,
+    config: &cpal::SupportedStreamConfig,
+    buffer: Arc<Mutex<Vec<f32>>>,
+    peak_out: Option<Arc<std::sync::atomic::AtomicU32>>,
+) -> Result<cpal::Stream, String> {
     let channels = config.channels() as usize;
 
-    if !QUIET.load(Ordering::Relaxed) {
-        let name = device.name().unwrap_or_else(|_| "unknown".to_string());
-        eprintln!("Recording from: {name} ({sample_rate}Hz, {channels}ch)");
-        eprintln!("Press Enter or Ctrl+C to stop recording...");
-    }
-
-    let buffer: Arc<Mutex<Vec<f32>>> = Arc::new(Mutex::new(Vec::new()));
-    let buffer_clone = Arc::clone(&buffer);
-
-    let err_flag: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
-    let err_clone = Arc::clone(&err_flag);
-
-    let stream = match config.sample_format() {
+    match config.sample_format() {
         SampleFormat::F32 => {
-            let buf = Arc::clone(&buffer_clone);
+            let buf = Arc::clone(&buffer);
+            let peak = peak_out.clone();
             device
                 .build_input_stream(
-                    &config.into(),
+                    &config.clone().into(),
                     move |data: &[f32], _: &cpal::InputCallbackInfo| {
-                        // Mix to mono on the fly
                         let mut guard = buf.lock().unwrap();
+                        let mut chunk_peak: f32 = 0.0;
                         if channels == 1 {
-                            guard.extend_from_slice(data);
+                            for &s in data {
+                                chunk_peak = chunk_peak.max(s.abs());
+                                guard.push(s);
+                            }
                         } else {
                             for chunk in data.chunks(channels) {
                                 let mono: f32 = chunk.iter().sum::<f32>() / channels as f32;
+                                chunk_peak = chunk_peak.max(mono.abs());
                                 guard.push(mono);
                             }
                         }
+                        if let Some(ref p) = peak {
+                            p.store(chunk_peak.to_bits(), Ordering::Relaxed);
+                        }
                     },
-                    move |err| {
-                        let mut guard = err_clone.lock().unwrap();
-                        *guard = Some(format!("Audio input error: {err}"));
-                    },
+                    |err| eprintln!("Audio input error: {err}"),
                     None,
                 )
-                .map_err(|e| format!("Failed to build input stream: {e}"))?
+                .map_err(|e| format!("Failed to build input stream: {e}"))
         }
         SampleFormat::I16 => {
-            let buf = Arc::clone(&buffer_clone);
+            let buf = Arc::clone(&buffer);
+            let peak = peak_out.clone();
             device
                 .build_input_stream(
-                    &config.into(),
+                    &config.clone().into(),
                     move |data: &[i16], _: &cpal::InputCallbackInfo| {
                         let mut guard = buf.lock().unwrap();
+                        let mut chunk_peak: f32 = 0.0;
                         if channels == 1 {
                             for &s in data {
-                                guard.push(s as f32 / 32768.0);
+                                let f = s as f32 / 32768.0;
+                                chunk_peak = chunk_peak.max(f.abs());
+                                guard.push(f);
                             }
                         } else {
                             for chunk in data.chunks(channels) {
                                 let mono: f32 =
                                     chunk.iter().map(|&s| s as f32 / 32768.0).sum::<f32>()
                                         / channels as f32;
+                                chunk_peak = chunk_peak.max(mono.abs());
                                 guard.push(mono);
                             }
                         }
+                        if let Some(ref p) = peak {
+                            p.store(chunk_peak.to_bits(), Ordering::Relaxed);
+                        }
                     },
-                    move |err| {
-                        let mut guard = err_flag.lock().unwrap();
-                        *guard = Some(format!("Audio input error: {err}"));
-                    },
+                    |err| eprintln!("Audio input error: {err}"),
                     None,
                 )
-                .map_err(|e| format!("Failed to build input stream: {e}"))?
+                .map_err(|e| format!("Failed to build input stream: {e}"))
         }
-        format => {
-            return Err(format!("Unsupported sample format: {format:?}"));
-        }
-    };
+        format => Err(format!("Unsupported sample format: {format:?}")),
+    }
+}
+
+/// Extract final samples from the shared buffer.
+fn extract_samples(buffer: Arc<Mutex<Vec<f32>>>) -> Vec<f32> {
+    match Arc::try_unwrap(buffer) {
+        Ok(mutex) => mutex.into_inner().unwrap(),
+        Err(arc) => arc.lock().unwrap().clone(),
+    }
+}
+
+/// Log recording stats to stderr (unless quiet).
+fn log_recording_stats(samples: &[f32], sample_rate: u32) {
+    if QUIET.load(Ordering::Relaxed) || samples.is_empty() {
+        return;
+    }
+
+    let duration = samples.len() as f32 / sample_rate as f32;
+    let max_abs = samples.iter().map(|s| s.abs()).fold(0.0f32, f32::max);
+    let rms = (samples.iter().map(|s| s * s).sum::<f32>() / samples.len() as f32).sqrt();
+    let nonzero = samples.iter().filter(|s| s.abs() > 1e-8).count();
+
+    eprintln!(
+        "Recorded {:.1}s ({} samples at {}Hz)",
+        duration,
+        samples.len(),
+        sample_rate
+    );
+    eprintln!(
+        "Audio levels: peak={:.6}, rms={:.6}, nonzero={}/{}",
+        max_abs,
+        rms,
+        nonzero,
+        samples.len()
+    );
+    if max_abs < 0.001 {
+        eprintln!(
+            "⚠️  Audio is nearly silent (peak={:.6}). Check your mic input level.",
+            max_abs
+        );
+    }
+}
+
+// ── Recording modes ────────────────────────────────────────────────────
+
+/// Record audio from the default input device until Enter or Ctrl+C.
+///
+/// Returns mono f32 samples at the device's native sample rate, plus the rate.
+pub fn record_until_interrupt() -> Result<(Vec<f32>, u32), String> {
+    let (device, config) = open_input_device()?;
+    let sample_rate = config.sample_rate().0;
+
+    if !QUIET.load(Ordering::Relaxed) {
+        let name = device.name().unwrap_or_else(|_| "unknown".to_string());
+        eprintln!(
+            "Recording from: {name} ({sample_rate}Hz, {}ch)",
+            config.channels()
+        );
+    }
+
+    // Play ding before recording starts
+    play_ding();
+
+    if !QUIET.load(Ordering::Relaxed) {
+        eprintln!("Press Enter or Ctrl+C to stop recording...");
+    }
+
+    let buffer: Arc<Mutex<Vec<f32>>> = Arc::new(Mutex::new(Vec::new()));
+    let stream = build_input_stream(&device, &config, Arc::clone(&buffer), None)?;
 
     stream
         .play()
         .map_err(|e| format!("Failed to start recording: {e}"))?;
 
-    // Wait for Enter key or Ctrl+C on a separate thread so we don't block
-    // the audio callback. The INTERRUPTED flag is set by the global Ctrl+C
-    // handler in main.rs.
+    // Wait for Enter key or Ctrl+C
     let enter_pressed = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let enter_clone = Arc::clone(&enter_pressed);
 
@@ -126,7 +241,6 @@ pub fn record_until_interrupt() -> Result<(Vec<f32>, u32), String> {
         enter_clone.store(true, Ordering::SeqCst);
     });
 
-    // Poll until interrupted or Enter pressed
     loop {
         if INTERRUPTED.load(Ordering::Relaxed) || enter_pressed.load(Ordering::Relaxed) {
             break;
@@ -134,68 +248,115 @@ pub fn record_until_interrupt() -> Result<(Vec<f32>, u32), String> {
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
 
-    // Stop recording
     drop(stream);
-
-    // Don't wait for stdin thread — it may be blocked on read_line.
-    // Just detach it; it'll exit when the process does.
     drop(stdin_thread);
 
-    let samples = match Arc::try_unwrap(buffer) {
-        Ok(mutex) => mutex.into_inner().unwrap(),
-        Err(arc) => arc.lock().unwrap().clone(),
-    };
-
-    let duration = samples.len() as f32 / sample_rate as f32;
-    if !QUIET.load(Ordering::Relaxed) {
-        eprintln!(
-            "Recorded {:.1}s ({} samples at {}Hz)",
-            duration,
-            samples.len(),
-            sample_rate
-        );
-
-        // Audio level diagnostics
-        if !samples.is_empty() {
-            let max_abs = samples.iter().map(|s| s.abs()).fold(0.0f32, f32::max);
-            let rms = (samples.iter().map(|s| s * s).sum::<f32>() / samples.len() as f32).sqrt();
-            let nonzero = samples.iter().filter(|s| s.abs() > 1e-8).count();
-            eprintln!(
-                "Audio levels: peak={:.6}, rms={:.6}, nonzero={}/{}",
-                max_abs,
-                rms,
-                nonzero,
-                samples.len()
-            );
-            if max_abs < 0.001 {
-                eprintln!(
-                    "⚠️  Audio is nearly silent (peak={:.6}). Check your mic input level.",
-                    max_abs
-                );
-            }
-        }
-    }
-
-    // Save recording to WAV for debugging if requested
-    if std::env::var("VOICE_SAVE_RECORDING").is_ok() {
-        let debug_path = "/tmp/voice_recording.wav";
-        let spec = hound::WavSpec {
-            channels: 1,
-            sample_rate,
-            bits_per_sample: 32,
-            sample_format: hound::SampleFormat::Float,
-        };
-        if let Ok(mut writer) = hound::WavWriter::create(debug_path, spec) {
-            for &s in &samples {
-                let _ = writer.write_sample(s);
-            }
-            let _ = writer.finalize();
-            eprintln!("Saved recording to {debug_path}");
-        }
-    }
+    let samples = extract_samples(buffer);
+    log_recording_stats(&samples, sample_rate);
+    maybe_save_recording(&samples, sample_rate);
 
     Ok((samples, sample_rate))
 }
+
+/// Record audio with voice activity detection (auto-stop on silence).
+///
+/// Plays a ding, starts recording, waits for speech to begin, then
+/// auto-stops after `silence_timeout_ms` of silence following speech.
+/// Also stops on `INTERRUPTED` flag (Ctrl+C / cancel) or `max_duration_ms`.
+///
+/// Returns mono f32 samples at the device's native sample rate, plus the rate.
+pub fn record_with_vad(
+    max_duration_ms: u64,
+    silence_timeout_ms: u64,
+    silence_threshold: f32,
+) -> Result<(Vec<f32>, u32), String> {
+    let (device, config) = open_input_device()?;
+    let sample_rate = config.sample_rate().0;
+
+    if !QUIET.load(Ordering::Relaxed) {
+        let name = device.name().unwrap_or_else(|_| "unknown".to_string());
+        eprintln!(
+            "Recording from: {name} ({sample_rate}Hz, {}ch)",
+            config.channels()
+        );
+    }
+
+    // Play ding BEFORE starting the stream so it's not captured by the mic
+    play_ding();
+
+    let buffer: Arc<Mutex<Vec<f32>>> = Arc::new(Mutex::new(Vec::new()));
+    let recent_peak: Arc<std::sync::atomic::AtomicU32> =
+        Arc::new(std::sync::atomic::AtomicU32::new(0));
+
+    let stream = build_input_stream(
+        &device,
+        &config,
+        Arc::clone(&buffer),
+        Some(Arc::clone(&recent_peak)),
+    )?;
+
+    stream
+        .play()
+        .map_err(|e| format!("Failed to start recording: {e}"))?;
+
+    // VAD state machine
+    let mut speech_started = false;
+    let mut silence_start: Option<std::time::Instant> = None;
+    let start_time = std::time::Instant::now();
+    let max_dur = std::time::Duration::from_millis(max_duration_ms);
+    let silence_dur = std::time::Duration::from_millis(silence_timeout_ms);
+
+    loop {
+        if INTERRUPTED.load(Ordering::Relaxed) {
+            break;
+        }
+
+        if start_time.elapsed() >= max_dur {
+            if !QUIET.load(Ordering::Relaxed) {
+                eprintln!("Max recording duration reached.");
+            }
+            break;
+        }
+
+        let peak_bits = recent_peak.load(Ordering::Relaxed);
+        let current_peak = f32::from_bits(peak_bits);
+        let is_speech = current_peak > silence_threshold;
+
+        if is_speech {
+            if !speech_started {
+                speech_started = true;
+                if !QUIET.load(Ordering::Relaxed) {
+                    eprintln!("Speech detected...");
+                }
+            }
+            silence_start = None;
+        } else if speech_started {
+            if silence_start.is_none() {
+                silence_start = Some(std::time::Instant::now());
+            }
+            if let Some(ss) = silence_start {
+                if ss.elapsed() >= silence_dur {
+                    if !QUIET.load(Ordering::Relaxed) {
+                        eprintln!("Silence detected, stopping recording.");
+                    }
+                    break;
+                }
+            }
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    drop(stream);
+
+    let samples = extract_samples(buffer);
+    log_recording_stats(&samples, sample_rate);
+    maybe_save_recording(&samples, sample_rate);
+
+    Ok((samples, sample_rate))
+}
+
+// ── Audio processing ───────────────────────────────────────────────────
 
 /// Trim leading and trailing silence from audio samples.
 ///
@@ -203,20 +364,14 @@ pub fn record_until_interrupt() -> Result<(Vec<f32>, u32), String> {
 /// actually flows, producing a block of zeros at the start. Moonshine
 /// is sensitive to the silence-to-speech ratio, especially on short
 /// recordings — trimming silence dramatically improves accuracy.
-///
-/// Uses a simple energy threshold: finds the first and last sample
-/// whose absolute value exceeds `threshold`, then keeps a small
-/// `padding` of extra samples on each side for natural attack/release.
 fn trim_silence(samples: &[f32], sample_rate: u32) -> Vec<f32> {
     if samples.is_empty() {
         return Vec::new();
     }
 
-    // Threshold: samples below this absolute value are considered silence.
-    // -40 dBFS ≈ 0.01 amplitude — conservative enough to keep quiet speech.
+    // Threshold: -40 dBFS ≈ 0.01 amplitude
     let threshold: f32 = 0.01;
-
-    // Padding: keep 100ms of context around detected speech edges.
+    // Keep 100ms of context around detected speech edges
     let padding = (sample_rate as usize) / 10;
 
     let first_voice = samples.iter().position(|s| s.abs() > threshold);
@@ -228,12 +383,69 @@ fn trim_silence(samples: &[f32], sample_rate: u32) -> Vec<f32> {
             let end = (end + padding).min(samples.len());
             samples[start..end].to_vec()
         }
-        _ => {
-            // All silence — return empty
-            Vec::new()
+        _ => Vec::new(),
+    }
+}
+
+// ── Debug recording save ───────────────────────────────────────────────
+
+/// Save samples to a timestamped WAV file in /tmp for debugging.
+/// Only runs if `VOICE_SAVE_RECORDING` env var is set.
+fn maybe_save_recording(samples: &[f32], sample_rate: u32) {
+    if std::env::var("VOICE_SAVE_RECORDING").is_err() || samples.is_empty() {
+        return;
+    }
+
+    let timestamp = {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let days = secs / 86400;
+        let time_of_day = secs % 86400;
+        let hours = time_of_day / 3600;
+        let minutes = (time_of_day % 3600) / 60;
+        let seconds = time_of_day % 60;
+        let (year, month, day) = days_to_ymd(days);
+        format!("{year:04}{month:02}{day:02}_{hours:02}{minutes:02}{seconds:02}")
+    };
+
+    let debug_path = format!("/tmp/voice_recording_{timestamp}.wav");
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate,
+        bits_per_sample: 32,
+        sample_format: hound::SampleFormat::Float,
+    };
+
+    if let Ok(mut writer) = hound::WavWriter::create(&debug_path, spec) {
+        for &s in samples {
+            let _ = writer.write_sample(s);
+        }
+        let _ = writer.finalize();
+        if !QUIET.load(Ordering::Relaxed) {
+            eprintln!("Saved recording to {debug_path}");
         }
     }
 }
+
+/// Convert days since Unix epoch to (year, month, day).
+fn days_to_ymd(days: u64) -> (u64, u64, u64) {
+    let z = days + 719468;
+    let era = z / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+// ── STT model helpers ──────────────────────────────────────────────────
 
 /// Default STT model. Override with `STT_MODEL` env var.
 /// moonshine-base (61M) is noticeably better than tiny (27M) for real mic audio.
@@ -243,20 +455,15 @@ fn stt_model_repo() -> String {
     std::env::var("STT_MODEL").unwrap_or_else(|_| DEFAULT_STT_MODEL.to_string())
 }
 
-/// Record from mic, transcribe with Moonshine, and print the result.
-///
-/// This is the main entry point for `voice listen`.
-///
-/// Uses moonshine-base by default. Override with `STT_MODEL` env var:
-///   STT_MODEL=UsefulSensors/moonshine-tiny voice listen
-pub fn listen_and_transcribe() {
+/// Load STT model and tokenizer. Prints progress to stderr unless quiet.
+fn load_stt() -> (voice_stt::MoonshineModel, voice_stt::tokenizers::Tokenizer) {
     let repo = stt_model_repo();
 
     if !QUIET.load(Ordering::Relaxed) {
         eprintln!("Loading speech-to-text model ({repo})...");
     }
 
-    let mut model = match voice_stt::load_model(&repo) {
+    let model = match voice_stt::load_model(&repo) {
         Ok(m) => m,
         Err(e) => {
             eprintln!("Failed to load STT model: {e}");
@@ -277,7 +484,55 @@ pub fn listen_and_transcribe() {
         eprintln!("Model loaded. Ready to listen.\n");
     }
 
-    // Record
+    (model, tokenizer)
+}
+
+/// Run transcription on recorded audio with silence trimming.
+fn transcribe_samples(
+    model: &mut voice_stt::MoonshineModel,
+    tokenizer: &voice_stt::tokenizers::Tokenizer,
+    samples: &[f32],
+    sample_rate: u32,
+) -> Option<voice_stt::TranscribeResult> {
+    // Trim leading/trailing silence
+    let original_len = samples.len();
+    let trimmed = trim_silence(samples, sample_rate);
+    let trimmed_duration = trimmed.len() as f32 / sample_rate as f32;
+
+    if !QUIET.load(Ordering::Relaxed) && trimmed.len() < original_len {
+        let original_duration = original_len as f32 / sample_rate as f32;
+        eprintln!(
+            "Trimmed silence: {:.1}s → {:.1}s of speech",
+            original_duration, trimmed_duration
+        );
+    }
+
+    if trimmed.is_empty() {
+        eprintln!("No speech detected in recording.");
+        return None;
+    }
+
+    if !QUIET.load(Ordering::Relaxed) {
+        eprintln!("Transcribing {:.1}s of audio...", trimmed_duration);
+    }
+
+    match voice_stt::transcribe_audio_with_tokenizer(model, &trimmed, sample_rate, tokenizer) {
+        Ok(r) => Some(r),
+        Err(e) => {
+            eprintln!("Transcription failed: {e}");
+            None
+        }
+    }
+}
+
+// ── Public entry points ────────────────────────────────────────────────
+
+/// Record from mic (manual stop), transcribe, print result.
+///
+/// Entry point for `voice listen`.
+pub fn listen_and_transcribe() {
+    let (mut model, tokenizer) = load_stt();
+
     let (samples, sample_rate) = match record_until_interrupt() {
         Ok(r) => r,
         Err(e) => {
@@ -291,84 +546,53 @@ pub fn listen_and_transcribe() {
         return;
     }
 
-    // Trim leading/trailing silence (Bluetooth mic latency, pauses)
-    let original_len = samples.len();
-    let samples = trim_silence(&samples, sample_rate);
-    let trimmed_duration = samples.len() as f32 / sample_rate as f32;
-
-    if !QUIET.load(Ordering::Relaxed) {
-        let original_duration = original_len as f32 / sample_rate as f32;
-        if samples.len() < original_len {
-            eprintln!(
-                "Trimmed silence: {:.1}s → {:.1}s of speech",
-                original_duration, trimmed_duration
-            );
-        }
-    }
-
-    if samples.is_empty() {
-        eprintln!("No speech detected in recording.");
-        return;
-    }
-
-    // Transcribe
-    if !QUIET.load(Ordering::Relaxed) {
-        eprintln!("Transcribing {:.1}s of audio...", trimmed_duration);
-    }
-
-    let result = match voice_stt::transcribe_audio_with_tokenizer(
-        &mut model,
-        &samples,
-        sample_rate,
-        &tokenizer,
-    ) {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("Transcription failed: {e}");
-            std::process::exit(1);
-        }
-    };
-
     // Reset interrupt so the process exits cleanly
     INTERRUPTED.store(false, Ordering::Relaxed);
 
-    // Print the transcription to stdout
-    println!("{}", result.text);
-
-    if !QUIET.load(Ordering::Relaxed) {
-        let _ = io::stderr().flush();
-        eprintln!("\n({} tokens)", result.tokens.len());
+    if let Some(result) = transcribe_samples(&mut model, &tokenizer, &samples, sample_rate) {
+        println!("{}", result.text);
+        if !QUIET.load(Ordering::Relaxed) {
+            let _ = io::stderr().flush();
+            eprintln!("\n({} tokens)", result.tokens.len());
+        }
     }
+}
+
+/// Record from mic (VAD auto-stop), transcribe, return result.
+///
+/// Used by the JSON-RPC `listen` method. Returns `None` if no speech
+/// was detected or transcription failed.
+pub fn listen_and_transcribe_vad(
+    model: &mut voice_stt::MoonshineModel,
+    tokenizer: &voice_stt::tokenizers::Tokenizer,
+    max_duration_ms: u64,
+    silence_timeout_ms: u64,
+    silence_threshold: f32,
+) -> Option<voice_stt::TranscribeResult> {
+    let (samples, sample_rate) =
+        match record_with_vad(max_duration_ms, silence_timeout_ms, silence_threshold) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("Recording failed: {e}");
+                return None;
+            }
+        };
+
+    if samples.is_empty() {
+        return None;
+    }
+
+    transcribe_samples(model, tokenizer, &samples, sample_rate)
 }
 
 /// Transcribe a WAV file and print the result.
 ///
 /// Entry point for `voice --transcribe <file>`.
 pub fn transcribe_file(path: &str) {
-    let repo = stt_model_repo();
+    let (mut model, tokenizer) = load_stt();
 
     if !QUIET.load(Ordering::Relaxed) {
-        eprintln!("Loading speech-to-text model ({repo})...");
-    }
-
-    let mut model = match voice_stt::load_model(&repo) {
-        Ok(m) => m,
-        Err(e) => {
-            eprintln!("Failed to load STT model: {e}");
-            std::process::exit(1);
-        }
-    };
-
-    let tokenizer = match voice_stt::load_tokenizer(&repo) {
-        Ok(t) => t,
-        Err(e) => {
-            eprintln!("Failed to load tokenizer: {e}");
-            std::process::exit(1);
-        }
-    };
-
-    if !QUIET.load(Ordering::Relaxed) {
-        eprintln!("Model loaded. Transcribing: {path}");
+        eprintln!("Transcribing: {path}");
     }
 
     // Load WAV

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -1,5 +1,10 @@
 //! Microphone recording and speech-to-text transcription.
 //!
+//! Debug: set `VOICE_SAVE_RECORDING=1` to save mic audio to `/tmp/voice_recording.wav`.
+//!
+//! Leading silence is automatically trimmed to handle Bluetooth mic latency
+//! (AirPods can take ~0.5-1s before the mic starts capturing real audio).
+//!
 //! Captures audio from the default input device, then runs Moonshine STT
 //! to produce a transcription. Two modes:
 //!
@@ -149,30 +154,118 @@ pub fn record_until_interrupt() -> Result<(Vec<f32>, u32), String> {
             samples.len(),
             sample_rate
         );
+
+        // Audio level diagnostics
+        if !samples.is_empty() {
+            let max_abs = samples.iter().map(|s| s.abs()).fold(0.0f32, f32::max);
+            let rms = (samples.iter().map(|s| s * s).sum::<f32>() / samples.len() as f32).sqrt();
+            let nonzero = samples.iter().filter(|s| s.abs() > 1e-8).count();
+            eprintln!(
+                "Audio levels: peak={:.6}, rms={:.6}, nonzero={}/{}",
+                max_abs,
+                rms,
+                nonzero,
+                samples.len()
+            );
+            if max_abs < 0.001 {
+                eprintln!(
+                    "⚠️  Audio is nearly silent (peak={:.6}). Check your mic input level.",
+                    max_abs
+                );
+            }
+        }
+    }
+
+    // Save recording to WAV for debugging if requested
+    if std::env::var("VOICE_SAVE_RECORDING").is_ok() {
+        let debug_path = "/tmp/voice_recording.wav";
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate,
+            bits_per_sample: 32,
+            sample_format: hound::SampleFormat::Float,
+        };
+        if let Ok(mut writer) = hound::WavWriter::create(debug_path, spec) {
+            for &s in &samples {
+                let _ = writer.write_sample(s);
+            }
+            let _ = writer.finalize();
+            eprintln!("Saved recording to {debug_path}");
+        }
     }
 
     Ok((samples, sample_rate))
 }
 
+/// Trim leading and trailing silence from audio samples.
+///
+/// Bluetooth microphones (e.g. AirPods) can take ~0.5-1s before audio
+/// actually flows, producing a block of zeros at the start. Moonshine
+/// is sensitive to the silence-to-speech ratio, especially on short
+/// recordings — trimming silence dramatically improves accuracy.
+///
+/// Uses a simple energy threshold: finds the first and last sample
+/// whose absolute value exceeds `threshold`, then keeps a small
+/// `padding` of extra samples on each side for natural attack/release.
+fn trim_silence(samples: &[f32], sample_rate: u32) -> Vec<f32> {
+    if samples.is_empty() {
+        return Vec::new();
+    }
+
+    // Threshold: samples below this absolute value are considered silence.
+    // -40 dBFS ≈ 0.01 amplitude — conservative enough to keep quiet speech.
+    let threshold: f32 = 0.01;
+
+    // Padding: keep 100ms of context around detected speech edges.
+    let padding = (sample_rate as usize) / 10;
+
+    let first_voice = samples.iter().position(|s| s.abs() > threshold);
+    let last_voice = samples.iter().rposition(|s| s.abs() > threshold);
+
+    match (first_voice, last_voice) {
+        (Some(start), Some(end)) => {
+            let start = start.saturating_sub(padding);
+            let end = (end + padding).min(samples.len());
+            samples[start..end].to_vec()
+        }
+        _ => {
+            // All silence — return empty
+            Vec::new()
+        }
+    }
+}
+
+/// Default STT model. Override with `STT_MODEL` env var.
+/// moonshine-base (61M) is noticeably better than tiny (27M) for real mic audio.
+const DEFAULT_STT_MODEL: &str = "UsefulSensors/moonshine-base";
+
+fn stt_model_repo() -> String {
+    std::env::var("STT_MODEL").unwrap_or_else(|_| DEFAULT_STT_MODEL.to_string())
+}
+
 /// Record from mic, transcribe with Moonshine, and print the result.
 ///
 /// This is the main entry point for `voice listen`.
+///
+/// Uses moonshine-base by default. Override with `STT_MODEL` env var:
+///   STT_MODEL=UsefulSensors/moonshine-tiny voice listen
 pub fn listen_and_transcribe() {
-    // Load the STT model
+    let repo = stt_model_repo();
+
     if !QUIET.load(Ordering::Relaxed) {
-        eprintln!("Loading speech-to-text model...");
+        eprintln!("Loading speech-to-text model ({repo})...");
     }
 
-    let mut model = match voice_stt::load_model("UsefulSensors/moonshine-tiny") {
+    let mut model = match voice_stt::load_model(&repo) {
         Ok(m) => m,
         Err(e) => {
             eprintln!("Failed to load STT model: {e}");
-            eprintln!("Model weights (~108MB) will be downloaded from HuggingFace on first run.");
+            eprintln!("Model weights will be downloaded from HuggingFace on first run.");
             std::process::exit(1);
         }
     };
 
-    let tokenizer = match voice_stt::load_tokenizer("UsefulSensors/moonshine-tiny") {
+    let tokenizer = match voice_stt::load_tokenizer(&repo) {
         Ok(t) => t,
         Err(e) => {
             eprintln!("Failed to load tokenizer: {e}");
@@ -198,9 +291,29 @@ pub fn listen_and_transcribe() {
         return;
     }
 
+    // Trim leading/trailing silence (Bluetooth mic latency, pauses)
+    let original_len = samples.len();
+    let samples = trim_silence(&samples, sample_rate);
+    let trimmed_duration = samples.len() as f32 / sample_rate as f32;
+
+    if !QUIET.load(Ordering::Relaxed) {
+        let original_duration = original_len as f32 / sample_rate as f32;
+        if samples.len() < original_len {
+            eprintln!(
+                "Trimmed silence: {:.1}s → {:.1}s of speech",
+                original_duration, trimmed_duration
+            );
+        }
+    }
+
+    if samples.is_empty() {
+        eprintln!("No speech detected in recording.");
+        return;
+    }
+
     // Transcribe
     if !QUIET.load(Ordering::Relaxed) {
-        eprintln!("Transcribing...");
+        eprintln!("Transcribing {:.1}s of audio...", trimmed_duration);
     }
 
     let result = match voice_stt::transcribe_audio_with_tokenizer(
@@ -232,11 +345,13 @@ pub fn listen_and_transcribe() {
 ///
 /// Entry point for `voice --transcribe <file>`.
 pub fn transcribe_file(path: &str) {
+    let repo = stt_model_repo();
+
     if !QUIET.load(Ordering::Relaxed) {
-        eprintln!("Loading speech-to-text model...");
+        eprintln!("Loading speech-to-text model ({repo})...");
     }
 
-    let mut model = match voice_stt::load_model("UsefulSensors/moonshine-tiny") {
+    let mut model = match voice_stt::load_model(&repo) {
         Ok(m) => m,
         Err(e) => {
             eprintln!("Failed to load STT model: {e}");
@@ -244,7 +359,7 @@ pub fn transcribe_file(path: &str) {
         }
     };
 
-    let tokenizer = match voice_stt::load_tokenizer("UsefulSensors/moonshine-tiny") {
+    let tokenizer = match voice_stt::load_tokenizer(&repo) {
         Ok(t) => t,
         Err(e) => {
             eprintln!("Failed to load tokenizer: {e}");

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -1,0 +1,324 @@
+//! Microphone recording and speech-to-text transcription.
+//!
+//! Captures audio from the default input device, then runs Moonshine STT
+//! to produce a transcription. Two modes:
+//!
+//! - **Single-shot** (`voice listen`): Records until Enter or Ctrl+C,
+//!   transcribes, prints the result.
+//! - **Continuous** (`voice listen --continuous`): Records in segments
+//!   separated by pauses, transcribes each segment as it completes.
+
+use std::io::{self, Write};
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
+
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use cpal::SampleFormat;
+
+use crate::{INTERRUPTED, QUIET};
+
+/// Record audio from the default input device until interrupted.
+///
+/// Returns mono f32 samples at the device's native sample rate, plus the rate.
+/// Recording stops when `INTERRUPTED` is set (Ctrl+C) or when `stop` is called.
+pub fn record_until_interrupt() -> Result<(Vec<f32>, u32), String> {
+    let host = cpal::default_host();
+    let device = host
+        .default_input_device()
+        .ok_or("No input device available")?;
+
+    let config = device
+        .default_input_config()
+        .map_err(|e| format!("Failed to get input config: {e}"))?;
+
+    let sample_rate = config.sample_rate().0;
+    let channels = config.channels() as usize;
+
+    if !QUIET.load(Ordering::Relaxed) {
+        let name = device.name().unwrap_or_else(|_| "unknown".to_string());
+        eprintln!("Recording from: {name} ({sample_rate}Hz, {channels}ch)");
+        eprintln!("Press Enter or Ctrl+C to stop recording...");
+    }
+
+    let buffer: Arc<Mutex<Vec<f32>>> = Arc::new(Mutex::new(Vec::new()));
+    let buffer_clone = Arc::clone(&buffer);
+
+    let err_flag: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let err_clone = Arc::clone(&err_flag);
+
+    let stream = match config.sample_format() {
+        SampleFormat::F32 => {
+            let buf = Arc::clone(&buffer_clone);
+            device
+                .build_input_stream(
+                    &config.into(),
+                    move |data: &[f32], _: &cpal::InputCallbackInfo| {
+                        // Mix to mono on the fly
+                        let mut guard = buf.lock().unwrap();
+                        if channels == 1 {
+                            guard.extend_from_slice(data);
+                        } else {
+                            for chunk in data.chunks(channels) {
+                                let mono: f32 = chunk.iter().sum::<f32>() / channels as f32;
+                                guard.push(mono);
+                            }
+                        }
+                    },
+                    move |err| {
+                        let mut guard = err_clone.lock().unwrap();
+                        *guard = Some(format!("Audio input error: {err}"));
+                    },
+                    None,
+                )
+                .map_err(|e| format!("Failed to build input stream: {e}"))?
+        }
+        SampleFormat::I16 => {
+            let buf = Arc::clone(&buffer_clone);
+            device
+                .build_input_stream(
+                    &config.into(),
+                    move |data: &[i16], _: &cpal::InputCallbackInfo| {
+                        let mut guard = buf.lock().unwrap();
+                        if channels == 1 {
+                            for &s in data {
+                                guard.push(s as f32 / 32768.0);
+                            }
+                        } else {
+                            for chunk in data.chunks(channels) {
+                                let mono: f32 =
+                                    chunk.iter().map(|&s| s as f32 / 32768.0).sum::<f32>()
+                                        / channels as f32;
+                                guard.push(mono);
+                            }
+                        }
+                    },
+                    move |err| {
+                        let mut guard = err_flag.lock().unwrap();
+                        *guard = Some(format!("Audio input error: {err}"));
+                    },
+                    None,
+                )
+                .map_err(|e| format!("Failed to build input stream: {e}"))?
+        }
+        format => {
+            return Err(format!("Unsupported sample format: {format:?}"));
+        }
+    };
+
+    stream
+        .play()
+        .map_err(|e| format!("Failed to start recording: {e}"))?;
+
+    // Wait for Enter key or Ctrl+C on a separate thread so we don't block
+    // the audio callback. The INTERRUPTED flag is set by the global Ctrl+C
+    // handler in main.rs.
+    let enter_pressed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let enter_clone = Arc::clone(&enter_pressed);
+
+    let stdin_thread = std::thread::spawn(move || {
+        let mut line = String::new();
+        let _ = io::stdin().read_line(&mut line);
+        enter_clone.store(true, Ordering::SeqCst);
+    });
+
+    // Poll until interrupted or Enter pressed
+    loop {
+        if INTERRUPTED.load(Ordering::Relaxed) || enter_pressed.load(Ordering::Relaxed) {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    // Stop recording
+    drop(stream);
+
+    // Don't wait for stdin thread — it may be blocked on read_line.
+    // Just detach it; it'll exit when the process does.
+    drop(stdin_thread);
+
+    let samples = match Arc::try_unwrap(buffer) {
+        Ok(mutex) => mutex.into_inner().unwrap(),
+        Err(arc) => arc.lock().unwrap().clone(),
+    };
+
+    let duration = samples.len() as f32 / sample_rate as f32;
+    if !QUIET.load(Ordering::Relaxed) {
+        eprintln!(
+            "Recorded {:.1}s ({} samples at {}Hz)",
+            duration,
+            samples.len(),
+            sample_rate
+        );
+    }
+
+    Ok((samples, sample_rate))
+}
+
+/// Record from mic, transcribe with Moonshine, and print the result.
+///
+/// This is the main entry point for `voice listen`.
+pub fn listen_and_transcribe() {
+    // Load the STT model
+    if !QUIET.load(Ordering::Relaxed) {
+        eprintln!("Loading speech-to-text model...");
+    }
+
+    let mut model = match voice_stt::load_model("UsefulSensors/moonshine-tiny") {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("Failed to load STT model: {e}");
+            eprintln!("Model weights (~108MB) will be downloaded from HuggingFace on first run.");
+            std::process::exit(1);
+        }
+    };
+
+    let tokenizer = match voice_stt::load_tokenizer("UsefulSensors/moonshine-tiny") {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("Failed to load tokenizer: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    if !QUIET.load(Ordering::Relaxed) {
+        eprintln!("Model loaded. Ready to listen.\n");
+    }
+
+    // Record
+    let (samples, sample_rate) = match record_until_interrupt() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Recording failed: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    if samples.is_empty() {
+        eprintln!("No audio recorded.");
+        return;
+    }
+
+    // Transcribe
+    if !QUIET.load(Ordering::Relaxed) {
+        eprintln!("Transcribing...");
+    }
+
+    let result = match voice_stt::transcribe_audio_with_tokenizer(
+        &mut model,
+        &samples,
+        sample_rate,
+        &tokenizer,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Transcription failed: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    // Reset interrupt so the process exits cleanly
+    INTERRUPTED.store(false, Ordering::Relaxed);
+
+    // Print the transcription to stdout
+    println!("{}", result.text);
+
+    if !QUIET.load(Ordering::Relaxed) {
+        let _ = io::stderr().flush();
+        eprintln!("\n({} tokens)", result.tokens.len());
+    }
+}
+
+/// Transcribe a WAV file and print the result.
+///
+/// Entry point for `voice --transcribe <file>`.
+pub fn transcribe_file(path: &str) {
+    if !QUIET.load(Ordering::Relaxed) {
+        eprintln!("Loading speech-to-text model...");
+    }
+
+    let mut model = match voice_stt::load_model("UsefulSensors/moonshine-tiny") {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("Failed to load STT model: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let tokenizer = match voice_stt::load_tokenizer("UsefulSensors/moonshine-tiny") {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("Failed to load tokenizer: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    if !QUIET.load(Ordering::Relaxed) {
+        eprintln!("Model loaded. Transcribing: {path}");
+    }
+
+    // Load WAV
+    let reader = match hound::WavReader::open(path) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Failed to open {path}: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let spec = reader.spec();
+    let channels = spec.channels as usize;
+    let sample_rate = spec.sample_rate;
+
+    let samples: Vec<f32> = match spec.sample_format {
+        hound::SampleFormat::Int => {
+            let max_val = (1u32 << (spec.bits_per_sample - 1)) as f32;
+            reader
+                .into_samples::<i32>()
+                .map(|s| s.unwrap_or(0) as f32 / max_val)
+                .collect()
+        }
+        hound::SampleFormat::Float => reader
+            .into_samples::<f32>()
+            .map(|s| s.unwrap_or(0.0))
+            .collect(),
+    };
+
+    // Mix to mono
+    let mono: Vec<f32> = if channels > 1 {
+        samples
+            .chunks(channels)
+            .map(|frame| frame.iter().sum::<f32>() / channels as f32)
+            .collect()
+    } else {
+        samples
+    };
+
+    let duration = mono.len() as f32 / sample_rate as f32;
+    if !QUIET.load(Ordering::Relaxed) {
+        eprintln!(
+            "Audio: {:.1}s ({} samples at {}Hz)",
+            duration,
+            mono.len(),
+            sample_rate
+        );
+    }
+
+    let result = match voice_stt::transcribe_audio_with_tokenizer(
+        &mut model,
+        &mono,
+        sample_rate,
+        &tokenizer,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Transcription failed: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    println!("{}", result.text);
+
+    if !QUIET.load(Ordering::Relaxed) {
+        eprintln!("\n({} tokens)", result.tokens.len());
+    }
+}

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -578,7 +578,7 @@ pub fn listen_and_transcribe_vad(
             }
         };
 
-    if samples.is_empty() {
+    if INTERRUPTED.load(Ordering::Relaxed) || samples.is_empty() {
         return None;
     }
 

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -94,11 +94,11 @@ struct Args {
 
     /// Record from microphone and transcribe (speech-to-text).
     /// Also triggered by `voice listen` as the first positional arg.
-    #[arg(long)]
+    #[arg(long, conflicts_with_all = ["text", "input_file", "phonemes", "jsonrpc", "transcribe"])]
     listen: bool,
 
     /// Transcribe a WAV audio file (speech-to-text).
-    #[arg(long, value_name = "FILE")]
+    #[arg(long, value_name = "FILE", conflicts_with_all = ["text", "input_file", "phonemes", "jsonrpc", "listen"])]
     transcribe: Option<PathBuf>,
 }
 

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod jsonrpc;
+mod listen;
 
 use clap::Parser;
 use pulldown_cmark::{Event, Options, Parser as MdParser, Tag, TagEnd};
@@ -40,7 +41,9 @@ macro_rules! info {
                   voice --phonemes \"hɛloʊ wɜːld\"\n  \
                   voice --markdown -f post.mdx\n  \
                   voice --sub nteract=enteract -f post.mdx\n  \
-                  voice --sub-file .voice-subs --markdown -f post.mdx"
+                  voice --sub-file .voice-subs --markdown -f post.mdx\n  \
+                  voice listen\n  \
+                  voice --transcribe recording.wav"
 )]
 struct Args {
     /// Text to speak
@@ -88,6 +91,15 @@ struct Args {
     /// Run as a JSON-RPC 2.0 server on stdin/stdout.
     #[arg(long)]
     jsonrpc: bool,
+
+    /// Record from microphone and transcribe (speech-to-text).
+    /// Also triggered by `voice listen` as the first positional arg.
+    #[arg(long)]
+    listen: bool,
+
+    /// Transcribe a WAV audio file (speech-to-text).
+    #[arg(long, value_name = "FILE")]
+    transcribe: Option<PathBuf>,
 }
 
 fn resolve_text(args: &Args) -> Result<String, String> {
@@ -407,6 +419,25 @@ fn main() {
     if args.quiet {
         QUIET.store(true, Ordering::Relaxed);
     }
+
+    // -- STT modes: listen (mic) and transcribe (file) -----------------------
+    // These bypass the TTS pipeline entirely.
+
+    // Support `voice listen` as a positional arg shortcut for `--listen`
+    let is_listen =
+        args.listen || (args.text.len() == 1 && args.text[0].eq_ignore_ascii_case("listen"));
+
+    if is_listen {
+        listen::listen_and_transcribe();
+        return;
+    }
+
+    if let Some(ref path) = args.transcribe {
+        listen::transcribe_file(&path.display().to_string());
+        return;
+    }
+
+    // -- TTS pipeline --------------------------------------------------------
 
     // Start model loading in a background thread immediately — this is the
     // slowest startup step (~200ms) and can run while we resolve text + G2P.

--- a/crates/voice-g2p/src/lexicon.rs
+++ b/crates/voice-g2p/src/lexicon.rs
@@ -1237,7 +1237,7 @@ mod tests {
 
     #[test]
     fn test_float_to_words() {
-        let result = float_to_words(3.14);
+        let result = float_to_words(std::f64::consts::PI);
         assert!(result.starts_with("three point"));
     }
 

--- a/crates/voice-g2p/src/tokenizer.rs
+++ b/crates/voice-g2p/src/tokenizer.rs
@@ -839,7 +839,7 @@ mod tests {
     #[test]
     fn subtokenize_apostrophe() {
         let result = subtokenize("don't");
-        assert!(result.len() >= 1, "Should handle apostrophe: {:?}", result);
+        assert!(!result.is_empty(), "Should handle apostrophe: {:?}", result);
     }
 
     #[test]

--- a/crates/voice-stt/Cargo.toml
+++ b/crates/voice-stt/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "voice-stt"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.85.0"
+description = "Speech-to-text library backed by MLX, starting with Moonshine"
+license = "MIT"
+repository = "https://github.com/rgbkrk/voicers"
+
+[dependencies]
+mlx-rs = { version = "0.25", features = ["safetensors"] }
+mlx-macros = "0.25.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+hf-hub = "0.5"
+hound = "3"
+thiserror = "2"
+tokenizers = "0.21"

--- a/crates/voice-stt/build.rs
+++ b/crates/voice-stt/build.rs
@@ -1,0 +1,64 @@
+//! Build-time check for Git LFS data.
+//!
+//! The embedded tokenizer file (`data/moonshine_tiny_tokenizer.json`) is tracked
+//! by Git LFS. If `git lfs` wasn't installed before cloning, the file will
+//! contain a tiny LFS pointer instead of the actual JSON tokenizer data. The
+//! build will succeed (the bytes are valid for `include_str!`), but the binary
+//! will fail at runtime when it tries to parse the pointer as a tokenizer.
+//!
+//! This script catches that at build time with a clear error message.
+
+use std::path::Path;
+
+/// LFS pointer files always start with this line.
+const LFS_SIGNATURE: &str = "version https://git-lfs.github.com/spec/v1";
+
+fn main() {
+    let lfs_files: &[&str] = &["data/moonshine_tiny_tokenizer.json"];
+
+    for rel_path in lfs_files {
+        let path = Path::new(rel_path);
+
+        // Re-run this check if the file changes (e.g. after `git lfs pull`).
+        println!("cargo:rerun-if-changed={}", rel_path);
+
+        let contents = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(e) => {
+                println!(
+                    "cargo:warning=Could not read {}: {}. \
+                     Build may fail if the file is missing.",
+                    rel_path, e
+                );
+                continue;
+            }
+        };
+
+        if contents.starts_with(LFS_SIGNATURE) {
+            eprintln!();
+            eprintln!(
+                "error: {} is a Git LFS pointer, not the actual data.",
+                rel_path
+            );
+            eprintln!();
+            eprintln!("  Git Large File Storage (git-lfs) was not installed when you");
+            eprintln!("  cloned this repository. The file contains:");
+            eprintln!();
+            for line in contents.lines().take(3) {
+                eprintln!("    {}", line);
+            }
+            eprintln!();
+            eprintln!("  To fix this, install git-lfs and re-fetch the data:");
+            eprintln!();
+            eprintln!("    brew install git-lfs");
+            eprintln!("    git lfs install");
+            eprintln!("    git lfs pull");
+            eprintln!();
+            eprintln!("  Then rebuild:");
+            eprintln!();
+            eprintln!("    cargo install --path crates/voice-cli");
+            eprintln!();
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/voice-stt/data/moonshine_tiny_config.json
+++ b/crates/voice-stt/data/moonshine_tiny_config.json
@@ -1,0 +1,33 @@
+{
+  "architectures": [
+    "MoonshineForConditionalGeneration"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "bos_token_id": 1,
+  "pad_token_id": 2,
+  "decoder_hidden_act": "silu",
+  "decoder_num_attention_heads": 8,
+  "decoder_num_hidden_layers": 6,
+  "decoder_num_key_value_heads": 8,
+  "decoder_start_token_id": 1,
+  "encoder_hidden_act": "gelu",
+  "encoder_num_attention_heads": 8,
+  "encoder_num_hidden_layers": 6,
+  "encoder_num_key_value_heads": 8,
+  "eos_token_id": 2,
+  "hidden_size": 288,
+  "initializer_range": 0.02,
+  "intermediate_size": 1152,
+  "is_encoder_decoder": true,
+  "max_position_embeddings": 194,
+  "model_type": "moonshine",
+  "partial_rotary_factor": 0.9,
+  "rope_scaling": null,
+  "rope_theta": 10000.0,
+  "torch_dtype": "float32",
+  "transformers_version": "4.48.0.dev0",
+  "use_cache": true,
+  "vocab_size": 32768,
+  "pad_head_dim_to_multiple_of": 8
+}

--- a/crates/voice-stt/data/moonshine_tiny_tokenizer.json
+++ b/crates/voice-stt/data/moonshine_tiny_tokenizer.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6579793438bc4fbafffacf699169ff53e3769c5a0a0f5e71cdee8853e8130deb
+size 1985530

--- a/crates/voice-stt/examples/transcribe.rs
+++ b/crates/voice-stt/examples/transcribe.rs
@@ -1,0 +1,111 @@
+//! Example: transcribe a WAV file using Moonshine.
+//!
+//! Usage:
+//!     cargo run -p voice-stt --example transcribe -- /path/to/audio.wav
+//!
+//! The WAV file must be 16kHz mono (16-bit or 32-bit float).
+//! Generate a test file with:
+//!     voice -o test.wav "Hello, this is a test."
+//!     ffmpeg -i test.wav -ar 16000 -acodec pcm_s16le test_16k.wav
+
+use std::env;
+use std::time::Instant;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: {} <audio.wav>", args[0]);
+        eprintln!();
+        eprintln!("The WAV file must be 16kHz mono.");
+        eprintln!("Generate a test file with:");
+        eprintln!("  voice -o test.wav \"Hello, this is a test.\"");
+        eprintln!("  ffmpeg -i test.wav -ar 16000 -acodec pcm_s16le test_16k.wav");
+        std::process::exit(1);
+    }
+    let audio_path = &args[1];
+
+    let repo =
+        env::var("MOONSHINE_MODEL").unwrap_or_else(|_| "UsefulSensors/moonshine-tiny".to_string());
+
+    eprintln!("Loading model: {repo}");
+    let t0 = Instant::now();
+    let mut model = voice_stt::load_model(&repo).expect("Failed to load model");
+    eprintln!("Model loaded in {:.2}s", t0.elapsed().as_secs_f64());
+
+    eprintln!("Loading tokenizer...");
+    let tokenizer = voice_stt::load_tokenizer(&repo).expect("Failed to load tokenizer");
+
+    eprintln!("Transcribing: {audio_path}");
+    let t1 = Instant::now();
+
+    // Load the WAV file
+    let samples = load_wav_16k(audio_path);
+    let duration_secs = samples.len() as f64 / 16000.0;
+    eprintln!(
+        "Audio: {:.2}s ({} samples at 16kHz)",
+        duration_secs,
+        samples.len()
+    );
+
+    let result =
+        voice_stt::transcribe_audio_with_tokenizer(&mut model, &samples, 16000, &tokenizer)
+            .expect("Transcription failed");
+
+    let elapsed = t1.elapsed().as_secs_f64();
+    let rtf = elapsed / duration_secs;
+
+    println!("{}", result.text);
+    eprintln!();
+    eprintln!(
+        "Tokens: {} generated in {:.2}s",
+        result.tokens.len(),
+        elapsed
+    );
+    eprintln!("RTF: {:.2}x (< 1.0 = faster than real-time)", rtf);
+}
+
+/// Load a 16kHz WAV file as mono f32 samples.
+///
+/// Handles both 16-bit integer and 32-bit float WAV formats.
+fn load_wav_16k(path: &str) -> Vec<f32> {
+    let reader = hound::WavReader::open(path).unwrap_or_else(|e| {
+        eprintln!("Failed to open {path}: {e}");
+        std::process::exit(1);
+    });
+
+    let spec = reader.spec();
+    if spec.sample_rate != 16000 {
+        eprintln!(
+            "Error: WAV sample rate is {}Hz, expected 16000Hz.",
+            spec.sample_rate
+        );
+        eprintln!("Convert with: ffmpeg -i {path} -ar 16000 -acodec pcm_s16le output_16k.wav");
+        std::process::exit(1);
+    }
+
+    let channels = spec.channels as usize;
+
+    let samples: Vec<f32> = match spec.sample_format {
+        hound::SampleFormat::Int => {
+            let max_val = (1u32 << (spec.bits_per_sample - 1)) as f32;
+            reader
+                .into_samples::<i32>()
+                .map(|s| s.unwrap_or(0) as f32 / max_val)
+                .collect()
+        }
+        hound::SampleFormat::Float => reader
+            .into_samples::<f32>()
+            .map(|s| s.unwrap_or(0.0))
+            .collect(),
+    };
+
+    // Mix to mono if needed
+    if channels > 1 {
+        samples
+            .chunks(channels)
+            .map(|frame| frame.iter().sum::<f32>() / channels as f32)
+            .collect()
+    } else {
+        samples
+    }
+}

--- a/crates/voice-stt/src/builtin.rs
+++ b/crates/voice-stt/src/builtin.rs
@@ -1,0 +1,112 @@
+//! Embedded model config and tokenizer data for instant startup.
+//!
+//! The Moonshine-tiny config and tokenizer are compiled into the binary via
+//! `include_str!`, enabling instant model initialization with no network or
+//! filesystem access for these small files. Model weights (~108MB) are still
+//! downloaded from HuggingFace Hub on first run.
+
+use crate::error::{Result, SttError};
+use crate::moonshine::MoonshineConfig;
+
+// Embedded data
+const MOONSHINE_TINY_CONFIG_JSON: &str = include_str!("../data/moonshine_tiny_config.json");
+const MOONSHINE_TINY_TOKENIZER_JSON: &str = include_str!("../data/moonshine_tiny_tokenizer.json");
+
+/// Default HuggingFace repo ID for Moonshine-tiny.
+pub const MOONSHINE_TINY_REPO: &str = "UsefulSensors/moonshine-tiny";
+
+/// Default HuggingFace repo ID for Moonshine-base.
+pub const MOONSHINE_BASE_REPO: &str = "UsefulSensors/moonshine-base";
+
+/// All known model repo IDs with embedded configs.
+pub const BUILTIN_MODELS: &[&str] = &[MOONSHINE_TINY_REPO];
+
+/// Parse the embedded Moonshine-tiny model config.
+pub fn builtin_config() -> Result<MoonshineConfig> {
+    let config: MoonshineConfig =
+        serde_json::from_str(MOONSHINE_TINY_CONFIG_JSON).map_err(SttError::Json)?;
+    Ok(config)
+}
+
+/// Return the raw JSON string for the embedded Moonshine-tiny tokenizer.
+///
+/// This can be passed to `tokenizers::Tokenizer::from_bytes()` to create
+/// a tokenizer without any filesystem or network access.
+pub fn builtin_tokenizer_json() -> &'static str {
+    MOONSHINE_TINY_TOKENIZER_JSON
+}
+
+/// Load the embedded Moonshine-tiny tokenizer.
+pub fn builtin_tokenizer() -> Result<tokenizers::Tokenizer> {
+    tokenizers::Tokenizer::from_bytes(MOONSHINE_TINY_TOKENIZER_JSON.as_bytes())
+        .map_err(|e| SttError::Tokenizer(format!("Failed to load embedded tokenizer: {e}")))
+}
+
+/// Check if a repo ID has an embedded config available.
+pub fn has_builtin_config(repo_id: &str) -> bool {
+    BUILTIN_MODELS.contains(&repo_id)
+}
+
+/// Get the embedded config for a repo ID, if available.
+pub fn config_for_repo(repo_id: &str) -> Option<Result<MoonshineConfig>> {
+    match repo_id {
+        MOONSHINE_TINY_REPO => Some(builtin_config()),
+        _ => None,
+    }
+}
+
+/// Get the embedded tokenizer for a repo ID, if available.
+pub fn tokenizer_for_repo(repo_id: &str) -> Option<Result<tokenizers::Tokenizer>> {
+    match repo_id {
+        MOONSHINE_TINY_REPO => Some(builtin_tokenizer()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_builtin_config_parses() {
+        let config = builtin_config().unwrap();
+        assert_eq!(config.model_type, "moonshine");
+        assert_eq!(config.hidden_size, 288);
+        assert_eq!(config.vocab_size, 32768);
+        assert_eq!(config.encoder_num_hidden_layers, 6);
+        assert_eq!(config.decoder_num_hidden_layers, 6);
+    }
+
+    #[test]
+    fn test_builtin_tokenizer_loads() {
+        let tokenizer = builtin_tokenizer().unwrap();
+        let vocab_size = tokenizer.get_vocab_size(true);
+        assert_eq!(vocab_size, 32768);
+    }
+
+    #[test]
+    fn test_builtin_tokenizer_decodes() {
+        let tokenizer = builtin_tokenizer().unwrap();
+        // Token 1 = BOS (<s>), Token 2 = EOS (</s>)
+        // Try decoding some basic tokens
+        let result = tokenizer.decode(&[1], true);
+        assert!(result.is_ok(), "Should decode BOS token");
+    }
+
+    #[test]
+    fn test_has_builtin() {
+        assert!(has_builtin_config("UsefulSensors/moonshine-tiny"));
+        assert!(!has_builtin_config("UsefulSensors/moonshine-base"));
+        assert!(!has_builtin_config("openai/whisper-tiny"));
+    }
+
+    #[test]
+    fn test_config_for_repo() {
+        let config = config_for_repo("UsefulSensors/moonshine-tiny");
+        assert!(config.is_some());
+        assert!(config.unwrap().is_ok());
+
+        let config = config_for_repo("unknown/model");
+        assert!(config.is_none());
+    }
+}

--- a/crates/voice-stt/src/error.rs
+++ b/crates/voice-stt/src/error.rs
@@ -1,0 +1,32 @@
+//! Error types for voice-stt.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SttError {
+    #[error("MLX error: {0}")]
+    Mlx(#[from] mlx_rs::error::Exception),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("Hub error: {0}")]
+    Hub(String),
+
+    #[error("Tokenizer error: {0}")]
+    Tokenizer(String),
+
+    #[error("Audio error: {0}")]
+    Audio(String),
+
+    #[error("Weight error: {0}")]
+    Weight(String),
+
+    #[error("Model error: {0}")]
+    Model(String),
+}
+
+pub type Result<T> = std::result::Result<T, SttError>;

--- a/crates/voice-stt/src/lib.rs
+++ b/crates/voice-stt/src/lib.rs
@@ -1,0 +1,315 @@
+//! Speech-to-text library backed by MLX, starting with Moonshine.
+//!
+//! # Quick start
+//!
+//! ```rust,no_run
+//! use voice_stt::{load_model, transcribe, TranscribeResult};
+//!
+//! let mut model = load_model("UsefulSensors/moonshine-tiny").unwrap();
+//! let result = transcribe(&mut model, "audio.wav").unwrap();
+//! println!("{}", result.text);
+//! ```
+//!
+//! # Supported models
+//!
+//! | Model | Repo ID | Params |
+//! |-------|---------|--------|
+//! | Moonshine Tiny | `UsefulSensors/moonshine-tiny` | 27M |
+//! | Moonshine Base | `UsefulSensors/moonshine-base` | 61M |
+//!
+//! # Architecture
+//!
+//! Moonshine uses a learned Conv1d audio frontend instead of mel spectrograms,
+//! so raw 16kHz audio goes directly into the encoder with no DSP preprocessing.
+
+pub mod error;
+pub mod moonshine;
+
+use std::path::{Path, PathBuf};
+
+pub use error::{Result, SttError};
+pub use mlx_rs::Array;
+pub use moonshine::{MoonshineConfig, MoonshineModel};
+
+/// Result of a transcription.
+#[derive(Debug, Clone)]
+pub struct TranscribeResult {
+    /// The transcribed text.
+    pub text: String,
+    /// Number of tokens generated (excluding BOS/EOS).
+    pub tokens: Vec<u32>,
+    /// Sample rate of the model (always 16000 for Moonshine).
+    pub sample_rate: u32,
+}
+
+/// Load a Moonshine model from a HuggingFace repo or local path.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// let mut model = voice_stt::load_model("UsefulSensors/moonshine-tiny").unwrap();
+/// ```
+pub fn load_model(path_or_repo: &str) -> Result<MoonshineModel> {
+    let model_dir = if Path::new(path_or_repo).exists() {
+        PathBuf::from(path_or_repo)
+    } else {
+        download_model(path_or_repo)?
+    };
+
+    let config_path = model_dir.join("config.json");
+    let config_str = std::fs::read_to_string(&config_path)?;
+    let config: MoonshineConfig = serde_json::from_str(&config_str)?;
+
+    let mut model = MoonshineModel::new(&config).map_err(SttError::Mlx)?;
+
+    // Load weights
+    let weights_path = model_dir.join("model.safetensors");
+    if !weights_path.exists() {
+        return Err(SttError::Weight(format!(
+            "model.safetensors not found in {}",
+            model_dir.display()
+        )));
+    }
+
+    let raw_weights =
+        Array::load_safetensors(&weights_path).map_err(|e| SttError::Weight(e.to_string()))?;
+
+    let weights = model
+        .sanitize(raw_weights)
+        .map_err(|e| SttError::Weight(e.to_string()))?;
+
+    // Apply weights to model parameters
+    {
+        use mlx_rs::module::ModuleParameters;
+        let mut params = model.parameters_mut().flatten();
+        let mut loaded = 0;
+        let mut missing = Vec::new();
+        for (key, value) in &weights {
+            if let Some(param) = params.get_mut(&**key) {
+                **param = value.clone();
+                loaded += 1;
+            } else {
+                missing.push(key.clone());
+            }
+        }
+        if !missing.is_empty() {
+            eprintln!(
+                "[WARN] Loaded {}/{} weights, {} unmatched",
+                loaded,
+                weights.len(),
+                missing.len()
+            );
+        }
+    }
+
+    Ok(model)
+}
+
+/// Load the tokenizer from a model directory.
+///
+/// Moonshine uses a HuggingFace fast tokenizer stored as `tokenizer.json`.
+pub fn load_tokenizer(path_or_repo: &str) -> Result<tokenizers::Tokenizer> {
+    let model_dir = if Path::new(path_or_repo).exists() {
+        PathBuf::from(path_or_repo)
+    } else {
+        download_model(path_or_repo)?
+    };
+
+    let tokenizer_path = model_dir.join("tokenizer.json");
+    if !tokenizer_path.exists() {
+        return Err(SttError::Tokenizer(format!(
+            "tokenizer.json not found in {}",
+            model_dir.display()
+        )));
+    }
+
+    tokenizers::Tokenizer::from_file(&tokenizer_path)
+        .map_err(|e| SttError::Tokenizer(e.to_string()))
+}
+
+/// Transcribe an audio file.
+///
+/// Loads the audio file as WAV (16-bit PCM or 32-bit float), converts to
+/// 16kHz mono f32, and runs greedy decoding.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// let mut model = voice_stt::load_model("UsefulSensors/moonshine-tiny").unwrap();
+/// let result = voice_stt::transcribe(&mut model, "audio.wav").unwrap();
+/// println!("{}", result.text);
+/// ```
+pub fn transcribe(
+    model: &mut MoonshineModel,
+    audio_path: impl AsRef<Path>,
+) -> Result<TranscribeResult> {
+    let audio_path = audio_path.as_ref();
+    let samples = load_wav_as_f32(audio_path)?;
+    transcribe_audio(model, &samples, model.config.sample_rate())
+}
+
+/// Transcribe raw audio samples.
+///
+/// - `samples`: mono f32 audio samples
+/// - `sample_rate`: sample rate of the input audio (will be resampled to 16kHz if different)
+pub fn transcribe_audio(
+    model: &mut MoonshineModel,
+    samples: &[f32],
+    sample_rate: u32,
+) -> Result<TranscribeResult> {
+    if sample_rate != 16000 {
+        return Err(SttError::Audio(format!(
+            "Expected 16kHz audio, got {sample_rate}Hz. Resampling not yet implemented."
+        )));
+    }
+
+    let audio = Array::from_slice(samples, &[samples.len() as i32]);
+
+    let tokens = model.generate(&audio, 200).map_err(SttError::Mlx)?;
+
+    // Decode tokens to text using the tokenizer if available,
+    // otherwise fall back to a basic ASCII decode.
+    let text = decode_tokens_fallback(&tokens);
+
+    Ok(TranscribeResult {
+        text,
+        tokens,
+        sample_rate: 16000,
+    })
+}
+
+/// Transcribe raw audio samples with a tokenizer for proper text decoding.
+pub fn transcribe_audio_with_tokenizer(
+    model: &mut MoonshineModel,
+    samples: &[f32],
+    sample_rate: u32,
+    tokenizer: &tokenizers::Tokenizer,
+) -> Result<TranscribeResult> {
+    if sample_rate != 16000 {
+        return Err(SttError::Audio(format!(
+            "Expected 16kHz audio, got {sample_rate}Hz. Resampling not yet implemented."
+        )));
+    }
+
+    let audio = Array::from_slice(samples, &[samples.len() as i32]);
+
+    let tokens = model.generate(&audio, 200).map_err(SttError::Mlx)?;
+
+    let text = tokenizer
+        .decode(&tokens, true)
+        .map_err(|e| SttError::Tokenizer(e.to_string()))?;
+
+    Ok(TranscribeResult {
+        text,
+        tokens,
+        sample_rate: 16000,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Download model files from HuggingFace Hub.
+fn download_model(repo_id: &str) -> Result<PathBuf> {
+    let api = hf_hub::api::sync::Api::new().map_err(|e| SttError::Hub(e.to_string()))?;
+    let repo = api.model(repo_id.to_string());
+
+    // Download required files
+    let config_path = repo
+        .get("config.json")
+        .map_err(|e| SttError::Hub(e.to_string()))?;
+
+    repo.get("model.safetensors")
+        .map_err(|e| SttError::Hub(e.to_string()))?;
+
+    // Try to download tokenizer (optional — not all model paths have it)
+    let _ = repo.get("tokenizer.json");
+
+    // Return the directory containing the downloaded files
+    let model_dir = config_path
+        .parent()
+        .ok_or_else(|| SttError::Hub("Could not determine model directory".to_string()))?;
+
+    Ok(model_dir.to_path_buf())
+}
+
+/// Load a WAV file and return mono f32 samples.
+///
+/// Handles both 16-bit integer and 32-bit float WAV formats.
+/// Multi-channel audio is mixed down to mono by averaging.
+fn load_wav_as_f32(path: &Path) -> Result<Vec<f32>> {
+    let reader = hound::WavReader::open(path)
+        .map_err(|e| SttError::Audio(format!("Failed to open {}: {e}", path.display())))?;
+
+    let spec = reader.spec();
+    let channels = spec.channels as usize;
+
+    let samples: Vec<f32> = match spec.sample_format {
+        hound::SampleFormat::Int => {
+            let bits = spec.bits_per_sample;
+            let max_val = (1u32 << (bits - 1)) as f32;
+            reader
+                .into_samples::<i32>()
+                .map(|s| s.unwrap_or(0) as f32 / max_val)
+                .collect()
+        }
+        hound::SampleFormat::Float => reader
+            .into_samples::<f32>()
+            .map(|s| s.unwrap_or(0.0))
+            .collect(),
+    };
+
+    // Mix down to mono if multi-channel
+    let mono = if channels > 1 {
+        samples
+            .chunks(channels)
+            .map(|frame| frame.iter().sum::<f32>() / channels as f32)
+            .collect()
+    } else {
+        samples
+    };
+
+    // Resample if needed (for now, just check)
+    if spec.sample_rate != 16000 {
+        return Err(SttError::Audio(format!(
+            "WAV sample rate is {}Hz, expected 16000Hz. Resampling not yet implemented.",
+            spec.sample_rate
+        )));
+    }
+
+    Ok(mono)
+}
+
+/// Fallback token decoder when no tokenizer is available.
+///
+/// Maps ASCII-range tokens to characters, and wraps others in `<id>` brackets.
+fn decode_tokens_fallback(tokens: &[u32]) -> String {
+    tokens
+        .iter()
+        .map(|&t| {
+            if (32..128).contains(&t) {
+                (t as u8 as char).to_string()
+            } else {
+                format!("<{t}>")
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_tokens_fallback_ascii() {
+        let tokens = vec![72, 101, 108, 108, 111]; // "Hello"
+        assert_eq!(decode_tokens_fallback(&tokens), "Hello");
+    }
+
+    #[test]
+    fn test_decode_tokens_fallback_non_ascii() {
+        let tokens = vec![1, 72, 101, 2];
+        assert_eq!(decode_tokens_fallback(&tokens), "<1>He<2>");
+    }
+}

--- a/crates/voice-stt/src/lib.rs
+++ b/crates/voice-stt/src/lib.rs
@@ -31,6 +31,7 @@ use std::path::{Path, PathBuf};
 pub use error::{Result, SttError};
 pub use mlx_rs::Array;
 pub use moonshine::{MoonshineConfig, MoonshineModel};
+pub use tokenizers;
 
 /// Result of a transcription.
 #[derive(Debug, Clone)]

--- a/crates/voice-stt/src/lib.rs
+++ b/crates/voice-stt/src/lib.rs
@@ -22,6 +22,7 @@
 //! Moonshine uses a learned Conv1d audio frontend instead of mel spectrograms,
 //! so raw 16kHz audio goes directly into the encoder with no DSP preprocessing.
 
+pub mod builtin;
 pub mod error;
 pub mod moonshine;
 
@@ -56,9 +57,14 @@ pub fn load_model(path_or_repo: &str) -> Result<MoonshineModel> {
         download_model(path_or_repo)?
     };
 
-    let config_path = model_dir.join("config.json");
-    let config_str = std::fs::read_to_string(&config_path)?;
-    let config: MoonshineConfig = serde_json::from_str(&config_str)?;
+    // Use embedded config if available, otherwise read from disk
+    let config: MoonshineConfig = if let Some(result) = builtin::config_for_repo(path_or_repo) {
+        result?
+    } else {
+        let config_path = model_dir.join("config.json");
+        let config_str = std::fs::read_to_string(&config_path)?;
+        serde_json::from_str(&config_str)?
+    };
 
     let mut model = MoonshineModel::new(&config).map_err(SttError::Mlx)?;
 
@@ -109,6 +115,11 @@ pub fn load_model(path_or_repo: &str) -> Result<MoonshineModel> {
 ///
 /// Moonshine uses a HuggingFace fast tokenizer stored as `tokenizer.json`.
 pub fn load_tokenizer(path_or_repo: &str) -> Result<tokenizers::Tokenizer> {
+    // Use embedded tokenizer if available
+    if let Some(result) = builtin::tokenizer_for_repo(path_or_repo) {
+        return result;
+    }
+
     let model_dir = if Path::new(path_or_repo).exists() {
         PathBuf::from(path_or_repo)
     } else {
@@ -167,9 +178,14 @@ pub fn transcribe_audio(
 
     let tokens = model.generate(&audio, 200).map_err(SttError::Mlx)?;
 
-    // Decode tokens to text using the tokenizer if available,
-    // otherwise fall back to a basic ASCII decode.
-    let text = decode_tokens_fallback(&tokens);
+    // Try embedded tokenizer first, then fall back to ASCII decode
+    let text = if let Ok(tokenizer) = builtin::builtin_tokenizer() {
+        tokenizer
+            .decode(&tokens, true)
+            .unwrap_or_else(|_| decode_tokens_fallback(&tokens))
+    } else {
+        decode_tokens_fallback(&tokens)
+    };
 
     Ok(TranscribeResult {
         text,

--- a/crates/voice-stt/src/lib.rs
+++ b/crates/voice-stt/src/lib.rs
@@ -168,13 +168,13 @@ pub fn transcribe_audio(
     samples: &[f32],
     sample_rate: u32,
 ) -> Result<TranscribeResult> {
-    if sample_rate != 16000 {
-        return Err(SttError::Audio(format!(
-            "Expected 16kHz audio, got {sample_rate}Hz. Resampling not yet implemented."
-        )));
-    }
+    let samples = if sample_rate != 16000 {
+        resample_linear(samples, sample_rate, 16000)
+    } else {
+        samples.to_vec()
+    };
 
-    let audio = Array::from_slice(samples, &[samples.len() as i32]);
+    let audio = Array::from_slice(&samples, &[samples.len() as i32]);
 
     let tokens = model.generate(&audio, 200).map_err(SttError::Mlx)?;
 
@@ -201,13 +201,13 @@ pub fn transcribe_audio_with_tokenizer(
     sample_rate: u32,
     tokenizer: &tokenizers::Tokenizer,
 ) -> Result<TranscribeResult> {
-    if sample_rate != 16000 {
-        return Err(SttError::Audio(format!(
-            "Expected 16kHz audio, got {sample_rate}Hz. Resampling not yet implemented."
-        )));
-    }
+    let samples = if sample_rate != 16000 {
+        resample_linear(samples, sample_rate, 16000)
+    } else {
+        samples.to_vec()
+    };
 
-    let audio = Array::from_slice(samples, &[samples.len() as i32]);
+    let audio = Array::from_slice(&samples, &[samples.len() as i32]);
 
     let tokens = model.generate(&audio, 200).map_err(SttError::Mlx)?;
 
@@ -286,15 +286,46 @@ fn load_wav_as_f32(path: &Path) -> Result<Vec<f32>> {
         samples
     };
 
-    // Resample if needed (for now, just check)
-    if spec.sample_rate != 16000 {
-        return Err(SttError::Audio(format!(
-            "WAV sample rate is {}Hz, expected 16000Hz. Resampling not yet implemented.",
-            spec.sample_rate
-        )));
-    }
+    // Resample to 16kHz if needed
+    let mono = if spec.sample_rate != 16000 {
+        resample_linear(&mono, spec.sample_rate, 16000)
+    } else {
+        mono
+    };
 
     Ok(mono)
+}
+
+/// Linear interpolation resampling.
+///
+/// Good enough for STT which is robust to minor audio artifacts.
+/// For production quality, consider `rubato` or polyphase filtering.
+pub fn resample_linear(samples: &[f32], from_rate: u32, to_rate: u32) -> Vec<f32> {
+    if from_rate == to_rate || samples.is_empty() {
+        return samples.to_vec();
+    }
+
+    let ratio = from_rate as f64 / to_rate as f64;
+    let out_len = (samples.len() as f64 / ratio).ceil() as usize;
+    let mut output = Vec::with_capacity(out_len);
+
+    for i in 0..out_len {
+        let src_pos = i as f64 * ratio;
+        let idx = src_pos as usize;
+        let frac = src_pos - idx as f64;
+
+        let sample = if idx + 1 < samples.len() {
+            samples[idx] as f64 * (1.0 - frac) + samples[idx + 1] as f64 * frac
+        } else if idx < samples.len() {
+            samples[idx] as f64
+        } else {
+            0.0
+        };
+
+        output.push(sample as f32);
+    }
+
+    output
 }
 
 /// Fallback token decoder when no tokenizer is available.

--- a/crates/voice-stt/src/moonshine/config.rs
+++ b/crates/voice-stt/src/moonshine/config.rs
@@ -1,0 +1,285 @@
+//! Moonshine model configuration.
+//!
+//! Matches the `config.json` structure from HuggingFace's
+//! `UsefulSensors/moonshine-tiny` and `UsefulSensors/moonshine-base`.
+
+use serde::Deserialize;
+
+/// Configuration for a Moonshine speech-to-text model.
+///
+/// Two official variants exist:
+///
+/// | Field | Tiny | Base |
+/// |-------|------|------|
+/// | `hidden_size` | 288 | 416 |
+/// | `intermediate_size` | 1152 | 1664 |
+/// | `encoder_num_hidden_layers` | 6 | 8 |
+/// | `decoder_num_hidden_layers` | 6 | 8 |
+/// | `partial_rotary_factor` | 0.9 | 0.62 |
+#[derive(Debug, Clone, Deserialize)]
+pub struct MoonshineConfig {
+    #[serde(default = "default_model_type")]
+    pub model_type: String,
+
+    #[serde(default = "default_vocab_size")]
+    pub vocab_size: usize,
+
+    #[serde(default = "default_hidden_size")]
+    pub hidden_size: usize,
+
+    #[serde(default = "default_intermediate_size")]
+    pub intermediate_size: usize,
+
+    #[serde(default = "default_encoder_num_hidden_layers")]
+    pub encoder_num_hidden_layers: usize,
+
+    #[serde(default = "default_decoder_num_hidden_layers")]
+    pub decoder_num_hidden_layers: usize,
+
+    #[serde(default = "default_num_attention_heads")]
+    pub encoder_num_attention_heads: usize,
+
+    #[serde(default = "default_num_attention_heads")]
+    pub decoder_num_attention_heads: usize,
+
+    /// Number of key-value heads for encoder attention (GQA).
+    /// Defaults to `encoder_num_attention_heads` if not set.
+    pub encoder_num_key_value_heads: Option<usize>,
+
+    /// Number of key-value heads for decoder attention (GQA).
+    /// Defaults to `decoder_num_attention_heads` if not set.
+    pub decoder_num_key_value_heads: Option<usize>,
+
+    #[serde(default = "default_encoder_hidden_act")]
+    pub encoder_hidden_act: String,
+
+    #[serde(default = "default_decoder_hidden_act")]
+    pub decoder_hidden_act: String,
+
+    #[serde(default = "default_max_position_embeddings")]
+    pub max_position_embeddings: usize,
+
+    #[serde(default)]
+    pub attention_bias: bool,
+
+    #[serde(default = "default_partial_rotary_factor")]
+    pub partial_rotary_factor: f32,
+
+    #[serde(default = "default_rope_theta")]
+    pub rope_theta: f32,
+
+    #[serde(default = "default_bos_token_id")]
+    pub bos_token_id: u32,
+
+    #[serde(default = "default_eos_token_id")]
+    pub eos_token_id: u32,
+
+    #[serde(default = "default_decoder_start_token_id")]
+    pub decoder_start_token_id: u32,
+
+    /// EOS is used as the pad token.
+    pub pad_token_id: Option<u32>,
+
+    #[serde(default = "default_tie_word_embeddings")]
+    pub tie_word_embeddings: bool,
+
+    /// Pad head dimension to a multiple of this value for hardware efficiency.
+    pub pad_head_dim_to_multiple_of: Option<usize>,
+}
+
+impl MoonshineConfig {
+    /// Effective number of KV heads for the encoder.
+    /// Falls back to `encoder_num_attention_heads` when not explicitly set.
+    pub fn encoder_kv_heads(&self) -> usize {
+        self.encoder_num_key_value_heads
+            .unwrap_or(self.encoder_num_attention_heads)
+    }
+
+    /// Effective number of KV heads for the decoder.
+    /// Falls back to `decoder_num_attention_heads` when not explicitly set.
+    pub fn decoder_kv_heads(&self) -> usize {
+        self.decoder_num_key_value_heads
+            .unwrap_or(self.decoder_num_attention_heads)
+    }
+
+    /// Per-head dimension: `hidden_size / num_heads`.
+    pub fn head_dim(&self) -> usize {
+        self.hidden_size / self.encoder_num_attention_heads
+    }
+
+    /// Number of dimensions that receive rotary positional encoding.
+    ///
+    /// Computed as `floor(head_dim * partial_rotary_factor)` rounded down
+    /// to the nearest even number.
+    pub fn rotary_ndims(&self) -> usize {
+        let raw = (self.head_dim() as f32 * self.partial_rotary_factor) as usize;
+        raw - (raw % 2)
+    }
+
+    /// Number of KV groups for GQA in the encoder.
+    /// Returns 1 for standard multi-head attention.
+    pub fn encoder_kv_groups(&self) -> usize {
+        self.encoder_num_attention_heads / self.encoder_kv_heads()
+    }
+
+    /// Number of KV groups for GQA in the decoder.
+    /// Returns 1 for standard multi-head attention.
+    pub fn decoder_kv_groups(&self) -> usize {
+        self.decoder_num_attention_heads / self.decoder_kv_heads()
+    }
+
+    /// Audio sample rate expected by the model.
+    pub fn sample_rate(&self) -> u32 {
+        16000
+    }
+}
+
+// -- Serde defaults ----------------------------------------------------------
+
+fn default_model_type() -> String {
+    "moonshine".to_string()
+}
+
+fn default_vocab_size() -> usize {
+    32768
+}
+
+fn default_hidden_size() -> usize {
+    288
+}
+
+fn default_intermediate_size() -> usize {
+    1152
+}
+
+fn default_encoder_num_hidden_layers() -> usize {
+    6
+}
+
+fn default_decoder_num_hidden_layers() -> usize {
+    6
+}
+
+fn default_num_attention_heads() -> usize {
+    8
+}
+
+fn default_encoder_hidden_act() -> String {
+    "gelu".to_string()
+}
+
+fn default_decoder_hidden_act() -> String {
+    "silu".to_string()
+}
+
+fn default_max_position_embeddings() -> usize {
+    512
+}
+
+fn default_partial_rotary_factor() -> f32 {
+    0.9
+}
+
+fn default_rope_theta() -> f32 {
+    10000.0
+}
+
+fn default_bos_token_id() -> u32 {
+    1
+}
+
+fn default_eos_token_id() -> u32 {
+    2
+}
+
+fn default_decoder_start_token_id() -> u32 {
+    1
+}
+
+fn default_tie_word_embeddings() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tiny_config() {
+        let json = r#"{
+            "model_type": "moonshine",
+            "hidden_size": 288,
+            "intermediate_size": 1152,
+            "encoder_num_hidden_layers": 6,
+            "decoder_num_hidden_layers": 6,
+            "encoder_num_attention_heads": 8,
+            "decoder_num_attention_heads": 8,
+            "partial_rotary_factor": 0.9,
+            "max_position_embeddings": 194,
+            "vocab_size": 32768,
+            "tie_word_embeddings": true
+        }"#;
+        let config: MoonshineConfig = serde_json::from_str(json).unwrap();
+
+        assert_eq!(config.hidden_size, 288);
+        assert_eq!(config.head_dim(), 36);
+        assert_eq!(config.rotary_ndims(), 32);
+        assert_eq!(config.encoder_kv_heads(), 8);
+        assert_eq!(config.encoder_kv_groups(), 1);
+        assert_eq!(config.sample_rate(), 16000);
+    }
+
+    #[test]
+    fn test_base_config() {
+        let json = r#"{
+            "model_type": "moonshine",
+            "hidden_size": 416,
+            "intermediate_size": 1664,
+            "encoder_num_hidden_layers": 8,
+            "decoder_num_hidden_layers": 8,
+            "encoder_num_attention_heads": 8,
+            "decoder_num_attention_heads": 8,
+            "partial_rotary_factor": 0.62,
+            "max_position_embeddings": 194,
+            "vocab_size": 32768
+        }"#;
+        let config: MoonshineConfig = serde_json::from_str(json).unwrap();
+
+        assert_eq!(config.hidden_size, 416);
+        assert_eq!(config.head_dim(), 52);
+        // floor(52 * 0.62) = 32, already even
+        assert_eq!(config.rotary_ndims(), 32);
+        assert_eq!(config.encoder_num_hidden_layers, 8);
+    }
+
+    #[test]
+    fn test_defaults() {
+        let config: MoonshineConfig = serde_json::from_str("{}").unwrap();
+
+        assert_eq!(config.model_type, "moonshine");
+        assert_eq!(config.vocab_size, 32768);
+        assert_eq!(config.hidden_size, 288);
+        assert!(!config.attention_bias);
+        assert!(config.tie_word_embeddings);
+        assert_eq!(config.bos_token_id, 1);
+        assert_eq!(config.eos_token_id, 2);
+        assert_eq!(config.encoder_kv_heads(), 8);
+        assert_eq!(config.decoder_kv_heads(), 8);
+    }
+
+    #[test]
+    fn test_gqa_config() {
+        let json = r#"{
+            "encoder_num_attention_heads": 8,
+            "decoder_num_attention_heads": 8,
+            "encoder_num_key_value_heads": 4,
+            "decoder_num_key_value_heads": 2
+        }"#;
+        let config: MoonshineConfig = serde_json::from_str(json).unwrap();
+
+        assert_eq!(config.encoder_kv_heads(), 4);
+        assert_eq!(config.encoder_kv_groups(), 2);
+        assert_eq!(config.decoder_kv_heads(), 2);
+        assert_eq!(config.decoder_kv_groups(), 4);
+    }
+}

--- a/crates/voice-stt/src/moonshine/mod.rs
+++ b/crates/voice-stt/src/moonshine/mod.rs
@@ -1,0 +1,27 @@
+//! Moonshine speech-to-text model.
+//!
+//! A compact encoder-decoder transformer designed for on-device speech
+//! recognition by [Useful Sensors](https://usefulsensors.com/).
+//!
+//! Two official variants are available on HuggingFace:
+//!
+//! | Variant | Params | Hidden | Layers (enc/dec) |
+//! |---------|--------|--------|------------------|
+//! | [`moonshine-tiny`](https://huggingface.co/UsefulSensors/moonshine-tiny) | 27M | 288 | 6 / 6 |
+//! | [`moonshine-base`](https://huggingface.co/UsefulSensors/moonshine-base) | 61M | 416 | 8 / 8 |
+//!
+//! # Architecture
+//!
+//! - **Learned audio frontend**: Three Conv1d layers with progressive stride
+//!   (64×3×2 = 384× total downsampling) replace mel spectrograms. Raw 16kHz
+//!   audio goes directly into the encoder.
+//! - **Partial RoPE**: Only a fraction of head dimensions receive rotary
+//!   positional encoding; the rest pass through unmodified.
+//! - **SwiGLU decoder MLP**: Gated SiLU activation for better gradient flow.
+//! - **Tied embeddings**: Output projection reuses the token embedding matrix.
+
+pub mod config;
+pub mod model;
+
+pub use config::MoonshineConfig;
+pub use model::{DecoderLayerCache, MoonshineModel};

--- a/crates/voice-stt/src/moonshine/model.rs
+++ b/crates/voice-stt/src/moonshine/model.rs
@@ -1,0 +1,913 @@
+//! Moonshine speech-to-text model architecture.
+//!
+//! Ported from mlx-audio's `mlx_audio/stt/models/moonshine/moonshine.py`.
+//!
+//! Moonshine is a compact encoder-decoder transformer designed for on-device
+//! speech recognition. Key architectural features:
+//!
+//! - **Learned audio frontend**: Three Conv1d layers with progressive stride
+//!   (64×3×2 = 384× total downsampling) replace mel spectrograms.
+//! - **Partial RoPE**: Only a fraction of head dimensions receive rotary
+//!   positional encoding; the rest pass through unmodified.
+//! - **SwiGLU decoder MLP**: Gated SiLU activation in the decoder for better
+//!   gradient flow.
+//! - **Tied embeddings**: Output projection reuses the token embedding matrix.
+
+use mlx_macros::ModuleParameters;
+use mlx_rs::builder::Builder;
+use mlx_rs::error::Exception;
+use mlx_rs::module::Module;
+use mlx_rs::nn::{self, Embedding, GroupNorm, LayerNorm, LayerNormBuilder, Linear, LinearBuilder};
+use mlx_rs::ops::indexing::{IndexOp, IntoStrideBy};
+use mlx_rs::ops::{concatenate_axis, expand_dims, stack_axis};
+use mlx_rs::Array;
+
+use super::config::MoonshineConfig;
+
+// ---------------------------------------------------------------------------
+// Rotary Positional Embedding
+// ---------------------------------------------------------------------------
+
+/// Precomputes inverse frequency bands for RoPE.
+///
+/// At call time, produces `(cos, sin)` tensors for the given position IDs.
+#[derive(Debug)]
+pub struct MoonshineRotaryEmbedding {
+    inv_freq: Array,
+    dim: usize,
+}
+
+impl MoonshineRotaryEmbedding {
+    pub fn new(dim: usize, _max_position_embeddings: usize, base: f32) -> Self {
+        // inv_freq = 1.0 / (base^(arange(0, dim, 2) / dim))
+        let half = (dim / 2) as i32;
+        let arange = Array::from_iter((0..dim).step_by(2).map(|i| i as f32 / dim as f32), &[half]);
+        let base_arr = Array::from_f32(base);
+        let inv_freq = Array::from_f32(1.0) / base_arr.power(&arange).unwrap();
+        Self { inv_freq, dim }
+    }
+
+    /// Compute (cos, sin) embeddings for the given position IDs.
+    ///
+    /// - `position_ids`: shape `[B, T]`
+    /// - Returns: `(cos, sin)` each shape `[B, T, rotary_ndims]`
+    pub fn forward(&self, position_ids: &Array) -> Result<(Array, Array), Exception> {
+        // position_ids: [B, T] -> [B, T, 1]
+        let pos = position_ids.reshape(&[
+            position_ids.shape()[0] as i32,
+            position_ids.shape()[1] as i32,
+            1,
+        ])?;
+        let pos = pos.as_dtype(mlx_rs::Dtype::Float32)?;
+
+        // inv_freq: [dim/2] -> [1, 1, dim/2]
+        let inv = self.inv_freq.reshape(&[1, 1, (self.dim / 2) as i32])?;
+
+        // freqs: [B, T, dim/2]
+        let freqs = pos.multiply(&inv)?;
+
+        // emb: [B, T, dim]  (concatenate freqs with itself)
+        let emb = concatenate_axis(&[&freqs, &freqs], -1)?;
+
+        let cos = emb.cos()?;
+        let sin = emb.sin()?;
+        Ok((cos, sin))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RoPE application helpers
+// ---------------------------------------------------------------------------
+
+/// Rotate interleaved pairs: [x0, x1, x2, x3, ...] -> [-x1, x0, -x3, x2, ...]
+fn rotate_half(x: &Array) -> Result<Array, Exception> {
+    // x1 = x[..., 0::2], x2 = x[..., 1::2]
+    let x1 = x.index((.., .., .., (0i32..).stride_by(2)));
+    let x2 = x.index((.., .., .., (1i32..).stride_by(2)));
+
+    // rotated = stack([-x2, x1], axis=-1) then reshape to x.shape
+    let neg_x2 = x2.negative()?;
+    let stacked = stack_axis(&[&neg_x2, &x1], -1)?;
+    stacked.reshape(x.shape())
+}
+
+/// Apply partial rotary positional embeddings to Q and K.
+///
+/// Only the first `rotary_dim` dimensions are rotated; the rest pass through.
+fn apply_rotary_pos_emb(
+    q: &Array,
+    k: &Array,
+    cos: &Array,
+    sin: &Array,
+    rotary_dim: usize,
+) -> Result<(Array, Array), Exception> {
+    // cos/sin: [B, T, rotary_dim] -> [B, 1, T, rotary_dim] (unsqueeze head dim)
+    let cos = expand_dims(cos, 1)?;
+    let sin = expand_dims(sin, 1)?;
+
+    // The cos/sin are [B, 1, T, dim] from concatenation.
+    // We need to expand them to cover interleaved pairs.
+    // half = rotary_dim / 2, then repeat each value twice to match interleaved layout.
+    let half = rotary_dim / 2;
+    let cos_half = cos.index((.., .., .., ..half as i32));
+    let sin_half = sin.index((.., .., .., ..half as i32));
+    // repeat(2, axis=-1) to interleave
+    let cos_exp = Array::repeat_axis::<f32>(cos_half, 2, -1)?;
+    let sin_exp = Array::repeat_axis::<f32>(sin_half, 2, -1)?;
+
+    let rd = rotary_dim as i32;
+
+    // Split Q into rotary and pass-through portions
+    let q_rot = q.index((.., .., .., ..rd));
+    let q_pass = q.index((.., .., .., rd..));
+    let k_rot = k.index((.., .., .., ..rd));
+    let k_pass = k.index((.., .., .., rd..));
+
+    // Apply rotation: x_embed = x * cos + rotate_half(x) * sin
+    let q_embed = q_rot
+        .multiply(&cos_exp)?
+        .add(&rotate_half(&q_rot)?.multiply(&sin_exp)?)?;
+    let k_embed = k_rot
+        .multiply(&cos_exp)?
+        .add(&rotate_half(&k_rot)?.multiply(&sin_exp)?)?;
+
+    // Concatenate rotary and pass-through parts
+    let q_out = concatenate_axis(&[&q_embed, &q_pass], -1)?;
+    let k_out = concatenate_axis(&[&k_embed, &k_pass], -1)?;
+
+    Ok((q_out, k_out))
+}
+
+// ---------------------------------------------------------------------------
+// Attention
+// ---------------------------------------------------------------------------
+
+/// Multi-head attention with partial RoPE and optional GQA.
+///
+/// Used in both encoder (non-causal, self-attention only) and decoder
+/// (causal self-attention + non-causal cross-attention).
+#[derive(Debug, ModuleParameters)]
+pub struct MoonshineAttention {
+    #[param]
+    pub q_proj: Linear,
+    #[param]
+    pub k_proj: Linear,
+    #[param]
+    pub v_proj: Linear,
+    #[param]
+    pub o_proj: Linear,
+
+    pub num_heads: usize,
+    pub num_kv_heads: usize,
+    pub head_dim: usize,
+    pub num_kv_groups: usize,
+    pub is_causal: bool,
+    pub scale: f32,
+    pub rotary_ndims: usize,
+    rotary_emb: MoonshineRotaryEmbedding,
+}
+
+impl MoonshineAttention {
+    pub fn new(
+        hidden_size: usize,
+        num_heads: usize,
+        num_kv_heads: usize,
+        bias: bool,
+        is_causal: bool,
+        partial_rotary_factor: f32,
+        max_position_embeddings: usize,
+        rope_theta: f32,
+    ) -> Result<Self, Exception> {
+        let head_dim = hidden_size / num_heads;
+        let num_kv_groups = num_heads / num_kv_heads;
+        let scale = (head_dim as f32).powf(-0.5);
+
+        let raw_rotary = (head_dim as f32 * partial_rotary_factor) as usize;
+        let rotary_ndims = raw_rotary - (raw_rotary % 2);
+
+        let q_proj = LinearBuilder::new(hidden_size as i32, (num_heads * head_dim) as i32)
+            .bias(bias)
+            .build()?;
+        let k_proj = LinearBuilder::new(hidden_size as i32, (num_kv_heads * head_dim) as i32)
+            .bias(bias)
+            .build()?;
+        let v_proj = LinearBuilder::new(hidden_size as i32, (num_kv_heads * head_dim) as i32)
+            .bias(bias)
+            .build()?;
+        let o_proj = LinearBuilder::new((num_heads * head_dim) as i32, hidden_size as i32)
+            .bias(false)
+            .build()?;
+
+        let rotary_emb =
+            MoonshineRotaryEmbedding::new(rotary_ndims, max_position_embeddings, rope_theta);
+
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            num_kv_groups,
+            is_causal,
+            scale,
+            rotary_ndims,
+            rotary_emb,
+        })
+    }
+
+    /// Forward pass.
+    ///
+    /// - `x`: input hidden states `[B, T, hidden_size]`
+    /// - `encoder_hidden_states`: if `Some`, this is cross-attention (K/V come from encoder)
+    /// - `cache`: optional `(K, V)` from previous steps
+    /// - `position_ids`: optional position IDs for RoPE; auto-computed if `None`
+    ///
+    /// Returns `(output, (new_K, new_V))`.
+    pub fn forward(
+        &mut self,
+        x: &Array,
+        encoder_hidden_states: Option<&Array>,
+        cache: Option<&(Array, Array)>,
+        position_ids: Option<&Array>,
+    ) -> Result<(Array, (Array, Array)), Exception> {
+        let b = x.shape()[0] as i32;
+        let t = x.shape()[1] as i32;
+        let is_cross_attention = encoder_hidden_states.is_some();
+
+        let q = self.q_proj.forward(x)?;
+        let (k, v) = if let Some(enc) = encoder_hidden_states {
+            (self.k_proj.forward(enc)?, self.v_proj.forward(enc)?)
+        } else {
+            (self.k_proj.forward(x)?, self.v_proj.forward(x)?)
+        };
+
+        let hd = self.head_dim as i32;
+        let nh = self.num_heads as i32;
+        let nkv = self.num_kv_heads as i32;
+
+        // Reshape to [B, T, num_heads, head_dim] then transpose to [B, num_heads, T, head_dim]
+        let q = q.reshape(&[b, t, nh, hd])?.transpose_axes(&[0, 2, 1, 3])?;
+        let s = k.shape()[1] as i32;
+        let mut k = k.reshape(&[b, s, nkv, hd])?.transpose_axes(&[0, 2, 1, 3])?;
+        let mut v = v.reshape(&[b, s, nkv, hd])?.transpose_axes(&[0, 2, 1, 3])?;
+
+        // Apply RoPE to self-attention only (not cross-attention)
+        let q = if !is_cross_attention {
+            let pos = if let Some(p) = position_ids {
+                p.clone()
+            } else {
+                let offset = if let Some(c) = cache {
+                    c.0.shape()[2] as i32
+                } else {
+                    0
+                };
+                let pos_range = Array::from_iter(offset..offset + t, &[t]);
+                pos_range.reshape(&[1, t as i32])?
+            };
+
+            let (cos, sin) = self.rotary_emb.forward(&pos)?;
+            let (q_rot, k_rot) = apply_rotary_pos_emb(&q, &k, &cos, &sin, self.rotary_ndims)?;
+            k = k_rot;
+            q_rot
+        } else {
+            q
+        };
+
+        // Apply KV cache
+        if let Some(c) = cache {
+            if is_cross_attention {
+                // Cross-attention: reuse frozen K/V from first step
+                k = c.0.clone();
+                v = c.1.clone();
+            } else {
+                // Self-attention: concatenate with previous K/V
+                k = concatenate_axis(&[&c.0, &k], 2)?;
+                v = concatenate_axis(&[&c.1, &v], 2)?;
+            }
+        }
+
+        // Expand KV for GQA if needed
+        let (k_exp, v_exp) = if self.num_kv_groups > 1 {
+            (
+                Array::repeat_axis::<f32>(k.clone(), self.num_kv_groups as i32, 1)?,
+                Array::repeat_axis::<f32>(v.clone(), self.num_kv_groups as i32, 1)?,
+            )
+        } else {
+            (k.clone(), v.clone())
+        };
+
+        // Causal mask for decoder self-attention
+        let mask = if self.is_causal && t > 1 {
+            let causal = nn::MultiHeadAttention::create_additive_causal_mask::<f32>(t)?;
+            let klen = k_exp.shape()[2] as i32;
+            if klen > t {
+                // Prefix zeros for cached keys
+                let prefix = Array::zeros::<f32>(&[t, klen - t])?;
+                Some(concatenate_axis(&[&prefix, &causal], 1)?)
+            } else {
+                Some(causal)
+            }
+        } else {
+            None
+        };
+
+        // Scaled dot-product attention
+        let o = if let Some(ref m) = mask {
+            mlx_rs::fast::scaled_dot_product_attention(&q, &k_exp, &v_exp, self.scale, m)?
+        } else {
+            mlx_rs::fast::scaled_dot_product_attention(
+                &q,
+                &k_exp,
+                &v_exp,
+                self.scale,
+                None::<mlx_rs::fast::ScaledDotProductAttentionMask>,
+            )?
+        };
+
+        // Reshape back: [B, num_heads, T, head_dim] -> [B, T, num_heads * head_dim]
+        let o = o.transpose_axes(&[0, 2, 1, 3])?.reshape(&[b, t, -1])?;
+
+        let out = self.o_proj.forward(&o)?;
+        Ok((out, (k, v)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MLPs
+// ---------------------------------------------------------------------------
+
+/// Encoder MLP: simple two-layer feedforward with GELU activation.
+///
+/// `dim → intermediate_size → dim`
+#[derive(Debug, ModuleParameters)]
+pub struct MoonshineEncoderMLP {
+    #[param]
+    pub fc1: Linear,
+    #[param]
+    pub fc2: Linear,
+    pub use_gelu: bool,
+}
+
+impl MoonshineEncoderMLP {
+    pub fn new(hidden_size: usize, intermediate_size: usize, act: &str) -> Result<Self, Exception> {
+        let fc1 = LinearBuilder::new(hidden_size as i32, intermediate_size as i32).build()?;
+        let fc2 = LinearBuilder::new(intermediate_size as i32, hidden_size as i32).build()?;
+        Ok(Self {
+            fc1,
+            fc2,
+            use_gelu: act == "gelu",
+        })
+    }
+
+    pub fn forward(&mut self, x: &Array) -> Result<Array, Exception> {
+        let h = self.fc1.forward(x)?;
+        let h = if self.use_gelu {
+            nn::gelu(&h)?
+        } else {
+            nn::silu(&h)?
+        };
+        self.fc2.forward(&h)
+    }
+}
+
+/// Decoder MLP: SwiGLU (gated SiLU) activation.
+///
+/// `fc1` projects to `2 * intermediate_size`, splits into value and gate,
+/// applies `silu(gate) * value`, then `fc2` projects back.
+#[derive(Debug, ModuleParameters)]
+pub struct MoonshineDecoderMLP {
+    #[param]
+    pub fc1: Linear,
+    #[param]
+    pub fc2: Linear,
+}
+
+impl MoonshineDecoderMLP {
+    pub fn new(hidden_size: usize, intermediate_size: usize) -> Result<Self, Exception> {
+        let fc1 = LinearBuilder::new(hidden_size as i32, (2 * intermediate_size) as i32).build()?;
+        let fc2 = LinearBuilder::new(intermediate_size as i32, hidden_size as i32).build()?;
+        Ok(Self { fc1, fc2 })
+    }
+
+    pub fn forward(&mut self, x: &Array) -> Result<Array, Exception> {
+        let h = self.fc1.forward(x)?;
+        let mid = h.shape().last().copied().unwrap_or(0) as i32;
+        let half = mid / 2;
+
+        // Split into value and gate halves
+        let value = h.index((.., .., ..half));
+        let gate = h.index((.., .., half..));
+
+        // SwiGLU: silu(gate) * value
+        let activated = nn::silu(&gate)?.multiply(&value)?;
+        self.fc2.forward(&activated)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Encoder layer
+// ---------------------------------------------------------------------------
+
+/// A single Moonshine encoder transformer layer.
+///
+/// Pre-LN architecture: LayerNorm → Self-Attention → residual → LayerNorm → MLP → residual
+#[derive(Debug, ModuleParameters)]
+pub struct MoonshineEncoderLayer {
+    #[param]
+    pub self_attn: MoonshineAttention,
+    #[param]
+    pub mlp: MoonshineEncoderMLP,
+    #[param]
+    pub input_layernorm: LayerNorm,
+    #[param]
+    pub post_attention_layernorm: LayerNorm,
+}
+
+impl MoonshineEncoderLayer {
+    pub fn new(config: &MoonshineConfig) -> Result<Self, Exception> {
+        let self_attn = MoonshineAttention::new(
+            config.hidden_size,
+            config.encoder_num_attention_heads,
+            config.encoder_kv_heads(),
+            config.attention_bias,
+            false, // encoder is non-causal
+            config.partial_rotary_factor,
+            config.max_position_embeddings,
+            config.rope_theta,
+        )?;
+        let mlp = MoonshineEncoderMLP::new(
+            config.hidden_size,
+            config.intermediate_size,
+            &config.encoder_hidden_act,
+        )?;
+        let input_layernorm = LayerNormBuilder::new(config.hidden_size as i32)
+            .affine(true)
+            .build()?;
+        let post_attention_layernorm = LayerNormBuilder::new(config.hidden_size as i32)
+            .affine(true)
+            .build()?;
+
+        Ok(Self {
+            self_attn,
+            mlp,
+            input_layernorm,
+            post_attention_layernorm,
+        })
+    }
+
+    pub fn forward(&mut self, x: &Array, position_ids: Option<&Array>) -> Result<Array, Exception> {
+        // Self-attention with pre-norm
+        let residual = x.clone();
+        let h = self.input_layernorm.forward(x)?;
+        let (h, _) = self.self_attn.forward(&h, None, None, position_ids)?;
+        let x = residual.add(&h)?;
+
+        // MLP with pre-norm
+        let residual = x.clone();
+        let h = self.post_attention_layernorm.forward(&x)?;
+        let h = self.mlp.forward(&h)?;
+        residual.add(&h)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decoder layer
+// ---------------------------------------------------------------------------
+
+/// A single Moonshine decoder transformer layer.
+///
+/// Three sub-blocks:
+/// 1. Causal self-attention with RoPE
+/// 2. Cross-attention to encoder output (no RoPE)
+/// 3. SwiGLU MLP
+#[derive(Debug, ModuleParameters)]
+pub struct MoonshineDecoderLayer {
+    #[param]
+    pub self_attn: MoonshineAttention,
+    #[param]
+    pub encoder_attn: MoonshineAttention,
+    #[param]
+    pub mlp: MoonshineDecoderMLP,
+    #[param]
+    pub input_layernorm: LayerNorm,
+    #[param]
+    pub post_attention_layernorm: LayerNorm,
+    #[param]
+    pub final_layernorm: LayerNorm,
+}
+
+impl MoonshineDecoderLayer {
+    pub fn new(config: &MoonshineConfig) -> Result<Self, Exception> {
+        let self_attn = MoonshineAttention::new(
+            config.hidden_size,
+            config.decoder_num_attention_heads,
+            config.decoder_kv_heads(),
+            config.attention_bias,
+            true, // decoder self-attention is causal
+            config.partial_rotary_factor,
+            config.max_position_embeddings,
+            config.rope_theta,
+        )?;
+        let encoder_attn = MoonshineAttention::new(
+            config.hidden_size,
+            config.decoder_num_attention_heads,
+            config.decoder_kv_heads(),
+            config.attention_bias,
+            false, // cross-attention is non-causal
+            config.partial_rotary_factor,
+            config.max_position_embeddings,
+            config.rope_theta,
+        )?;
+        let mlp = MoonshineDecoderMLP::new(config.hidden_size, config.intermediate_size)?;
+
+        let input_layernorm = LayerNormBuilder::new(config.hidden_size as i32)
+            .affine(true)
+            .build()?;
+        let post_attention_layernorm = LayerNormBuilder::new(config.hidden_size as i32)
+            .affine(true)
+            .build()?;
+        let final_layernorm = LayerNormBuilder::new(config.hidden_size as i32)
+            .affine(true)
+            .build()?;
+
+        Ok(Self {
+            self_attn,
+            encoder_attn,
+            mlp,
+            input_layernorm,
+            post_attention_layernorm,
+            final_layernorm,
+        })
+    }
+
+    /// Forward pass.
+    ///
+    /// Returns `(output, new_self_attn_cache, new_cross_attn_cache)`.
+    pub fn forward(
+        &mut self,
+        x: &Array,
+        encoder_hidden_states: &Array,
+        self_attn_cache: Option<&(Array, Array)>,
+        cross_attn_cache: Option<&(Array, Array)>,
+    ) -> Result<(Array, (Array, Array), (Array, Array)), Exception> {
+        // 1. Causal self-attention
+        let residual = x.clone();
+        let h = self.input_layernorm.forward(x)?;
+        let (h, new_self_cache) = self.self_attn.forward(&h, None, self_attn_cache, None)?;
+        let x = residual.add(&h)?;
+
+        // 2. Cross-attention to encoder output
+        let residual = x.clone();
+        let h = self.post_attention_layernorm.forward(&x)?;
+        let (h, new_cross_cache) =
+            self.encoder_attn
+                .forward(&h, Some(encoder_hidden_states), cross_attn_cache, None)?;
+        let x = residual.add(&h)?;
+
+        // 3. SwiGLU MLP
+        let residual = x.clone();
+        let h = self.final_layernorm.forward(&x)?;
+        let h = self.mlp.forward(&h)?;
+        let x = residual.add(&h)?;
+
+        Ok((x, new_self_cache, new_cross_cache))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Encoder
+// ---------------------------------------------------------------------------
+
+/// Moonshine encoder: learned Conv1d audio frontend + transformer layers.
+///
+/// Takes raw 16kHz audio and produces contextual hidden representations.
+/// Total downsampling factor: 64 × 3 × 2 = 384 (24ms per output frame).
+#[derive(Debug, ModuleParameters)]
+pub struct MoonshineEncoder {
+    #[param]
+    pub conv1: nn::Conv1d,
+    #[param]
+    pub groupnorm: GroupNorm,
+    #[param]
+    pub conv2: nn::Conv1d,
+    #[param]
+    pub conv3: nn::Conv1d,
+    #[param]
+    pub layers: Vec<MoonshineEncoderLayer>,
+    #[param]
+    pub layer_norm: LayerNorm,
+}
+
+impl MoonshineEncoder {
+    pub fn new(config: &MoonshineConfig) -> Result<Self, Exception> {
+        let dim = config.hidden_size;
+
+        let conv1 = nn::Conv1dBuilder::new(1, dim as i32, 127)
+            .stride(64)
+            .bias(false)
+            .build()?;
+
+        let groupnorm = nn::GroupNormBuilder::new(1, dim as i32).build()?;
+
+        let conv2 = nn::Conv1dBuilder::new(dim as i32, (2 * dim) as i32, 7)
+            .stride(3)
+            .bias(true)
+            .build()?;
+
+        let conv3 = nn::Conv1dBuilder::new((2 * dim) as i32, dim as i32, 3)
+            .stride(2)
+            .bias(true)
+            .build()?;
+
+        let layers = (0..config.encoder_num_hidden_layers)
+            .map(|_| MoonshineEncoderLayer::new(config))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let layer_norm = LayerNormBuilder::new(dim as i32).affine(true).build()?;
+
+        Ok(Self {
+            conv1,
+            groupnorm,
+            conv2,
+            conv3,
+            layers,
+            layer_norm,
+        })
+    }
+
+    /// Encode raw audio waveform to hidden representations.
+    ///
+    /// - `audio`: shape `[samples]` (1D) or `[B, samples]` (2D, batched)
+    /// - Returns: `[B, T', hidden_size]` where `T' ≈ samples / 384`
+    pub fn forward(&mut self, audio: &Array) -> Result<Array, Exception> {
+        // Ensure [B, T] shape
+        let audio = if audio.ndim() == 1 {
+            audio.reshape(&[1, -1])?
+        } else {
+            audio.clone()
+        };
+
+        // [B, T] -> [B, T, 1] for Conv1d (channel-last in MLX)
+        let x = audio.reshape(&[audio.shape()[0] as i32, audio.shape()[1] as i32, 1])?;
+
+        // Conv frontend with progressive downsampling
+        let x = self.conv1.forward(&x)?;
+        let x = mlx_rs::ops::tanh(&x)?;
+        let x = self.groupnorm.forward(&x)?;
+        let x = self.conv2.forward(&x)?;
+        let x = nn::gelu(&x)?;
+        let x = self.conv3.forward(&x)?;
+        let x = nn::gelu(&x)?;
+
+        // Position IDs for transformer layers
+        let seq_len = x.shape()[1] as i32;
+        let position_ids = Array::from_iter(0..seq_len, &[seq_len]).reshape(&[1, seq_len])?;
+
+        // Transformer layers
+        let mut x = x;
+        for layer in &mut self.layers {
+            x = layer.forward(&x, Some(&position_ids))?;
+        }
+
+        self.layer_norm.forward(&x)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decoder
+// ---------------------------------------------------------------------------
+
+/// Per-layer KV cache for the decoder.
+#[derive(Clone)]
+pub struct DecoderLayerCache {
+    pub self_attn: Option<(Array, Array)>,
+    pub cross_attn: Option<(Array, Array)>,
+}
+
+/// Moonshine decoder: token embedding + transformer layers with cross-attention.
+#[derive(Debug, ModuleParameters)]
+pub struct MoonshineDecoder {
+    #[param]
+    pub embed_tokens: Embedding,
+    #[param]
+    pub layers: Vec<MoonshineDecoderLayer>,
+    #[param]
+    pub norm: LayerNorm,
+}
+
+impl MoonshineDecoder {
+    pub fn new(config: &MoonshineConfig) -> Result<Self, Exception> {
+        let embed_tokens = Embedding::new(config.vocab_size as i32, config.hidden_size as i32)?;
+
+        let layers = (0..config.decoder_num_hidden_layers)
+            .map(|_| MoonshineDecoderLayer::new(config))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let norm = LayerNormBuilder::new(config.hidden_size as i32)
+            .affine(true)
+            .build()?;
+
+        Ok(Self {
+            embed_tokens,
+            layers,
+            norm,
+        })
+    }
+
+    /// Forward pass.
+    ///
+    /// - `tokens`: token IDs `[B, T]`
+    /// - `encoder_hidden_states`: encoder output `[B, T_enc, hidden_size]`
+    /// - `cache`: optional per-layer KV cache
+    ///
+    /// Returns `(hidden_states, new_cache)`.
+    pub fn forward(
+        &mut self,
+        tokens: &Array,
+        encoder_hidden_states: &Array,
+        cache: Option<&[DecoderLayerCache]>,
+    ) -> Result<(Array, Vec<DecoderLayerCache>), Exception> {
+        let x = self.embed_tokens.forward(tokens)?;
+
+        let num_layers = self.layers.len();
+        let empty_cache = vec![
+            DecoderLayerCache {
+                self_attn: None,
+                cross_attn: None,
+            };
+            num_layers
+        ];
+        let layer_caches = cache.unwrap_or(&empty_cache);
+
+        let mut new_cache = Vec::with_capacity(num_layers);
+        let mut x = x;
+
+        for (i, layer) in self.layers.iter_mut().enumerate() {
+            let lc = &layer_caches[i];
+            let (out, new_self, new_cross) = layer.forward(
+                &x,
+                encoder_hidden_states,
+                lc.self_attn.as_ref(),
+                lc.cross_attn.as_ref(),
+            )?;
+            x = out;
+            new_cache.push(DecoderLayerCache {
+                self_attn: Some(new_self),
+                cross_attn: Some(new_cross),
+            });
+        }
+
+        let x = self.norm.forward(&x)?;
+        Ok((x, new_cache))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Full Model
+// ---------------------------------------------------------------------------
+
+/// Complete Moonshine speech-to-text model.
+///
+/// Encoder-decoder architecture with a learned audio frontend.
+/// Supports greedy autoregressive decoding.
+#[derive(Debug, ModuleParameters)]
+pub struct MoonshineModel {
+    #[param]
+    pub encoder: MoonshineEncoder,
+    #[param]
+    pub decoder: MoonshineDecoder,
+
+    pub config: MoonshineConfig,
+}
+
+impl MoonshineModel {
+    pub fn new(config: &MoonshineConfig) -> Result<Self, Exception> {
+        let encoder = MoonshineEncoder::new(config)?;
+        let decoder = MoonshineDecoder::new(config)?;
+
+        Ok(Self {
+            encoder,
+            decoder,
+            config: config.clone(),
+        })
+    }
+
+    /// Compute logits from decoder hidden states.
+    ///
+    /// When `tie_word_embeddings` is true, reuses the embedding matrix
+    /// as the output projection (no separate `proj_out` weight).
+    pub fn get_logits(&self, hidden_states: &Array) -> Result<Array, Exception> {
+        if self.config.tie_word_embeddings {
+            self.decoder.embed_tokens.as_linear(hidden_states)
+        } else {
+            // Non-tied case would need a separate proj_out linear layer.
+            // All official Moonshine models use tied embeddings.
+            Err(Exception::from(
+                "Non-tied embeddings not implemented for Moonshine",
+            ))
+        }
+    }
+
+    /// Encode audio to hidden representations.
+    pub fn encode(&mut self, audio: &Array) -> Result<Array, Exception> {
+        self.encoder.forward(audio)
+    }
+
+    /// Run one decoder step.
+    ///
+    /// - `tokens`: token IDs for this step `[B, 1]`
+    /// - `encoder_out`: encoder hidden states
+    /// - `cache`: per-layer KV cache from previous step
+    ///
+    /// Returns `(hidden_states, new_cache)`.
+    pub fn decode(
+        &mut self,
+        tokens: &Array,
+        encoder_out: &Array,
+        cache: Option<&[DecoderLayerCache]>,
+    ) -> Result<(Array, Vec<DecoderLayerCache>), Exception> {
+        self.decoder.forward(tokens, encoder_out, cache)
+    }
+
+    /// Greedy autoregressive transcription.
+    ///
+    /// - `audio`: raw 16kHz waveform, shape `[samples]` or `[1, samples]`
+    /// - `max_tokens`: maximum number of tokens to generate
+    ///
+    /// Returns the generated token IDs (excluding BOS, excluding EOS).
+    pub fn generate(&mut self, audio: &Array, max_tokens: usize) -> Result<Vec<u32>, Exception> {
+        // Encode
+        let encoder_out = self.encode(audio)?;
+        encoder_out.eval()?;
+
+        let bos = self.config.decoder_start_token_id;
+        let eos = self.config.eos_token_id;
+
+        let mut tokens: Vec<u32> = vec![bos];
+        let mut cache: Option<Vec<DecoderLayerCache>> = None;
+
+        for _ in 0..max_tokens {
+            let last_token = *tokens.last().unwrap();
+            let token_ids = Array::from_int(last_token as i32).reshape(&[1, 1])?;
+
+            let (hidden, new_cache) = self.decode(&token_ids, &encoder_out, cache.as_deref())?;
+            hidden.eval()?;
+
+            // Get logits for the last position
+            let last_hidden = hidden.index((.., -1, ..));
+            let logits = self.get_logits(&last_hidden)?;
+
+            // Greedy: argmax
+            let next_token = mlx_rs::ops::indexing::argmax_axis(&logits, -1, false)?;
+            let next_token_val: u32 = next_token.item();
+
+            if next_token_val == eos {
+                break;
+            }
+
+            tokens.push(next_token_val);
+            cache = Some(new_cache);
+        }
+
+        // Remove BOS token
+        Ok(tokens[1..].to_vec())
+    }
+
+    /// Sanitize weight keys from HuggingFace format to our module structure.
+    ///
+    /// - Strips `model.` prefix from `model.encoder.*` and `model.decoder.*`
+    /// - Transposes Conv1d weights from PyTorch `[out, in, kernel]` to MLX
+    ///   `[out, kernel, in]`
+    /// - Skips `proj_out.weight` when `tie_word_embeddings` is true
+    pub fn sanitize(
+        &self,
+        weights: std::collections::HashMap<String, Array>,
+    ) -> Result<std::collections::HashMap<String, Array>, Exception> {
+        let mut sanitized = std::collections::HashMap::new();
+
+        for (key, value) in weights {
+            // Strip "model." prefix
+            let new_key = if key.starts_with("model.") {
+                key[6..].to_string()
+            } else if key.starts_with("proj_out.") && self.config.tie_word_embeddings {
+                continue;
+            } else {
+                key
+            };
+
+            // Transpose Conv1d weights: PyTorch [out, in, kernel] -> MLX [out, kernel, in]
+            let value =
+                if new_key.contains("conv") && new_key.contains("weight") && value.ndim() == 3 {
+                    value.transpose_axes(&[0, 2, 1])?
+                } else {
+                    value
+                };
+
+            sanitized.insert(new_key, value);
+        }
+
+        Ok(sanitized)
+    }
+}

--- a/crates/voice-stt/src/moonshine/model.rs
+++ b/crates/voice-stt/src/moonshine/model.rs
@@ -891,11 +891,14 @@ impl MoonshineModel {
             // Strip "model." prefix
             let new_key = if key.starts_with("model.") {
                 key.strip_prefix("model.").unwrap().to_string()
-            } else if key.starts_with("proj_out.") && self.config.tie_word_embeddings {
-                continue;
             } else {
                 key
             };
+
+            // Skip proj_out when tied embeddings (checked after prefix strip)
+            if new_key.starts_with("proj_out.") && self.config.tie_word_embeddings {
+                continue;
+            }
 
             // Transpose Conv1d weights: PyTorch [out, in, kernel] -> MLX [out, kernel, in]
             let value =

--- a/crates/voice-stt/src/moonshine/model.rs
+++ b/crates/voice-stt/src/moonshine/model.rs
@@ -53,11 +53,7 @@ impl MoonshineRotaryEmbedding {
     /// - Returns: `(cos, sin)` each shape `[B, T, rotary_ndims]`
     pub fn forward(&self, position_ids: &Array) -> Result<(Array, Array), Exception> {
         // position_ids: [B, T] -> [B, T, 1]
-        let pos = position_ids.reshape(&[
-            position_ids.shape()[0] as i32,
-            position_ids.shape()[1] as i32,
-            1,
-        ])?;
+        let pos = position_ids.reshape(&[position_ids.shape()[0], position_ids.shape()[1], 1])?;
         let pos = pos.as_dtype(mlx_rs::Dtype::Float32)?;
 
         // inv_freq: [dim/2] -> [1, 1, dim/2]
@@ -168,6 +164,7 @@ pub struct MoonshineAttention {
 }
 
 impl MoonshineAttention {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         hidden_size: usize,
         num_heads: usize,
@@ -232,8 +229,8 @@ impl MoonshineAttention {
         cache: Option<&(Array, Array)>,
         position_ids: Option<&Array>,
     ) -> Result<(Array, (Array, Array)), Exception> {
-        let b = x.shape()[0] as i32;
-        let t = x.shape()[1] as i32;
+        let b = x.shape()[0];
+        let t = x.shape()[1];
         let is_cross_attention = encoder_hidden_states.is_some();
 
         let q = self.q_proj.forward(x)?;
@@ -249,7 +246,7 @@ impl MoonshineAttention {
 
         // Reshape to [B, T, num_heads, head_dim] then transpose to [B, num_heads, T, head_dim]
         let q = q.reshape(&[b, t, nh, hd])?.transpose_axes(&[0, 2, 1, 3])?;
-        let s = k.shape()[1] as i32;
+        let s = k.shape()[1];
         let mut k = k.reshape(&[b, s, nkv, hd])?.transpose_axes(&[0, 2, 1, 3])?;
         let mut v = v.reshape(&[b, s, nkv, hd])?.transpose_axes(&[0, 2, 1, 3])?;
 
@@ -259,12 +256,12 @@ impl MoonshineAttention {
                 p.clone()
             } else {
                 let offset = if let Some(c) = cache {
-                    c.0.shape()[2] as i32
+                    c.0.shape()[2]
                 } else {
                     0
                 };
                 let pos_range = Array::from_iter(offset..offset + t, &[t]);
-                pos_range.reshape(&[1, t as i32])?
+                pos_range.reshape(&[1, t])?
             };
 
             let (cos, sin) = self.rotary_emb.forward(&pos)?;
@@ -301,7 +298,7 @@ impl MoonshineAttention {
         // Causal mask for decoder self-attention
         let mask = if self.is_causal && t > 1 {
             let causal = nn::MultiHeadAttention::create_additive_causal_mask::<f32>(t)?;
-            let klen = k_exp.shape()[2] as i32;
+            let klen = k_exp.shape()[2];
             if klen > t {
                 // Prefix zeros for cached keys
                 let prefix = Array::zeros::<f32>(&[t, klen - t])?;
@@ -393,7 +390,7 @@ impl MoonshineDecoderMLP {
 
     pub fn forward(&mut self, x: &Array) -> Result<Array, Exception> {
         let h = self.fc1.forward(x)?;
-        let mid = h.shape().last().copied().unwrap_or(0) as i32;
+        let mid = h.shape().last().copied().unwrap_or(0);
         let half = mid / 2;
 
         // Split into value and gate halves
@@ -476,6 +473,9 @@ impl MoonshineEncoderLayer {
 // Decoder layer
 // ---------------------------------------------------------------------------
 
+/// Output of a single decoder layer: `(hidden_states, self_attn_cache, cross_attn_cache)`.
+type DecoderLayerOutput = (Array, (Array, Array), (Array, Array));
+
 /// A single Moonshine decoder transformer layer.
 ///
 /// Three sub-blocks:
@@ -551,7 +551,7 @@ impl MoonshineDecoderLayer {
         encoder_hidden_states: &Array,
         self_attn_cache: Option<&(Array, Array)>,
         cross_attn_cache: Option<&(Array, Array)>,
-    ) -> Result<(Array, (Array, Array), (Array, Array)), Exception> {
+    ) -> Result<DecoderLayerOutput, Exception> {
         // 1. Causal self-attention
         let residual = x.clone();
         let h = self.input_layernorm.forward(x)?;
@@ -650,7 +650,7 @@ impl MoonshineEncoder {
         };
 
         // [B, T] -> [B, T, 1] for Conv1d (channel-last in MLX)
-        let x = audio.reshape(&[audio.shape()[0] as i32, audio.shape()[1] as i32, 1])?;
+        let x = audio.reshape(&[audio.shape()[0], audio.shape()[1], 1])?;
 
         // Conv frontend with progressive downsampling
         let x = self.conv1.forward(&x)?;
@@ -890,7 +890,7 @@ impl MoonshineModel {
         for (key, value) in weights {
             // Strip "model." prefix
             let new_key = if key.starts_with("model.") {
-                key[6..].to_string()
+                key.strip_prefix("model.").unwrap().to_string()
             } else if key.starts_with("proj_out.") && self.config.tie_word_embeddings {
                 continue;
             } else {

--- a/crates/voice-tts/tests/istft_roundtrip.rs
+++ b/crates/voice-tts/tests/istft_roundtrip.rs
@@ -10,7 +10,7 @@ fn test_istft_roundtrip() {
     let signal: Vec<f32> = (0..n_samples)
         .map(|i| (2.0 * std::f32::consts::PI * freq * i as f32 / sr).sin() * 0.5)
         .collect();
-    let signal_arr = Array::from_slice(&signal, &[n_samples as i32]);
+    let signal_arr = Array::from_slice(&signal, &[n_samples]);
 
     let n_fft = 20;
     let hop = 5;

--- a/examples/conversation.py
+++ b/examples/conversation.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Voice conversation loop using the JSON-RPC server.
+
+Alternates between listening (mic → STT) and speaking (TTS → speaker).
+The agent responds with a simple echo/commentary for now — swap in an
+LLM API call to make it actually intelligent.
+
+Usage:
+    python3 .context/conversation.py
+    python3 .context/conversation.py --voice am_michael
+    python3 .context/conversation.py --max-turns 5
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+
+
+class VoiceConversation:
+    def __init__(self, voice: str = "af_heart", speed: float = 1.0):
+        self.voice = voice
+        self.speed = speed
+        self._id = 0
+        self._proc = None
+
+    def start(self):
+        self._proc = subprocess.Popen(
+            ["voice", "-v", self.voice, "-s", str(self.speed), "--jsonrpc", "-q"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            bufsize=1,
+        )
+        resp = self.rpc("ping")
+        if resp.get("result") != "pong":
+            print(f"Server didn't respond to ping: {resp}", file=sys.stderr)
+            sys.exit(1)
+
+    def rpc(self, method: str, params: dict | None = None) -> dict:
+        self._id += 1
+        msg = {"jsonrpc": "2.0", "method": method, "id": self._id}
+        if params:
+            msg["params"] = params
+        self._proc.stdin.write(json.dumps(msg) + "\n")
+        self._proc.stdin.flush()
+        # Read lines until we get our response (skip notifications)
+        while True:
+            line = self._proc.stdout.readline()
+            if not line:
+                return {"error": {"message": "Server closed"}}
+            obj = json.loads(line)
+            if "id" in obj and obj["id"] is not None:
+                return obj
+
+    def speak(self, text: str):
+        print(f"\033[36m  🔊 {text}\033[0m")
+        self.rpc("speak", {"text": text})
+
+    def listen(
+        self, max_duration_ms: int = 10000, silence_timeout_ms: int = 2000
+    ) -> str:
+        resp = self.rpc(
+            "listen",
+            {
+                "max_duration_ms": max_duration_ms,
+                "silence_timeout_ms": silence_timeout_ms,
+            },
+        )
+        if "error" in resp:
+            print(f"\033[31m  Error: {resp['error']['message']}\033[0m")
+            return ""
+        result = resp.get("result", {})
+        text = result.get("text", "").strip()
+        tokens = result.get("tokens", 0)
+        duration = result.get("duration_ms", 0)
+        if text:
+            print(
+                f"\033[33m  🎤 {text}\033[0m  \033[2m({tokens} tokens, {duration}ms)\033[0m"
+            )
+        else:
+            print(f"\033[2m  (no speech detected)\033[0m")
+        return text
+
+    def shutdown(self):
+        if self._proc:
+            try:
+                self._proc.stdin.close()
+            except OSError:
+                pass
+            self._proc.wait(timeout=5)
+
+
+def generate_response(user_text: str, turn: int) -> str:
+    """Generate a response to the user's speech.
+
+    This is a simple placeholder — replace with an LLM API call
+    (OpenAI, Anthropic, local model, etc.) to make it intelligent.
+    """
+    text = user_text.lower()
+
+    if not user_text:
+        return "I didn't catch that. Could you say it again?"
+
+    if any(w in text for w in ["hello", "hi", "hey"]):
+        return f"Hey there! You said: {user_text}. What else is on your mind?"
+
+    if any(w in text for w in ["bye", "goodbye", "quit", "exit", "stop"]):
+        return "Goodbye! It was nice talking to you."
+
+    if "?" in user_text:
+        return (
+            f"That's a great question. You asked: {user_text}. Let me think about that."
+        )
+
+    if len(user_text.split()) < 5:
+        return f"You said {user_text}. Tell me more!"
+
+    return f"Interesting! I heard you say: {user_text}. What would you like to talk about next?"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Voice conversation loop")
+    parser.add_argument("-v", "--voice", default="af_heart", help="TTS voice")
+    parser.add_argument("-s", "--speed", type=float, default=1.0, help="TTS speed")
+    parser.add_argument(
+        "--max-turns", type=int, default=10, help="Max conversation turns"
+    )
+    parser.add_argument(
+        "--max-listen",
+        type=int,
+        default=10000,
+        help="Max listen duration in ms",
+    )
+    parser.add_argument(
+        "--silence",
+        type=int,
+        default=2000,
+        help="Silence timeout in ms (auto-stop after this much quiet)",
+    )
+    args = parser.parse_args()
+
+    conv = VoiceConversation(voice=args.voice, speed=args.speed)
+    conv.start()
+
+    print(f"\033[1mVoice Conversation\033[0m — {args.voice} ×{args.speed}")
+    print(
+        f"\033[2mMax {args.max_turns} turns, {args.max_listen}ms listen, {args.silence}ms silence timeout\033[0m"
+    )
+    print()
+
+    # Opening greeting
+    conv.speak("Hello! I'm listening. Go ahead and speak after the ding.")
+
+    should_exit = False
+
+    for turn in range(args.max_turns):
+        print(f"\n\033[2m── Turn {turn + 1}/{args.max_turns} ──\033[0m")
+
+        # Listen
+        user_text = conv.listen(
+            max_duration_ms=args.max_listen,
+            silence_timeout_ms=args.silence,
+        )
+
+        if not user_text:
+            conv.speak("I didn't hear anything. Let's try again.")
+            continue
+
+        # Check for exit
+        if any(
+            w in user_text.lower() for w in ["goodbye", "bye", "quit", "exit", "stop"]
+        ):
+            should_exit = True
+
+        # Generate and speak response
+        response = generate_response(user_text, turn)
+        conv.speak(response)
+
+        if should_exit:
+            break
+
+        # Brief pause between turns
+        time.sleep(0.3)
+
+    if not should_exit:
+        conv.speak("That's all the turns we have. Thanks for chatting!")
+
+    print()
+    conv.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/conversation.py
+++ b/examples/conversation.py
@@ -6,9 +6,9 @@ The agent responds with a simple echo/commentary for now — swap in an
 LLM API call to make it actually intelligent.
 
 Usage:
-    python3 .context/conversation.py
-    python3 .context/conversation.py --voice am_michael
-    python3 .context/conversation.py --max-turns 5
+    python3 examples/conversation.py
+    python3 examples/conversation.py --voice am_michael
+    python3 examples/conversation.py --max-turns 5
 """
 
 import argparse


### PR DESCRIPTION
Speech-to-text via Moonshine, end-to-end from mic to transcription.

## New crate: `voice-stt`

Moonshine encoder-decoder transformer ported from mlx-audio to Rust/MLX:

- **Learned audio frontend**: Conv1d stack (384× downsampling), no mel spectrogram needed — raw 16kHz audio goes directly into the encoder
- **Partial RoPE** encoder + **SwiGLU decoder** with cross-attention and KV cache
- **Greedy autoregressive decoding** with tied embeddings
- Supports `moonshine-tiny` (27M) and `moonshine-base` (61M) from HuggingFace
- Embedded config + tokenizer for instant startup, model weights downloaded on first run (~108-246MB)
- Linear resampling accepts any sample rate input

**Performance (Apple Silicon, moonshine-base):**
- Model load (cached): ~20ms
- 3s audio → 60ms transcription (0.02x RTF, 50× real-time)
- 17s audio → 200ms transcription

## CLI: `voice listen` and `voice --transcribe`

```
voice listen                    # Record from mic, transcribe on Enter/Ctrl+C
voice --transcribe audio.wav    # Transcribe a WAV file
STT_MODEL=UsefulSensors/moonshine-tiny voice listen  # Use smaller model
```

- 🔔 Ding sound when mic is ready (helps with Bluetooth latency)
- Leading/trailing silence trimming (fixes AirPods zero-audio issue)
- VAD auto-stop for JSON-RPC (stops after 2s silence following speech)

## JSON-RPC: `listen` method

```
→ {"jsonrpc":"2.0","method":"listen","id":1}
  🔔 ding → mic records → VAD auto-stops after 2s silence
← {"jsonrpc":"2.0","result":{"text":"Hello world","tokens":3,"duration_ms":4200},"id":1}
```

Full voice conversation loop: `listen` → `speak` → `listen` → repeat.

## Voice conversation example

```
python3 examples/conversation.py -v am_michael
```

No version bump — landing as foundation for Whisper support next.

Note: CI clippy failure appears to be a runner cache issue — all checks pass locally on stable 1.92.