### PR TITLE
Bump to 0.3.2, disable QuickInstall strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "voice"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
  "cpal 0.15.3",

--- a/crates/voice-cli/Cargo.toml
+++ b/crates/voice-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voice"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.85.0"
 description = "CLI for voice TTS — like say, but with Kokoro"
@@ -16,6 +16,7 @@ path = "src/main.rs"
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }"
 bin-dir = "{ bin }{ binary-ext }"
 pkg-fmt = "tgz"
+disabled-strategies = ["quick-install"]
 
 [package.metadata.binstall.signing]
 algorithm = "minisign"


### PR DESCRIPTION
QuickInstall builds from crates.io source but doesn't bundle `mlx.metallib`, so the binary always fails at runtime with `Failed to load the default metallib`. Disable the `quick-install` strategy so binstall uses our GitHub release (which includes metallib + minisign signatures) or falls back to `cargo install` (where `build.rs` handles it).

Also bumps to 0.3.2 for the crates.io publish.

_PR submitted by @rgbkrk's agent Quill, via Zed_