### PR TITLE
Add voice converse subcommand

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -26,6 +26,16 @@ voice say -o result.wav "Here is your audio."
 voice say --phonemes "həlˈO wˈɜɹld"
 ```
 
+### Converse (speak + listen)
+
+```bash
+# Speak text, then immediately listen for a response
+voice converse "How are you today?"
+
+# With voice and speed options
+voice converse -v am_michael -s 1.2 "What do you think about that?"
+```
+
 ### Listen (STT)
 
 ```bash
@@ -67,7 +77,7 @@ voice serve -v am_michael
 - **Read content**: Pipe text through `voice say` to read back docs, errors, or summaries
 - **Confirm actions**: "Deploying to production" before doing something irreversible
 - **Listen for input**: Use `voice listen` to capture a spoken response from the user
-- **Voice conversation**: Use `voice serve` with JSON-RPC to alternate between speaking and listening
+- **Voice conversation**: Use `voice converse` to speak then listen in one shot, or `voice serve` for programmatic control
 - **Transcribe recordings**: Use `voice transcribe` to convert audio files to text
 
 ## Tips
@@ -103,6 +113,7 @@ voice serve -v am_michael
 |---------|-------------|
 | `voice <text>` | Speak text (implicit `say`, backward compatible) |
 | `voice say` | Speak text with full TTS options |
