### PR TITLE
Migrate audio I/O from cpal to rodio, fix ding timing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,18 +39,6 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alsa"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
-dependencies = [
- "alsa-sys",
- "bitflags 2.11.0",
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "alsa"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c88dbbce13b232b26250e1e2e6ac18b6a891a646b8148285036ebce260ac5c3"
@@ -199,24 +187,6 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.11.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
 
 [[package]]
 name = "bit-set"
@@ -403,8 +373,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -413,15 +381,6 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
 
 [[package]]
 name = "cfg-if"
@@ -444,17 +403,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "rand_core 0.10.0",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -621,17 +569,6 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation-sys",
- "coreaudio-sys",
-]
-
-[[package]]
-name = "coreaudio-rs"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aae284fbaf7d27aa0e292f7677dfbe26503b0d555026f702940805a630eac17"
@@ -645,51 +582,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "coreaudio-sys"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
-dependencies = [
- "bindgen",
-]
-
-[[package]]
-name = "cpal"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
-dependencies = [
- "alsa 0.9.1",
- "core-foundation-sys",
- "coreaudio-rs 0.11.3",
- "dasp_sample",
- "jni",
- "js-sys",
- "libc",
- "mach2 0.4.3",
- "ndk 0.8.0",
- "ndk-context",
- "oboe",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "windows 0.54.0",
-]
-
-[[package]]
 name = "cpal"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b1f9c7312f19fc2fa12fd7acaf38de54e8320ba10d1a02dcbe21038def51ccb"
 dependencies = [
- "alsa 0.10.0",
- "coreaudio-rs 0.13.0",
+ "alsa",
+ "coreaudio-rs",
  "dasp_sample",
  "jni",
  "js-sys",
  "libc",
- "mach2 0.5.0",
- "ndk 0.9.0",
+ "mach2",
+ "ndk",
  "ndk-context",
  "num-derive",
  "num-traits",
@@ -703,7 +608,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -1486,12 +1391,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,15 +1782,6 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1926,16 +1816,6 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -2013,15 +1893,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "mach2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "mach2"
@@ -2162,20 +2033,6 @@ dependencies = [
 
 [[package]]
 name = "ndk"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
-dependencies = [
- "bitflags 2.11.0",
- "jni-sys",
- "log",
- "ndk-sys 0.5.0+25.2.9519653",
- "num_enum",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
@@ -2183,7 +2040,7 @@ dependencies = [
  "bitflags 2.11.0",
  "jni-sys",
  "log",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum",
  "thiserror 1.0.69",
 ]
@@ -2193,15 +2050,6 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
-name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
-dependencies = [
- "jni-sys",
-]
 
 [[package]]
 name = "ndk-sys"
@@ -2474,29 +2322,6 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
-]
-
-[[package]]
-name = "oboe"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
-dependencies = [
- "jni",
- "ndk 0.8.0",
- "ndk-context",
- "num-derive",
- "num-traits",
- "oboe-sys",
-]
-
-[[package]]
-name = "oboe-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -2858,7 +2683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
 dependencies = [
  "either",
- "itertools 0.14.0",
+ "itertools",
  "rayon",
 ]
 
@@ -2990,7 +2815,7 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a536bb79db59098ef71a4dd4246c02eb87b316deceb1b68e0cde7167ec01eb"
 dependencies = [
- "cpal 0.17.1",
+ "cpal",
  "dasp_sample",
  "num-rational",
  "rand 0.10.0",
@@ -3021,12 +2846,6 @@ dependencies = [
  "visibility",
  "windowfunctions",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustfft"
@@ -3673,7 +3492,7 @@ dependencies = [
  "esaxx-rs",
  "getrandom 0.3.4",
  "indicatif 0.17.11",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "macro_rules_attribute",
  "monostate",
@@ -4076,7 +3895,6 @@ version = "0.4.2"
 dependencies = [
  "candle-core",
  "clap",
- "cpal 0.15.3",
  "ctrlc",
  "hound",
  "pulldown-cmark",
@@ -4395,22 +4213,12 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
-dependencies = [
- "windows-core 0.54.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -4421,17 +4229,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
-dependencies = [
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -4443,7 +4241,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
 ]
 
@@ -4453,7 +4251,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
 ]
@@ -4492,7 +4290,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
 ]
 
@@ -4503,17 +4301,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/crates/voice-cli/Cargo.toml
+++ b/crates/voice-cli/Cargo.toml
@@ -34,4 +34,3 @@ pulldown-cmark = "0.13.1"
 ctrlc = "3.5.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-cpal = "0.15"

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -27,8 +27,7 @@ use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use cpal::SampleFormat;
+use rodio::microphone::MicrophoneBuilder;
 use rodio::{buffer::SamplesBuffer, DeviceSinkBuilder, Player};
 
 use crate::{INTERRUPTED, QUIET};
@@ -258,7 +257,7 @@ fn play_ding() {
             sample_rate: s.sample_rate,
             channels: s.channels,
         });
-    play_cached_or_synth(custom.as_ref(), 880.0, 200, 0.06, 0.15, 50);
+    play_cached_or_synth(custom.as_ref(), 880.0, 100, 0.03, 0.20, 0);
 }
 
 /// Play two ascending blips to signal that listening has stopped.
@@ -329,104 +328,67 @@ fn play_dong() {
 
 // ── Mic input helpers ──────────────────────────────────────────────────
 
-/// Open the default input device and return its config.
-fn open_input_device() -> Result<(cpal::Device, cpal::SupportedStreamConfig), String> {
-    let host = cpal::default_host();
-    let device = host
-        .default_input_device()
-        .ok_or("No input device available")?;
-    let config = device
-        .default_input_config()
-        .map_err(|e| format!("Failed to get input config: {e}"))?;
-    Ok((device, config))
-}
-
-/// Build an input stream that writes mono f32 samples into `buffer`.
+/// Open a microphone via rodio and return (name, sample_rate, mic).
 ///
-/// If `peak_out` is `Some`, each callback also writes the chunk's peak
-/// amplitude (as `f32::to_bits()`) into the atomic for VAD polling.
-fn build_input_stream(
-    device: &cpal::Device,
-    config: &cpal::SupportedStreamConfig,
-    buffer: Arc<Mutex<Vec<f32>>>,
-    peak_out: Option<Arc<std::sync::atomic::AtomicU32>>,
-) -> Result<cpal::Stream, String> {
-    let channels = config.channels() as usize;
+/// Uses the default input device. Rodio handles sample format conversion
+/// and multi-channel mixing internally.
+fn open_mic() -> Result<(String, u32, rodio::microphone::Microphone), String> {
+    let mic = MicrophoneBuilder::new()
+        .default_device()
+        .map_err(|e| format!("No input device: {e}"))?
+        .default_config()
+        .map_err(|e| format!("No input config: {e}"))?
+        .open_stream()
+        .map_err(|e| format!("Failed to open mic: {e}"))?;
 
-    match config.sample_format() {
-        SampleFormat::F32 => {
-            let buf = Arc::clone(&buffer);
-            let peak = peak_out.clone();
-            device
-                .build_input_stream(
-                    &config.clone().into(),
-                    move |data: &[f32], _: &cpal::InputCallbackInfo| {
-                        let mut guard = buf.lock().unwrap();
-                        let mut chunk_peak: f32 = 0.0;
-                        if channels == 1 {
-                            for &s in data {
-                                chunk_peak = chunk_peak.max(s.abs());
-                                guard.push(s);
-                            }
-                        } else {
-                            for chunk in data.chunks(channels) {
-                                let mono: f32 = chunk.iter().sum::<f32>() / channels as f32;
-                                chunk_peak = chunk_peak.max(mono.abs());
-                                guard.push(mono);
-                            }
-                        }
-                        if let Some(ref p) = peak {
-                            p.store(chunk_peak.to_bits(), Ordering::Relaxed);
-                        }
-                    },
-                    |err| eprintln!("Audio input error: {err}"),
-                    None,
-                )
-                .map_err(|e| format!("Failed to build input stream: {e}"))
-        }
-        SampleFormat::I16 => {
-            let buf = Arc::clone(&buffer);
-            let peak = peak_out.clone();
-            device
-                .build_input_stream(
-                    &config.clone().into(),
-                    move |data: &[i16], _: &cpal::InputCallbackInfo| {
-                        let mut guard = buf.lock().unwrap();
-                        let mut chunk_peak: f32 = 0.0;
-                        if channels == 1 {
-                            for &s in data {
-                                let f = s as f32 / 32768.0;
-                                chunk_peak = chunk_peak.max(f.abs());
-                                guard.push(f);
-                            }
-                        } else {
-                            for chunk in data.chunks(channels) {
-                                let mono: f32 =
-                                    chunk.iter().map(|&s| s as f32 / 32768.0).sum::<f32>()
-                                        / channels as f32;
-                                chunk_peak = chunk_peak.max(mono.abs());
-                                guard.push(mono);
-                            }
-                        }
-                        if let Some(ref p) = peak {
-                            p.store(chunk_peak.to_bits(), Ordering::Relaxed);
-                        }
-                    },
-                    |err| eprintln!("Audio input error: {err}"),
-                    None,
-                )
-                .map_err(|e| format!("Failed to build input stream: {e}"))
-        }
-        format => Err(format!("Unsupported sample format: {format:?}")),
-    }
+    let config = mic.config();
+    let sample_rate = config.sample_rate.get();
+    let name = "default".to_string(); // rodio doesn't expose device name easily
+
+    Ok((name, sample_rate, mic))
 }
 
-/// Extract final samples from the shared buffer.
-fn extract_samples(buffer: Arc<Mutex<Vec<f32>>>) -> Vec<f32> {
-    match Arc::try_unwrap(buffer) {
-        Ok(mutex) => mutex.into_inner().unwrap(),
-        Err(arc) => arc.lock().unwrap().clone(),
-    }
+/// Drain a Microphone iterator into a shared buffer on a background thread.
+///
+/// Returns the peak amplitude tracker. The mic thread runs until the
+/// `stop` flag is set or the mic stream ends.
+fn start_mic_drain(
+    mic: rodio::microphone::Microphone,
+    buffer: Arc<Mutex<Vec<f32>>>,
+    peak_out: Arc<std::sync::atomic::AtomicU32>,
+    stop: Arc<std::sync::atomic::AtomicBool>,
+    channels: u16,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let ch = channels.max(1) as usize;
+        let mut chunk_peak: f32 = 0.0;
+        let mut sample_count = 0usize;
+
+        for sample in mic {
+            if stop.load(Ordering::Relaxed) {
+                break;
+            }
+
+            let abs = sample.abs();
+            chunk_peak = chunk_peak.max(abs);
+            sample_count += 1;
+
+            // For multi-channel, mix to mono by averaging
+            if ch == 1 {
+                buffer.lock().unwrap().push(sample);
+            } else if sample_count % ch == 0 {
+                // We get interleaved samples — just take every ch-th sample
+                // (rodio's SampleTypeConverter already converts to f32)
+                buffer.lock().unwrap().push(sample);
+            }
+
+            // Update peak every ~100 samples to avoid atomic contention
+            if sample_count % 100 == 0 {
+                peak_out.store(chunk_peak.to_bits(), Ordering::Relaxed);
+                chunk_peak = 0.0;
+            }
+        }
+    })
 }
 
 /// Log recording stats to stderr (unless quiet).
@@ -467,26 +429,27 @@ fn log_recording_stats(samples: &[f32], sample_rate: u32) {
 ///
 /// Returns mono f32 samples at the device's native sample rate, plus the rate.
 pub fn record_until_interrupt() -> Result<(Vec<f32>, u32), String> {
-    let (device, config) = open_input_device()?;
-    let sample_rate = config.sample_rate().0;
-
-    if !QUIET.load(Ordering::Relaxed) {
-        let name = device.name().unwrap_or_else(|_| "unknown".to_string());
-        eprintln!(
-            "Recording from: {name} ({sample_rate}Hz, {}ch)",
-            config.channels()
-        );
-    }
-
-    // Play ding before mic so user hears the "ready" signal
+    // Ding before mic so Bluetooth users hear the "ready" signal
     play_ding();
 
-    let buffer: Arc<Mutex<Vec<f32>>> = Arc::new(Mutex::new(Vec::new()));
-    let stream = build_input_stream(&device, &config, Arc::clone(&buffer), None)?;
+    let (name, sample_rate, mic) = open_mic()?;
 
-    stream
-        .play()
-        .map_err(|e| format!("Failed to start recording: {e}"))?;
+    if !QUIET.load(Ordering::Relaxed) {
+        eprintln!("Recording from: {name} ({sample_rate}Hz)");
+    }
+
+    let buffer: Arc<Mutex<Vec<f32>>> = Arc::new(Mutex::new(Vec::new()));
+    let peak = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let channels = mic.config().channel_count.get();
+
+    let mic_thread = start_mic_drain(
+        mic,
+        Arc::clone(&buffer),
+        Arc::clone(&peak),
+        Arc::clone(&stop),
+        channels,
+    );
 
     if !QUIET.load(Ordering::Relaxed) {
         eprintln!("Press Enter or Ctrl+C to stop recording...");
@@ -509,11 +472,15 @@ pub fn record_until_interrupt() -> Result<(Vec<f32>, u32), String> {
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
 
-    drop(stream);
+    stop.store(true, Ordering::SeqCst);
+    let _ = mic_thread.join();
     drop(stdin_thread);
     play_dong();
 
-    let samples = extract_samples(buffer);
+    let samples = match Arc::try_unwrap(buffer) {
+        Ok(mutex) => mutex.into_inner().unwrap(),
+        Err(arc) => arc.lock().unwrap().clone(),
+    };
     log_recording_stats(&samples, sample_rate);
     maybe_save_recording(&samples, sample_rate);
 
@@ -534,41 +501,34 @@ pub fn record_with_vad(
     noise_multiplier: f32,
     calibration_ms: u64,
 ) -> Result<(Vec<f32>, u32), String> {
-    let (device, config) = open_input_device()?;
-    let sample_rate = config.sample_rate().0;
-
+    // Play ding BEFORE opening mic. On Bluetooth (AirPods), opening the
+    // mic triggers an HFP profile switch that can swallow audio output.
+    // Playing first ensures the user hears the "ready" signal.
+    play_ding();
     if !QUIET.load(Ordering::Relaxed) {
-        let name = device.name().unwrap_or_else(|_| "unknown".to_string());
-        eprintln!(
-            "Recording from: {name} ({sample_rate}Hz, {}ch)",
-            config.channels()
-        );
+        eprintln!("Listening...");
     }
 
-    // Play ding BEFORE opening mic so the user hears the "ready" signal.
-    // There's a small gap (~50ms) between ding ending and mic starting
-    // to capture, but the silence trimmer's 500ms lead padding compensates.
-    play_ding();
+    let (name, sample_rate, mic) = open_mic()?;
+
+    if !QUIET.load(Ordering::Relaxed) {
+        eprintln!("Recording from: {name} ({sample_rate}Hz)");
+    }
 
     let buffer: Arc<Mutex<Vec<f32>>> = Arc::new(Mutex::new(Vec::new()));
-    let recent_peak: Arc<std::sync::atomic::AtomicU32> =
-        Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let recent_peak = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let channels = mic.config().channel_count.get();
 
-    let stream = build_input_stream(
-        &device,
-        &config,
+    let mic_thread = start_mic_drain(
+        mic,
         Arc::clone(&buffer),
-        Some(Arc::clone(&recent_peak)),
-    )?;
+        Arc::clone(&recent_peak),
+        Arc::clone(&stop),
+        channels,
+    );
 
-    stream
-        .play()
-        .map_err(|e| format!("Failed to start recording: {e}"))?;
-
-    // Adaptive noise floor calibration — also serves as Bluetooth warmup.
-    // The mic just started so the first ~200ms may be garbage from BT spin-up,
-    // but that's fine — it just inflates the noise floor slightly, making
-    // the speech threshold more conservative (a safe direction).
+    // Adaptive noise floor calibration
     let adaptive_threshold = if calibration_ms > 0 {
         let cal_start = std::time::Instant::now();
         let calibration_duration = std::time::Duration::from_millis(calibration_ms);
@@ -576,8 +536,12 @@ pub fn record_with_vad(
 
         while cal_start.elapsed() < calibration_duration {
             if INTERRUPTED.load(Ordering::Relaxed) {
-                drop(stream);
-                let samples = extract_samples(buffer);
+                stop.store(true, Ordering::SeqCst);
+                let _ = mic_thread.join();
+                let samples = match Arc::try_unwrap(buffer) {
+                    Ok(mutex) => mutex.into_inner().unwrap(),
+                    Err(arc) => arc.lock().unwrap().clone(),
+                };
                 return Ok((samples, sample_rate));
             }
             let peak_bits = recent_peak.load(Ordering::Relaxed);
@@ -599,10 +563,6 @@ pub fn record_with_vad(
     } else {
         silence_threshold
     };
-
-    // Keep calibration audio in the buffer — trim_silence will strip
-    // the leading silence later. Clearing the buffer here causes speech
-    // loss when the user starts speaking during or right after calibration.
 
     // VAD state machine
     let mut speech_started = false;
@@ -652,10 +612,14 @@ pub fn record_with_vad(
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
 
-    drop(stream);
+    stop.store(true, Ordering::SeqCst);
+    let _ = mic_thread.join();
     play_dong();
 
-    let samples = extract_samples(buffer);
+    let samples = match Arc::try_unwrap(buffer) {
+        Ok(mutex) => mutex.into_inner().unwrap(),
+        Err(arc) => arc.lock().unwrap().clone(),
+    };
     log_recording_stats(&samples, sample_rate);
     maybe_save_recording(&samples, sample_rate);
 
@@ -672,6 +636,23 @@ pub fn record_with_vad(
 /// is reached.
 ///
 /// Plays a ding at the start. No dings between segments.
+/// Stop handle for continuous recording. Drop or call stop() to end.
+pub struct RecordingHandle {
+    stop: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl RecordingHandle {
+    pub fn stop(&self) {
+        self.stop.store(true, Ordering::SeqCst);
+    }
+}
+
+impl Drop for RecordingHandle {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
 pub fn record_continuous(
     silence_timeout_ms: u64,
     silence_threshold: f32,
@@ -680,44 +661,35 @@ pub fn record_continuous(
     max_segment_ms: u64,
     noise_multiplier: f32,
     calibration_ms: u64,
-) -> Result<(mpsc::Receiver<Segment>, u32, cpal::Stream), String> {
-    let (device, config) = open_input_device()?;
-    let sample_rate = config.sample_rate().0;
-
-    if !QUIET.load(Ordering::Relaxed) {
-        let name = device.name().unwrap_or_else(|_| "unknown".to_string());
-        eprintln!(
-            "Recording from: {name} ({sample_rate}Hz, {}ch)",
-            config.channels()
-        );
-    }
-
-    // Play ding before mic so user hears the "ready" signal
+) -> Result<(mpsc::Receiver<Segment>, u32, RecordingHandle), String> {
+    // Ding before mic so Bluetooth users hear it
     play_ding();
 
+    let (name, sample_rate, mic) = open_mic()?;
+
+    if !QUIET.load(Ordering::Relaxed) {
+        eprintln!("Recording from: {name} ({sample_rate}Hz)");
+    }
+
     let segment_buffer: Arc<Mutex<Vec<f32>>> = Arc::new(Mutex::new(Vec::new()));
-    let recent_peak: Arc<std::sync::atomic::AtomicU32> =
-        Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let recent_peak = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let channels = mic.config().channel_count.get();
 
-    let stream = build_input_stream(
-        &device,
-        &config,
+    let _mic_thread = start_mic_drain(
+        mic,
         Arc::clone(&segment_buffer),
-        Some(Arc::clone(&recent_peak)),
-    )?;
-
-    stream
-        .play()
-        .map_err(|e| format!("Failed to start recording: {e}"))?;
+        Arc::clone(&recent_peak),
+        Arc::clone(&stop),
+        channels,
+    );
 
     let (tx, rx) = mpsc::channel::<Segment>();
 
     let min_samples = (sample_rate as u64 * min_segment_ms / 1000) as usize;
     let max_samples = (sample_rate as u64 * max_segment_ms / 1000) as usize;
 
-    // VAD monitor thread — watches peak levels, snapshots segments
-    // Note: `stream` is NOT moved here — it's returned to the caller
-    // who must keep it alive for the duration of recording.
+    // VAD monitor thread
     std::thread::spawn(move || {
         let mut speech_started = false;
         let mut silence_start: Option<Instant> = None;
@@ -894,7 +866,10 @@ pub fn record_continuous(
         // Channel drops here, signaling the consumer that recording is done
     });
 
-    Ok((rx, sample_rate, stream))
+    let handle = RecordingHandle {
+        stop: Arc::clone(&stop),
+    };
+    Ok((rx, sample_rate, handle))
 }
 
 /// Consume segments from the recording queue and transcribe each one.
@@ -969,7 +944,7 @@ pub fn listen_continuous() {
         eprintln!("Listening continuously... (Ctrl+C to stop)\n");
     }
 
-    let (segments_rx, _sample_rate, _stream) = match record_continuous(
+    let (segments_rx, _sample_rate, _handle) = match record_continuous(
         1500,     // silence_timeout_ms
         0.01,     // silence_threshold
         u64::MAX, // max_duration_ms (unlimited — Ctrl+C to stop)
@@ -1021,7 +996,7 @@ pub fn listen_continuous_for_rpc(
     noise_multiplier: f32,
     calibration_ms: u64,
 ) -> Result<mpsc::Receiver<SegmentResult>, String> {
-    let (segments_rx, _sample_rate, _stream) = record_continuous(
+    let (segments_rx, _sample_rate, _handle) = record_continuous(
         silence_timeout_ms,
         0.01, // silence_threshold
         max_duration_ms,


### PR DESCRIPTION
## Summary

- **Drop cpal dependency**: All audio I/O now goes through rodio (single cpal 0.17, no more 0.15/0.17 version conflict)
- **Rodio Microphone API**: Replace raw cpal `open_input_device()` + `build_input_stream()` with `MicrophoneBuilder`. Mic drain runs on a dedicated thread. -237 lines of sample format handling code
- **Ding timing for Bluetooth**: Play ding synchronously before opening mic. AirPods HFP codec switch during mic open swallows concurrent audio, so ding-first is the only reliable approach
- **Shorter ding**: 100ms (down from 200ms) with no post-delay to minimize the gap between ding and mic capture
- **RecordingHandle**: Continuous mode returns a stop handle instead of a raw `cpal::Stream`

Net: **-237 lines** (165 added, 402 removed)

## Known limitation

Bluetooth ding is unreliable (~50% audible with AirPods) due to macOS HFP profile switching. Works consistently with wired audio. This is a platform limitation we'll explore fixes for (system sounds, CoreBluetooth haptics, etc.)

## Test plan

- [x] `cargo build --release -p voice` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean  
- [x] `cargo tree -p voice | grep cpal` — single cpal 0.17.1 via rodio
- [x] TTS round-trip — perfect transcription
- [x] Live `voice converse` with AirPods — speech captured, no clipping when ding plays
- [x] "The quick brown fox" — full phrase transcribed correctly