### PR TITLE
Subcommand refactor + continuous listen + adaptive noise floor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "audio-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ebbf82d06013f4c41fe71303feb980cddd78496d904d06be627972de51a24"
+
+[[package]]
+name = "audioadapter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e25c5bb54993ad4693d8b68b6f29f872c5fd9f92a6469d0acb0cbaf80a13d0f9"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-buffers"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6af89882334c4e501faa08992888593ada468f9e1ab211635c32f9ada7786e0"
+dependencies = [
+ "audioadapter",
+ "audioadapter-sample",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-sample"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e9a3d502fec0b21aa420febe0b110875cf8a7057c49e83a0cace1df6a73e03e"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,6 +2305,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2413,6 +2459,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "realfft"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2541,6 +2596,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7204ed6420f698836b76d4d5c2ec5dec7585fd5c3a788fd1cde855d1de598239"
 
 [[package]]
+name = "rubato"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90173154a8a14e6adb109ea641743bc95ec81c093d94e70c6763565f7108ebeb"
+dependencies = [
+ "audioadapter",
+ "audioadapter-buffers",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "realfft",
+ "visibility",
+ "windowfunctions",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2551,6 +2622,20 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+]
 
 [[package]]
 name = "rustix"
@@ -2798,6 +2883,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strsim"
@@ -3328,6 +3419,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3478,6 +3579,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "voice"
 version = "0.3.1"
 dependencies = [
@@ -3526,10 +3638,12 @@ dependencies = [
 name = "voice-stt"
 version = "0.1.0"
 dependencies = [
+ "audioadapter-buffers",
  "hf-hub",
  "hound",
  "mlx-macros",
  "mlx-rs",
+ "rubato",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3768,6 +3882,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windowfunctions"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90628d739333b7c5d2ee0b70210b97b8cddc38440c682c96fd9e2c24c2db5f3a"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "windows"

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ STT_MODEL=UsefulSensors/moonshine-tiny voice listen
 | Method | Description |
 |--------|-------------|
 | `speak` | Speak text or phonemes. Params: `text`, `phonemes`, `voice`, `speed`, `markdown`, `detail` |
-| `listen` | Record from mic and transcribe. Params: `max_duration_ms`, `silence_timeout_ms` |
+| `listen` | Record from mic and transcribe. Params: `max_duration_ms`, `silence_timeout_ms`, `silence_threshold`, `noise_multiplier`, `calibration_ms` |
 | `cancel` | Interrupt current speak playback |
 | `set_voice` | Change the default voice. Params: `voice` |
 | `set_speed` | Change the default speed. Params: `speed` |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # voice
 
-Rust TTS on Apple Silicon, powered by [MLX](https://github.com/oxiglade/mlx-rs). Ships the [Kokoro](https://huggingface.co/prince-canuma/Kokoro-82M) 82M-parameter model with a full English G2P pipeline.
+Rust TTS & STT on Apple Silicon, powered by [MLX](https://github.com/oxiglade/mlx-rs). Ships the [Kokoro](https://huggingface.co/prince-canuma/Kokoro-82M) 82M-parameter TTS model with a full English G2P pipeline, and [Moonshine](https://huggingface.co/UsefulSensors/moonshine-base) for speech-to-text.
 
-Faster time-to-first-speech than macOS `say`, with dramatically better audio quality.
+Faster time-to-first-speech than macOS `say`, with dramatically better audio quality. STT runs at ~50× real-time on Apple Silicon.
 
 ## Install
 
@@ -14,8 +14,8 @@ brew install git-lfs
 git lfs install
 
 # Clone and build
-git clone https://github.com/rgbkrk/voicers.git
-cd voicers
+git clone https://github.com/rgbkrk/voice.git
+cd voice
 cargo install --path crates/voice-cli
 ```
 
@@ -23,40 +23,53 @@ cargo install --path crates/voice-cli
 
 > **Why git-lfs?** Voice data (`.safetensors`) and tagger weights are stored with Git LFS. Without it, those files are tiny pointers instead of actual data — the build will catch this and tell you what to do.
 
-This puts the `voice` binary on your `$PATH`. Model weights (~312MB) are downloaded from HuggingFace Hub on first run and cached in `~/.cache/huggingface/hub/`. Seven popular voices and the model config are embedded in the binary — no network needed for common use.
+This puts the `voice` binary on your `$PATH`. Model weights are downloaded from HuggingFace Hub on first run and cached in `~/.cache/huggingface/hub/`. Seven popular voices and the model config are embedded in the binary — no network needed for common use.
 
 ## Usage
 
 ```bash
-# Just talk
+# Just talk (backward compatible — no subcommand needed)
 voice Hello world, this is voice speaking.
 
-# Pick a voice
-voice -v am_michael "How are you today?"
+# Explicit say subcommand with options
+voice say -v am_michael "How are you today?"
 
 # Pipe text in
-echo "The quick brown fox jumps over the lazy dog." | voice
+echo "The quick brown fox jumps over the lazy dog." | voice say
 
 # Save to file instead of playing
-voice -o speech.wav "Good morning everyone."
+voice say -o speech.wav "Good morning everyone."
 
-# Read from a file
-voice -f script.txt
+# Read from a file, strip markdown
+voice say --markdown -f blog-post.mdx
 
 # Adjust speed
-voice -s 0.8 "Take it slow."
-
-# Strip markdown before speaking
-voice --markdown -f blog-post.mdx
+voice say -s 0.8 "Take it slow."
 
 # Raw phoneme input
-voice --phonemes "həlˈO wˈɜɹld"
+voice say --phonemes "həlˈO wˈɜɹld"
+
+# Listen — single-shot speech-to-text from mic
+voice listen
+
+# Continuous listening — segments split on silence
+voice listen --continuous
+
+# Transcribe an audio file
+voice transcribe recording.wav
+
+# JSON-RPC server for agent integration
+voice serve
 ```
 
 ## CLI options
 
+### `voice say`
+
 ```
-Usage: voice [OPTIONS] [TEXT]...
+Speak text aloud (default when no subcommand given)
+
+Usage: voice say [OPTIONS] [TEXT]...
 
 Arguments:
   [TEXT]...                       Text to speak
@@ -70,11 +83,98 @@ Options:
       --markdown                 Strip markdown/MDX formatting before speaking
       --sub <WORD=REPLACEMENT>   Word substitution (repeatable)
       --sub-file <PATH>          Load substitutions from a file
-  -q, --quiet                    Suppress progress output (errors still print)
+  -q, --quiet                    Suppress progress output
   -h, --help                     Print help
 ```
 
-If no text, `--phonemes`, or `-f` is given, reads from stdin.
+### `voice listen`
+
+```
+Record from microphone and transcribe (speech-to-text)
+
+Usage: voice listen [OPTIONS]
+
+Options:
+      --continuous   Continuous mode — record and transcribe segments
+                     as you speak. Segments split on silence.
+  -q, --quiet        Suppress progress output
+  -h, --help         Print help
+```
+
+### `voice transcribe`
+
+```
+Transcribe a WAV audio file
+
+Usage: voice transcribe <FILE>
+```
+
+### `voice serve`
+
+```
+Run as a JSON-RPC 2.0 server on stdin/stdout
+
+Usage: voice serve [OPTIONS]
+
+Options:
+  -v, --voice <VOICE>            Voice name [default: af_heart]
+  -s, --speed <SPEED>            Speech speed factor [default: 1.0]
+      --sub <WORD=REPLACEMENT>   Word substitution (repeatable)
+      --sub-file <PATH>          Load substitutions from a file
+```
+
+## Speech-to-text
+
+STT uses the [Moonshine](https://huggingface.co/UsefulSensors/moonshine-base) model from Useful Sensors — a compact encoder-decoder transformer designed for on-device speech recognition.
+
+| Model | Repo ID | Params |
+|-------|---------|--------|
+| Moonshine Tiny | `UsefulSensors/moonshine-tiny` | 27M |
+| Moonshine Base | `UsefulSensors/moonshine-base` | 61M |
+
+Performance is ~50× real-time on Apple Silicon (a 10-second recording transcribes in ~200ms).
+
+**Adaptive noise floor**: Before recording, `voice listen` calibrates against ambient noise for ~500ms, then sets a silence threshold relative to the noise floor. This avoids false triggers in noisy environments and missed speech in quiet ones. A **ding** sound plays when the mic is ready.
+
+**Model selection**: The default model is `moonshine-base`. Override with the `STT_MODEL` environment variable:
+
+```bash
+STT_MODEL=UsefulSensors/moonshine-tiny voice listen
+```
+
+## JSON-RPC server
+
+`voice serve` runs a JSON-RPC 2.0 server on stdin/stdout, designed for integration with AI agents and tool-using LLMs.
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `speak` | Speak text or phonemes. Params: `text`, `phonemes`, `voice`, `speed`, `markdown`, `detail` |
+| `listen` | Record from mic and transcribe. Params: `max_duration_ms`, `silence_timeout_ms` |
+| `cancel` | Interrupt current speak playback |
+| `set_voice` | Change the default voice. Params: `voice` |
+| `set_speed` | Change the default speed. Params: `speed` |
+| `list_voices` | List available builtin voices |
+| `ping` | Health check — returns `"pong"` |
+
+When `detail` is `"full"`, `speak` emits `speak.progress` notifications with chunk/phoneme info as audio streams.
+
+### Example session
+
+```jsonc
+// Client → Server
+{"jsonrpc": "2.0", "method": "speak", "params": {"text": "Hello! I'm listening."}, "id": 1}
+// Server → Client
+{"jsonrpc": "2.0", "result": {"duration_ms": 1520, "chunks": 1}, "id": 1}
+
+// Client → Server
+{"jsonrpc": "2.0", "method": "listen", "params": {"silence_timeout_ms": 2000}, "id": 2}
+// Server → Client (after user speaks and silence is detected)
+{"jsonrpc": "2.0", "result": {"text": "What's the weather like?", "tokens": 6, "duration_ms": 3200}, "id": 2}
+```
+
+See [`examples/conversation.py`](examples/conversation.py) for a full speak/listen conversation loop.
 
 ## LLM-friendly design
 
@@ -82,9 +182,10 @@ If no text, `--phonemes`, or `-f` is given, reads from stdin.
 
 - **Phoneme output**: The CLI emits phoneme chunks to stderr, so agents can see the IPA representation of what's being spoken
 - **Phoneme input**: `--phonemes` accepts raw IPA strings, giving agents precise control over pronunciation without going through G2P
-- **Stdin pipe**: `echo "text" | voice` lets agents speak from any script or tool
+- **Stdin pipe**: `echo "text" | voice say` lets agents speak from any script or tool
 - **Markdown stripping**: `--markdown` cleans up LLM-generated markdown before speaking
-- **Word substitutions**: `--sub` and `.voice-subs` files let you fix pronunciation of project-specific terms (package names, acronyms, etc.)
+- **Word substitutions**: `--sub` and `.voice-subs` files let you fix pronunciation of project-specific terms
+- **JSON-RPC server**: `voice serve` gives agents structured, bidirectional TTS + STT over stdin/stdout
 
 See [SKILL.md](SKILL.md) for a lightweight reference card that AI agents can use to learn the `voice` tool.
 
@@ -95,7 +196,7 @@ Fix pronunciation of names, acronyms, or technical terms.
 ### Inline
 
 ```bash
-voice --sub nteract=enteract --sub PyTorch=pie-torch "nteract uses PyTorch"
+voice say --sub nteract=enteract --sub PyTorch=pie-torch "nteract uses PyTorch"
 ```
 
 ### `.voice-subs` file
@@ -117,10 +218,10 @@ Text substitutions are applied before G2P. Phoneme overrides (the `/slash/` synt
 
 ```bash
 # Uses .voice-subs automatically
-voice --markdown -f README.md
+voice say --markdown -f README.md
 
 # Or specify a file explicitly
-voice --sub-file my-project.subs -f notes.txt
+voice say --sub-file my-project.subs -f notes.txt
 ```
 
 ## Builtin voices
@@ -145,17 +246,29 @@ All other voices are fetched from HuggingFace Hub on first use:
 
 **Other languages**: French (`ff_siwis`), Hindi (`hf_alpha`, `hf_beta`, `hm_omega`, `hm_psi`), Italian (`if_sara`, `im_nicola`), Japanese (`jf_alpha`, `jf_gongitsune`, `jf_nezumi`, `jf_tebukuro`, `jm_kumo`), Portuguese (`pf_dora`, `pm_alex`, `pm_santa`), Spanish (`ef_dora`, `em_alex`, `em_santa`), Chinese (`zf_xiaobei`, `zf_xiaoni`, `zf_xiaoxiao`, `zf_xiaoyi`, `zm_yunjian`, `zm_yunxi`, `zm_yunxia`, `zm_yunyang`)
 
+## Crates
+
+| Crate | Description |
+|-------|-------------|
+| [`voice`](https://crates.io/crates/voice) | CLI binary — installs as `voice` |
+| [`voice-tts`](https://crates.io/crates/voice-tts) | Core TTS library — model loading, inference, WAV output |
+| [`voice-stt`](https://crates.io/crates/voice-stt) | Speech-to-text library — Moonshine model, transcription, resampling |
+| [`voice-nn`](https://crates.io/crates/voice-nn) | Neural network modules — ALBERT, BiLSTM, vocoder, prosody |
+| [`voice-dsp`](https://crates.io/crates/voice-dsp) | DSP primitives — STFT, iSTFT, overlap-add, windowing |
+| [`voice-g2p`](https://crates.io/crates/voice-g2p) | Grapheme-to-phoneme — misaki dictionary + espeak-ng fallback |
+
 ## Library usage
 
 Add the crates you need:
 
 ```toml
 [dependencies]
-voice-tts = "0.1"
-voice-g2p = "0.1"  # if you need text-to-phoneme conversion
+voice-tts = "0.2"
+voice-stt = "0.1"   # if you need speech-to-text
+voice-g2p = "0.2"   # if you need text-to-phoneme conversion
 ```
 
-### Generate from phonemes
+### Text-to-speech
 
 ```rust
 use std::path::Path;
@@ -178,7 +291,6 @@ fn main() -> voice_tts::Result<()> {
     let mut model = voice_tts::load_model("prince-canuma/Kokoro-82M")?;
     let voice = voice_tts::load_voice("af_heart", None)?;
 
-    // Convert text to phoneme chunks (handles the 510-token model limit)
     let chunks = voice_g2p::text_to_phoneme_chunks("Hello world, this is a test.")
         .expect("G2P failed");
 
@@ -188,47 +300,37 @@ fn main() -> voice_tts::Result<()> {
         all_samples.extend_from_slice(audio.as_slice());
     }
 
-    let spec = hound::WavSpec {
-        channels: 1,
-        sample_rate: 24000,
-        bits_per_sample: 32,
-        sample_format: hound::SampleFormat::Float,
-    };
-    let mut writer = hound::WavWriter::create("output.wav", spec).unwrap();
-    for &s in &all_samples {
-        writer.write_sample(s).unwrap();
-    }
-    writer.finalize().unwrap();
-
+    voice_tts::save_wav_samples(&all_samples, std::path::Path::new("output.wav"), 24000)?;
     Ok(())
 }
 ```
 
-## Crates
+### Speech-to-text
 
-| Crate | Description |
-|-------|-------------|
-| [`voice`](https://crates.io/crates/voice) | CLI binary — installs as `voice` |
-| [`voice-tts`](https://crates.io/crates/voice-tts) | Core TTS library — model loading, inference, WAV output |
-| [`voice-nn`](https://crates.io/crates/voice-nn) | Neural network modules — ALBERT, BiLSTM, vocoder, prosody |
-| [`voice-dsp`](https://crates.io/crates/voice-dsp) | DSP primitives — STFT, iSTFT, overlap-add, windowing |
-| [`voice-g2p`](https://crates.io/crates/voice-g2p) | Grapheme-to-phoneme — misaki dictionary + espeak-ng fallback |
+```rust
+fn main() -> voice_stt::Result<()> {
+    let mut model = voice_stt::load_model("UsefulSensors/moonshine-tiny")?;
+    let result = voice_stt::transcribe(&mut model, "audio.wav")?;
+    println!("{}", result.text);
+    Ok(())
+}
+```
 
 ## Architecture
 
-### G2P pipeline
+### TTS: Kokoro (82M)
 
-The `voice-g2p` crate ports [misaki](https://github.com/hexgrad/misaki)'s English G2P:
+- **G2P pipeline**: Ports [misaki](https://github.com/hexgrad/misaki)'s English G2P — POS tagging (embedded averaged perceptron), 90k gold + 93k silver dictionary entries, morphological decomposition, number/currency handling, espeak-ng fallback
+- **Inference**: StyleTTS2-based model with ISTFT vocoder head. Audio chunks stream to speakers as they're generated — the first chunk plays while subsequent chunks are still synthesizing
+- **Startup**: Model loads in a background thread while text resolution, G2P, and voice loading happen on the main thread
 
-- **POS tagging**: Embedded averaged perceptron tagger (no Python/spaCy dependency)
-- **Dictionary lookup**: 90k gold + 93k silver pronunciation entries embedded at compile time
-- **Morphological decomposition**: -s, -ed, -ing suffix rules with voicing logic
-- **Number handling**: Cardinals, ordinals, years, currency
-- **Fallback**: espeak-ng subprocess for unknown words
+### STT: Moonshine (27M / 61M)
 
-### Startup pipeline
-
-Model loading runs in a background thread while text resolution, G2P, and voice loading happen on the main thread. Audio chunks stream to the speakers as they're generated — the first chunk plays immediately while subsequent chunks are still being synthesized.
+- **Learned audio frontend**: Three Conv1d layers with progressive stride (384× total downsampling) replace mel spectrograms — raw 16kHz audio goes directly into the encoder
+- **Partial RoPE**: Only a fraction of head dimensions receive rotary positional encoding; the rest pass through unmodified
+- **SwiGLU decoder MLP**: Gated SiLU activation for better gradient flow
+- **Tied embeddings**: Output projection reuses the token embedding matrix
+- **Greedy decode with KV cache**: Encoder output is computed once, then cached cross-attention keys/values are reused across all decoder steps
 
 ## Requirements
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,44 +1,112 @@
-# voice — TTS tool for AI agents
+# voice — TTS & STT tool for AI agents
 
-`voice` speaks text aloud using Kokoro TTS on Apple Silicon. Use it to get your user's attention, read back content, or confirm actions audibly.
+`voice` speaks text aloud using Kokoro TTS and transcribes speech using Moonshine STT on Apple Silicon. Use it to talk to your user, listen for their response, or run a full voice conversation loop.
 
 ## Quick reference
 
+### Speak (TTS)
+
 ```bash
-# Speak text
+# Speak text (backward compatible — no subcommand needed)
 voice Hello, I finished the task.
 
+# Explicit say subcommand with options
+voice say -v am_michael "Switching to a male voice."
+
 # Speak from a pipe
-echo "Build complete." | voice
+echo "Build complete." | voice say
 
 # Read a file aloud (strip markdown first)
-voice --markdown -f README.md
+voice say --markdown -f README.md
 
 # Save to WAV instead of playing
-voice -o result.wav "Here is your audio."
-
-# Use a specific voice
-voice -v am_michael "Switching to a male voice."
+voice say -o result.wav "Here is your audio."
 
 # Precise pronunciation via IPA phonemes
-voice --phonemes "həlˈO wˈɜɹld"
+voice say --phonemes "həlˈO wˈɜɹld"
+```
+
+### Listen (STT)
+
+```bash
+# Record from mic, transcribe on Enter/Ctrl+C
+voice listen
+
+# Continuous mode — transcribe segments as you speak, split on silence
+voice listen --continuous
+
+# Transcribe a WAV file
+voice transcribe recording.wav
+```
+
+### JSON-RPC server
+
+```bash
+# Start the server (for programmatic control)
+voice serve -v am_michael
+```
+
+```jsonl
+# Speak
+→ {"jsonrpc":"2.0","method":"speak","params":{"text":"Hello"},"id":1}
+← {"jsonrpc":"2.0","result":{"duration_ms":1800,"chunks":1},"id":1}
+
+# Listen (ding plays, records, auto-stops on silence)
+→ {"jsonrpc":"2.0","method":"listen","id":2}
+← {"jsonrpc":"2.0","result":{"text":"I heard you","tokens":4,"duration_ms":3200},"id":2}
+
+# Cancel current playback or recording
+→ {"jsonrpc":"2.0","method":"cancel","id":3}
+
+# Other methods: set_voice, set_speed, list_voices, ping
 ```
 
 ## When to use
 
 - **Get attention**: Speak when a long task finishes, a build fails, or you need input
-- **Read content**: Pipe text through `voice` to read back docs, errors, or summaries
+- **Read content**: Pipe text through `voice say` to read back docs, errors, or summaries
 - **Confirm actions**: "Deploying to production" before doing something irreversible
+- **Listen for input**: Use `voice listen` to capture a spoken response from the user
+- **Voice conversation**: Use `voice serve` with JSON-RPC to alternate between speaking and listening
+- **Transcribe recordings**: Use `voice transcribe` to convert audio files to text
 
 ## Tips
 
+### TTS tips
+
 - Use `-q` for quiet mode — suppresses phonemes and progress, only errors print
-- Put flags before the text: `voice -v af_bella "text"` not `voice "text" -v af_bella`
 - For long text, `voice` automatically chunks at ~510 phonemes and streams playback
 - Stderr shows phoneme output — useful for debugging pronunciation
-- Use `--sub word=replacement` to fix names: `voice --sub kubectl=cube-cuddle "Restarting kubectl"`
+- Use `--sub word=replacement` to fix names: `voice say --sub kubectl=cube-cuddle "Restarting kubectl"`
 - A `.voice-subs` file in the project root is auto-discovered for persistent fixes
 - Wrap substitution values in `/slashes/` for raw phoneme overrides: `Kokoro=/kˈOkəɹO/`
+
+### STT tips
+
+- A ding sound plays when the mic is ready — wait for it before speaking
+- Bluetooth mics (AirPods) have ~0.5s latency; the ding helps you time it
+- Noise floor is calibrated automatically — works with MacBook mic or AirPods
+- Use `STT_MODEL=UsefulSensors/moonshine-tiny` for faster (but less accurate) transcription
+- Default model is `moonshine-base` (61M params, ~50× real-time on Apple Silicon)
+
+### JSON-RPC tips
+
+- `voice serve` loads the TTS model at startup; STT model loads lazily on first `listen`
+- `cancel` interrupts the current speak or listen mid-operation
+- `speak` supports per-request `voice` and `speed` overrides without changing defaults
+- `listen` params are tunable: `noise_multiplier`, `calibration_ms`, `silence_timeout_ms`
+- Notifications (requests without `id`) are fire-and-forget — no response returned
+
+## Subcommands
+
+| Command | What it does |
+|---------|-------------|
+| `voice <text>` | Speak text (implicit `say`, backward compatible) |
+| `voice say` | Speak text with full TTS options |
+| `voice listen` | Record from mic, transcribe once |
+| `voice listen --continuous` | Record and transcribe segments continuously |
+| `voice transcribe <file>` | Transcribe a WAV file |
+| `voice serve` | Start JSON-RPC server on stdin/stdout |
 
 ## Builtin voices (no network)
 
@@ -47,7 +115,9 @@ voice --phonemes "həlˈO wˈɜɹld"
 ## Install
 
 ```bash
-cargo install voice
+git clone https://github.com/rgbkrk/voice.git
+cd voice
+cargo install --path crates/voice-cli
 ```
 
-Requires macOS with Apple Silicon. Model weights download on first run (~312MB, cached).
+Requires macOS with Apple Silicon, Git LFS, and Rust 1.85+. TTS model weights download on first `voice say` (~312MB, cached). STT model weights download on first `voice listen` (~246MB, cached).

--- a/crates/voice-cli/README.md
+++ b/crates/voice-cli/README.md
@@ -1,58 +1,98 @@
 # voice
 
-Like `say`, but with [Kokoro](https://huggingface.co/prince-canuma/Kokoro-82M). A command-line TTS tool for macOS powered by MLX.
+Like `say`, but with [Kokoro](https://huggingface.co/prince-canuma/Kokoro-82M) TTS and [Moonshine](https://huggingface.co/UsefulSensors/moonshine-tiny) STT. A command-line speech tool for macOS, powered by MLX on Apple Silicon.
 
 ## Install
 
+Build from source (requires Git LFS for embedded voice/model data):
+
 ```bash
-cargo install voice
+# Install git-lfs if you don't have it
+brew install git-lfs
+git lfs install
+
+# Clone and build
+git clone https://github.com/rgbkrk/voicers.git
+cd voicers
+cargo install --path crates/voice-cli
 ```
 
-This puts the `voice` binary on your `$PATH`.
+> **Note:** `cargo install voice` is the package name on crates.io, but building from source is recommended — see the [main README](../../README.md) for details on why.
 
 ## Usage
 
 ```bash
-# Just talk
+# Just talk (backward compatible — no subcommand needed)
 voice Hello world
 
-# Pick a voice
-voice -v am_adam "How are you today?"
+# Text-to-speech with the say subcommand
+voice say -v am_michael "How are you today?"
+voice say -f script.txt -o output.wav
+echo "Hello" | voice say
+voice say --markdown -f post.mdx
 
-# Pipe text in
-echo "The quick brown fox jumps over the lazy dog." | voice
+# Speech-to-text from microphone
+voice listen
+voice listen --continuous
 
-# Read from a file
-voice -f script.txt
+# Transcribe an audio file
+voice transcribe recording.wav
 
-# Save to WAV instead of playing
-voice -o speech.wav "Good morning everyone."
-
-# Adjust speed
-voice -s 0.8 "Take it slow."
-
-# Raw phonemes (advanced)
-voice --phonemes "həlˈO wˈɜɹld"
+# JSON-RPC 2.0 server on stdin/stdout
+voice serve -v am_michael
 ```
 
 ## Options
 
+### Top-level
+
 ```
-Usage: voice [OPTIONS] [TEXT]...
+Usage: voice [OPTIONS] [COMMAND] [TEXT]...
+
+Commands:
+  say         Speak text aloud (default when no subcommand given)
+  listen      Record from microphone and transcribe (speech-to-text)
+  transcribe  Transcribe a WAV audio file
+  serve       Run as a JSON-RPC 2.0 server on stdin/stdout
 
 Arguments:
-  [TEXT]...  Text to speak
+  [TEXT]...  Text to speak (shorthand for `voice say <text>`)
 
 Options:
-  -f, --input-file <FILE>   Read text from a file (use - for stdin)
-      --phonemes <IPA>      Raw phoneme string (IPA)
-  -v, --voice <VOICE>       Voice name [default: af_heart]
-  -o, --output <PATH>       Write WAV to file instead of playing
-  -s, --speed <SPEED>       Speech speed factor [default: 1.0]
-  -h, --help                Print help
+  -q, --quiet  Suppress progress output
+  -h, --help   Print help
 ```
 
-If no text, `--phonemes`, or `-f` is given, reads from stdin.
+### `voice say`
+
+```
+Usage: voice say [OPTIONS] [TEXT]...
+
+Options:
+  -f, --input-file <FILE>        Read text from a file (use - for stdin)
+      --phonemes <IPA>           Raw phoneme string (IPA)
+  -v, --voice <VOICE>            Voice name [default: af_heart]
+  -o, --output <PATH>            Write WAV to file instead of playing
+  -s, --speed <SPEED>            Speech speed factor [default: 1.0]
+      --markdown                 Strip markdown/MDX formatting before speaking
+      --sub <WORD=REPLACEMENT>   Word substitution (repeatable)
+      --sub-file <PATH>          Load substitutions from a file
+```
+
+### `voice listen`
+
+```
+Usage: voice listen [OPTIONS]
+
+Options:
+      --continuous  Record and transcribe segments continuously
+```
+
+### `voice transcribe`
+
+```
+Usage: voice transcribe <FILE>
+```
 
 ## Voices
 
@@ -60,7 +100,7 @@ If no text, `--phonemes`, or `-f` is given, reads from stdin.
 
 **British**: `bf_emma`, `bf_isabella`, `bm_george`, `bm_lewis`
 
-See the full list in the [main README](../../README.md#available-voices).
+See the full list in the [main README](../../README.md#builtin-voices).
 
 ## License
 

--- a/crates/voice-cli/README.md
+++ b/crates/voice-cli/README.md
@@ -12,8 +12,8 @@ brew install git-lfs
 git lfs install
 
 # Clone and build
-git clone https://github.com/rgbkrk/voicers.git
-cd voicers
+git clone https://github.com/rgbkrk/voice.git
+cd voice
 cargo install --path crates/voice-cli
 ```
 

--- a/crates/voice-cli/src/jsonrpc.rs
+++ b/crates/voice-cli/src/jsonrpc.rs
@@ -156,8 +156,16 @@ struct ListenParams {
     max_duration_ms: Option<u64>,
     /// Stop after this many ms of silence following speech (default: 2000).
     silence_timeout_ms: Option<u64>,
-    /// Amplitude threshold for voice activity detection (default: 0.01).
+    /// Minimum amplitude threshold for voice activity detection (default: 0.01).
+    /// The actual threshold is max(this, noise_floor × noise_multiplier).
     silence_threshold: Option<f32>,
+    /// Multiplier applied to the calibrated noise floor to set the adaptive
+    /// threshold (default: 3.0). Higher = less sensitive, lower = more sensitive.
+    noise_multiplier: Option<f32>,
+    /// Duration in milliseconds to calibrate the noise floor at the start
+    /// of recording (default: 500). Set to 0 to skip calibration and use
+    /// silence_threshold directly.
+    calibration_ms: Option<u64>,
 }
 
 // ── Session state ──────────────────────────────────────────────────────
@@ -408,6 +416,8 @@ fn handle_listen(session: &mut Session, params: Value) -> Result<Value, RpcErr> 
             max_duration_ms: None,
             silence_timeout_ms: None,
             silence_threshold: None,
+            noise_multiplier: None,
+            calibration_ms: None,
         }
     } else {
         serde_json::from_value(params)
@@ -417,6 +427,8 @@ fn handle_listen(session: &mut Session, params: Value) -> Result<Value, RpcErr> 
     let max_duration = p.max_duration_ms.unwrap_or(30_000);
     let silence_timeout = p.silence_timeout_ms.unwrap_or(2_000);
     let threshold = p.silence_threshold.unwrap_or(0.01);
+    let noise_multiplier = p.noise_multiplier.unwrap_or(3.0);
+    let calibration_ms = p.calibration_ms.unwrap_or(500);
 
     // Lazily load STT model on first listen call
     if session.stt_model.is_none() {
@@ -451,6 +463,8 @@ fn handle_listen(session: &mut Session, params: Value) -> Result<Value, RpcErr> 
         max_duration,
         silence_timeout,
         threshold,
+        noise_multiplier,
+        calibration_ms,
     );
 
     let duration_ms = started.elapsed().as_millis() as u64;

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -44,6 +44,7 @@ pub struct Segment {
 }
 
 /// Result of transcribing a single segment.
+#[allow(dead_code)]
 pub struct SegmentResult {
     pub text: String,
     pub tokens: Vec<u32>,
@@ -717,7 +718,7 @@ pub fn transcribe_segments(
 ///
 /// Entry point for `voice listen --continuous`.
 pub fn listen_continuous() {
-    let (mut model, tokenizer) = load_stt();
+    let (model, tokenizer) = load_stt();
 
     if !QUIET.load(Ordering::Relaxed) {
         eprintln!("Listening continuously... (Ctrl+C to stop)\n");
@@ -766,6 +767,7 @@ pub fn listen_continuous() {
 ///
 /// Returns a receiver of SegmentResult. The caller (jsonrpc dispatch)
 /// sends notifications per result and a final response on completion.
+#[allow(dead_code)]
 pub fn listen_continuous_for_rpc(
     model: voice_stt::MoonshineModel,
     tokenizer: voice_stt::tokenizers::Tokenizer,

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -296,6 +296,8 @@ pub fn record_with_vad(
     max_duration_ms: u64,
     silence_timeout_ms: u64,
     silence_threshold: f32,
+    noise_multiplier: f32,
+    calibration_ms: u64,
 ) -> Result<(Vec<f32>, u32), String> {
     let (device, config) = open_input_device()?;
     let sample_rate = config.sample_rate().0;
@@ -333,6 +335,44 @@ pub fn record_with_vad(
     let max_dur = std::time::Duration::from_millis(max_duration_ms);
     let silence_dur = std::time::Duration::from_millis(silence_timeout_ms);
 
+    // Adaptive noise floor calibration
+    let adaptive_threshold = if calibration_ms > 0 {
+        let calibration_duration = std::time::Duration::from_millis(calibration_ms);
+        let mut max_ambient_peak: f32 = 0.0;
+
+        while start_time.elapsed() < calibration_duration {
+            if INTERRUPTED.load(Ordering::Relaxed) {
+                drop(stream);
+                let samples = extract_samples(buffer);
+                return Ok((samples, sample_rate));
+            }
+            let peak_bits = recent_peak.load(Ordering::Relaxed);
+            let current_peak = f32::from_bits(peak_bits);
+            max_ambient_peak = max_ambient_peak.max(current_peak);
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+
+        let threshold = (max_ambient_peak * noise_multiplier).max(silence_threshold);
+
+        if !QUIET.load(Ordering::Relaxed) {
+            eprintln!(
+                "Noise floor: {:.4}, threshold: {:.4} (×{:.1})",
+                max_ambient_peak, threshold, noise_multiplier
+            );
+        }
+
+        // Clear the calibration audio from the buffer
+        {
+            let mut guard = buffer.lock().unwrap();
+            guard.clear();
+        }
+
+        threshold
+    } else {
+        // Skip calibration, use raw threshold
+        silence_threshold
+    };
+
     loop {
         if INTERRUPTED.load(Ordering::Relaxed) {
             break;
@@ -347,7 +387,7 @@ pub fn record_with_vad(
 
         let peak_bits = recent_peak.load(Ordering::Relaxed);
         let current_peak = f32::from_bits(peak_bits);
-        let is_speech = current_peak > silence_threshold;
+        let is_speech = current_peak > adaptive_threshold;
 
         if is_speech {
             if !speech_started {
@@ -399,6 +439,8 @@ pub fn record_continuous(
     max_duration_ms: u64,
     min_segment_ms: u64,
     max_segment_ms: u64,
+    noise_multiplier: f32,
+    calibration_ms: u64,
 ) -> Result<(mpsc::Receiver<Segment>, u32, cpal::Stream), String> {
     let (device, config) = open_input_device()?;
     let sample_rate = config.sample_rate().0;
@@ -446,6 +488,45 @@ pub fn record_continuous(
         let max_dur = std::time::Duration::from_millis(max_duration_ms);
         let silence_dur = std::time::Duration::from_millis(silence_timeout_ms);
 
+        // Adaptive noise floor calibration
+        let adaptive_threshold = if calibration_ms > 0 {
+            let calibration_duration = std::time::Duration::from_millis(calibration_ms);
+            let mut max_ambient_peak: f32 = 0.0;
+
+            if !QUIET.load(Ordering::Relaxed) {
+                eprintln!("Calibrating noise floor...");
+            }
+
+            while start_time.elapsed() < calibration_duration {
+                if INTERRUPTED.load(Ordering::Relaxed) {
+                    return;
+                }
+                let peak_bits = recent_peak.load(Ordering::Relaxed);
+                let current_peak = f32::from_bits(peak_bits);
+                max_ambient_peak = max_ambient_peak.max(current_peak);
+                std::thread::sleep(std::time::Duration::from_millis(25));
+            }
+
+            let threshold = (max_ambient_peak * noise_multiplier).max(silence_threshold);
+
+            if !QUIET.load(Ordering::Relaxed) {
+                eprintln!(
+                    "Noise floor: {:.4}, threshold: {:.4} (×{:.1})",
+                    max_ambient_peak, threshold, noise_multiplier
+                );
+            }
+
+            // Clear the calibration audio from the segment buffer
+            {
+                let mut guard = segment_buffer.lock().unwrap();
+                guard.clear();
+            }
+
+            threshold
+        } else {
+            silence_threshold
+        };
+
         loop {
             if INTERRUPTED.load(Ordering::Relaxed) {
                 // Flush any remaining speech as a final segment
@@ -486,7 +567,7 @@ pub fn record_continuous(
 
             let peak_bits = recent_peak.load(Ordering::Relaxed);
             let current_peak = f32::from_bits(peak_bits);
-            let is_speech = current_peak > silence_threshold;
+            let is_speech = current_peak > adaptive_threshold;
 
             if is_speech {
                 if !speech_started {
@@ -648,6 +729,8 @@ pub fn listen_continuous() {
         300_000, // max_duration_ms (5 min)
         500,     // min_segment_ms
         30_000,  // max_segment_ms
+        3.0,     // noise_multiplier
+        500,     // calibration_ms
     ) {
         Ok(r) => r,
         Err(e) => {
@@ -688,6 +771,8 @@ pub fn listen_continuous_for_rpc(
     tokenizer: voice_stt::tokenizers::Tokenizer,
     silence_timeout_ms: u64,
     max_duration_ms: u64,
+    noise_multiplier: f32,
+    calibration_ms: u64,
 ) -> Result<mpsc::Receiver<SegmentResult>, String> {
     let (segments_rx, _sample_rate, _stream) = record_continuous(
         silence_timeout_ms,
@@ -695,6 +780,8 @@ pub fn listen_continuous_for_rpc(
         max_duration_ms,
         500,    // min_segment_ms
         30_000, // max_segment_ms
+        noise_multiplier,
+        calibration_ms,
     )?;
 
     Ok(transcribe_segments(model, tokenizer, segments_rx))
@@ -912,15 +999,22 @@ pub fn listen_and_transcribe_vad(
     max_duration_ms: u64,
     silence_timeout_ms: u64,
     silence_threshold: f32,
+    noise_multiplier: f32,
+    calibration_ms: u64,
 ) -> Option<voice_stt::TranscribeResult> {
-    let (samples, sample_rate) =
-        match record_with_vad(max_duration_ms, silence_timeout_ms, silence_threshold) {
-            Ok(r) => r,
-            Err(e) => {
-                eprintln!("Recording failed: {e}");
-                return None;
-            }
-        };
+    let (samples, sample_rate) = match record_with_vad(
+        max_duration_ms,
+        silence_timeout_ms,
+        silence_threshold,
+        noise_multiplier,
+        calibration_ms,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Recording failed: {e}");
+            return None;
+        }
+    };
 
     if INTERRUPTED.load(Ordering::Relaxed) || samples.is_empty() {
         return None;

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -21,6 +21,7 @@
 
 use std::io::{self, Write};
 use std::num::NonZero;
+use std::path::Path;
 use std::sync::atomic::Ordering;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
@@ -582,14 +583,21 @@ pub fn record_continuous(
                 if let Some(ss) = silence_start {
                     if ss.elapsed() >= silence_dur {
                         // End of speech segment — snapshot and send
-                        let mut guard = segment_buffer.lock().unwrap();
-                        let current_len = guard.len();
+                        let segment_data = {
+                            let mut guard = segment_buffer.lock().unwrap();
+                            if guard.len() >= min_samples {
+                                segment_id += 1;
+                                let samples = std::mem::take(&mut *guard);
+                                let elapsed = start_time.elapsed().as_millis() as u64;
+                                Some((samples, elapsed))
+                            } else {
+                                // Too short — discard
+                                guard.clear();
+                                None
+                            }
+                        };
 
-                        if current_len >= min_samples {
-                            segment_id += 1;
-                            let samples = std::mem::take(&mut *guard);
-                            let elapsed = start_time.elapsed().as_millis() as u64;
-
+                        if let Some((samples, elapsed)) = segment_data {
                             if !QUIET.load(Ordering::Relaxed) {
                                 let dur = samples.len() as f32 / sample_rate as f32;
                                 eprintln!("  segment {segment_id}: {dur:.1}s of speech");
@@ -603,9 +611,6 @@ pub fn record_continuous(
                                 segment_id,
                                 timestamp_ms: elapsed,
                             });
-                        } else {
-                            // Too short — discard
-                            guard.clear();
                         }
 
                         speech_started = false;
@@ -615,32 +620,35 @@ pub fn record_continuous(
             }
 
             // Force-split very long segments
-            {
-                let guard = segment_buffer.lock().unwrap();
+            let forced_split: Option<(Vec<f32>, u64, u64)> = {
+                let mut guard = segment_buffer.lock().unwrap();
                 if guard.len() >= max_samples && speech_started {
-                    drop(guard);
-                    let mut guard = segment_buffer.lock().unwrap();
                     segment_id += 1;
                     let samples = std::mem::take(&mut *guard);
                     let elapsed = start_time.elapsed().as_millis() as u64;
-
-                    if !QUIET.load(Ordering::Relaxed) {
-                        let dur = samples.len() as f32 / sample_rate as f32;
-                        eprintln!("  segment {segment_id}: {dur:.1}s (max length split)");
-                    }
-
-                    maybe_save_recording(&samples, sample_rate);
-
-                    let _ = tx.send(Segment {
-                        samples,
-                        sample_rate,
-                        segment_id,
-                        timestamp_ms: elapsed,
-                    });
-
-                    // Stay in speech_started state — next audio continues the segment
-                    silence_start = None;
+                    Some((samples, segment_id, elapsed))
+                } else {
+                    None
                 }
+            };
+
+            if let Some((samples, seg_id, elapsed)) = forced_split {
+                if !QUIET.load(Ordering::Relaxed) {
+                    let dur = samples.len() as f32 / sample_rate as f32;
+                    eprintln!("  segment {seg_id}: {dur:.1}s (max length split)");
+                }
+
+                maybe_save_recording(&samples, sample_rate);
+
+                let _ = tx.send(Segment {
+                    samples,
+                    sample_rate,
+                    segment_id: seg_id,
+                    timestamp_ms: elapsed,
+                });
+
+                // Stay in speech_started state — next audio continues the segment
+                silence_start = None;
             }
 
             std::thread::sleep(std::time::Duration::from_millis(50));
@@ -725,13 +733,13 @@ pub fn listen_continuous() {
     }
 
     let (segments_rx, _sample_rate, _stream) = match record_continuous(
-        1500,    // silence_timeout_ms
-        0.01,    // silence_threshold
-        300_000, // max_duration_ms (5 min)
-        500,     // min_segment_ms
-        30_000,  // max_segment_ms
-        3.0,     // noise_multiplier
-        500,     // calibration_ms
+        1500,     // silence_timeout_ms
+        0.01,     // silence_threshold
+        u64::MAX, // max_duration_ms (unlimited — Ctrl+C to stop)
+        500,      // min_segment_ms
+        30_000,   // max_segment_ms
+        3.0,      // noise_multiplier
+        500,      // calibration_ms
     ) {
         Ok(r) => r,
         Err(e) => {
@@ -1028,18 +1036,18 @@ pub fn listen_and_transcribe_vad(
 /// Transcribe a WAV file and print the result.
 ///
 /// Entry point for `voice --transcribe <file>`.
-pub fn transcribe_file(path: &str) {
+pub fn transcribe_file(path: &Path) {
     let (mut model, tokenizer) = load_stt();
 
     if !QUIET.load(Ordering::Relaxed) {
-        eprintln!("Transcribing: {path}");
+        eprintln!("Transcribing: {}", path.display());
     }
 
     // Load WAV
     let reader = match hound::WavReader::open(path) {
         Ok(r) => r,
         Err(e) => {
-            eprintln!("Failed to open {path}: {e}");
+            eprintln!("Failed to open {}: {e}", path.display());
             std::process::exit(1);
         }
     };

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -8,23 +8,50 @@
 //! A pleasant ding sound plays when the mic is ready to record, so you know
 //! when to start speaking (especially helpful with Bluetooth mic latency).
 //!
-//! Two recording modes:
+//! Three recording modes:
 //!
 //! - **Manual stop** (`voice listen`): Records until Enter or Ctrl+C.
 //! - **VAD auto-stop** (`record_with_vad`): Records until speech is detected
 //!   and then silence follows for a configurable timeout. Used by the JSON-RPC
 //!   `listen` method so agents don't need to send a signal to stop recording.
+//! - **Continuous** (`voice listen --continuous`): Records indefinitely,
+//!   splitting on silence into segments. Each segment is transcribed as it
+//!   completes while recording continues. Audio thread → segment queue →
+//!   transcription thread → output.
 
 use std::io::{self, Write};
 use std::num::NonZero;
 use std::sync::atomic::Ordering;
+use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::SampleFormat;
 use rodio::{buffer::SamplesBuffer, DeviceSinkBuilder, Player};
 
 use crate::{INTERRUPTED, QUIET};
+
+// ── Segment types ──────────────────────────────────────────────────────
+
+/// A chunk of recorded audio delimited by silence boundaries.
+pub struct Segment {
+    pub samples: Vec<f32>,
+    pub sample_rate: u32,
+    pub segment_id: u64,
+    /// Milliseconds since recording started.
+    pub timestamp_ms: u64,
+}
+
+/// Result of transcribing a single segment.
+pub struct SegmentResult {
+    pub text: String,
+    pub tokens: Vec<u32>,
+    pub segment_id: u64,
+    pub timestamp_ms: u64,
+    /// How long inference took in milliseconds.
+    pub transcribe_ms: u64,
+}
 
 // ── Ding sound ─────────────────────────────────────────────────────────
 
@@ -354,6 +381,323 @@ pub fn record_with_vad(
     maybe_save_recording(&samples, sample_rate);
 
     Ok((samples, sample_rate))
+}
+
+// ── Continuous recording ───────────────────────────────────────────────
+
+/// Record continuously, splitting speech into segments by silence.
+///
+/// Returns a receiver that yields `Segment` values as each speech segment
+/// completes (silence detected after speech). Recording runs on the audio
+/// thread and never stops until `INTERRUPTED` is set or `max_duration_ms`
+/// is reached.
+///
+/// Plays a ding at the start. No dings between segments.
+pub fn record_continuous(
+    silence_timeout_ms: u64,
+    silence_threshold: f32,
+    max_duration_ms: u64,
+    min_segment_ms: u64,
+    max_segment_ms: u64,
+) -> Result<(mpsc::Receiver<Segment>, u32, cpal::Stream), String> {
+    let (device, config) = open_input_device()?;
+    let sample_rate = config.sample_rate().0;
+
+    if !QUIET.load(Ordering::Relaxed) {
+        let name = device.name().unwrap_or_else(|_| "unknown".to_string());
+        eprintln!(
+            "Recording from: {name} ({sample_rate}Hz, {}ch)",
+            config.channels()
+        );
+    }
+
+    // Play ding once at the start
+    play_ding();
+
+    // Shared state between audio callback and VAD monitor
+    let segment_buffer: Arc<Mutex<Vec<f32>>> = Arc::new(Mutex::new(Vec::new()));
+    let recent_peak: Arc<std::sync::atomic::AtomicU32> =
+        Arc::new(std::sync::atomic::AtomicU32::new(0));
+
+    let stream = build_input_stream(
+        &device,
+        &config,
+        Arc::clone(&segment_buffer),
+        Some(Arc::clone(&recent_peak)),
+    )?;
+
+    stream
+        .play()
+        .map_err(|e| format!("Failed to start recording: {e}"))?;
+
+    let (tx, rx) = mpsc::channel::<Segment>();
+
+    let min_samples = (sample_rate as u64 * min_segment_ms / 1000) as usize;
+    let max_samples = (sample_rate as u64 * max_segment_ms / 1000) as usize;
+
+    // VAD monitor thread — watches peak levels, snapshots segments
+    // Note: `stream` is NOT moved here — it's returned to the caller
+    // who must keep it alive for the duration of recording.
+    std::thread::spawn(move || {
+        let mut speech_started = false;
+        let mut silence_start: Option<Instant> = None;
+        let mut segment_id: u64 = 0;
+        let start_time = Instant::now();
+        let max_dur = std::time::Duration::from_millis(max_duration_ms);
+        let silence_dur = std::time::Duration::from_millis(silence_timeout_ms);
+
+        loop {
+            if INTERRUPTED.load(Ordering::Relaxed) {
+                // Flush any remaining speech as a final segment
+                let mut guard = segment_buffer.lock().unwrap();
+                if guard.len() >= min_samples {
+                    segment_id += 1;
+                    let samples = std::mem::take(&mut *guard);
+                    let elapsed = start_time.elapsed().as_millis() as u64;
+                    let _ = tx.send(Segment {
+                        samples,
+                        sample_rate,
+                        segment_id,
+                        timestamp_ms: elapsed,
+                    });
+                }
+                break;
+            }
+
+            if start_time.elapsed() >= max_dur {
+                if !QUIET.load(Ordering::Relaxed) {
+                    eprintln!("Max recording duration reached.");
+                }
+                // Flush remaining
+                let mut guard = segment_buffer.lock().unwrap();
+                if guard.len() >= min_samples {
+                    segment_id += 1;
+                    let samples = std::mem::take(&mut *guard);
+                    let elapsed = start_time.elapsed().as_millis() as u64;
+                    let _ = tx.send(Segment {
+                        samples,
+                        sample_rate,
+                        segment_id,
+                        timestamp_ms: elapsed,
+                    });
+                }
+                break;
+            }
+
+            let peak_bits = recent_peak.load(Ordering::Relaxed);
+            let current_peak = f32::from_bits(peak_bits);
+            let is_speech = current_peak > silence_threshold;
+
+            if is_speech {
+                if !speech_started {
+                    speech_started = true;
+                }
+                silence_start = None;
+            } else if speech_started {
+                if silence_start.is_none() {
+                    silence_start = Some(Instant::now());
+                }
+                if let Some(ss) = silence_start {
+                    if ss.elapsed() >= silence_dur {
+                        // End of speech segment — snapshot and send
+                        let mut guard = segment_buffer.lock().unwrap();
+                        let current_len = guard.len();
+
+                        if current_len >= min_samples {
+                            segment_id += 1;
+                            let samples = std::mem::take(&mut *guard);
+                            let elapsed = start_time.elapsed().as_millis() as u64;
+
+                            if !QUIET.load(Ordering::Relaxed) {
+                                let dur = samples.len() as f32 / sample_rate as f32;
+                                eprintln!("  segment {segment_id}: {dur:.1}s of speech");
+                            }
+
+                            maybe_save_recording(&samples, sample_rate);
+
+                            let _ = tx.send(Segment {
+                                samples,
+                                sample_rate,
+                                segment_id,
+                                timestamp_ms: elapsed,
+                            });
+                        } else {
+                            // Too short — discard
+                            guard.clear();
+                        }
+
+                        speech_started = false;
+                        silence_start = None;
+                    }
+                }
+            }
+
+            // Force-split very long segments
+            {
+                let guard = segment_buffer.lock().unwrap();
+                if guard.len() >= max_samples && speech_started {
+                    drop(guard);
+                    let mut guard = segment_buffer.lock().unwrap();
+                    segment_id += 1;
+                    let samples = std::mem::take(&mut *guard);
+                    let elapsed = start_time.elapsed().as_millis() as u64;
+
+                    if !QUIET.load(Ordering::Relaxed) {
+                        let dur = samples.len() as f32 / sample_rate as f32;
+                        eprintln!("  segment {segment_id}: {dur:.1}s (max length split)");
+                    }
+
+                    maybe_save_recording(&samples, sample_rate);
+
+                    let _ = tx.send(Segment {
+                        samples,
+                        sample_rate,
+                        segment_id,
+                        timestamp_ms: elapsed,
+                    });
+
+                    // Stay in speech_started state — next audio continues the segment
+                    silence_start = None;
+                }
+            }
+
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+
+        // Channel drops here, signaling the consumer that recording is done
+    });
+
+    Ok((rx, sample_rate, stream))
+}
+
+/// Consume segments from the recording queue and transcribe each one.
+///
+/// Spawns a thread that pulls segments, trims silence, resamples, and
+/// runs Moonshine inference. Results are sent to the returned receiver.
+///
+/// The model and tokenizer are moved into this thread — they're not
+/// thread-safe, so single-threaded access is correct.
+pub fn transcribe_segments(
+    mut model: voice_stt::MoonshineModel,
+    tokenizer: voice_stt::tokenizers::Tokenizer,
+    segments: mpsc::Receiver<Segment>,
+) -> mpsc::Receiver<SegmentResult> {
+    let (tx, rx) = mpsc::channel::<SegmentResult>();
+
+    std::thread::spawn(move || {
+        for segment in segments {
+            if INTERRUPTED.load(Ordering::Relaxed) {
+                break;
+            }
+
+            let trimmed = trim_silence(&segment.samples, segment.sample_rate);
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            let t0 = Instant::now();
+            let result = voice_stt::transcribe_audio_with_tokenizer(
+                &mut model,
+                &trimmed,
+                segment.sample_rate,
+                &tokenizer,
+            );
+
+            let transcribe_ms = t0.elapsed().as_millis() as u64;
+
+            match result {
+                Ok(r) if !r.text.trim().is_empty() => {
+                    let _ = tx.send(SegmentResult {
+                        text: r.text,
+                        tokens: r.tokens,
+                        segment_id: segment.segment_id,
+                        timestamp_ms: segment.timestamp_ms,
+                        transcribe_ms,
+                    });
+                }
+                Ok(_) => {} // empty transcription — skip
+                Err(e) => {
+                    if !QUIET.load(Ordering::Relaxed) {
+                        eprintln!(
+                            "  transcription error on segment {}: {e}",
+                            segment.segment_id
+                        );
+                    }
+                }
+            }
+        }
+        // Channel drops here, signaling the output consumer
+    });
+
+    rx
+}
+
+/// Run continuous listen mode: record → segment → transcribe → print.
+///
+/// Entry point for `voice listen --continuous`.
+pub fn listen_continuous() {
+    let (mut model, tokenizer) = load_stt();
+
+    if !QUIET.load(Ordering::Relaxed) {
+        eprintln!("Listening continuously... (Ctrl+C to stop)\n");
+    }
+
+    let (segments_rx, _sample_rate, _stream) = match record_continuous(
+        1500,    // silence_timeout_ms
+        0.01,    // silence_threshold
+        300_000, // max_duration_ms (5 min)
+        500,     // min_segment_ms
+        30_000,  // max_segment_ms
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Recording failed: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let results_rx = transcribe_segments(model, tokenizer, segments_rx);
+
+    let start = Instant::now();
+    let mut total_segments = 0u64;
+
+    for result in results_rx {
+        total_segments += 1;
+        let ts_secs = result.timestamp_ms / 1000;
+        let ts_mins = ts_secs / 60;
+        let ts_rem = ts_secs % 60;
+        println!("[{ts_mins}:{ts_rem:02}] {}", result.text);
+        let _ = io::stdout().flush();
+    }
+
+    // Reset interrupt for clean exit
+    INTERRUPTED.store(false, Ordering::Relaxed);
+
+    let total_secs = start.elapsed().as_secs_f64();
+    if !QUIET.load(Ordering::Relaxed) {
+        eprintln!("\n{total_segments} segments transcribed in {total_secs:.1}s");
+    }
+}
+
+/// Run continuous listen for JSON-RPC, yielding segment results.
+///
+/// Returns a receiver of SegmentResult. The caller (jsonrpc dispatch)
+/// sends notifications per result and a final response on completion.
+pub fn listen_continuous_for_rpc(
+    model: voice_stt::MoonshineModel,
+    tokenizer: voice_stt::tokenizers::Tokenizer,
+    silence_timeout_ms: u64,
+    max_duration_ms: u64,
+) -> Result<mpsc::Receiver<SegmentResult>, String> {
+    let (segments_rx, _sample_rate, _stream) = record_continuous(
+        silence_timeout_ms,
+        0.01, // silence_threshold
+        max_duration_ms,
+        500,    // min_segment_ms
+        30_000, // max_segment_ms
+    )?;
+
+    Ok(transcribe_segments(model, tokenizer, segments_rx))
 }
 
 // ── Audio processing ───────────────────────────────────────────────────

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -97,6 +97,11 @@ struct Args {
     #[arg(long, conflicts_with_all = ["text", "input_file", "phonemes", "jsonrpc", "transcribe"])]
     listen: bool,
 
+    /// Continuous listen mode — record and transcribe segments as you speak.
+    /// Segments are split on silence and transcribed in the background.
+    #[arg(long, conflicts_with_all = ["text", "input_file", "phonemes", "jsonrpc", "transcribe"])]
+    continuous: bool,
+
     /// Transcribe a WAV audio file (speech-to-text).
     #[arg(long, value_name = "FILE", conflicts_with_all = ["text", "input_file", "phonemes", "jsonrpc", "listen"])]
     transcribe: Option<PathBuf>,
@@ -427,8 +432,18 @@ fn main() {
     let is_listen =
         args.listen || (args.text.len() == 1 && args.text[0].eq_ignore_ascii_case("listen"));
 
+    if is_listen && args.continuous {
+        listen::listen_continuous();
+        return;
+    }
+
     if is_listen {
         listen::listen_and_transcribe();
+        return;
+    }
+
+    if args.continuous {
+        listen::listen_continuous();
         return;
     }
 

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -191,27 +191,6 @@ fn resolve_text(say: &SayArgs) -> Result<String, String> {
     Ok(text)
 }
 
-/// Resolve text from bare positional args (backward compat: `voice Hello world`)
-fn resolve_text_from_bare(text: &[String]) -> Result<String, String> {
-    if !text.is_empty() {
-        return Ok(text.join(" "));
-    }
-
-    if io::stdin().is_terminal() {
-        return Err("No text provided. Pass text as arguments, use -f, or pipe to stdin.".into());
-    }
-
-    let mut buf = String::new();
-    io::stdin()
-        .read_to_string(&mut buf)
-        .map_err(|e| format!("Failed to read stdin: {e}"))?;
-    let text = buf.trim().to_string();
-    if text.is_empty() {
-        return Err("No text provided on stdin".into());
-    }
-    Ok(text)
-}
-
 /// Strip markdown/MDX to clean prose for TTS using pulldown-cmark.
 ///
 /// Keeps text content from paragraphs, headings, list items, and block quotes.

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -30,22 +30,50 @@ macro_rules! info {
 #[derive(Parser, Debug)]
 #[command(
     name = "voice",
-    about = "Kokoro TTS from the command line",
-    after_help = "If no text, --phonemes, or -f is given, reads from stdin.\n\
-                  A .voice-subs file is auto-discovered from the working directory upward.\n\n\
-                  Examples:\n  \
+    about = "Rust TTS & STT on Apple Silicon",
+    after_help = "Examples:\n  \
                   voice Hello world\n  \
-                  voice -v am_adam \"How are you today?\"\n  \
-                  echo \"Hello\" | voice\n  \
-                  voice -f speech.txt -o output.wav\n  \
-                  voice --phonemes \"hɛloʊ wɜːld\"\n  \
-                  voice --markdown -f post.mdx\n  \
-                  voice --sub nteract=enteract -f post.mdx\n  \
-                  voice --sub-file .voice-subs --markdown -f post.mdx\n  \
+                  voice say -v am_adam \"How are you today?\"\n  \
+                  echo \"Hello\" | voice say\n  \
+                  voice say -f speech.txt -o output.wav\n  \
+                  voice say --phonemes \"hɛloʊ wɜːld\"\n  \
+                  voice say --markdown -f post.mdx\n  \
                   voice listen\n  \
-                  voice --transcribe recording.wav"
+                  voice listen --continuous\n  \
+                  voice transcribe recording.wav\n  \
+                  voice serve -v am_michael"
 )]
 struct Args {
+    /// Suppress progress output (phonemes, chunk info, loading messages).
+    /// Errors are always printed.
+    #[arg(short, long, global = true)]
+    quiet: bool,
+
+    #[command(subcommand)]
+    command: Option<Command>,
+
+    /// Text to speak (shorthand for `voice say <text>`)
+    #[arg(trailing_var_arg = true)]
+    text: Vec<String>,
+}
+
+#[derive(clap::Subcommand, Debug)]
+enum Command {
+    /// Speak text aloud (default when no subcommand given)
+    Say(SayArgs),
+
+    /// Record from microphone and transcribe (speech-to-text)
+    Listen(ListenArgs),
+
+    /// Transcribe a WAV audio file
+    Transcribe(TranscribeArgs),
+
+    /// Run as a JSON-RPC 2.0 server on stdin/stdout
+    Serve(ServeArgs),
+}
+
+#[derive(clap::Args, Debug)]
+struct SayArgs {
     /// Text to speak
     #[arg(trailing_var_arg = true)]
     text: Vec<String>,
@@ -82,39 +110,49 @@ struct Args {
     /// If not set, .voice-subs is auto-discovered from the working directory upward.
     #[arg(long = "sub-file", value_name = "PATH")]
     sub_file: Option<PathBuf>,
-
-    /// Suppress progress output (phonemes, chunk info, loading messages).
-    /// Errors are always printed.
-    #[arg(short, long)]
-    quiet: bool,
-
-    /// Run as a JSON-RPC 2.0 server on stdin/stdout.
-    #[arg(long)]
-    jsonrpc: bool,
-
-    /// Record from microphone and transcribe (speech-to-text).
-    /// Also triggered by `voice listen` as the first positional arg.
-    #[arg(long, conflicts_with_all = ["text", "input_file", "phonemes", "jsonrpc", "transcribe"])]
-    listen: bool,
-
-    /// Continuous listen mode — record and transcribe segments as you speak.
-    /// Segments are split on silence and transcribed in the background.
-    #[arg(long, conflicts_with_all = ["text", "input_file", "phonemes", "jsonrpc", "transcribe"])]
-    continuous: bool,
-
-    /// Transcribe a WAV audio file (speech-to-text).
-    #[arg(long, value_name = "FILE", conflicts_with_all = ["text", "input_file", "phonemes", "jsonrpc", "listen"])]
-    transcribe: Option<PathBuf>,
 }
 
-fn resolve_text(args: &Args) -> Result<String, String> {
+#[derive(clap::Args, Debug)]
+struct ListenArgs {
+    /// Continuous mode — record and transcribe segments as you speak.
+    /// Segments are split on silence and transcribed in the background.
+    #[arg(long)]
+    continuous: bool,
+}
+
+#[derive(clap::Args, Debug)]
+struct TranscribeArgs {
+    /// Path to WAV audio file
+    file: PathBuf,
+}
+
+#[derive(clap::Args, Debug)]
+struct ServeArgs {
+    /// Voice name (e.g. af_heart, am_adam)
+    #[arg(short, long, default_value = "af_heart")]
+    voice: String,
+
+    /// Speech speed factor (1.0 = normal)
+    #[arg(short, long, default_value = "1.0")]
+    speed: f32,
+
+    /// Word substitutions (pre-processing), e.g. --sub nteract=enteract
+    #[arg(long = "sub", value_name = "WORD=REPLACEMENT")]
+    subs: Vec<String>,
+
+    /// Load substitutions from a file (one WORD=REPLACEMENT per line, # comments).
+    #[arg(long = "sub-file", value_name = "PATH")]
+    sub_file: Option<PathBuf>,
+}
+
+fn resolve_text(say: &SayArgs) -> Result<String, String> {
     // --phonemes takes a completely separate path
-    if args.phonemes.is_some() {
+    if say.phonemes.is_some() {
         return Err("phonemes".into()); // sentinel, not a real error
     }
 
     // -f / --input-file
-    if let Some(path) = &args.input_file {
+    if let Some(path) = &say.input_file {
         let text = if path.to_str() == Some("-") {
             let mut buf = String::new();
             io::stdin()
@@ -133,11 +171,32 @@ fn resolve_text(args: &Args) -> Result<String, String> {
     }
 
     // Positional text args
-    if !args.text.is_empty() {
-        return Ok(args.text.join(" "));
+    if !say.text.is_empty() {
+        return Ok(say.text.join(" "));
     }
 
     // Fall back to stdin if it's not a TTY
+    if io::stdin().is_terminal() {
+        return Err("No text provided. Pass text as arguments, use -f, or pipe to stdin.".into());
+    }
+
+    let mut buf = String::new();
+    io::stdin()
+        .read_to_string(&mut buf)
+        .map_err(|e| format!("Failed to read stdin: {e}"))?;
+    let text = buf.trim().to_string();
+    if text.is_empty() {
+        return Err("No text provided on stdin".into());
+    }
+    Ok(text)
+}
+
+/// Resolve text from bare positional args (backward compat: `voice Hello world`)
+fn resolve_text_from_bare(text: &[String]) -> Result<String, String> {
+    if !text.is_empty() {
+        return Ok(text.join(" "));
+    }
+
     if io::stdin().is_terminal() {
         return Err("No text provided. Pass text as arguments, use -f, or pipe to stdin.".into());
     }
@@ -425,60 +484,96 @@ fn main() {
         QUIET.store(true, Ordering::Relaxed);
     }
 
-    // -- STT modes: listen (mic) and transcribe (file) -----------------------
-    // These bypass the TTS pipeline entirely.
-
-    // Support `voice listen` as a positional arg shortcut for `--listen`
-    let is_listen =
-        args.listen || (args.text.len() == 1 && args.text[0].eq_ignore_ascii_case("listen"));
-
-    if is_listen && args.continuous {
-        listen::listen_continuous();
-        return;
+    match args.command {
+        Some(Command::Listen(listen_args)) => {
+            if listen_args.continuous {
+                listen::listen_continuous();
+            } else {
+                listen::listen_and_transcribe();
+            }
+        }
+        Some(Command::Transcribe(transcribe_args)) => {
+            listen::transcribe_file(&transcribe_args.file.display().to_string());
+        }
+        Some(Command::Serve(serve_args)) => {
+            run_serve(serve_args);
+        }
+        Some(Command::Say(say_args)) => {
+            run_say(say_args);
+        }
+        None => {
+            // Backward compatibility: `voice Hello world` = `voice say Hello world`
+            // Also: bare `voice` with piped stdin = `voice say` with stdin
+            if args.text.is_empty() && io::stdin().is_terminal() {
+                // No text, no pipe — show help
+                Args::parse_from(["voice", "--help"]);
+            } else {
+                let say_args = SayArgs {
+                    text: args.text,
+                    input_file: None,
+                    phonemes: None,
+                    voice: "af_heart".to_string(),
+                    output: None,
+                    speed: 1.0,
+                    markdown: false,
+                    subs: Vec::new(),
+                    sub_file: None,
+                };
+                run_say(say_args);
+            }
+        }
     }
+}
 
-    if is_listen {
-        listen::listen_and_transcribe();
-        return;
-    }
+fn run_serve(serve_args: ServeArgs) {
+    let model_handle = std::thread::spawn(|| voice_tts::load_model(MODEL_REPO));
 
-    if args.continuous {
-        listen::listen_continuous();
-        return;
-    }
+    let voice = match voice_tts::load_voice(&serve_args.voice, Some(MODEL_REPO)) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Failed to load voice '{}': {e}", serve_args.voice);
+            std::process::exit(1);
+        }
+    };
 
-    if let Some(ref path) = args.transcribe {
-        listen::transcribe_file(&path.display().to_string());
-        return;
-    }
+    let model = load_tts_model(model_handle);
+    let sample_rate = model.sample_rate as u32;
+    let sub_file = serve_args.sub_file.clone().or_else(find_sub_file);
 
-    // -- TTS pipeline --------------------------------------------------------
+    jsonrpc::run(jsonrpc::ServerConfig {
+        model,
+        voice,
+        voice_name: serve_args.voice,
+        speed: serve_args.speed,
+        sample_rate,
+        repo_id: MODEL_REPO.to_string(),
+        cli_subs: serve_args.subs,
+        sub_file_path: sub_file,
+    });
+}
 
+fn run_say(say_args: SayArgs) {
     // Start model loading in a background thread immediately — this is the
     // slowest startup step (~200ms) and can run while we resolve text + G2P.
     let model_handle = std::thread::spawn(|| voice_tts::load_model(MODEL_REPO));
 
     // Resolve phoneme chunks (text resolution + G2P are fast with the
     // embedded perceptron tagger, ~1-2ms total).
-    // In JSON-RPC mode, text is resolved per-request.
-    let phoneme_chunks: Vec<String> = if args.jsonrpc {
-        Vec::new()
-    } else if let Some(phonemes) = &args.phonemes {
+    let phoneme_chunks: Vec<String> = if let Some(phonemes) = &say_args.phonemes {
         vec![phonemes.clone()]
     } else {
-        match resolve_text(&args) {
+        match resolve_text(&say_args) {
             Ok(text) => {
-                let text = if args.markdown {
+                let text = if say_args.markdown {
                     strip_markdown(&text)
                 } else {
                     text
                 };
-                // Resolve sub file: explicit --sub-file, or auto-discover .voice-subs
-                let sub_file = args.sub_file.clone().or_else(find_sub_file);
+                let sub_file = say_args.sub_file.clone().or_else(find_sub_file);
                 if let Some(ref path) = sub_file {
                     info!("Using substitutions from {}", path.display());
                 }
-                let (subs, phoneme_overrides) = collect_subs(&args.subs, sub_file.as_deref());
+                let (subs, phoneme_overrides) = collect_subs(&say_args.subs, sub_file.as_deref());
                 let text = apply_tech_subs(&text);
                 let text = if subs.is_empty() {
                     text
@@ -512,18 +607,46 @@ fn main() {
     };
 
     // Load voice (fast for builtins — embedded in binary, ~5ms).
-    let voice = match voice_tts::load_voice(&args.voice, Some(MODEL_REPO)) {
+    let voice = match voice_tts::load_voice(&say_args.voice, Some(MODEL_REPO)) {
         Ok(v) => v,
         Err(e) => {
-            eprintln!("Failed to load voice '{}': {e}", args.voice);
+            eprintln!("Failed to load voice '{}': {e}", say_args.voice);
             eprintln!("Available voices include: af_heart, af_bella, af_nicole, af_sarah, af_sky,");
             eprintln!("  am_adam, am_michael, bf_emma, bf_isabella, bm_george, bm_lewis");
             std::process::exit(1);
         }
     };
 
-    // Wait for model loading to finish.
-    let mut model = match model_handle.join().expect("model loading thread panicked") {
+    let mut model = load_tts_model(model_handle);
+    let sample_rate = model.sample_rate as u32;
+
+    if let Some(output_path) = &say_args.output {
+        generate_to_file(
+            &mut model,
+            &voice,
+            &phoneme_chunks,
+            say_args.speed,
+            sample_rate,
+            output_path,
+        );
+    } else {
+        stream_playback(
+            &mut model,
+            &voice,
+            &phoneme_chunks,
+            say_args.speed,
+            sample_rate,
+        );
+    }
+}
+
+/// Wait for TTS model loading to finish and handle errors.
+fn load_tts_model(
+    handle: std::thread::JoinHandle<
+        std::result::Result<voice_tts::KokoroModel, voice_tts::VoicersError>,
+    >,
+) -> voice_tts::KokoroModel {
+    match handle.join().expect("model loading thread panicked") {
         Ok(m) => m,
         Err(e) => {
             let msg = format!("{e}");
@@ -536,8 +659,8 @@ fn main() {
                 eprintln!();
                 eprintln!("Fix: build from source instead:");
                 eprintln!();
-                eprintln!("  git clone https://github.com/rgbkrk/voicers.git");
-                eprintln!("  cd voicers");
+                eprintln!("  git clone https://github.com/rgbkrk/voice.git");
+                eprintln!("  cd voice");
                 eprintln!("  cargo install --path crates/voice-cli");
                 eprintln!();
                 eprintln!("Or copy the metallib manually:");
@@ -550,41 +673,6 @@ fn main() {
             }
             std::process::exit(1);
         }
-    };
-
-    let sample_rate = model.sample_rate as u32;
-
-    if args.jsonrpc {
-        let sub_file = args.sub_file.clone().or_else(find_sub_file);
-        jsonrpc::run(jsonrpc::ServerConfig {
-            model,
-            voice,
-            voice_name: args.voice.clone(),
-            speed: args.speed,
-            sample_rate,
-            repo_id: MODEL_REPO.to_string(),
-            cli_subs: args.subs.clone(),
-            sub_file_path: sub_file,
-        });
-        return;
-    }
-
-    if let Some(output_path) = &args.output {
-        // File output: batch generate all chunks, then write WAV
-        // (WAV header needs total sample count upfront).
-        generate_to_file(
-            &mut model,
-            &voice,
-            &phoneme_chunks,
-            args.speed,
-            sample_rate,
-            output_path,
-        );
-    } else {
-        // Streaming playback: generate chunks and feed them to rodio as
-        // they're ready. The first chunk starts playing immediately while
-        // subsequent chunks are generated in the background.
-        stream_playback(&mut model, &voice, &phoneme_chunks, args.speed, sample_rate);
     }
 }
 

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -472,7 +472,7 @@ fn main() {
             }
         }
         Some(Command::Transcribe(transcribe_args)) => {
-            listen::transcribe_file(&transcribe_args.file.display().to_string());
+            listen::transcribe_file(&transcribe_args.file);
         }
         Some(Command::Serve(serve_args)) => {
             run_serve(serve_args);

--- a/crates/voice-stt/README.md
+++ b/crates/voice-stt/README.md
@@ -1,0 +1,88 @@
+# voice-stt
+
+Speech-to-text on Apple Silicon, powered by [MLX](https://github.com/oxiglade/mlx-rs). Ships with [Moonshine](https://huggingface.co/UsefulSensors/moonshine-tiny) support — a compact encoder-decoder transformer designed for on-device speech recognition.
+
+## Install
+
+```toml
+[dependencies]
+voice-stt = "0.1"
+```
+
+> **Note:** Requires macOS with Apple Silicon (MLX requirement). Model weights (~108-246MB) are downloaded from HuggingFace Hub on first run and cached locally.
+
+## Usage
+
+### Transcribe a file
+
+```rust
+fn main() -> voice_stt::Result<()> {
+    let mut model = voice_stt::load_model("UsefulSensors/moonshine-tiny")?;
+    let result = voice_stt::transcribe(&mut model, "audio.wav")?;
+    println!("{}", result.text);
+    Ok(())
+}
+```
+
+### Transcribe raw audio samples
+
+```rust
+fn main() -> voice_stt::Result<()> {
+    let mut model = voice_stt::load_model("UsefulSensors/moonshine-base")?;
+    let tokenizer = voice_stt::load_tokenizer("UsefulSensors/moonshine-base")?;
+
+    let samples: Vec<f32> = /* 16kHz mono f32 samples */;
+    let result = voice_stt::transcribe_audio_with_tokenizer(
+        &mut model, &samples, 16000, &tokenizer
+    )?;
+    println!("{}", result.text);
+    Ok(())
+}
+```
+
+Audio at any sample rate is automatically resampled to 16kHz using a high-quality sinc resampler.
+
+## Supported Models
+
+| Model | Repo ID | Params | Size | Notes |
+|-------|---------|--------|------|-------|
+| Moonshine Tiny | `UsefulSensors/moonshine-tiny` | 27M | 108MB | Fast, embedded config + tokenizer |
+| Moonshine Base | `UsefulSensors/moonshine-base` | 61M | 246MB | Better accuracy for real mic audio |
+
+## Performance
+
+On Apple Silicon (cached model):
+
+| Audio Length | Transcription Time | RTF |
+|-------------|-------------------|-----|
+| 3s | ~60ms | 0.02× (50× real-time) |
+| 9s | ~100ms | 0.01× (89× real-time) |
+| 17s | ~200ms | 0.01× |
+
+## Architecture
+
+Moonshine uses a **learned audio frontend** instead of mel spectrograms — raw 16kHz audio goes directly into the encoder:
+
+- **Encoder**: Three Conv1d layers (384× total downsampling) → transformer layers with partial RoPE
+- **Decoder**: Token embedding → transformer layers with causal self-attention + cross-attention + SwiGLU MLP
+- **Output**: Tied embedding projection → greedy autoregressive decoding with KV cache
+
+The Moonshine-tiny config and tokenizer are embedded in the binary for instant startup. Model weights are downloaded from HuggingFace on first use.
+
+## Features
+
+- **High-quality resampling**: Sinc interpolation via [rubato](https://crates.io/crates/rubato) — accepts audio at any sample rate
+- **WAV loading**: 16-bit integer and 32-bit float WAV files, with automatic mono mixdown
+- **Embedded tokenizer**: SentencePiece BPE tokenizer compiled into the binary (no filesystem access needed)
+- **HuggingFace Hub**: Automatic model download and caching via [hf-hub](https://crates.io/crates/hf-hub)
+- **Weight sanitization**: Loads HuggingFace safetensors directly, handles PyTorch→MLX conv weight transposition
+
+## Requirements
+
+- macOS with Apple Silicon
+- Rust 1.85+
+- Xcode command line tools (for MLX Metal compilation)
+
+## License
+
+MIT


### PR DESCRIPTION
## CLI Subcommand Refactor

Replaces the flag soup (`--listen`, `--continuous`, `--transcribe`, `--jsonrpc`) with clean subcommands:

```
voice Hello world                    # backward compat (implicit say)
voice say -v am_michael "Hello"      # explicit say
voice listen                         # single-shot STT
voice listen --continuous            # continuous STT
voice transcribe audio.wav           # file STT
voice serve -v am_michael            # JSON-RPC server
```

No subcommand = `say` (full backward compatibility). `-q`/`--quiet` is a global flag.

## Continuous Listen Mode

`voice listen --continuous` — records indefinitely, splitting speech into segments by silence. Each segment is transcribed in the background while recording continues.

```
$ voice listen --continuous
Listening continuously... (Ctrl+C to stop)

[0:02] Hello, this is a test.
[0:06] I'm speaking in multiple sentences now.
[0:11] And each one gets transcribed separately.

^C
3 segments transcribed in 11.2s
```

Architecture: Audio thread (cpal) → VAD segmentation → mpsc queue → transcription thread → output. Recording never stops between segments.

## Adaptive Noise Floor

Measures ambient mic level for 500ms at recording start, sets speech detection threshold at 3× the noise floor. Fixes MacBook built-in mic (~0.02 ambient peak) where the old fixed 0.01 threshold thought ambient noise was speech and never detected silence.

Tunable via JSON-RPC:
```
{"method":"listen","params":{"noise_multiplier":2.0,"calibration_ms":1000}}
```

| Param | Default | Effect |
|-------|---------|--------|
| `noise_multiplier` | 3.0 | Higher = less sensitive to quiet speech |
| `calibration_ms` | 500 | Duration to measure noise floor. 0 = skip |
| `silence_threshold` | 0.01 | Minimum floor (used when calibration gives very low noise) |