+| `voice converse` | Speak text, then listen for a response |
 | `voice listen` | Record from mic, transcribe once |
 | `voice listen --continuous` | Record and transcribe segments continuously |
 | `voice transcribe <file>` | Transcribe a WAV file |

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -971,6 +971,30 @@ fn transcribe_samples(
 /// Record from mic (manual stop), transcribe, print result.
 ///
 /// Entry point for `voice listen`.
+/// Record from mic with VAD auto-stop, transcribe, print result.
+///
+/// Like `listen_and_transcribe` but uses voice activity detection instead
+/// of waiting for Enter/Ctrl+C — stops automatically after silence.
+pub fn listen_and_transcribe_auto() {
+    let (mut model, tokenizer) = load_stt();
+
+    if let Some(result) = listen_and_transcribe_vad(
+        &mut model,
+        &tokenizer,
+        30_000, // max_duration_ms
+        2_000,  // silence_timeout_ms
+        0.01,   // silence_threshold
+        3.0,    // noise_multiplier
+        500,    // calibration_ms
+    ) {
+        println!("{}", result.text);
+        if !QUIET.load(Ordering::Relaxed) {
+            let _ = io::stderr().flush();
+            eprintln!("\n({} tokens)", result.tokens.len());
+        }
+    }
+}
+
 pub fn listen_and_transcribe() {
     let (mut model, tokenizer) = load_stt();
 

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -979,9 +979,7 @@ pub fn listen_and_transcribe_auto() {
     let (mut model, tokenizer) = load_stt();
 
     if let Some(result) = listen_and_transcribe_vad(
-        &mut model,
-        &tokenizer,
-        30_000, // max_duration_ms
+        &mut model, &tokenizer, 30_000, // max_duration_ms
         2_000,  // silence_timeout_ms
         0.01,   // silence_threshold
         3.0,    // noise_multiplier

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -797,8 +797,8 @@ fn run_converse(args: ConverseArgs) {
         std::process::exit(130);
     }
 
-    // Listen for response
-    listen::listen_and_transcribe();
+    // Listen for response (VAD auto-stop — no Enter key needed)
+    listen::listen_and_transcribe_auto();
 }
 
 /// Wait for TTS model loading to finish and handle errors.

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -63,6 +63,9 @@ enum Command {
     /// Speak text aloud (default when no subcommand given)
     Say(SayArgs),
 
+    /// Speak text aloud, then listen for a response (speak + listen in one shot)
+    Converse(ConverseArgs),
+
     /// Record from microphone and transcribe (speech-to-text)
     Listen(ListenArgs),
 
@@ -112,6 +115,33 @@ struct SayArgs {
 
     /// Load substitutions from a file (one WORD=REPLACEMENT per line, # comments).
     /// If not set, .voice-subs is auto-discovered from the working directory upward.
+    #[arg(long = "sub-file", value_name = "PATH")]
+    sub_file: Option<PathBuf>,
+}
+
+#[derive(clap::Args, Debug)]
+struct ConverseArgs {
+    /// Text to speak before listening
+    #[arg(trailing_var_arg = true)]
+    text: Vec<String>,
+
+    /// Voice name (e.g. af_heart, am_adam)
+    #[arg(short, long, default_value = "af_heart")]
+    voice: String,
+
+    /// Speech speed factor (1.0 = normal)
+    #[arg(short, long, default_value = "1.0")]
+    speed: f32,
+
+    /// Strip markdown/MDX formatting before speaking
+    #[arg(long)]
+    markdown: bool,
+
+    /// Word substitutions (pre-processing), e.g. --sub nteract=enteract
+    #[arg(long = "sub", value_name = "WORD=REPLACEMENT")]
+    subs: Vec<String>,
+
+    /// Load substitutions from a file (one WORD=REPLACEMENT per line, # comments).
     #[arg(long = "sub-file", value_name = "PATH")]
     sub_file: Option<PathBuf>,
 }
@@ -526,6 +556,9 @@ fn main() {
                 listen::listen_and_transcribe();
             }
         }
+        Some(Command::Converse(converse_args)) => {
+            run_converse(converse_args);
+        }
         Some(Command::Transcribe(transcribe_args)) => {
             listen::transcribe_file(&transcribe_args.file);
         }
@@ -702,6 +735,70 @@ fn run_say(say_args: SayArgs) {
             sample_rate,
         );
     }
+}
+
+fn run_converse(args: ConverseArgs) {
+    if args.text.is_empty() {
+        eprintln!("Error: No text provided. Usage: voice converse <text>");
+        std::process::exit(1);
+    }
+
+    let text = args.text.join(" ");
+    let model_handle = std::thread::spawn(|| voice_tts::load_model(MODEL_REPO));
+
+    let sub_file = args.sub_file.clone().or_else(find_sub_file);
+    let (subs, phoneme_overrides) = collect_subs(&args.subs, sub_file.as_deref());
+
+    let text = if args.markdown {
+        strip_markdown(&text)
+    } else {
+        text
+    };
+    let text = apply_tech_subs(&text);
+    let text = if subs.is_empty() {
+        text
+    } else {
+        apply_substitutions(&text, &subs)
+    };
+
+    info!("Converting text to phonemes...");
+    let phoneme_chunks = if phoneme_overrides.is_empty() {
+        voice_g2p::text_to_phoneme_chunks(&text)
+    } else {
+        voice_g2p::text_to_phoneme_chunks_with_overrides(&text, &phoneme_overrides)
+    };
+    let phoneme_chunks = match phoneme_chunks {
+        Ok(chunks) => {
+            for (i, chunk) in chunks.iter().enumerate() {
+                info!("  chunk {}: {}", i + 1, chunk);
+            }
+            chunks
+        }
+        Err(e) => {
+            eprintln!("G2P error: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let voice = match voice_tts::load_voice(&args.voice, Some(MODEL_REPO)) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Failed to load voice '{}': {e}", args.voice);
+            std::process::exit(1);
+        }
+    };
+
+    let mut model = load_tts_model(model_handle);
+    let sample_rate = model.sample_rate as u32;
+
+    stream_playback(&mut model, &voice, &phoneme_chunks, args.speed, sample_rate);
+
+    if interrupted() {
+        std::process::exit(130);
+    }
+
+    // Listen for response
+    listen::listen_and_transcribe();
 }
 
 /// Wait for TTS model loading to finish and handle errors.


### PR DESCRIPTION
## Summary
- Adds `voice converse "text"` — speaks text aloud then immediately listens for a response
- One command for the full speak+listen round trip, useful for agents and interactive use
- Supports all say options: `--voice`, `--speed`, `--markdown`, `--sub`
- Updates SKILL.md with converse docs and subcommand table

## Usage

```bash
voice converse "How are you today?"
voice converse -v am_michael "What do you think?"
```

## Test plan
- [x] Builds clean on top of MCP merge
- [x] `voice converse "hello"` speaks then listens
- [x] `voice converse` with no text shows error
- [x] `--voice` and `--speed` flags work