### PR TITLE
Add voice-chat: audio conversation with local LLMs via Ollama

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +851,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dyn-stack"
@@ -1895,6 +1923,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,6 +2368,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ollama-rs"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f647d8676b95a6b6205e11453c9fac338d73c9cdcc011c94d1ba9c9bfea582cd"
+dependencies = [
+ "async-stream",
+ "log",
+ "reqwest",
+ "schemars",
+ "serde",
+ "serde_json",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "url",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2413,6 +2469,29 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "paste"
@@ -2719,6 +2798,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2727,6 +2815,26 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2978,6 +3086,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3043,11 +3182,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -3081,6 +3232,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -3528,7 +3689,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -3562,6 +3725,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -3908,6 +4082,23 @@ dependencies = [
  "rodio",
  "serde",
  "serde_json",
+ "voice-g2p",
+ "voice-stt",
+ "voice-tts",
+]
+
+[[package]]
+name = "voice-chat"
+version = "0.1.0"
+dependencies = [
+ "candle-core",
+ "clap",
+ "ctrlc",
+ "ollama-rs",
+ "pulldown-cmark",
+ "rodio",
+ "tokio",
+ "tokio-stream",
  "voice-g2p",
  "voice-stt",
  "voice-tts",

--- a/crates/voice-chat/Cargo.toml
+++ b/crates/voice-chat/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "voice-chat"
+version = "0.1.0"
+edition = "2021"
+description = "Audio chat with local LLMs via ollama — speak, listen, repeat"
+
+[[bin]]
+name = "voice-chat"
+path = "src/main.rs"
+
+[dependencies]
+voice-tts = { path = "../voice-tts" }
+voice-stt = { path = "../voice-stt" }
+voice-g2p = { path = "../voice-g2p" }
+candle-core = { version = "0.9", features = ["metal"] }
+rodio = { version = "0.22", features = ["experimental"] }
+pulldown-cmark = "0.13.1"
+ollama-rs = { version = "0.3", features = ["stream"] }
+tokio = { version = "1", features = ["full"] }
+tokio-stream = "0.1"
+clap = { version = "4", features = ["derive"] }
+ctrlc = "3.5"

--- a/crates/voice-chat/src/main.rs
+++ b/crates/voice-chat/src/main.rs
@@ -1,0 +1,550 @@
+//! Audio chat with a local LLM via Ollama.
+//!
+//! Loops: mic → Whisper STT → Ollama → streaming TTS → speaker → repeat.
+//!
+//! Usage:
+//!     voice-chat
+//!     voice-chat --model llama3.2
+//!     voice-chat --voice af_nicole --speed 1.1
+
+use std::io::Write;
+use std::num::NonZero;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use clap::Parser;
+use ollama_rs::generation::chat::request::ChatMessageRequest;
+use ollama_rs::generation::chat::ChatMessage;
+use ollama_rs::Ollama;
+use pulldown_cmark::{Event, Options, Parser as MdParser, Tag, TagEnd};
+use rodio::buffer::SamplesBuffer;
+use rodio::microphone::MicrophoneBuilder;
+use rodio::{DeviceSinkBuilder, Player};
+use tokio_stream::StreamExt;
+
+const MODEL_REPO: &str = "prince-canuma/Kokoro-82M";
+const STT_REPO: &str = "distil-whisper/distil-large-v3";
+
+static INTERRUPTED: AtomicBool = AtomicBool::new(false);
+
+#[derive(Parser)]
+#[command(about = "Audio chat with a local LLM via Ollama")]
+struct Args {
+    /// Ollama model name
+    #[arg(short, long, default_value = "qwen3")]
+    model: String,
+
+    /// TTS voice name
+    #[arg(short, long, default_value = "af_heart")]
+    voice: String,
+
+    /// TTS speed
+    #[arg(short, long, default_value = "1.0")]
+    speed: f32,
+
+    /// Ollama host
+    #[arg(long, default_value = "http://localhost")]
+    host: String,
+
+    /// Ollama port
+    #[arg(long, default_value = "11434")]
+    port: u16,
+
+    /// System prompt
+    #[arg(long)]
+    system: Option<String>,
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+
+    ctrlc::set_handler(|| INTERRUPTED.store(true, Ordering::SeqCst))
+        .expect("Failed to set Ctrl+C handler");
+
+    eprintln!("Loading TTS model...");
+    let mut tts_model = voice_tts::load_model(MODEL_REPO).expect("Failed to load TTS model");
+    let sample_rate = tts_model.sample_rate;
+    let voice = tts_model
+        .load_voice(&args.voice, Some(MODEL_REPO))
+        .expect("Failed to load voice");
+
+    eprintln!("Loading STT model...");
+    let mut stt_model = voice_stt::load_model(STT_REPO).expect("Failed to load STT model");
+
+    let ollama = Ollama::new(args.host, args.port);
+    let history = Arc::new(Mutex::new(Vec::<ChatMessage>::new()));
+
+    // Add system prompt if provided
+    if let Some(system) = &args.system {
+        history
+            .lock()
+            .unwrap()
+            .push(ChatMessage::system(system.clone()));
+    }
+
+    eprintln!(
+        "\nReady — model: {}, voice: {}, speed: {}",
+        args.model, args.voice, args.speed
+    );
+    eprintln!("Ctrl+C to quit.\n");
+
+    // Open mic once at startup — stays open for the whole session.
+    // The Bluetooth HFP codec switch happens now, not during conversation.
+    eprintln!("Opening mic...");
+    let mic = PersistentMic::open().expect("Failed to open mic");
+
+    // Kick off the conversation with a greeting
+    speak(
+        &mut tts_model,
+        &voice,
+        "Good evening.",
+        args.speed,
+        sample_rate,
+    );
+
+    // Conversation loop
+    loop {
+        if INTERRUPTED.load(Ordering::Relaxed) {
+            break;
+        }
+
+        // ── Listen ──────────────────────────────────────────────────
+        let user_text = match record_and_transcribe(&mic, &mut stt_model) {
+            Some(text) if !text.trim().is_empty() => text.trim().to_string(),
+            _ => {
+                if INTERRUPTED.load(Ordering::Relaxed) {
+                    break;
+                }
+                eprintln!("(no speech detected, listening again...)");
+                continue;
+            }
+        };
+
+        eprintln!("\x1b[33mYou:\x1b[0m {user_text}");
+
+        // Check for exit
+        let lower = user_text.to_lowercase();
+        if ["goodbye", "bye", "quit", "exit", "stop"]
+            .iter()
+            .any(|w| lower.contains(w))
+        {
+            speak(
+                &mut tts_model,
+                &voice,
+                "Goodbye!",
+                args.speed,
+                sample_rate,
+            );
+            break;
+        }
+
+        // ── Chat with Ollama (streaming) ────────────────────────────
+        let request = ChatMessageRequest::new(
+            args.model.clone(),
+            vec![ChatMessage::user(user_text.clone())],
+        );
+
+        let stream_result = ollama
+            .send_chat_messages_with_history_stream(history.clone(), request)
+            .await;
+
+        let mut stream = match stream_result {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("Ollama error: {e}");
+                speak(
+                    &mut tts_model,
+                    &voice,
+                    "Sorry, I couldn't reach the model.",
+                    args.speed,
+                    sample_rate,
+                );
+                continue;
+            }
+        };
+
+        // Accumulate tokens into sentences, speak each sentence as it completes
+        let mut sentence_buf = String::new();
+        let mut full_response = String::new();
+
+        // Open audio output once for the whole response
+        let Ok(mut audio_stream) = DeviceSinkBuilder::open_default_sink() else {
+            eprintln!("Failed to open audio output");
+            continue;
+        };
+        audio_stream.log_on_drop(false);
+        let player = Player::connect_new(audio_stream.mixer());
+        let channels = NonZero::new(1u16).unwrap();
+        let rate = NonZero::new(sample_rate).unwrap();
+
+        eprint!("\x1b[36mAssistant:\x1b[0m ");
+
+        while let Some(res) = stream.next().await {
+            if INTERRUPTED.load(Ordering::Relaxed) {
+                break;
+            }
+
+            let Ok(res) = res else { continue };
+
+            // Skip the final chunk — it has done=true and content is empty or
+            // duplicated. The response was already built up incrementally.
+            if res.done {
+                break;
+            }
+
+            let token = &res.message.content;
+            full_response.push_str(token);
+            sentence_buf.push_str(token);
+            eprint!("{token}");
+            let _ = std::io::stderr().flush();
+
+            // Check if we have a sentence boundary
+            if has_sentence_end(&sentence_buf) {
+                let text = prepare_for_tts(&sentence_buf);
+                if !text.trim().is_empty() {
+                    generate_and_queue(&mut tts_model, &voice, &text, args.speed, &player, channels, rate);
+                }
+                sentence_buf.clear();
+            }
+        }
+
+        // Speak any remaining text
+        if !sentence_buf.trim().is_empty() {
+            let text = prepare_for_tts(&sentence_buf);
+            if !text.trim().is_empty() {
+                generate_and_queue(&mut tts_model, &voice, &text, args.speed, &player, channels, rate);
+            }
+        }
+
+        eprintln!();
+
+        // Wait for playback to finish
+        while !player.empty() {
+            if INTERRUPTED.load(Ordering::Relaxed) {
+                player.stop();
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    }
+
+    eprintln!("\nBye!");
+}
+
+// ── TTS helpers ──────────────────────────────────────────────────────
+
+fn generate_and_queue(
+    model: &mut voice_tts::KokoroModel,
+    voice: &candle_core::Tensor,
+    text: &str,
+    speed: f32,
+    player: &Player,
+    channels: NonZero<u16>,
+    rate: NonZero<u32>,
+) {
+    let chunks = match voice_g2p::text_to_phoneme_chunks(text) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("\n  G2P error: {e}");
+            return;
+        }
+    };
+
+    for phonemes in &chunks {
+        if phonemes.is_empty() {
+            continue;
+        }
+        match voice_tts::generate(model, phonemes, voice, speed) {
+            Ok(audio) => {
+                player.append(SamplesBuffer::new(channels, rate, audio));
+            }
+            Err(e) => {
+                eprintln!("\n  TTS error: {e}");
+            }
+        }
+    }
+}
+
+fn speak(
+    model: &mut voice_tts::KokoroModel,
+    voice: &candle_core::Tensor,
+    text: &str,
+    speed: f32,
+    sample_rate: u32,
+) {
+    let Ok(mut stream) = DeviceSinkBuilder::open_default_sink() else {
+        return;
+    };
+    stream.log_on_drop(false);
+    let player = Player::connect_new(stream.mixer());
+    let channels = NonZero::new(1u16).unwrap();
+    let rate = NonZero::new(sample_rate).unwrap();
+
+    generate_and_queue(model, voice, text, speed, &player, channels, rate);
+
+    while !player.empty() {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+// ── Persistent mic ──────────────────────────────────────────────────
+
+/// Mic that stays open for the whole session. Avoids repeated Bluetooth
+/// HFP codec switches — the switch happens once at startup.
+struct PersistentMic {
+    sample_rate: u32,
+    buffer: Arc<Mutex<Vec<f32>>>,
+    peak: Arc<std::sync::atomic::AtomicU32>,
+    _stop: Arc<AtomicBool>,
+}
+
+impl PersistentMic {
+    fn open() -> Result<Self, String> {
+        let mic = MicrophoneBuilder::new()
+            .default_device()
+            .map_err(|e| format!("No input device: {e}"))?
+            .default_config()
+            .map_err(|e| format!("No input config: {e}"))?
+            .open_stream()
+            .map_err(|e| format!("Failed to open mic: {e}"))?;
+
+        let sample_rate = mic.config().sample_rate.get();
+        let channels = mic.config().channel_count.get().max(1) as usize;
+
+        let buffer: Arc<Mutex<Vec<f32>>> = Arc::new(Mutex::new(Vec::new()));
+        let peak = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let buf_clone = Arc::clone(&buffer);
+        let peak_clone = Arc::clone(&peak);
+        let stop_clone = Arc::clone(&stop);
+        std::thread::spawn(move || {
+            let mut chunk_peak: f32 = 0.0;
+            let mut count = 0usize;
+            for sample in mic {
+                if stop_clone.load(Ordering::Relaxed) {
+                    break;
+                }
+                chunk_peak = chunk_peak.max(sample.abs());
+                count += 1;
+                if channels == 1 {
+                    buf_clone.lock().unwrap().push(sample);
+                } else if count % channels == 0 {
+                    buf_clone.lock().unwrap().push(sample);
+                }
+                if count % 100 == 0 {
+                    peak_clone.store(chunk_peak.to_bits(), Ordering::Relaxed);
+                    chunk_peak = 0.0;
+                }
+            }
+        });
+
+        Ok(Self {
+            sample_rate,
+            buffer,
+            peak,
+            _stop: stop,
+        })
+    }
+
+    /// Clear the buffer and record with VAD. Mic stays open after.
+    fn record_vad(&self) -> Option<(Vec<f32>, u32)> {
+        play_ding();
+        eprintln!("Listening...");
+
+        // Clear old audio
+        self.buffer.lock().unwrap().clear();
+
+        // Calibrate noise floor (300ms)
+        let cal_start = std::time::Instant::now();
+        let mut max_ambient: f32 = 0.0;
+        while cal_start.elapsed() < std::time::Duration::from_millis(300) {
+            if INTERRUPTED.load(Ordering::Relaxed) {
+                return None;
+            }
+            let p = f32::from_bits(self.peak.load(Ordering::Relaxed));
+            max_ambient = max_ambient.max(p);
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        let threshold = (max_ambient * 3.0).max(0.01);
+
+        // VAD
+        let mut speech_started = false;
+        let mut silence_start: Option<std::time::Instant> = None;
+        let start = std::time::Instant::now();
+
+        loop {
+            if INTERRUPTED.load(Ordering::Relaxed)
+                || start.elapsed() > std::time::Duration::from_secs(60)
+            {
+                break;
+            }
+            let p = f32::from_bits(self.peak.load(Ordering::Relaxed));
+            if p > threshold {
+                if !speech_started {
+                    speech_started = true;
+                    eprintln!("Speech detected...");
+                }
+                silence_start = None;
+            } else if speech_started {
+                let ss = silence_start.get_or_insert_with(std::time::Instant::now);
+                if ss.elapsed() > std::time::Duration::from_millis(1500) {
+                    eprintln!("Silence detected.");
+                    break;
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+
+        // Snapshot the buffer — don't stop the mic
+        let samples = self.buffer.lock().unwrap().clone();
+        Some((samples, self.sample_rate))
+    }
+}
+
+// ── STT / Recording ─────────────────────────────────────────────────
+
+fn record_and_transcribe(
+    mic: &PersistentMic,
+    stt_model: &mut voice_stt::WhisperModel,
+) -> Option<String> {
+    let (samples, sample_rate) = mic.record_vad()?;
+
+    if samples.is_empty() {
+        return None;
+    }
+
+    let trimmed = trim_leading_silence(&samples, sample_rate);
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let duration = trimmed.len() as f32 / sample_rate as f32;
+    eprintln!("Transcribing {duration:.1}s...");
+
+    match voice_stt::transcribe_audio(stt_model, &trimmed, sample_rate) {
+        Ok(r) => Some(r.text),
+        Err(e) => {
+            eprintln!("Transcription error: {e}");
+            None
+        }
+    }
+}
+
+fn play_ding() {
+    let sample_rate = 44100u32;
+    let num_samples = sample_rate as usize * 120 / 1000;
+
+    let mut samples = Vec::with_capacity((num_samples + 882) * 2);
+    for i in 0..num_samples {
+        let t = i as f32 / sample_rate as f32;
+        let envelope = (-t / 0.03f32).exp() * 0.20;
+        let s = (2.0 * std::f32::consts::PI * 880.0 * t).sin() * envelope;
+        samples.push(s);
+        samples.push(s);
+    }
+    samples.extend(std::iter::repeat_n(0.0f32, 882 * 2));
+
+    let Ok(mut stream) = DeviceSinkBuilder::open_default_sink() else {
+        return;
+    };
+    stream.log_on_drop(false);
+    let player = Player::connect_new(stream.mixer());
+    player.append(SamplesBuffer::new(
+        NonZero::new(2u16).unwrap(),
+        NonZero::new(sample_rate).unwrap(),
+        samples,
+    ));
+    while !player.empty() {
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+}
+
+fn trim_leading_silence(samples: &[f32], sample_rate: u32) -> Vec<f32> {
+    let window = (sample_rate as usize) / 100; // 10ms
+    let threshold: f32 = 0.005;
+    let leading_context = (sample_rate as usize) / 2; // 500ms
+
+    // Find first window above threshold
+    let speech_start = samples
+        .windows(window)
+        .position(|w| {
+            let rms = (w.iter().map(|s| s * s).sum::<f32>() / w.len() as f32).sqrt();
+            rms > threshold
+        })
+        .unwrap_or(0);
+
+    let start = speech_start.saturating_sub(leading_context);
+    samples[start..].to_vec()
+}
+
+// ── Text processing ─────────────────────────────────────────────────
+
+fn has_sentence_end(text: &str) -> bool {
+    let trimmed = text.trim_end();
+    trimmed.ends_with('.')
+        || trimmed.ends_with('!')
+        || trimmed.ends_with('?')
+        || trimmed.ends_with('\n')
+}
+
+fn prepare_for_tts(text: &str) -> String {
+    let stripped = strip_markdown(text);
+    apply_tech_subs(&stripped)
+}
+
+fn strip_markdown(text: &str) -> String {
+    let opts = Options::ENABLE_STRIKETHROUGH | Options::ENABLE_TABLES;
+    let parser = MdParser::new_ext(text, opts);
+
+    let mut out = String::new();
+    let mut skip_depth: usize = 0;
+
+    for event in parser {
+        match event {
+            Event::Start(Tag::CodeBlock(_)) | Event::Start(Tag::Image { .. }) => {
+                skip_depth += 1;
+            }
+            Event::End(TagEnd::CodeBlock) | Event::End(TagEnd::Image) => {
+                skip_depth = skip_depth.saturating_sub(1);
+            }
+            _ if skip_depth > 0 => {}
+            Event::Text(t) => out.push_str(&t),
+            Event::SoftBreak => out.push(' '),
+            Event::HardBreak | Event::End(TagEnd::Paragraph) | Event::End(TagEnd::Heading(_)) => {
+                out.push(' ');
+            }
+            Event::Code(t) => out.push_str(&t),
+            _ => {}
+        }
+    }
+
+    out
+}
+
+const TECH_SUBS: &[(&str, &str)] = &[
+    ("JSON", "jay-sahn"),
+    ("json", "jay-sahn"),
+    ("YAML", "yam-ul"),
+    ("yaml", "yam-ul"),
+    ("TOML", "tom-ul"),
+    ("toml", "tom-ul"),
+    ("WASM", "waz-um"),
+    ("wasm", "waz-um"),
+    ("OAuth", "oh-auth"),
+    ("NGINX", "engine-X"),
+    ("nginx", "engine-X"),
+    ("PostgreSQL", "post-gres-Q-L"),
+    ("SQLite", "S-Q-lite"),
+    ("macOS", "mac O S"),
+    ("iOS", "eye-O-S"),
+];
+
+fn apply_tech_subs(text: &str) -> String {
+    let mut result = text.to_string();
+    for (from, to) in TECH_SUBS {
+        result = result.replace(from, to);
+    }
+    result
+}

--- a/crates/voice-chat/src/main.rs
+++ b/crates/voice-chat/src/main.rs
@@ -129,13 +129,7 @@ async fn main() {
             .iter()
             .any(|w| lower.contains(w))
         {
-            speak(
-                &mut tts_model,
-                &voice,
-                "Goodbye!",
-                args.speed,
-                sample_rate,
-            );
+            speak(&mut tts_model, &voice, "Goodbye!", args.speed, sample_rate);
             break;
         }
 
@@ -203,7 +197,15 @@ async fn main() {
             if has_sentence_end(&sentence_buf) {
                 let text = prepare_for_tts(&sentence_buf);
                 if !text.trim().is_empty() {
-                    generate_and_queue(&mut tts_model, &voice, &text, args.speed, &player, channels, rate);
+                    generate_and_queue(
+                        &mut tts_model,
+                        &voice,
+                        &text,
+                        args.speed,
+                        &player,
+                        channels,
+                        rate,
+                    );
                 }
                 sentence_buf.clear();
             }
@@ -213,7 +215,15 @@ async fn main() {
         if !sentence_buf.trim().is_empty() {
             let text = prepare_for_tts(&sentence_buf);
             if !text.trim().is_empty() {
-                generate_and_queue(&mut tts_model, &voice, &text, args.speed, &player, channels, rate);
+                generate_and_queue(
+                    &mut tts_model,
+                    &voice,
+                    &text,
+                    args.speed,
+                    &player,
+                    channels,
+                    rate,
+                );
             }
         }
 

--- a/crates/voice-cli/src/mcp.rs
+++ b/crates/voice-cli/src/mcp.rs
@@ -693,7 +693,7 @@ fn voice_listen(session: &mut Session, params: Value) -> Result<Value, RpcErr> {
             .map_err(|e| RpcErr::invalid_params(format!("bad listen params: {e}")))?
     };
 
-    let max_duration = p.max_duration_ms.unwrap_or(30_000);
+    let max_duration = p.max_duration_ms.unwrap_or(60_000);
     let silence_timeout = p.silence_timeout_ms.unwrap_or(2_000);
     let threshold = p.silence_threshold.unwrap_or(0.01);
     let noise_multiplier = p.noise_multiplier.unwrap_or(3.0);


### PR DESCRIPTION
## Summary
New `voice-chat` crate — full audio conversation loop with local LLMs:

1. Mic → Whisper STT → text
2. Text → Ollama (streaming) → response tokens
3. Tokens accumulated into sentences → Kokoro TTS → speaker
4. Repeat

Key features:
- **Persistent mic** — opens once at startup, no repeated Bluetooth HFP codec switches
- **Streaming TTS** — speaks each sentence as it completes, doesn't wait for full response
- **Markdown stripping** — model output cleaned before TTS
- **Configurable** — `--model`, `--voice`, `--speed`, `--system` flags

```
voice-chat --model qwen3 --voice af_nicole --system "Keep it brief."
```

## Test plan
- [x] `cargo build --release -p voice-chat` — clean
- [x] Tested with qwen3 via Ollama — streaming works, sentences spoken as they arrive
- [x] Persistent mic verified on AirPods — no HFP switch after first turn