### PR TITLE
Pre-release cleanup: fix deps, centralize workspace, upgrade candle 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,9 +276,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "candle-core"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15b675b80d994b2eadb20a4bbe434eabeb454eac3ee5e2b4cf6f147ee9be091"
+checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
 dependencies = [
  "byteorder",
  "candle-metal-kernels",
@@ -297,15 +297,16 @@ dependencies = [
  "rayon",
  "safetensors 0.7.0",
  "thiserror 2.0.18",
+ "tokenizers 0.22.2",
  "yoke 0.8.1",
  "zip",
 ]
 
 [[package]]
 name = "candle-metal-kernels"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fdfe9d06de16ce49961e49084e5b79a75a9bdf157246e7c7b6328e87a7aa25d"
+checksum = "4b6b5a4cae6b4e1ab0efcee4dc05272d11b374a3d1ba121b3a961e36be54ab60"
 dependencies = [
  "half",
  "objc2",
@@ -318,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "candle-nn"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3045fa9e7aef8567d209a27d56b692f60b96f4d0569f4c3011f8ca6715c65e03"
+checksum = "a9317a09d6530b758990ed7f625ac69ff43653bc9ee28b0464644ad1169ada87"
 dependencies = [
  "candle-core",
  "candle-metal-kernels",
@@ -336,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "candle-transformers"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b538ec4aa807c416a2ddd3621044888f188827862e2a6fcacba4738e89795d01"
+checksum = "f59d08c89e9f4af9c464e2f3a8e16199e7cc601e6f34538c2cfbb42b623b1783"
 dependencies = [
  "byteorder",
  "candle-core",
@@ -355,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "candle-ug"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22d62be69068bf58987a45f690612739d8d2ea1bf508c1b87dc6815a019575d"
+checksum = "ca0fc3167cbc99c8ec1be618cb620aa21dca95038f118c3579a79370e3dc5f77"
 dependencies = [
  "ug",
  "ug-metal",
@@ -945,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "float8"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719a903cc23e4a89e87962c2a80fdb45cdaad0983a89bd150bb57b4c8571a7d5"
+checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
 dependencies = [
  "half",
  "num-traits",
@@ -3520,6 +3521,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.2",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3958,7 +3992,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tokenizers",
+ "tokenizers 0.21.4",
  "voice-whisper",
 ]
 
@@ -3988,7 +4022,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_distr 0.5.1",
  "thiserror 2.0.18",
- "tokenizers",
+ "tokenizers 0.21.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,10 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.dependencies]
-candle-core = { version = "0.9", features = ["metal"] }
-candle-nn = { version = "0.9", features = ["metal"] }
-candle-transformers = { version = "0.9" }
-candle-metal-kernels = "0.9"
+candle-core = { version = "0.10", features = ["metal"] }
+candle-nn = { version = "0.10", features = ["metal"] }
+candle-transformers = { version = "0.10" }
+candle-metal-kernels = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,16 @@
 [workspace]
 members = ["crates/*"]
 resolver = "2"
+
+[workspace.dependencies]
+candle-core = { version = "0.9", features = ["metal"] }
+candle-nn = { version = "0.9", features = ["metal"] }
+candle-transformers = { version = "0.9" }
+candle-metal-kernels = "0.9"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+hf-hub = "0.5"
+safetensors = "0.6"
+hound = "3"
+tokenizers = "0.21"

--- a/crates/voice-cli/Cargo.toml
+++ b/crates/voice-cli/Cargo.toml
@@ -25,7 +25,7 @@ pubkey = "RWRmHACtt9SpjQB/l+dAoCe+3iqxq/Xe/90P6dyCW70axzy3UkWl+Ave"
 [dependencies]
 voice-tts = { version = "0.3.0", path = "../voice-tts" }
 candle-core = { version = "0.9", features = ["metal"] }
-voice-g2p = { version = "0.2.0", path = "../voice-g2p" }
+voice-g2p = { version = "0.2.2", path = "../voice-g2p" }
 voice-stt = { version = "0.2.0", path = "../voice-stt" }
 clap = { version = "4", features = ["derive"] }
 rodio = { version = "0.22", features = ["experimental"] }

--- a/crates/voice-cli/Cargo.toml
+++ b/crates/voice-cli/Cargo.toml
@@ -24,13 +24,13 @@ pubkey = "RWRmHACtt9SpjQB/l+dAoCe+3iqxq/Xe/90P6dyCW70axzy3UkWl+Ave"
 
 [dependencies]
 voice-tts = { version = "0.3.0", path = "../voice-tts" }
-candle-core = { version = "0.9", features = ["metal"] }
+candle-core = { workspace = true }
 voice-g2p = { version = "0.2.2", path = "../voice-g2p" }
 voice-stt = { version = "0.2.0", path = "../voice-stt" }
 clap = { version = "4", features = ["derive"] }
 rodio = { version = "0.22", features = ["experimental"] }
-hound = "3"
+hound = { workspace = true }
 pulldown-cmark = "0.13.1"
 ctrlc = "3.5.2"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/voice-cli/Cargo.toml
+++ b/crates/voice-cli/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.85.0"
 description = "CLI for fast text-to-speech and speech-to-text"
 license = "MIT"
-repository = "https://github.com/rgbkrk/voicers"
+repository = "https://github.com/rgbkrk/voice"
 readme = "README.md"
 
 [[bin]]

--- a/crates/voice-g2p/Cargo.toml
+++ b/crates/voice-g2p/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/rgbkrk/voicers"
 
 [dependencies]
 fancy-regex = "0.17"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "2"
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 unicode-normalization = "0.1"

--- a/crates/voice-g2p/Cargo.toml
+++ b/crates/voice-g2p/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.85.0"
 description = "Grapheme-to-phoneme conversion: misaki dictionary + espeak-ng fallback"
 license = "MIT"
-repository = "https://github.com/rgbkrk/voicers"
+repository = "https://github.com/rgbkrk/voice"
 
 [dependencies]
 fancy-regex = "0.17"

--- a/crates/voice-kokoro/Cargo.toml
+++ b/crates/voice-kokoro/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.85.0"
 description = "Kokoro-82M TTS on candle with Metal acceleration"
 license = "MIT"
-repository = "https://github.com/rgbkrk/voicers"
+repository = "https://github.com/rgbkrk/voice"
 
 [dependencies]
 candle-core = { workspace = true }

--- a/crates/voice-kokoro/Cargo.toml
+++ b/crates/voice-kokoro/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 rust-version = "1.85.0"
 description = "Kokoro-82M TTS on candle with Metal acceleration"
-license = "Apache-2.0"
-repository = "https://github.com/rgbkrk/kokoro-candle"
+license = "MIT"
+repository = "https://github.com/rgbkrk/voicers"
 
 [dependencies]
 candle-core = { version = "0.9", features = ["metal"] }

--- a/crates/voice-kokoro/Cargo.toml
+++ b/crates/voice-kokoro/Cargo.toml
@@ -8,16 +8,16 @@ license = "MIT"
 repository = "https://github.com/rgbkrk/voicers"
 
 [dependencies]
-candle-core = { version = "0.9", features = ["metal"] }
-candle-nn = { version = "0.9", features = ["metal"] }
-candle-transformers = { version = "0.9" }
-candle-metal-kernels = "0.9"
+candle-core = { workspace = true }
+candle-nn = { workspace = true }
+candle-transformers = { workspace = true }
+candle-metal-kernels = { workspace = true }
 half = { version = "2", features = ["num-traits"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-hf-hub = "0.5"
-safetensors = "0.6"
-thiserror = "2"
+serde = { workspace = true }
+serde_json = { workspace = true }
+hf-hub = { workspace = true }
+safetensors = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 hound = "3"

--- a/crates/voice-stt/Cargo.toml
+++ b/crates/voice-stt/Cargo.toml
@@ -9,15 +9,15 @@ repository = "https://github.com/rgbkrk/voicers"
 
 [dependencies]
 voice-whisper = { path = "../voice-whisper" }
-candle-core = { version = "0.9", features = ["metal"] }
-candle-nn = { version = "0.9", features = ["metal"] }
-candle-transformers = "0.9"
-safetensors = "0.6"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-hf-hub = "0.5"
-hound = "3"
-thiserror = "2"
-tokenizers = "0.21"
+candle-core = { workspace = true }
+candle-nn = { workspace = true }
+candle-transformers = { workspace = true }
+safetensors = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+hf-hub = { workspace = true }
+hound = { workspace = true }
+thiserror = { workspace = true }
+tokenizers = { workspace = true }
 rubato = "1.0"
 audioadapter-buffers = "2.0"

--- a/crates/voice-stt/Cargo.toml
+++ b/crates/voice-stt/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.85.0"
 description = "Speech-to-text library backed by candle + Metal, using Whisper"
 license = "MIT"
-repository = "https://github.com/rgbkrk/voicers"
+repository = "https://github.com/rgbkrk/voice"
 
 [dependencies]
 voice-whisper = { path = "../voice-whisper" }

--- a/crates/voice-tts/Cargo.toml
+++ b/crates/voice-tts/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.85.0"
 description = "Rust TTS library backed by candle + Metal, starting with Kokoro"
 license = "MIT"
-repository = "https://github.com/rgbkrk/voicers"
+repository = "https://github.com/rgbkrk/voice"
 
 [dependencies]
 voice-kokoro = { path = "../voice-kokoro" }

--- a/crates/voice-tts/Cargo.toml
+++ b/crates/voice-tts/Cargo.toml
@@ -9,11 +9,11 @@ repository = "https://github.com/rgbkrk/voicers"
 
 [dependencies]
 voice-kokoro = { path = "../voice-kokoro" }
-candle-core = { version = "0.9", features = ["metal"] }
-candle-nn = { version = "0.9", features = ["metal"] }
-safetensors = "0.6"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-hf-hub = "0.5"
-hound = "3"
-thiserror = "2"
+candle-core = { workspace = true }
+candle-nn = { workspace = true }
+safetensors = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+hf-hub = { workspace = true }
+hound = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/voice-whisper/Cargo.toml
+++ b/crates/voice-whisper/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.85.0"
 description = "Whisper STT on candle with Metal acceleration"
 license = "MIT"
-repository = "https://github.com/rgbkrk/voicers"
+repository = "https://github.com/rgbkrk/voice"
 
 [dependencies]
 candle-core = { workspace = true }

--- a/crates/voice-whisper/Cargo.toml
+++ b/crates/voice-whisper/Cargo.toml
@@ -8,11 +8,11 @@ license = "MIT"
 repository = "https://github.com/rgbkrk/voicers"
 
 [dependencies]
-candle-core = { version = "0.9", features = ["metal"] }
-candle-nn = { version = "0.9", features = ["metal"] }
-candle-transformers = "0.9"
+candle-core = { workspace = true }
+candle-nn = { workspace = true }
+candle-transformers = { workspace = true }
 byteorder = "1"
-tokenizers = "0.21"
-thiserror = "2"
+tokenizers = { workspace = true }
+thiserror = { workspace = true }
 rand = "0.9"
 rand_distr = "0.5"


### PR DESCRIPTION
## Summary

- **Fix voice-g2p version mismatch** — voice-cli depended on 0.2.0 but the crate is 0.2.2
- **Align voice-kokoro metadata** — was Apache-2.0 + kokoro-candle repo from when it was standalone, now MIT + voicers like the rest
- **Centralize workspace.dependencies** — candle, serde, thiserror, hf-hub, safetensors, hound, tokenizers deduplicated across 6 crates
- **Upgrade candle 0.9 → 0.10** — resolves to 0.10.2, no code changes required

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace` clean
- [x] `cargo test --workspace` passes (156 tests)
- [ ] Smoke test TTS: `voice "Hello world"`
- [ ] Smoke test STT: `voice listen`