### PR TITLE
Add cargo-binstall support with signed releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          lfs: true
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # Homebrew's llvm@15 clang lacks __bf16 support, which breaks
+      # mlx-sys bindgen. Point bindgen to Xcode's clang instead.
+      - name: Fix clang for bindgen
+        run: |
+          brew unlink llvm@15 2>/dev/null || true
+          TOOLCHAIN=$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain
+          echo "LIBCLANG_PATH=${TOOLCHAIN}/usr/lib" >> "$GITHUB_ENV"
+          SDK_PATH=$(xcrun --show-sdk-path)
+          echo "BINDGEN_EXTRA_CLANG_ARGS=-isysroot ${SDK_PATH}" >> "$GITHUB_ENV"
+
+      - name: Build release
+        run: cargo build --release -p voice
+
+      - name: Package
+        run: |
+          mkdir -p dist
+
+          # Binary
+          cp target/release/voice dist/
+          cd dist && tar czf voice-aarch64-apple-darwin.tar.gz voice && cd ..
+
+          # Metallib — needed at runtime for MLX Metal kernels
+          METALLIB=$(find target/release/build -name "mlx.metallib" -print -quit)
+          if [ -n "$METALLIB" ]; then
+            cp "$METALLIB" dist/mlx.metallib
+          else
+            echo "::error::mlx.metallib not found in build output"
+            exit 1
+          fi
+
+      - name: Sign release assets
+        if: env.MINISIGN_KEY != ''
+        env:
+          MINISIGN_KEY: ${{ secrets.MINISIGN_KEY }}
+        run: |
+          brew install minisign
+          echo "$MINISIGN_KEY" > /tmp/signing.key
+          minisign -S -W -s /tmp/signing.key -m dist/voice-aarch64-apple-darwin.tar.gz
+          minisign -S -W -s /tmp/signing.key -m dist/mlx.metallib
+          rm -f /tmp/signing.key
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/voice-aarch64-apple-darwin.tar.gz
+            dist/voice-aarch64-apple-darwin.tar.gz.minisig
+            dist/mlx.metallib
+            dist/mlx.metallib.minisig
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref, '-rc.') || contains(github.ref, '-alpha.') || contains(github.ref, '-beta.') }}
+          fail_on_unmatched_files: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,7 +1201,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "ureq",
+ "ureq 3.2.0",
  "windows-sys 0.61.2",
 ]
 
@@ -3502,6 +3502,22 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
@@ -3521,7 +3537,7 @@ dependencies = [
  "ureq-proto",
  "utf-8",
  "webpki-root-certs",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3601,6 +3617,7 @@ dependencies = [
  "rodio",
  "serde",
  "serde_json",
+ "ureq 2.12.1",
  "voice-g2p",
  "voice-stt",
  "voice-tts",
@@ -3841,6 +3858,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/crates/voice-cli/Cargo.toml
+++ b/crates/voice-cli/Cargo.toml
@@ -12,6 +12,15 @@ readme = "../../README.md"
 name = "voice"
 path = "src/main.rs"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.signing]
+algorithm = "minisign"
+pubkey = "RWRmHACtt9SpjQB/l+dAoCe+3iqxq/Xe/90P6dyCW70axzy3UkWl+Ave"
+
 [dependencies]
 voice-tts = { version = "0.2.0", path = "../voice-tts" }
 voice-g2p = { version = "0.2.0", path = "../voice-g2p" }
@@ -24,3 +33,4 @@ ctrlc = "3.5.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 cpal = "0.15"
+ureq = "2"

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -398,13 +398,59 @@ fn collect_subs(
     (text_subs, phoneme_overrides)
 }
 
+/// Download `mlx.metallib` from the GitHub release matching this binary's version.
+///
+/// The release workflow uploads the metallib as a standalone asset alongside
+/// the binary tarball.  This lets `cargo binstall` users (who skip the build
+/// step entirely) get the Metal kernels on first run.
+fn download_metallib(dest: &Path) -> Result<(), String> {
+    let repo = env!("CARGO_PKG_REPOSITORY");
+    let version = env!("CARGO_PKG_VERSION");
+    let url = format!("{repo}/releases/download/v{version}/mlx.metallib");
+
+    info!("Downloading mlx.metallib from GitHub release v{version}...");
+
+    let resp = ureq::get(&url)
+        .call()
+        .map_err(|e| format!("Failed to download mlx.metallib: {e}"))?;
+
+    let size_msg = resp
+        .header("content-length")
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(|len| format!(" ({} MB)", len / 1_048_576))
+        .unwrap_or_default();
+    info!("Downloading mlx.metallib{size_msg}...");
+
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create {}: {e}", parent.display()))?;
+    }
+
+    // Write to a temp file then rename for atomicity
+    let tmp = dest.with_extension("metallib.tmp");
+    let mut file = std::fs::File::create(&tmp)
+        .map_err(|e| format!("Failed to create {}: {e}", tmp.display()))?;
+
+    std::io::copy(&mut resp.into_reader(), &mut file)
+        .map_err(|e| format!("Failed to write mlx.metallib: {e}"))?;
+
+    std::fs::rename(&tmp, dest)
+        .map_err(|e| format!("Failed to rename to {}: {e}", dest.display()))?;
+
+    info!("Saved mlx.metallib to {}", dest.display());
+    Ok(())
+}
+
 /// Ensure `mlx.metallib` is co-located with the voice binary.
 ///
 /// MLX searches for the metallib next to the running binary before falling back
 /// to the compile-time `METAL_PATH`. When installed via `cargo install`, the
-/// compile-time path points to a deleted temp directory. This function copies
+/// binary lands in `~/.cargo/bin/` but the build tree is gone — so we copy
 /// the metallib from `~/.mlx/lib/` (where our build.rs places it) to sit next
 /// to the binary, making the co-located search succeed.
+///
+/// When installed via `cargo binstall`, there's no build step at all — so we
+/// download the metallib from the matching GitHub release on first run.
 fn ensure_metallib() {
     let exe = match std::env::current_exe() {
         Ok(p) => p,
@@ -429,8 +475,13 @@ fn ensure_metallib() {
         .join(".mlx")
         .join("lib")
         .join("mlx.metallib");
+
     if !stable.exists() {
-        return; // Not available — the error will be caught later with a helpful message
+        // Not built locally — try downloading from the GitHub release
+        if let Err(e) = download_metallib(&stable) {
+            eprintln!("{e}");
+            return;
+        }
     }
 
     // Copy to sit next to the binary


### PR DESCRIPTION
`cargo binstall voice` instead of waiting 15 minutes for mlx-sys to compile from source.

## What this does

**Binstall metadata** in `voice-cli/Cargo.toml` — tells cargo-binstall where to find release archives, with minisign signature verification.

**Release workflow** (`.github/workflows/release.yml`) — on `v*` tags: builds on macOS-15, packages the binary as a tarball, extracts `mlx.metallib` from the build, signs both with minisign, publishes as GitHub release assets. Prerelease tags (`-rc`, `-alpha`, `-beta`) are marked accordingly.

**Runtime metallib download** — `cargo binstall` skips the build step entirely, so there's no `mlx.metallib` on disk. On first run, `ensure_metallib()` now downloads it from the matching GitHub release and caches at `~/.mlx/lib/`. Same pattern as the HF Hub model weight download.

## New dep

`ureq = "2"` for the metallib HTTP download.

_PR submitted by @rgbkrk's agent Quill, via Zed_