### PR TITLE
Lower default volume for listen sounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            ~/.mlx
             target
           key: ${{ runner.os }}-${{ github.repository }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -258,7 +258,7 @@ fn play_ding() {
             sample_rate: s.sample_rate,
             channels: s.channels,
         });
-    play_cached_or_synth(custom.as_ref(), 880.0, 200, 0.06, 0.3, 50);
+    play_cached_or_synth(custom.as_ref(), 880.0, 200, 0.06, 0.15, 50);
 }
 
 /// Play two ascending blips to signal that listening has stopped.
@@ -292,7 +292,7 @@ fn play_dong() {
 
     let sample_rate = 44100u32;
     let pi2 = 2.0 * std::f32::consts::PI;
-    let volume = 0.18f32;
+    let volume = 0.10f32;
 
     // Two blips: C5 (120ms) → gap (60ms) → E5 (120ms)
     let blip_samples = sample_rate as usize * 120 / 1000;


### PR DESCRIPTION
## Summary

- Reduce start ding volume from 0.3 to 0.15
- Reduce stop blips volume from 0.18 to 0.10

Headphones with adaptive volume were ducking the speech after a loud start ding.