### PR TITLE
Bump to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "voice"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "clap",
  "cpal 0.15.3",

--- a/crates/voice-cli/Cargo.toml
+++ b/crates/voice-cli/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "voice"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.85.0"
-description = "CLI for voice TTS — like say, but with Kokoro"
+description = "CLI for fast text-to-speech and speech-to-text"
 license = "MIT"
 repository = "https://github.com/rgbkrk/voicers"
 readme = "../../README.md"


### PR DESCRIPTION
## Summary
- Bump voice CLI version to 0.4.0
- Update crate description to "CLI for fast text-to-speech and speech-to-text"

## New in 0.4.0
- MCP server (`voice mcp`) for agent integration
- `voice converse` subcommand — speak + VAD listen in one shot