### PR TITLE
Fix readme path in voice-cli Cargo.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,21 @@ Faster time-to-first-speech than macOS `say`, with dramatically better audio qua
 
 ## Install
 
-Build from source (requires Git LFS for embedded voice/model data):
+### Pre-built binary (recommended)
+
+Install with [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) to get a pre-built binary — no compilation required:
+
+```bash
+# Install cargo-binstall if you don't have it
+cargo install cargo-binstall
+
+# Install voice
+cargo binstall voice
+```
+
+### Build from source
+
+Requires Git LFS for embedded voice/model data:
 
 ```bash
 # Install git-lfs if you don't have it
@@ -19,7 +33,7 @@ cd voice
 cargo install --path crates/voice-cli
 ```
 
-> **Why not `cargo install voice`?** The Metal shader library path is baked in at compile time by mlx-sys and points to a temp directory that gets cleaned up after install. This is an [upstream mlx-rs issue](https://github.com/oxiglade/mlx-rs/issues/327). Building from source avoids this entirely.
+> **Why not `cargo install voice`?** The Metal shader library path is baked in at compile time by mlx-sys and points to a temp directory that gets cleaned up after install. This is an [upstream mlx-rs issue](https://github.com/oxiglade/mlx-rs/issues/327). Building from source or using `cargo binstall` avoids this entirely.
 
 > **Why git-lfs?** Voice data (`.safetensors`) and tagger weights are stored with Git LFS. Without it, those files are tiny pointers instead of actual data — the build will catch this and tell you what to do.
 

--- a/crates/voice-cli/Cargo.toml
+++ b/crates/voice-cli/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.85.0"
 description = "CLI for fast text-to-speech and speech-to-text"
 license = "MIT"
 repository = "https://github.com/rgbkrk/voicers"
-readme = "../../README.md"
+readme = "README.md"
 
 [[bin]]
 name = "voice"

--- a/crates/voice-cli/README.md
+++ b/crates/voice-cli/README.md
@@ -4,7 +4,21 @@ Like `say`, but with [Kokoro](https://huggingface.co/prince-canuma/Kokoro-82M) T
 
 ## Install
 
-Build from source (requires Git LFS for embedded voice/model data):
+### Pre-built binary (recommended)
+
+Install with [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) to get a pre-built binary — no compilation required:
+
+```bash
+# Install cargo-binstall if you don't have it
+cargo install cargo-binstall
+
+# Install voice
+cargo binstall voice
+```
+
+### Build from source
+
+Requires Git LFS for embedded voice/model data:
 
 ```bash
 # Install git-lfs if you don't have it
@@ -17,7 +31,7 @@ cd voice
 cargo install --path crates/voice-cli
 ```
 
-> **Note:** `cargo install voice` is the package name on crates.io, but building from source is recommended — see the [main README](../../README.md) for details on why.
+> **Note:** `cargo install voice` compiles from source on crates.io, but the Metal shader library path can break — see the [main README](../../README.md) for details. Use `cargo binstall voice` or build from a local clone instead.
 
 ## Usage
 


### PR DESCRIPTION
Point to the local crate `README.md` instead of `../../README.md`.

Cargo was warning during `cargo publish` that the path appeared outside the package and was using the local copy anyway.