### PR TITLE
Tune recording parameters for conversational pace

### DIFF
--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -1230,11 +1230,12 @@ pub fn listen_and_transcribe_auto() {
     let (mut model, tokenizer) = load_stt();
 
     if let Some(result) = listen_and_transcribe_vad(
-        &mut model, &tokenizer, 30_000, // max_duration_ms
-        2_000,  // silence_timeout_ms
+        &mut model, &tokenizer,
+        15_000, // max_duration_ms (15s — good for conversational turns)
+        1_500,  // silence_timeout_ms
         0.01,   // silence_threshold
         3.0,    // noise_multiplier
-        500,    // calibration_ms
+        300,    // calibration_ms
     ) {
         println!("{}", result.text);
         if !QUIET.load(Ordering::Relaxed) {


### PR DESCRIPTION
## Summary

Tighten recording defaults for snappier conversational feel:
- Max duration: 30s → 15s (plenty for turn-taking, prevents runaway recordings)
- Silence timeout: 2000ms → 1500ms (quicker cutoff after speech stops)
- Calibration: 500ms → 300ms (less dead time before recording starts)

Tested live with `voice converse` on AirPods — silence detection triggers promptly, no trailing delay.

## Test plan

- [x] `voice converse` — snappy turn-taking, silence detected within ~1.5s
- [x] Short responses (~5s) work well
- [x] Longer responses (~14s) work, hits 15s max gracefully