### PR TITLE
Fix CI: stale cache from repo rename + llvm@15 bindgen issue + upgrade to macos-15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,15 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      # Force bindgen to use Xcode's clang instead of homebrew's llvm@15,
-      # which lacks __bf16 support needed by mlx-sys.
-      - name: Set LIBCLANG_PATH
+      # Homebrew's llvm@15 clang lacks __bf16 support, which breaks
+      # mlx-sys bindgen. Remove it and point to Xcode's clang instead.
+      - name: Fix clang for bindgen
         run: |
+          brew unlink llvm@15 2>/dev/null || true
           TOOLCHAIN=$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain
           echo "LIBCLANG_PATH=${TOOLCHAIN}/usr/lib" >> "$GITHUB_ENV"
+          SDK_PATH=$(xcrun --show-sdk-path)
+          echo "BINDGEN_EXTRA_CLANG_ARGS=-isysroot ${SDK_PATH}" >> "$GITHUB_ENV"
 
       - uses: actions/cache@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,25 +17,15 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      # Homebrew's llvm@15 clang lacks __bf16 support, which breaks
-      # mlx-sys bindgen. Remove it and point to Xcode's clang instead.
-      - name: Fix clang for bindgen
-        run: |
-          brew unlink llvm@15 2>/dev/null || true
-          TOOLCHAIN=$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain
-          echo "LIBCLANG_PATH=${TOOLCHAIN}/usr/lib" >> "$GITHUB_ENV"
-          SDK_PATH=$(xcrun --show-sdk-path)
-          echo "BINDGEN_EXTRA_CLANG_ARGS=-isysroot ${SDK_PATH}" >> "$GITHUB_ENV"
-
       - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ github.repository }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-${{ github.repository }}-cargo-
 
       - run: cargo fmt --check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,16 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      # Homebrew's llvm@15 clang lacks __bf16 support, which breaks
+      # mlx-sys bindgen. Point bindgen to Xcode's clang instead.
+      - name: Fix clang for bindgen
+        run: |
+          brew unlink llvm@15 2>/dev/null || true
+          TOOLCHAIN=$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain
+          echo "LIBCLANG_PATH=${TOOLCHAIN}/usr/lib" >> "$GITHUB_ENV"
+          SDK_PATH=$(xcrun --show-sdk-path)
+          echo "BINDGEN_EXTRA_CLANG_ARGS=-isysroot ${SDK_PATH}" >> "$GITHUB_ENV"
+
       - uses: actions/cache@v5
         with:
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,13 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      # Force bindgen to use Xcode's clang instead of homebrew's llvm@15,
+      # which lacks __bf16 support needed by mlx-sys.
+      - name: Set LIBCLANG_PATH
+        run: |
+          TOOLCHAIN=$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain
+          echo "LIBCLANG_PATH=${TOOLCHAIN}/usr/lib" >> "$GITHUB_ENV"
+
       - uses: actions/cache@v5
         with:
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Two issues were causing CI failures after the repo rename from `voicers` to `voice`:

**1. Stale CMake cache** — The `actions/cache` restored `target/` from the old `voicers` repo name, but `CMakeCache.txt` had the old checkout path baked in (`/Users/runner/work/voicers/voicers/target/...`). CMake refused to use it. **Fix:** add `github.repository` to the cache key.

**2. Homebrew llvm@15 breaks bindgen** — The `macos-14` runner has `llvm@15` which `bindgen` picks up. That clang lacks `__bf16` support, causing `mlx-sys` to fail. **Fix:** set `LIBCLANG_PATH` and `BINDGEN_EXTRA_CLANG_ARGS` to use Xcode's clang.

**Also upgraded to `macos-15` runner** which has newer tooling and Xcode 16+.

Verified green on both `macos-14` (with workarounds) and `macos-15`.