### PR TITLE
Add built-in G2P overrides for commonly mispronounced words

### DIFF
--- a/crates/voice-g2p/src/lib.rs
+++ b/crates/voice-g2p/src/lib.rs
@@ -64,8 +64,21 @@ impl G2P {
             lexicon: Lexicon::new(),
             fallback: EspeakFallback::with_path(config.espeak_path),
             unk: String::new(),
-            overrides: HashMap::new(),
+            overrides: Self::builtin_overrides(),
         }
+    }
+
+    /// Words whose default lexicon/espeak phonemes are wrong or misleading.
+    fn builtin_overrides() -> HashMap<String, String> {
+        HashMap::from([
+            ("demos".into(), "dˈɛmOz".into()),
+            ("demo".into(), "dˈɛmO".into()),
+            ("todo".into(), "tˈudu".into()),
+            ("demuxing".into(), "dˌimˈʌksɪŋ".into()),
+            ("demux".into(), "dˌimˈʌks".into()),
+            ("demultiplexing".into(), "dˌimˈʌltɪplɛksɪŋ".into()),
+            ("demultiplex".into(), "dˌimˈʌltɪplɛks".into()),
+        ])
     }
 
     /// Set custom word-to-phoneme overrides (builder pattern).
@@ -73,7 +86,7 @@ impl G2P {
     /// Overrides map lowercase words to phoneme strings, checked before
     /// the lexicon and espeak fallback.
     pub fn with_overrides(mut self, overrides: HashMap<String, String>) -> Self {
-        self.overrides = overrides;
+        self.overrides.extend(overrides);
         self
     }
 
@@ -723,5 +736,17 @@ mod tests {
             result.contains(';'),
             "Semicolon should appear in phonemes: {result}"
         );
+    }
+
+    #[test]
+    fn test_builtin_overrides() {
+        let g2p = G2P::new();
+        assert_eq!(g2p.convert("demos").unwrap(), "dˈɛmOz");
+        assert_eq!(g2p.convert("demo").unwrap(), "dˈɛmO");
+        assert_eq!(g2p.convert("TODO").unwrap(), "tˈudu");
+        assert_eq!(g2p.convert("demuxing").unwrap(), "dˌimˈʌksɪŋ");
+        assert_eq!(g2p.convert("demux").unwrap(), "dˌimˈʌks");
+        assert_eq!(g2p.convert("demultiplexing").unwrap(), "dˌimˈʌltɪplɛksɪŋ");
+        assert_eq!(g2p.convert("demultiplex").unwrap(), "dˌimˈʌltɪplɛks");
     }
 }

--- a/crates/voice-g2p/src/lib.rs
+++ b/crates/voice-g2p/src/lib.rs
@@ -70,15 +70,21 @@ impl G2P {
 
     /// Words whose default lexicon/espeak phonemes are wrong or misleading.
     fn builtin_overrides() -> HashMap<String, String> {
-        HashMap::from([
-            ("demos".into(), "dˈɛmOz".into()),
-            ("demo".into(), "dˈɛmO".into()),
-            ("todo".into(), "tˈudu".into()),
-            ("demuxing".into(), "dˌimˈʌksɪŋ".into()),
-            ("demux".into(), "dˌimˈʌks".into()),
-            ("demultiplexing".into(), "dˌimˈʌltɪplɛksɪŋ".into()),
-            ("demultiplex".into(), "dˌimˈʌltɪplɛks".into()),
-        ])
+        const ENTRIES: &[(&str, &str)] = &[
+            ("demo", "dˈɛmO"),
+            ("demos", "dˈɛmOz"),
+            ("demultiplex", "dˌimˈʌltɪplɛks"),
+            ("demultiplexing", "dˌimˈʌltɪplɛksɪŋ"),
+            ("demux", "dˌimˈʌks"),
+            ("demuxing", "dˌimˈʌksɪŋ"),
+            ("jupyter", "ʤˈupɪTəɹ"),
+            ("nteract", "ˈɛntəɹˌækt"),
+            ("todo", "tˈudu"),
+        ];
+        ENTRIES
+            .iter()
+            .map(|(k, v)| ((*k).into(), (*v).into()))
+            .collect()
     }
 
     /// Set custom word-to-phoneme overrides (builder pattern).
@@ -748,5 +754,7 @@ mod tests {
         assert_eq!(g2p.convert("demux").unwrap(), "dˌimˈʌks");
         assert_eq!(g2p.convert("demultiplexing").unwrap(), "dˌimˈʌltɪplɛksɪŋ");
         assert_eq!(g2p.convert("demultiplex").unwrap(), "dˌimˈʌltɪplɛks");
+        assert_eq!(g2p.convert("Jupyter").unwrap(), "ʤˈupɪTəɹ");
+        assert_eq!(g2p.convert("nteract").unwrap(), "ˈɛntəɹˌækt");
     }
 }


### PR DESCRIPTION
Fixes #38

## Summary

- Add `builtin_overrides()` to `G2P` with corrected phonemes for demos, TODO, demux, demultiplex and their variants
- Built-in overrides seed every `G2P` instance, checked before lexicon/espeak
- `with_overrides()` now extends (not replaces) builtins, so user overrides win

| Word | Before | After |
|------|--------|-------|
| demos | `dˈimˌɑs` ("DEE-moss") | `dˈɛmOz` ("DEM-ohz") |
| TODO | `tˌiˌOdˌiˈO` (spelled out) | `tˈudu` ("to-do") |
| demuxing | `dˈɛmʌksɪŋ` (wrong stress) | `dˌimˈʌksɪŋ` ("dee-MUCKS-ing") |
| demultiplexing | `dˈɛməltˌɪplɛksɪŋ` (wrong prefix) | `dˌimˈʌltɪplɛksɪŋ` ("dee-MUL-ti-PLEX-ing") |

## Test plan

- [x] `cargo test -p voice-g2p` — 147 tests pass (new `test_builtin_overrides`)
- [x] Listened to TTS output with `voice` — all four words sound correct
- [x] Verified `--sub` flags still override builtins