### PR TITLE
Embed 129k-word bronze dictionary, make espeak-ng optional at runtime

### DIFF
--- a/crates/voice-g2p/Cargo.toml
+++ b/crates/voice-g2p/Cargo.toml
@@ -7,6 +7,10 @@ description = "Grapheme-to-phoneme conversion: misaki dictionary + espeak-ng fal
 license = "MIT"
 repository = "https://github.com/rgbkrk/voice"
 
+[[bin]]
+name = "generate-bronze"
+path = "src/bin/generate_bronze.rs"
+
 [dependencies]
 fancy-regex = "0.17"
 serde = { workspace = true }

--- a/crates/voice-g2p/src/bin/generate_bronze.rs
+++ b/crates/voice-g2p/src/bin/generate_bronze.rs
@@ -22,12 +22,11 @@ const US_SILVER_JSON: &str = include_str!("../../data/us_silver.json");
 fn main() {
     let args: Vec<String> = std::env::args().collect();
 
-    let wordlist_path = get_arg(&args, "--wordlist")
-        .unwrap_or_else(|| "/usr/share/dict/words".to_string());
-    let output_path = get_arg(&args, "--output")
-        .unwrap_or_else(|| "data/us_bronze.json".to_string());
-    let espeak_path = get_arg(&args, "--espeak-path")
-        .unwrap_or_else(|| "espeak-ng".to_string());
+    let wordlist_path =
+        get_arg(&args, "--wordlist").unwrap_or_else(|| "/usr/share/dict/words".to_string());
+    let output_path =
+        get_arg(&args, "--output").unwrap_or_else(|| "data/us_bronze.json".to_string());
+    let espeak_path = get_arg(&args, "--espeak-path").unwrap_or_else(|| "espeak-ng".to_string());
 
     // Load existing dictionaries to skip known words
     eprintln!("Loading gold and silver dictionaries...");
@@ -51,8 +50,7 @@ fn main() {
 
     // Read and filter word list
     eprintln!("Reading word list from {}...", wordlist_path);
-    let wordlist_file =
-        std::fs::read_to_string(&wordlist_path).expect("failed to read word list");
+    let wordlist_file = std::fs::read_to_string(&wordlist_path).expect("failed to read word list");
 
     let mut words: Vec<String> = wordlist_file
         .lines()
@@ -75,11 +73,7 @@ fn main() {
     eprintln!("Running espeak-ng in chunks of {}...", CHUNK_SIZE);
     for (chunk_idx, chunk) in words.chunks(CHUNK_SIZE).enumerate() {
         let chunk_start = chunk_idx * CHUNK_SIZE;
-        eprint!(
-            "\r  {}/{} words processed...",
-            chunk_start,
-            words.len()
-        );
+        eprint!("\r  {}/{} words processed...", chunk_start, words.len());
 
         let mut child = Command::new(&espeak_path)
             .args(["--ipa", "-q", "-v", "en-us", "--tie=^"])
@@ -98,7 +92,10 @@ fn main() {
 
         let output = child.wait_with_output().expect("espeak-ng failed");
         if !output.status.success() {
-            eprintln!("\nespeak-ng failed on chunk {}, falling back to per-word", chunk_idx);
+            eprintln!(
+                "\nespeak-ng failed on chunk {}, falling back to per-word",
+                chunk_idx
+            );
             let fallback = process_per_word(chunk, &espeak_path);
             result.extend(fallback);
             continue;
@@ -110,7 +107,9 @@ fn main() {
         if lines.len() != chunk.len() {
             eprintln!(
                 "\nWARNING: chunk {} got {} lines for {} words, falling back",
-                chunk_idx, lines.len(), chunk.len()
+                chunk_idx,
+                lines.len(),
+                chunk.len()
             );
             let fallback = process_per_word(chunk, &espeak_path);
             result.extend(fallback);
@@ -172,8 +171,7 @@ fn process_per_word(words: &[String], espeak_path: &str) -> BTreeMap<String, Str
 }
 
 fn write_output(result: &BTreeMap<String, String>, output_path: &str) {
-    let json =
-        serde_json::to_string_pretty(result).expect("failed to serialize JSON");
+    let json = serde_json::to_string_pretty(result).expect("failed to serialize JSON");
     std::fs::write(output_path, &json).expect("failed to write output file");
     let size_mb = json.len() as f64 / 1_048_576.0;
     eprintln!(

--- a/crates/voice-g2p/src/bin/generate_bronze.rs
+++ b/crates/voice-g2p/src/bin/generate_bronze.rs
@@ -1,0 +1,192 @@
+//! Generate the bronze pronunciation dictionary by running espeak-ng in batch
+//! mode against a word list, then applying E2M conversion to produce Kokoro
+//! phonemes. The output is a JSON file suitable for embedding in voice-g2p.
+//!
+//! Usage:
+//!   cargo run --bin generate-bronze -- [OPTIONS]
+//!
+//! Options:
+//!   --wordlist <PATH>    Word list file (default: /usr/share/dict/words)
+//!   --output <PATH>      Output JSON file (default: data/us_bronze.json)
+//!   --espeak-path <PATH> Path to espeak-ng binary (default: espeak-ng)
+
+use std::collections::{BTreeMap, HashSet};
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use voice_g2p::espeak::apply_e2m_us;
+
+const US_GOLD_JSON: &str = include_str!("../../data/us_gold.json");
+const US_SILVER_JSON: &str = include_str!("../../data/us_silver.json");
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    let wordlist_path = get_arg(&args, "--wordlist")
+        .unwrap_or_else(|| "/usr/share/dict/words".to_string());
+    let output_path = get_arg(&args, "--output")
+        .unwrap_or_else(|| "data/us_bronze.json".to_string());
+    let espeak_path = get_arg(&args, "--espeak-path")
+        .unwrap_or_else(|| "espeak-ng".to_string());
+
+    // Load existing dictionaries to skip known words
+    eprintln!("Loading gold and silver dictionaries...");
+    let gold: serde_json::Value =
+        serde_json::from_str(US_GOLD_JSON).expect("failed to parse us_gold.json");
+    let silver: serde_json::Value =
+        serde_json::from_str(US_SILVER_JSON).expect("failed to parse us_silver.json");
+
+    let mut known: HashSet<String> = HashSet::new();
+    if let serde_json::Value::Object(map) = &gold {
+        for key in map.keys() {
+            known.insert(key.to_lowercase());
+        }
+    }
+    if let serde_json::Value::Object(map) = &silver {
+        for key in map.keys() {
+            known.insert(key.to_lowercase());
+        }
+    }
+    eprintln!("  {} known words from gold+silver", known.len());
+
+    // Read and filter word list
+    eprintln!("Reading word list from {}...", wordlist_path);
+    let wordlist_file =
+        std::fs::read_to_string(&wordlist_path).expect("failed to read word list");
+
+    let mut words: Vec<String> = wordlist_file
+        .lines()
+        .map(|l| l.trim().to_lowercase())
+        .filter(|w| !w.is_empty())
+        .filter(|w| w.chars().all(|c| c.is_ascii_alphabetic()))
+        .filter(|w| !known.contains(w))
+        .collect();
+
+    words.sort();
+    words.dedup();
+    eprintln!("  {} new words to process", words.len());
+
+    // Process in chunks to avoid pipe buffer deadlock.
+    // Each chunk spawns espeak-ng, writes words to stdin, reads all stdout.
+    const CHUNK_SIZE: usize = 5000;
+    let mut result: BTreeMap<String, String> = BTreeMap::new();
+    let mut skipped = 0;
+
+    eprintln!("Running espeak-ng in chunks of {}...", CHUNK_SIZE);
+    for (chunk_idx, chunk) in words.chunks(CHUNK_SIZE).enumerate() {
+        let chunk_start = chunk_idx * CHUNK_SIZE;
+        eprint!(
+            "\r  {}/{} words processed...",
+            chunk_start,
+            words.len()
+        );
+
+        let mut child = Command::new(&espeak_path)
+            .args(["--ipa", "-q", "-v", "en-us", "--tie=^"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to start espeak-ng — is it installed?");
+
+        {
+            let stdin = child.stdin.as_mut().expect("failed to open stdin");
+            for word in chunk {
+                writeln!(stdin, "{}", word).expect("failed to write to stdin");
+            }
+        }
+
+        let output = child.wait_with_output().expect("espeak-ng failed");
+        if !output.status.success() {
+            eprintln!("\nespeak-ng failed on chunk {}, falling back to per-word", chunk_idx);
+            let fallback = process_per_word(chunk, &espeak_path);
+            result.extend(fallback);
+            continue;
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let lines: Vec<&str> = stdout.lines().collect();
+
+        if lines.len() != chunk.len() {
+            eprintln!(
+                "\nWARNING: chunk {} got {} lines for {} words, falling back",
+                chunk_idx, lines.len(), chunk.len()
+            );
+            let fallback = process_per_word(chunk, &espeak_path);
+            result.extend(fallback);
+            continue;
+        }
+
+        for (word, ipa_line) in chunk.iter().zip(lines.iter()) {
+            let ipa = ipa_line.trim();
+            if ipa.is_empty() {
+                skipped += 1;
+                continue;
+            }
+            let phonemes = apply_e2m_us(ipa);
+            if phonemes.trim().is_empty() {
+                skipped += 1;
+                continue;
+            }
+            result.insert(word.clone(), phonemes);
+        }
+    }
+
+    eprintln!(
+        "\r  {} entries generated, {} skipped (empty output)     ",
+        result.len(),
+        skipped
+    );
+
+    write_output(&result, &output_path);
+}
+
+/// Fallback: process words one at a time if batch mode has line count mismatch.
+fn process_per_word(words: &[String], espeak_path: &str) -> BTreeMap<String, String> {
+    let mut result = BTreeMap::new();
+    let total = words.len();
+
+    for (i, word) in words.iter().enumerate() {
+        if i % 10000 == 0 {
+            eprintln!("  processing word {}/{}", i, total);
+        }
+        let output = Command::new(espeak_path)
+            .args(["--ipa", "-q", "-v", "en-us", "--tie=^", word])
+            .output();
+
+        if let Ok(output) = output {
+            if output.status.success() {
+                let raw = String::from_utf8_lossy(&output.stdout);
+                let ipa = raw.trim();
+                if !ipa.is_empty() {
+                    let phonemes = apply_e2m_us(ipa);
+                    if !phonemes.trim().is_empty() {
+                        result.insert(word.clone(), phonemes);
+                    }
+                }
+            }
+        }
+    }
+
+    result
+}
+
+fn write_output(result: &BTreeMap<String, String>, output_path: &str) {
+    let json =
+        serde_json::to_string_pretty(result).expect("failed to serialize JSON");
+    std::fs::write(output_path, &json).expect("failed to write output file");
+    let size_mb = json.len() as f64 / 1_048_576.0;
+    eprintln!(
+        "Wrote {} entries to {} ({:.1} MB)",
+        result.len(),
+        output_path,
+        size_mb
+    );
+}
+
+fn get_arg(args: &[String], flag: &str) -> Option<String> {
+    args.iter()
+        .position(|a| a == flag)
+        .and_then(|i| args.get(i + 1))
+        .cloned()
+}

--- a/crates/voice-g2p/src/espeak.rs
+++ b/crates/voice-g2p/src/espeak.rs
@@ -244,6 +244,35 @@ mod tests {
     }
 
     #[test]
+    fn test_apply_e2m_us_goat_vowel() {
+        // o^ʊ → O (goat diphthong with tie marker)
+        let input = "h\u{0259}l\u{02C8}o^\u{028A}";
+        let result = apply_e2m_us(input);
+        assert!(
+            result.contains('O'),
+            "Expected O diphthong in: {result}"
+        );
+        assert!(
+            !result.contains('^'),
+            "Tie markers should be removed: {result}"
+        );
+    }
+
+    #[test]
+    fn test_apply_e2m_us_affricates() {
+        // d^ʒ → ʤ, t^ʃ → ʧ
+        assert!(apply_e2m_us("d^\u{0292}\u{028C}mp").contains('\u{02A4}'));
+        assert!(apply_e2m_us("t^\u{0283}\u{026A}p").contains('\u{02A7}'));
+    }
+
+    #[test]
+    fn test_apply_e2m_us_nurse_vowel() {
+        // ɜːɹ → ɜɹ (nurse vowel, remove length mark)
+        let result = apply_e2m_us("w\u{025C}\u{02D0}\u{0279}ld");
+        assert_eq!(result, "w\u{025C}\u{0279}ld");
+    }
+
+    #[test]
     fn test_convert_word_available() {
         let fb = EspeakFallback::new();
         if !fb.is_available() {

--- a/crates/voice-g2p/src/espeak.rs
+++ b/crates/voice-g2p/src/espeak.rs
@@ -248,10 +248,7 @@ mod tests {
         // o^ʊ → O (goat diphthong with tie marker)
         let input = "h\u{0259}l\u{02C8}o^\u{028A}";
         let result = apply_e2m_us(input);
-        assert!(
-            result.contains('O'),
-            "Expected O diphthong in: {result}"
-        );
+        assert!(result.contains('O'), "Expected O diphthong in: {result}");
         assert!(
             !result.contains('^'),
             "Tie markers should be removed: {result}"

--- a/crates/voice-g2p/src/espeak.rs
+++ b/crates/voice-g2p/src/espeak.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 
 /// Espeak-to-Misaki replacement pairs, sorted by key length descending
 /// so longest-match-first replacement works correctly.
-const E2M: &[(&str, &str)] = &[
+pub(crate) const E2M: &[(&str, &str)] = &[
     // 4+ character sequences
     ("\u{0294}\u{02CC}n\u{0329}", "t\u{1D4A}n"), // ʔˌn̩ → tᵊn
     // 3 character sequences
@@ -91,38 +91,23 @@ impl EspeakFallback {
             return None;
         }
 
-        let mut ps = ps.to_string();
-
-        // Apply E2M replacements (longest-match-first, already sorted by key length desc)
-        for &(old, new) in E2M {
-            ps = ps.replace(old, new);
-        }
-
-        // Handle syllabic consonant diacritic U+0329: (\S)\u0329 → ᵊ\1
-        // We do this with a simple char-based approach instead of pulling in regex.
-        ps = replace_syllabic_mark(&ps);
-
-        // Language-specific adjustments
         if self.british {
+            // British path kept inline (not extracted since bronze is US-only)
+            let mut ps = ps.to_string();
+            for &(old, new) in E2M {
+                ps = ps.replace(old, new);
+            }
+            ps = replace_syllabic_mark(&ps);
             ps = ps.replace("e^ə", "\u{025B}\u{02D0}"); // e^ə → ɛː
             ps = ps.replace("i\u{0259}", "\u{026A}\u{0259}"); // iə → ɪə
             ps = ps.replace("\u{0259}^\u{028A}", "Q"); // ə^ʊ → Q
+            ps = ps.replace('^', "");
+            ps = ps.replace('\u{027E}', "T");
+            ps = ps.replace('\u{0294}', "t");
+            Some((ps, 2))
         } else {
-            ps = ps.replace("o^\u{028A}", "O"); // o^ʊ → O
-            ps = ps.replace("\u{025C}\u{02D0}\u{0279}", "\u{025C}\u{0279}"); // ɜːɹ → ɜɹ
-            ps = ps.replace("\u{025C}\u{02D0}", "\u{025C}\u{0279}"); // ɜː → ɜɹ
-            ps = ps.replace("\u{026A}\u{0259}", "i\u{0259}"); // ɪə → iə
-            ps = ps.replace('\u{02D0}', ""); // remove remaining ː
+            Some((apply_e2m_us(ps), 2))
         }
-
-        // Remove remaining tie markers
-        ps = ps.replace('^', "");
-
-        // Legacy conversion (version != 2.0)
-        ps = ps.replace('\u{027E}', "T"); // ɾ → T
-        ps = ps.replace('\u{0294}', "t"); // ʔ → t
-
-        Some((ps, 2))
     }
 }
 
@@ -135,7 +120,7 @@ impl Default for EspeakFallback {
 /// Handle the syllabic consonant diacritic (U+0329 COMBINING VERTICAL LINE BELOW).
 /// Pattern: any non-whitespace char followed by U+0329 → ᵊ + that char.
 /// Then remove any remaining U+0329.
-fn replace_syllabic_mark(input: &str) -> String {
+pub(crate) fn replace_syllabic_mark(input: &str) -> String {
     let chars: Vec<char> = input.chars().collect();
     let mut result = String::with_capacity(input.len());
     let mut i = 0;
@@ -156,6 +141,38 @@ fn replace_syllabic_mark(input: &str) -> String {
     }
 
     result
+}
+
+/// Convert raw espeak-ng IPA output (with tie markers) to Kokoro phonemes.
+///
+/// Applies the E2M mapping table, syllabic mark handling, US-English vowel
+/// adjustments, tie marker removal, and legacy conversions.
+pub fn apply_e2m_us(raw_ipa: &str) -> String {
+    let mut ps = raw_ipa.to_string();
+
+    // Apply E2M replacements (longest-match-first, already sorted by key length desc)
+    for &(old, new) in E2M {
+        ps = ps.replace(old, new);
+    }
+
+    // Handle syllabic consonant diacritic U+0329
+    ps = replace_syllabic_mark(&ps);
+
+    // US-English adjustments
+    ps = ps.replace("o^\u{028A}", "O"); // o^ʊ → O
+    ps = ps.replace("\u{025C}\u{02D0}\u{0279}", "\u{025C}\u{0279}"); // ɜːɹ → ɜɹ
+    ps = ps.replace("\u{025C}\u{02D0}", "\u{025C}\u{0279}"); // ɜː → ɜɹ
+    ps = ps.replace("\u{026A}\u{0259}", "i\u{0259}"); // ɪə → iə
+    ps = ps.replace('\u{02D0}', ""); // remove remaining ː
+
+    // Remove remaining tie markers
+    ps = ps.replace('^', "");
+
+    // Legacy conversion
+    ps = ps.replace('\u{027E}', "T"); // ɾ → T
+    ps = ps.replace('\u{0294}', "t"); // ʔ → t
+
+    ps
 }
 
 /// Sentence-level espeak-ng phonemization (no tie marker).

--- a/crates/voice-g2p/src/lexicon.rs
+++ b/crates/voice-g2p/src/lexicon.rs
@@ -111,7 +111,9 @@ impl Lexicon {
             cap_stresses: (0.5, 2.0),
             golds: Self::grow_dictionary(golds_raw),
             silvers: Self::grow_dictionary(silvers_raw),
-            bronzes: Self::grow_dictionary(bronzes_raw),
+            // Bronze entries are all lowercase (generated), so skip grow_dictionary —
+            // the get_word lowercasing logic handles case variants already.
+            bronzes: bronzes_raw,
         }
     }
 

--- a/crates/voice-g2p/src/lexicon.rs
+++ b/crates/voice-g2p/src/lexicon.rs
@@ -29,6 +29,7 @@ pub enum LexEntry {
 
 const US_GOLD_JSON: &str = include_str!("../data/us_gold.json");
 const US_SILVER_JSON: &str = include_str!("../data/us_silver.json");
+const US_BRONZE_JSON: &str = include_str!("../data/us_bronze.json");
 
 // ---------------------------------------------------------------------------
 // Symbol tables (mirrors Python ADD_SYMBOLS / SYMBOLS)
@@ -87,6 +88,7 @@ pub struct Lexicon {
     cap_stresses: (f32, f32),
     golds: HashMap<String, LexEntry>,
     silvers: HashMap<String, LexEntry>,
+    bronzes: HashMap<String, LexEntry>,
 }
 
 impl Default for Lexicon {
@@ -102,11 +104,14 @@ impl Lexicon {
             serde_json::from_str(US_GOLD_JSON).expect("failed to parse us_gold.json");
         let silvers_raw: HashMap<String, LexEntry> =
             serde_json::from_str(US_SILVER_JSON).expect("failed to parse us_silver.json");
+        let bronzes_raw: HashMap<String, LexEntry> =
+            serde_json::from_str(US_BRONZE_JSON).expect("failed to parse us_bronze.json");
 
         Self {
             cap_stresses: (0.5, 2.0),
             golds: Self::grow_dictionary(golds_raw),
             silvers: Self::grow_dictionary(silvers_raw),
+            bronzes: Self::grow_dictionary(bronzes_raw),
         }
     }
 
@@ -285,7 +290,11 @@ impl Lexicon {
     // -----------------------------------------------------------------------
 
     pub fn is_known(&self, word: &str, _tag: &str) -> bool {
-        if self.golds.contains_key(word) || is_symbol(word) || self.silvers.contains_key(word) {
+        if self.golds.contains_key(word)
+            || is_symbol(word)
+            || self.silvers.contains_key(word)
+            || self.bronzes.contains_key(word)
+        {
             return true;
         } else if !is_alpha(word) || !all_lexicon_ords(word) {
             return false;
@@ -328,6 +337,13 @@ impl Lexicon {
             if let Some(entry) = self.silvers.get(&word) {
                 ps_entry = Some(entry.clone());
                 rating = 3;
+            }
+        }
+
+        if ps_entry.is_none() && is_nnp != Some(true) {
+            if let Some(entry) = self.bronzes.get(&word) {
+                ps_entry = Some(entry.clone());
+                rating = 2;
             }
         }
 
@@ -575,9 +591,11 @@ impl Lexicon {
             && (tag != "NNP" || word.chars().count() > 7)
             && !self.golds.contains_key(&word)
             && !self.silvers.contains_key(&word)
+            && !self.bronzes.contains_key(&word)
             && (word == word.to_uppercase() || is_lower_after_first(&word))
             && (self.golds.contains_key(&wl)
                 || self.silvers.contains_key(&wl)
+                || self.bronzes.contains_key(&wl)
                 || self.stem_s(&wl, tag, stress, ctx).0.is_some()
                 || self.stem_ed(&wl, tag, stress, ctx).0.is_some()
                 || self.stem_ing(&wl, tag, stress, ctx).0.is_some())


### PR DESCRIPTION
Partially addresses #62

## Summary

- **Bronze dictionary**: 129,099 additional words generated from `/usr/share/dict/words` via espeak-ng at dev time. Embedded as a third lookup tier (rating 2) after gold (4) and silver (3).
- **Total coverage**: 307k words (90k gold + 93k silver + 129k bronze) — espeak-ng is now optional at runtime.
- **Generator binary**: `cargo run --bin generate-bronze` processes words in 5k chunks through espeak-ng, applies E2M conversion, outputs sorted JSON.
- **Refactored E2M**: Extracted `apply_e2m_us()` from `EspeakFallback::convert_word` for reuse by the generator.

Binary size impact: +4.6 MB of dictionary data (comparable to existing gold+silver at 6 MB combined).

## Test plan

- [x] `cargo test -p voice-g2p` — 148 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] Listened to obscure words: abstemious, abecedarian, defenestration, triskaidekaphobia — all resolved correctly without espeak-ng
- [ ] Test with espeak-ng removed from PATH to verify graceful degradation