### PR TITLE
Fix minisign .sig extension for binstall

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,8 @@ jobs:
         run: |
           brew install minisign
           echo "$MINISIGN_KEY" > /tmp/signing.key
-          minisign -S -W -s /tmp/signing.key -m dist/voice-aarch64-apple-darwin.tar.gz
-          minisign -S -W -s /tmp/signing.key -m dist/mlx.metallib
+          minisign -S -W -s /tmp/signing.key -x dist/voice-aarch64-apple-darwin.tar.gz.sig -m dist/voice-aarch64-apple-darwin.tar.gz
+          minisign -S -W -s /tmp/signing.key -x dist/mlx.metallib.sig -m dist/mlx.metallib
           rm -f /tmp/signing.key
 
       - name: Create release
@@ -63,9 +63,9 @@ jobs:
         with:
           files: |
             dist/voice-aarch64-apple-darwin.tar.gz
-            dist/voice-aarch64-apple-darwin.tar.gz.minisig
+            dist/voice-aarch64-apple-darwin.tar.gz.sig
             dist/mlx.metallib
-            dist/mlx.metallib.minisig
+            dist/mlx.metallib.sig
           generate_release_notes: true
           prerelease: ${{ contains(github.ref, '-rc.') || contains(github.ref, '-alpha.') || contains(github.ref, '-beta.') }}
           fail_on_unmatched_files: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "voice"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "clap",
  "cpal 0.15.3",

--- a/crates/voice-cli/Cargo.toml
+++ b/crates/voice-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voice"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 rust-version = "1.85.0"
 description = "CLI for voice TTS — like say, but with Kokoro"


### PR DESCRIPTION
Binstall's default signature file template is `{ url }.sig`, but minisign produces `.minisig` by default. The v0.3.2 release has `.minisig` files, so binstall can't find them and falls back to `cargo install`.

Fix: use minisign's `-x` flag to output `.sig` files matching binstall's expectation.

Bumps to 0.3.3 since v0.3.2 release has the wrong filenames.

_PR submitted by @rgbkrk's agent Quill, via Zed_