### PR TITLE
Voice daemon: shared TTS/STT service with request queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4013,6 +4013,7 @@ dependencies = [
  "serde",
  "serde_json",
  "voice-g2p",
+ "voice-protocol",
  "voice-stt",
  "voice-tts",
 ]
@@ -4069,6 +4070,7 @@ dependencies = [
 name = "voice-protocol"
 version = "0.1.0"
 dependencies = [
+ "dirs",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4026,6 +4026,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "uuid",
+ "voice-protocol",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,6 +1896,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2416,6 +2425,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2720,6 +2752,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2979,6 +3020,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3082,6 +3129,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -3562,7 +3619,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -3908,6 +3967,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3945,6 +4015,17 @@ dependencies = [
  "voice-g2p",
  "voice-stt",
  "voice-tts",
+]
+
+[[package]]
+name = "voice-daemon"
+version = "0.1.0"
+dependencies = [
+ "dirs",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4021,12 +4021,16 @@ dependencies = [
 name = "voice-daemon"
 version = "0.1.0"
 dependencies = [
+ "candle-core",
  "dirs",
+ "rodio",
  "serde",
  "serde_json",
  "tokio",
  "uuid",
+ "voice-g2p",
  "voice-protocol",
+ "voice-tts",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4059,6 +4059,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "voice-protocol"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "voice-stt"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4023,6 +4023,7 @@ version = "0.1.0"
 dependencies = [
  "candle-core",
  "dirs",
+ "hound",
  "rodio",
  "serde",
  "serde_json",
@@ -4030,6 +4031,7 @@ dependencies = [
  "uuid",
  "voice-g2p",
  "voice-protocol",
+ "voice-stt",
  "voice-tts",
 ]
 

--- a/crates/voice-cli/Cargo.toml
+++ b/crates/voice-cli/Cargo.toml
@@ -34,3 +34,4 @@ pulldown-cmark = "0.13.1"
 ctrlc = "3.5.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
+voice-protocol = { path = "../voice-protocol" }

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -579,6 +579,20 @@ fn run_say(say_args: SayArgs) {
                     std::process::exit(1);
                 }
             };
+            // Apply the same preprocessing the local path uses
+            let text = if say_args.markdown {
+                strip_markdown(&text)
+            } else {
+                text
+            };
+            let text = apply_tech_subs(&text);
+            let sub_file = say_args.sub_file.clone().or_else(find_sub_file);
+            let (subs, _phoneme_overrides) = collect_subs(&say_args.subs, sub_file.as_deref());
+            let text = if subs.is_empty() {
+                text
+            } else {
+                apply_substitutions(&text, &subs)
+            };
             match daemon.speak(&text, Some(&say_args.voice), Some(say_args.speed as f64)) {
                 Ok(_resp) => return,
                 Err(e) => {

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -456,6 +456,22 @@ fn main() {
         Some(Command::Listen(listen_args)) => {
             if listen_args.continuous {
                 listen::listen_continuous();
+            } else if let Some(mut daemon) = voice_protocol::client::DaemonClient::connect() {
+                match daemon.listen(None) {
+                    Ok(resp) => {
+                        if let Some(result) = resp.result {
+                            if let Some(r) = result.get("result").and_then(|v| v.as_str()) {
+                                println!("{}", r);
+                            }
+                        } else if let Some(err) = resp.error {
+                            eprintln!("Daemon error: {}", err.message);
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("Daemon error: {e}, falling back to local");
+                        listen::listen_and_transcribe();
+                    }
+                }
             } else {
                 listen::listen_and_transcribe();
             }
@@ -553,6 +569,25 @@ fn run_mcp(serve_args: ServeArgs) {
 }
 
 fn run_say(say_args: SayArgs) {
+    // If the daemon is running and we're not writing to a file, delegate to it.
+    if say_args.output.is_none() {
+        if let Some(mut daemon) = voice_protocol::client::DaemonClient::connect() {
+            let text = match resolve_text(&say_args) {
+                Ok(t) => t,
+                Err(msg) => {
+                    eprintln!("Error: {msg}");
+                    std::process::exit(1);
+                }
+            };
+            match daemon.speak(&text, Some(&say_args.voice), Some(say_args.speed as f64)) {
+                Ok(_resp) => return,
+                Err(e) => {
+                    eprintln!("Daemon error: {e}, falling back to local");
+                }
+            }
+        }
+    }
+
     // Start model loading in a background thread immediately — this is the
     // slowest startup step (~200ms) and can run while we resolve text + G2P.
     let model_handle = std::thread::spawn(|| voice_tts::load_model(MODEL_REPO));
@@ -648,6 +683,27 @@ fn run_converse(args: ConverseArgs) {
     }
 
     let text = args.text.join(" ");
+
+    // Delegate to daemon if available
+    if let Some(mut daemon) = voice_protocol::client::DaemonClient::connect() {
+        match daemon.converse(&text, Some(&args.voice)) {
+            Ok(resp) => {
+                // Extract and print the heard text
+                if let Some(result) = resp.result {
+                    if let Some(r) = result.get("result").and_then(|v| v.as_str()) {
+                        println!("{}", r);
+                    }
+                } else if let Some(err) = resp.error {
+                    eprintln!("Daemon error: {}", err.message);
+                }
+                return;
+            }
+            Err(e) => {
+                eprintln!("Daemon error: {e}, falling back to local");
+            }
+        }
+    }
+
     let model_handle = std::thread::spawn(|| voice_tts::load_model(MODEL_REPO));
 
     let sub_file = args.sub_file.clone().or_else(find_sub_file);

--- a/crates/voice-cli/src/mcp.rs
+++ b/crates/voice-cli/src/mcp.rs
@@ -153,6 +153,9 @@ struct Session {
     /// Persistent mic — kept open across calls to avoid Bluetooth HFP switches.
     warm_mic: Option<listen::WarmMic>,
     mem_stats: bool,
+    /// Connection to the voice daemon. When present, speak/listen/converse
+    /// are delegated to the daemon instead of running locally.
+    daemon: Option<voice_protocol::client::DaemonClient>,
 }
 
 impl Session {
@@ -192,6 +195,14 @@ enum StdinMsg {
 pub fn run(config: ServerConfig) {
     let (subs, phoneme_overrides) = collect_subs(&config.cli_subs, config.sub_file_path.as_deref());
 
+    // Try to connect to the voice daemon for shared model access
+    let daemon = voice_protocol::client::DaemonClient::connect();
+    if daemon.is_some() {
+        if !QUIET.load(Ordering::Relaxed) {
+            eprintln!("voice mcp: connected to voiced daemon");
+        }
+    }
+
     let mut voice_cache = HashMap::new();
     voice_cache.insert(config.voice_name.clone(), config.voice.clone());
 
@@ -208,6 +219,7 @@ pub fn run(config: ServerConfig) {
         stt_model: None,
         warm_mic: None,
         mem_stats: config.mem_stats,
+        daemon,
     };
 
     // Note: Metal memory management is handled by candle's Metal backend.
@@ -498,6 +510,54 @@ fn handle_tools_call(
 ) -> Response {
     let name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
+
+    // Delegate to the voice daemon if connected (speak/listen/converse/cancel).
+    // The daemon queues requests and owns the audio hardware.
+    if let Some(ref mut daemon) = session.daemon {
+        let daemon_result = match name {
+            "speak" => Some(daemon.speak(
+                arguments.get("text").and_then(|v| v.as_str()).unwrap_or(""),
+                arguments.get("voice").and_then(|v| v.as_str()),
+                arguments.get("speed").and_then(|v| v.as_f64()),
+            )),
+            "listen" => {
+                Some(daemon.listen(arguments.get("max_duration_ms").and_then(|v| v.as_u64())))
+            }
+            "converse" => Some(daemon.converse(
+                arguments.get("text").and_then(|v| v.as_str()).unwrap_or(""),
+                arguments.get("voice").and_then(|v| v.as_str()),
+            )),
+            "cancel" => Some(daemon.cancel()),
+            _ => None,
+        };
+
+        if let Some(result) = daemon_result {
+            return match result {
+                Ok(resp) => {
+                    let text = if let Some(r) = resp.result {
+                        serde_json::to_string(&r).unwrap_or_default()
+                    } else if let Some(e) = resp.error {
+                        format!("daemon error: {}", e.message)
+                    } else {
+                        "{}".to_string()
+                    };
+                    Response::success(
+                        id,
+                        serde_json::json!({
+                            "content": [{ "type": "text", "text": text }]
+                        }),
+                    )
+                }
+                Err(e) => {
+                    // Daemon connection failed — drop it and fall through to local
+                    eprintln!("voice mcp: daemon error: {}, falling back to local", e);
+                    session.daemon = None;
+                    // Re-dispatch locally below
+                    handle_tools_call(session, stdout, params, id)
+                }
+            };
+        }
+    }
 
     let mut result = match name {
         "speak" => voice_speak(session, stdout, arguments),

--- a/crates/voice-cli/src/mcp.rs
+++ b/crates/voice-cli/src/mcp.rs
@@ -197,10 +197,8 @@ pub fn run(config: ServerConfig) {
 
     // Try to connect to the voice daemon for shared model access
     let daemon = voice_protocol::client::DaemonClient::connect();
-    if daemon.is_some() {
-        if !QUIET.load(Ordering::Relaxed) {
-            eprintln!("voice mcp: connected to voiced daemon");
-        }
+    if daemon.is_some() && !QUIET.load(Ordering::Relaxed) {
+        eprintln!("voice mcp: connected to voiced daemon");
     }
 
     let mut voice_cache = HashMap::new();

--- a/crates/voice-cli/src/mcp.rs
+++ b/crates/voice-cli/src/mcp.rs
@@ -513,18 +513,31 @@ fn handle_tools_call(
     // The daemon queues requests and owns the audio hardware.
     if let Some(ref mut daemon) = session.daemon {
         let daemon_result = match name {
-            "speak" => Some(daemon.speak(
-                arguments.get("text").and_then(|v| v.as_str()).unwrap_or(""),
-                arguments.get("voice").and_then(|v| v.as_str()),
-                arguments.get("speed").and_then(|v| v.as_f64()),
-            )),
+            "speak" => {
+                let raw = arguments.get("text").and_then(|v| v.as_str()).unwrap_or("");
+                let markdown = arguments
+                    .get("markdown")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let text = preprocess_for_daemon(raw, markdown, &session.subs);
+                Some(daemon.speak(
+                    &text,
+                    arguments.get("voice").and_then(|v| v.as_str()),
+                    arguments.get("speed").and_then(|v| v.as_f64()),
+                ))
+            }
             "listen" => {
                 Some(daemon.listen(arguments.get("max_duration_ms").and_then(|v| v.as_u64())))
             }
-            "converse" => Some(daemon.converse(
-                arguments.get("text").and_then(|v| v.as_str()).unwrap_or(""),
-                arguments.get("voice").and_then(|v| v.as_str()),
-            )),
+            "converse" => {
+                let raw = arguments.get("text").and_then(|v| v.as_str()).unwrap_or("");
+                let markdown = arguments
+                    .get("markdown")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let text = preprocess_for_daemon(raw, markdown, &session.subs);
+                Some(daemon.converse(&text, arguments.get("voice").and_then(|v| v.as_str())))
+            }
             "cancel" => Some(daemon.cancel()),
             _ => None,
         };
@@ -1069,6 +1082,22 @@ fn voice_play_sound(params: Value) -> Result<Value, RpcErr> {
 }
 
 // ── Audio playback ────────────────────────────────────────────────────
+
+/// Apply the same text preprocessing the local TTS path uses, so the daemon
+/// gets clean text even though it doesn't know about our subs config.
+fn preprocess_for_daemon(raw: &str, markdown: bool, subs: &[(String, String)]) -> String {
+    let text = if markdown {
+        strip_markdown(raw)
+    } else {
+        raw.to_string()
+    };
+    let text = apply_tech_subs(&text);
+    if subs.is_empty() {
+        text
+    } else {
+        apply_substitutions(&text, subs)
+    }
+}
 
 fn stream_chunks(
     session: &mut Session,

--- a/crates/voice-daemon/Cargo.toml
+++ b/crates/voice-daemon/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "voice-daemon"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.85.0"
+description = "Voice daemon: queues TTS/STT requests from multiple clients"
+license = "MIT"
+repository = "https://github.com/rgbkrk/voice"
+
+[[bin]]
+name = "voiced"
+path = "src/main.rs"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { version = "1", features = ["v4"] }
+dirs = "6"

--- a/crates/voice-daemon/Cargo.toml
+++ b/crates/voice-daemon/Cargo.toml
@@ -19,6 +19,8 @@ uuid = { version = "1", features = ["v4"] }
 dirs = "6"
 voice-protocol = { path = "../voice-protocol" }
 voice-tts = { path = "../voice-tts" }
+voice-stt = { path = "../voice-stt" }
 voice-g2p = { path = "../voice-g2p" }
 candle-core = { workspace = true }
 rodio = { version = "0.22", features = ["experimental"] }
+hound = { workspace = true }

--- a/crates/voice-daemon/Cargo.toml
+++ b/crates/voice-daemon/Cargo.toml
@@ -18,3 +18,7 @@ serde_json = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"
 voice-protocol = { path = "../voice-protocol" }
+voice-tts = { path = "../voice-tts" }
+voice-g2p = { path = "../voice-g2p" }
+candle-core = { workspace = true }
+rodio = { version = "0.22", features = ["experimental"] }

--- a/crates/voice-daemon/Cargo.toml
+++ b/crates/voice-daemon/Cargo.toml
@@ -17,3 +17,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"
+voice-protocol = { path = "../voice-protocol" }

--- a/crates/voice-daemon/src/main.rs
+++ b/crates/voice-daemon/src/main.rs
@@ -13,6 +13,8 @@ mod worker;
 
 use queue::RequestQueue;
 use std::sync::Arc;
+use voice_protocol::frames::{read_frame, write_frame, Frame, FrameType};
+use voice_protocol::rpc;
 
 #[tokio::main]
 async fn main() {
@@ -28,7 +30,6 @@ async fn main() {
     // Check if another instance is already running
     let sock_path = socket::socket_path();
     if sock_path.exists() {
-        // Try connecting — if it works, another daemon is running
         if tokio::net::UnixStream::connect(&sock_path).await.is_ok() {
             eprintln!(
                 "voiced: another instance is already running at {}",
@@ -37,7 +38,6 @@ async fn main() {
             eprintln!("voiced: use `voiced --status` to check state");
             std::process::exit(1);
         }
-        // Stale socket, remove it
         eprintln!("voiced: removing stale socket");
         std::fs::remove_file(&sock_path).ok();
     }
@@ -45,13 +45,13 @@ async fn main() {
     let queue = Arc::new(RequestQueue::new());
 
     // Handle ctrl-c
-    let cleanup_queue = queue.clone();
-    tokio::spawn(async move {
-        tokio::signal::ctrl_c().await.ok();
-        eprintln!("\nvoiced: shutting down");
-        let _ = cleanup_queue; // keep alive
-        socket::cleanup();
-        std::process::exit(0);
+    tokio::spawn({
+        async move {
+            tokio::signal::ctrl_c().await.ok();
+            eprintln!("\nvoiced: shutting down");
+            socket::cleanup();
+            std::process::exit(0);
+        }
     });
 
     // Start worker and socket server concurrently
@@ -72,18 +72,29 @@ async fn print_status() {
 
     match tokio::net::UnixStream::connect(&path).await {
         Ok(stream) => {
-            use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-            let (reader, mut writer) = stream.into_split();
-            let req = r#"{"type":"status"}"#;
-            writer.write_all(format!("{}\n", req).as_bytes()).await.ok();
-            let mut lines = BufReader::new(reader).lines();
-            if let Ok(Some(line)) = lines.next_line().await {
-                // Pretty-print the JSON
-                if let Ok(val) = serde_json::from_str::<serde_json::Value>(&line) {
-                    println!("{}", serde_json::to_string_pretty(&val).unwrap());
-                } else {
-                    println!("{}", line);
+            let (mut reader, mut writer) = stream.into_split();
+
+            // Send a status request using the frame protocol
+            let req = rpc::Request::new("status", serde_json::json!({})).with_id(1);
+            let json = serde_json::to_vec(&req).unwrap();
+            let frame = Frame::request(&json);
+            if write_frame(&mut writer, &frame).await.is_err() {
+                println!("voiced: failed to send status request");
+                return;
+            }
+
+            // Read the response frame
+            match read_frame(&mut reader).await {
+                Ok(Some(frame)) if frame.frame_type == FrameType::Response => {
+                    if let Ok(resp) = frame.json::<rpc::Response>() {
+                        if let Some(result) = resp.result {
+                            println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                        } else if let Some(err) = resp.error {
+                            println!("Error: {}", err.message);
+                        }
+                    }
                 }
+                _ => println!("voiced: unexpected response"),
             }
         }
         Err(_) => {

--- a/crates/voice-daemon/src/main.rs
+++ b/crates/voice-daemon/src/main.rs
@@ -1,0 +1,96 @@
+//! voiced — the voice daemon.
+//!
+//! Listens on ~/.voice/daemon.sock for TTS/STT requests and processes
+//! them sequentially so multiple MCP clients never overlap audio.
+//!
+//! Usage:
+//!   voiced              # start the daemon
+//!   voiced --status     # print daemon state and exit
+
+mod queue;
+mod socket;
+mod worker;
+
+use queue::RequestQueue;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.iter().any(|a| a == "--status") {
+        print_status().await;
+        return;
+    }
+
+    eprintln!("voiced: starting voice daemon");
+
+    // Check if another instance is already running
+    let sock_path = socket::socket_path();
+    if sock_path.exists() {
+        // Try connecting — if it works, another daemon is running
+        if tokio::net::UnixStream::connect(&sock_path).await.is_ok() {
+            eprintln!(
+                "voiced: another instance is already running at {}",
+                sock_path.display()
+            );
+            eprintln!("voiced: use `voiced --status` to check state");
+            std::process::exit(1);
+        }
+        // Stale socket, remove it
+        eprintln!("voiced: removing stale socket");
+        std::fs::remove_file(&sock_path).ok();
+    }
+
+    let queue = Arc::new(RequestQueue::new());
+
+    // Handle ctrl-c
+    let cleanup_queue = queue.clone();
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.ok();
+        eprintln!("\nvoiced: shutting down");
+        let _ = cleanup_queue; // keep alive
+        socket::cleanup();
+        std::process::exit(0);
+    });
+
+    // Start worker and socket server concurrently
+    let worker_queue = queue.clone();
+    tokio::spawn(async move {
+        worker::run(worker_queue).await;
+    });
+
+    socket::serve(queue).await;
+}
+
+async fn print_status() {
+    let path = socket::socket_path();
+    if !path.exists() {
+        println!("voiced: not running (no socket at {})", path.display());
+        return;
+    }
+
+    match tokio::net::UnixStream::connect(&path).await {
+        Ok(stream) => {
+            use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+            let (reader, mut writer) = stream.into_split();
+            let req = r#"{"type":"status"}"#;
+            writer.write_all(format!("{}\n", req).as_bytes()).await.ok();
+            let mut lines = BufReader::new(reader).lines();
+            if let Ok(Some(line)) = lines.next_line().await {
+                // Pretty-print the JSON
+                if let Ok(val) = serde_json::from_str::<serde_json::Value>(&line) {
+                    println!("{}", serde_json::to_string_pretty(&val).unwrap());
+                } else {
+                    println!("{}", line);
+                }
+            }
+        }
+        Err(_) => {
+            println!(
+                "voiced: not responding (stale socket at {})",
+                path.display()
+            );
+        }
+    }
+}

--- a/crates/voice-daemon/src/queue.rs
+++ b/crates/voice-daemon/src/queue.rs
@@ -1,0 +1,174 @@
+//! Request queue for serializing voice operations.
+//!
+//! All TTS/STT requests go through this queue so only one operation
+//! runs at a time, preventing audio overlap between multiple clients.
+
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use tokio::sync::{Mutex, Notify};
+use uuid::Uuid;
+
+/// A voice request from a client.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum VoiceRequest {
+    #[serde(rename = "speak")]
+    Speak {
+        text: String,
+        voice: Option<String>,
+        speed: Option<f64>,
+    },
+    #[serde(rename = "listen")]
+    Listen { max_duration_ms: Option<u64> },
+    #[serde(rename = "converse")]
+    Converse { text: String, voice: Option<String> },
+    #[serde(rename = "cancel")]
+    Cancel,
+    #[serde(rename = "status")]
+    Status,
+}
+
+/// Status of a queued item.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ItemStatus {
+    Queued,
+    Processing,
+    Completed,
+    Cancelled,
+    Failed,
+}
+
+/// A single item in the queue with metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueueItem {
+    pub id: String,
+    pub client_id: String,
+    pub request: VoiceRequest,
+    pub status: ItemStatus,
+    pub created_at: u64,
+    pub result: Option<String>,
+}
+
+/// Snapshot of daemon state, serializable for any viewer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonState {
+    pub status: String,
+    pub current: Option<QueueItem>,
+    pub pending: Vec<QueueItem>,
+    pub recent: Vec<QueueItem>,
+}
+
+/// Manages the request queue and notifies the worker when items arrive.
+pub struct RequestQueue {
+    pub items: Mutex<VecDeque<QueueItem>>,
+    pub current: Mutex<Option<QueueItem>>,
+    pub recent: Mutex<VecDeque<QueueItem>>,
+    pub notify: Notify,
+}
+
+impl RequestQueue {
+    pub fn new() -> Self {
+        Self {
+            items: Mutex::new(VecDeque::new()),
+            current: Mutex::new(None),
+            recent: Mutex::new(VecDeque::new()),
+            notify: Notify::new(),
+        }
+    }
+
+    /// Add a request to the queue. Returns the queue item ID.
+    pub async fn enqueue(&self, client_id: String, request: VoiceRequest) -> String {
+        let id = Uuid::new_v4().to_string()[..8].to_string();
+        let item = QueueItem {
+            id: id.clone(),
+            client_id,
+            request,
+            status: ItemStatus::Queued,
+            created_at: now_secs(),
+            result: None,
+        };
+        self.items.lock().await.push_back(item);
+        self.notify.notify_one();
+        id
+    }
+
+    /// Take the next pending item for processing.
+    pub async fn dequeue(&self) -> Option<QueueItem> {
+        let mut items = self.items.lock().await;
+        if let Some(mut item) = items.pop_front() {
+            item.status = ItemStatus::Processing;
+            *self.current.lock().await = Some(item.clone());
+            Some(item)
+        } else {
+            None
+        }
+    }
+
+    /// Mark the current item as completed.
+    pub async fn complete(&self, result: Option<String>) {
+        if let Some(mut item) = self.current.lock().await.take() {
+            item.status = ItemStatus::Completed;
+            item.result = result;
+            self.push_recent(item).await;
+        }
+    }
+
+    /// Mark the current item as failed.
+    #[allow(dead_code)]
+    pub async fn fail(&self, error: String) {
+        if let Some(mut item) = self.current.lock().await.take() {
+            item.status = ItemStatus::Failed;
+            item.result = Some(error);
+            self.push_recent(item).await;
+        }
+    }
+
+    /// Cancel all pending items from a client. Returns count cancelled.
+    pub async fn cancel_client(&self, client_id: &str) -> usize {
+        let mut items = self.items.lock().await;
+        let before = items.len();
+        items.retain(|item| item.client_id != client_id);
+        before - items.len()
+    }
+
+    /// Get a snapshot of the full daemon state.
+    pub async fn snapshot(&self) -> DaemonState {
+        let current = self.current.lock().await.clone();
+        let pending: Vec<QueueItem> = self.items.lock().await.iter().cloned().collect();
+        let recent: Vec<QueueItem> = self.recent.lock().await.iter().cloned().collect();
+
+        let status = match &current {
+            Some(item) => match &item.request {
+                VoiceRequest::Speak { .. } => "speaking",
+                VoiceRequest::Listen { .. } => "listening",
+                VoiceRequest::Converse { .. } => "conversing",
+                _ => "idle",
+            },
+            None if !pending.is_empty() => "queued",
+            None => "idle",
+        };
+
+        DaemonState {
+            status: status.to_string(),
+            current,
+            pending,
+            recent,
+        }
+    }
+
+    async fn push_recent(&self, item: QueueItem) {
+        let mut recent = self.recent.lock().await;
+        recent.push_front(item);
+        if recent.len() > 20 {
+            recent.pop_back();
+        }
+    }
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}

--- a/crates/voice-daemon/src/queue.rs
+++ b/crates/voice-daemon/src/queue.rs
@@ -8,9 +8,9 @@ use std::collections::VecDeque;
 use tokio::sync::{Mutex, Notify};
 use uuid::Uuid;
 
-/// A voice request from a client.
+/// A voice request — what the worker will execute.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type")]
+#[serde(tag = "method")]
 pub enum VoiceRequest {
     #[serde(rename = "speak")]
     Speak {
@@ -22,10 +22,6 @@ pub enum VoiceRequest {
     Listen { max_duration_ms: Option<u64> },
     #[serde(rename = "converse")]
     Converse { text: String, voice: Option<String> },
-    #[serde(rename = "cancel")]
-    Cancel,
-    #[serde(rename = "status")]
-    Status,
 }
 
 /// Status of a queued item.
@@ -35,7 +31,6 @@ pub enum ItemStatus {
     Queued,
     Processing,
     Completed,
-    Cancelled,
     Failed,
 }
 
@@ -50,7 +45,7 @@ pub struct QueueItem {
     pub result: Option<String>,
 }
 
-/// Snapshot of daemon state, serializable for any viewer.
+/// Snapshot of daemon state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DaemonState {
     pub status: String,
@@ -59,11 +54,10 @@ pub struct DaemonState {
     pub recent: Vec<QueueItem>,
 }
 
-/// Manages the request queue and notifies the worker when items arrive.
 pub struct RequestQueue {
-    pub items: Mutex<VecDeque<QueueItem>>,
-    pub current: Mutex<Option<QueueItem>>,
-    pub recent: Mutex<VecDeque<QueueItem>>,
+    items: Mutex<VecDeque<QueueItem>>,
+    current: Mutex<Option<QueueItem>>,
+    recent: Mutex<VecDeque<QueueItem>>,
     pub notify: Notify,
 }
 
@@ -77,8 +71,37 @@ impl RequestQueue {
         }
     }
 
-    /// Add a request to the queue. Returns the queue item ID.
-    pub async fn enqueue(&self, client_id: String, request: VoiceRequest) -> String {
+    // -- Typed enqueue methods ------------------------------------------------
+
+    pub async fn enqueue_speak(
+        &self,
+        client_id: String,
+        text: String,
+        voice: Option<String>,
+        speed: Option<f64>,
+    ) -> String {
+        self.enqueue(client_id, VoiceRequest::Speak { text, voice, speed })
+            .await
+    }
+
+    pub async fn enqueue_listen(&self, client_id: String, max_duration_ms: Option<u64>) -> String {
+        self.enqueue(client_id, VoiceRequest::Listen { max_duration_ms })
+            .await
+    }
+
+    pub async fn enqueue_converse(
+        &self,
+        client_id: String,
+        text: String,
+        voice: Option<String>,
+    ) -> String {
+        self.enqueue(client_id, VoiceRequest::Converse { text, voice })
+            .await
+    }
+
+    // -- Core queue operations ------------------------------------------------
+
+    async fn enqueue(&self, client_id: String, request: VoiceRequest) -> String {
         let id = Uuid::new_v4().to_string()[..8].to_string();
         let item = QueueItem {
             id: id.clone(),
@@ -93,7 +116,6 @@ impl RequestQueue {
         id
     }
 
-    /// Take the next pending item for processing.
     pub async fn dequeue(&self) -> Option<QueueItem> {
         let mut items = self.items.lock().await;
         if let Some(mut item) = items.pop_front() {
@@ -105,7 +127,6 @@ impl RequestQueue {
         }
     }
 
-    /// Mark the current item as completed.
     pub async fn complete(&self, result: Option<String>) {
         if let Some(mut item) = self.current.lock().await.take() {
             item.status = ItemStatus::Completed;
@@ -114,7 +135,6 @@ impl RequestQueue {
         }
     }
 
-    /// Mark the current item as failed.
     #[allow(dead_code)]
     pub async fn fail(&self, error: String) {
         if let Some(mut item) = self.current.lock().await.take() {
@@ -124,7 +144,6 @@ impl RequestQueue {
         }
     }
 
-    /// Cancel all pending items from a client. Returns count cancelled.
     pub async fn cancel_client(&self, client_id: &str) -> usize {
         let mut items = self.items.lock().await;
         let before = items.len();
@@ -132,7 +151,6 @@ impl RequestQueue {
         before - items.len()
     }
 
-    /// Get a snapshot of the full daemon state.
     pub async fn snapshot(&self) -> DaemonState {
         let current = self.current.lock().await.clone();
         let pending: Vec<QueueItem> = self.items.lock().await.iter().cloned().collect();
@@ -143,7 +161,6 @@ impl RequestQueue {
                 VoiceRequest::Speak { .. } => "speaking",
                 VoiceRequest::Listen { .. } => "listening",
                 VoiceRequest::Converse { .. } => "conversing",
-                _ => "idle",
             },
             None if !pending.is_empty() => "queued",
             None => "idle",

--- a/crates/voice-daemon/src/queue.rs
+++ b/crates/voice-daemon/src/queue.rs
@@ -135,12 +135,31 @@ impl RequestQueue {
         id
     }
 
-    /// Register a waiter for a queue item. Returns a receiver that fires
-    /// when the item completes (or fails).
-    pub async fn wait_for(&self, queue_id: &str) -> oneshot::Receiver<CompletionResult> {
+    /// Enqueue and atomically register a waiter. The waiter is registered
+    /// *before* the item is pushed so the worker can never complete it
+    /// before we start listening. Returns (queue_id, receiver).
+    pub async fn enqueue_and_wait(
+        &self,
+        client_id: String,
+        request: VoiceRequest,
+    ) -> (String, oneshot::Receiver<CompletionResult>) {
+        let id = Uuid::new_v4().to_string()[..8].to_string();
         let (tx, rx) = oneshot::channel();
-        self.waiters.lock().await.insert(queue_id.to_string(), tx);
-        rx
+
+        // Register waiter first, then push
+        self.waiters.lock().await.insert(id.clone(), tx);
+
+        let entry = QueueEntry {
+            id: id.clone(),
+            client_id,
+            request,
+            status: ItemStatus::Queued,
+            created_at: now_secs(),
+            result: None,
+        };
+        self.items.lock().await.push_back(entry);
+        self.notify.notify_one();
+        (id, rx)
     }
 
     pub async fn dequeue(&self) -> Option<QueueEntry> {

--- a/crates/voice-daemon/src/queue.rs
+++ b/crates/voice-daemon/src/queue.rs
@@ -1,7 +1,7 @@
 //! Request queue for serializing voice operations.
 
-use std::collections::VecDeque;
-use tokio::sync::{Mutex, Notify};
+use std::collections::{HashMap, VecDeque};
+use tokio::sync::{oneshot, Mutex, Notify};
 use uuid::Uuid;
 use voice_protocol::rpc::{DaemonState, ItemStatus, QueueItem};
 
@@ -42,7 +42,7 @@ impl VoiceRequest {
     }
 }
 
-/// Internal queue entry (richer than the protocol QueueItem).
+/// Internal queue entry.
 #[derive(Debug, Clone)]
 pub struct QueueEntry {
     pub id: String,
@@ -54,7 +54,6 @@ pub struct QueueEntry {
 }
 
 impl QueueEntry {
-    /// Convert to the protocol's QueueItem for serialization.
     fn to_protocol(&self) -> QueueItem {
         QueueItem {
             id: self.id.clone(),
@@ -68,10 +67,19 @@ impl QueueEntry {
     }
 }
 
+/// Result sent through the completion channel.
+#[derive(Debug, Clone)]
+pub struct CompletionResult {
+    pub status: ItemStatus,
+    pub result: Option<String>,
+}
+
 pub struct RequestQueue {
     items: Mutex<VecDeque<QueueEntry>>,
     current: Mutex<Option<QueueEntry>>,
     recent: Mutex<VecDeque<QueueEntry>>,
+    /// Completion channels: queue_id → sender. Signaled when an item finishes.
+    waiters: Mutex<HashMap<String, oneshot::Sender<CompletionResult>>>,
     pub notify: Notify,
 }
 
@@ -81,6 +89,7 @@ impl RequestQueue {
             items: Mutex::new(VecDeque::new()),
             current: Mutex::new(None),
             recent: Mutex::new(VecDeque::new()),
+            waiters: Mutex::new(HashMap::new()),
             notify: Notify::new(),
         }
     }
@@ -126,6 +135,14 @@ impl RequestQueue {
         id
     }
 
+    /// Register a waiter for a queue item. Returns a receiver that fires
+    /// when the item completes (or fails).
+    pub async fn wait_for(&self, queue_id: &str) -> oneshot::Receiver<CompletionResult> {
+        let (tx, rx) = oneshot::channel();
+        self.waiters.lock().await.insert(queue_id.to_string(), tx);
+        rx
+    }
+
     pub async fn dequeue(&self) -> Option<QueueEntry> {
         let mut items = self.items.lock().await;
         if let Some(mut entry) = items.pop_front() {
@@ -139,18 +156,35 @@ impl RequestQueue {
 
     pub async fn complete(&self, result: Option<String>) {
         if let Some(mut entry) = self.current.lock().await.take() {
+            let id = entry.id.clone();
             entry.status = ItemStatus::Completed;
-            entry.result = result;
+            entry.result = result.clone();
             self.push_recent(entry).await;
+            self.signal_waiter(
+                &id,
+                CompletionResult {
+                    status: ItemStatus::Completed,
+                    result,
+                },
+            )
+            .await;
         }
     }
 
-    #[allow(dead_code)]
     pub async fn fail(&self, error: String) {
         if let Some(mut entry) = self.current.lock().await.take() {
+            let id = entry.id.clone();
             entry.status = ItemStatus::Failed;
-            entry.result = Some(error);
+            entry.result = Some(error.clone());
             self.push_recent(entry).await;
+            self.signal_waiter(
+                &id,
+                CompletionResult {
+                    status: ItemStatus::Failed,
+                    result: Some(error),
+                },
+            )
+            .await;
         }
     }
 
@@ -161,7 +195,6 @@ impl RequestQueue {
         before - items.len()
     }
 
-    /// Snapshot using the shared protocol types.
     pub async fn snapshot(&self) -> DaemonState {
         let current = self.current.lock().await.as_ref().map(|e| e.to_protocol());
         let pending: Vec<QueueItem> = self
@@ -203,6 +236,12 @@ impl RequestQueue {
         recent.push_front(entry);
         if recent.len() > 20 {
             recent.pop_back();
+        }
+    }
+
+    async fn signal_waiter(&self, id: &str, result: CompletionResult) {
+        if let Some(tx) = self.waiters.lock().await.remove(id) {
+            let _ = tx.send(result);
         }
     }
 }

--- a/crates/voice-daemon/src/queue.rs
+++ b/crates/voice-daemon/src/queue.rs
@@ -1,42 +1,50 @@
 //! Request queue for serializing voice operations.
-//!
-//! All TTS/STT requests go through this queue so only one operation
-//! runs at a time, preventing audio overlap between multiple clients.
 
-use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use tokio::sync::{Mutex, Notify};
 use uuid::Uuid;
+use voice_protocol::rpc::{DaemonState, ItemStatus, QueueItem};
 
-/// A voice request — what the worker will execute.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "method")]
+/// What the worker will execute.
+#[derive(Debug, Clone)]
 pub enum VoiceRequest {
-    #[serde(rename = "speak")]
     Speak {
         text: String,
         voice: Option<String>,
         speed: Option<f64>,
     },
-    #[serde(rename = "listen")]
-    Listen { max_duration_ms: Option<u64> },
-    #[serde(rename = "converse")]
-    Converse { text: String, voice: Option<String> },
+    Listen {
+        max_duration_ms: Option<u64>,
+    },
+    Converse {
+        text: String,
+        voice: Option<String>,
+    },
 }
 
-/// Status of a queued item.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
-pub enum ItemStatus {
-    Queued,
-    Processing,
-    Completed,
-    Failed,
+impl VoiceRequest {
+    pub fn method(&self) -> &str {
+        match self {
+            Self::Speak { .. } => "speak",
+            Self::Listen { .. } => "listen",
+            Self::Converse { .. } => "converse",
+        }
+    }
+
+    pub fn text_preview(&self) -> Option<String> {
+        match self {
+            Self::Speak { text, .. } | Self::Converse { text, .. } => {
+                let preview: String = text.chars().take(80).collect();
+                Some(preview)
+            }
+            Self::Listen { .. } => None,
+        }
+    }
 }
 
-/// A single item in the queue with metadata.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct QueueItem {
+/// Internal queue entry (richer than the protocol QueueItem).
+#[derive(Debug, Clone)]
+pub struct QueueEntry {
     pub id: String,
     pub client_id: String,
     pub request: VoiceRequest,
@@ -45,19 +53,25 @@ pub struct QueueItem {
     pub result: Option<String>,
 }
 
-/// Snapshot of daemon state.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DaemonState {
-    pub status: String,
-    pub current: Option<QueueItem>,
-    pub pending: Vec<QueueItem>,
-    pub recent: Vec<QueueItem>,
+impl QueueEntry {
+    /// Convert to the protocol's QueueItem for serialization.
+    fn to_protocol(&self) -> QueueItem {
+        QueueItem {
+            id: self.id.clone(),
+            client_id: self.client_id.clone(),
+            method: self.request.method().to_string(),
+            status: self.status.clone(),
+            created_at: self.created_at,
+            text_preview: self.request.text_preview(),
+            result: self.result.clone(),
+        }
+    }
 }
 
 pub struct RequestQueue {
-    items: Mutex<VecDeque<QueueItem>>,
-    current: Mutex<Option<QueueItem>>,
-    recent: Mutex<VecDeque<QueueItem>>,
+    items: Mutex<VecDeque<QueueEntry>>,
+    current: Mutex<Option<QueueEntry>>,
+    recent: Mutex<VecDeque<QueueEntry>>,
     pub notify: Notify,
 }
 
@@ -70,8 +84,6 @@ impl RequestQueue {
             notify: Notify::new(),
         }
     }
-
-    // -- Typed enqueue methods ------------------------------------------------
 
     pub async fn enqueue_speak(
         &self,
@@ -99,11 +111,9 @@ impl RequestQueue {
             .await
     }
 
-    // -- Core queue operations ------------------------------------------------
-
     async fn enqueue(&self, client_id: String, request: VoiceRequest) -> String {
         let id = Uuid::new_v4().to_string()[..8].to_string();
-        let item = QueueItem {
+        let entry = QueueEntry {
             id: id.clone(),
             client_id,
             request,
@@ -111,56 +121,70 @@ impl RequestQueue {
             created_at: now_secs(),
             result: None,
         };
-        self.items.lock().await.push_back(item);
+        self.items.lock().await.push_back(entry);
         self.notify.notify_one();
         id
     }
 
-    pub async fn dequeue(&self) -> Option<QueueItem> {
+    pub async fn dequeue(&self) -> Option<QueueEntry> {
         let mut items = self.items.lock().await;
-        if let Some(mut item) = items.pop_front() {
-            item.status = ItemStatus::Processing;
-            *self.current.lock().await = Some(item.clone());
-            Some(item)
+        if let Some(mut entry) = items.pop_front() {
+            entry.status = ItemStatus::Processing;
+            *self.current.lock().await = Some(entry.clone());
+            Some(entry)
         } else {
             None
         }
     }
 
     pub async fn complete(&self, result: Option<String>) {
-        if let Some(mut item) = self.current.lock().await.take() {
-            item.status = ItemStatus::Completed;
-            item.result = result;
-            self.push_recent(item).await;
+        if let Some(mut entry) = self.current.lock().await.take() {
+            entry.status = ItemStatus::Completed;
+            entry.result = result;
+            self.push_recent(entry).await;
         }
     }
 
     #[allow(dead_code)]
     pub async fn fail(&self, error: String) {
-        if let Some(mut item) = self.current.lock().await.take() {
-            item.status = ItemStatus::Failed;
-            item.result = Some(error);
-            self.push_recent(item).await;
+        if let Some(mut entry) = self.current.lock().await.take() {
+            entry.status = ItemStatus::Failed;
+            entry.result = Some(error);
+            self.push_recent(entry).await;
         }
     }
 
     pub async fn cancel_client(&self, client_id: &str) -> usize {
         let mut items = self.items.lock().await;
         let before = items.len();
-        items.retain(|item| item.client_id != client_id);
+        items.retain(|e| e.client_id != client_id);
         before - items.len()
     }
 
+    /// Snapshot using the shared protocol types.
     pub async fn snapshot(&self) -> DaemonState {
-        let current = self.current.lock().await.clone();
-        let pending: Vec<QueueItem> = self.items.lock().await.iter().cloned().collect();
-        let recent: Vec<QueueItem> = self.recent.lock().await.iter().cloned().collect();
+        let current = self.current.lock().await.as_ref().map(|e| e.to_protocol());
+        let pending: Vec<QueueItem> = self
+            .items
+            .lock()
+            .await
+            .iter()
+            .map(|e| e.to_protocol())
+            .collect();
+        let recent: Vec<QueueItem> = self
+            .recent
+            .lock()
+            .await
+            .iter()
+            .map(|e| e.to_protocol())
+            .collect();
 
         let status = match &current {
-            Some(item) => match &item.request {
-                VoiceRequest::Speak { .. } => "speaking",
-                VoiceRequest::Listen { .. } => "listening",
-                VoiceRequest::Converse { .. } => "conversing",
+            Some(item) => match item.method.as_str() {
+                "speak" => "speaking",
+                "listen" => "listening",
+                "converse" => "conversing",
+                _ => "idle",
             },
             None if !pending.is_empty() => "queued",
             None => "idle",
@@ -174,9 +198,9 @@ impl RequestQueue {
         }
     }
 
-    async fn push_recent(&self, item: QueueItem) {
+    async fn push_recent(&self, entry: QueueEntry) {
         let mut recent = self.recent.lock().await;
-        recent.push_front(item);
+        recent.push_front(entry);
         if recent.len() > 20 {
             recent.pop_back();
         }

--- a/crates/voice-daemon/src/socket.rs
+++ b/crates/voice-daemon/src/socket.rs
@@ -96,7 +96,14 @@ async fn handle_client(
 }
 
 async fn dispatch(req: rpc::Request, queue: &Arc<RequestQueue>, client_id: &str) -> Response {
-    match req.method.as_str() {
+    let wait = req
+        .params
+        .get("wait")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    // Enqueue the request
+    let queue_id = match req.method.as_str() {
         "speak" => {
             let text = req.params.get("text").and_then(|v| v.as_str());
             let Some(text) = text else {
@@ -108,26 +115,19 @@ async fn dispatch(req: rpc::Request, queue: &Arc<RequestQueue>, client_id: &str)
                 .and_then(|v| v.as_str())
                 .map(String::from);
             let speed = req.params.get("speed").and_then(|v| v.as_f64());
-
-            let queue_id = queue
-                .enqueue_speak(client_id.to_string(), text.to_string(), voice, speed)
-                .await;
-
-            Response::success(
-                req.id,
-                serde_json::json!({ "queue_id": queue_id, "status": "queued" }),
+            Some(
+                queue
+                    .enqueue_speak(client_id.to_string(), text.to_string(), voice, speed)
+                    .await,
             )
         }
 
         "listen" => {
             let max_duration_ms = req.params.get("max_duration_ms").and_then(|v| v.as_u64());
-            let queue_id = queue
-                .enqueue_listen(client_id.to_string(), max_duration_ms)
-                .await;
-
-            Response::success(
-                req.id,
-                serde_json::json!({ "queue_id": queue_id, "status": "queued" }),
+            Some(
+                queue
+                    .enqueue_listen(client_id.to_string(), max_duration_ms)
+                    .await,
             )
         }
 
@@ -141,32 +141,56 @@ async fn dispatch(req: rpc::Request, queue: &Arc<RequestQueue>, client_id: &str)
                 .get("voice")
                 .and_then(|v| v.as_str())
                 .map(String::from);
-
-            let queue_id = queue
-                .enqueue_converse(client_id.to_string(), text.to_string(), voice)
-                .await;
-
-            Response::success(
-                req.id,
-                serde_json::json!({ "queue_id": queue_id, "status": "queued" }),
+            Some(
+                queue
+                    .enqueue_converse(client_id.to_string(), text.to_string(), voice)
+                    .await,
             )
         }
 
         "cancel" => {
             let count = queue.cancel_client(client_id).await;
-            Response::success(req.id, serde_json::json!({ "cancelled_count": count }))
+            return Response::success(req.id, serde_json::json!({ "cancelled_count": count }));
         }
 
         "status" => {
             let state = queue.snapshot().await;
-            Response::success(req.id, serde_json::to_value(&state).unwrap())
+            return Response::success(req.id, serde_json::to_value(&state).unwrap());
         }
 
-        _ => Response::error(
+        _ => {
+            return Response::error(
+                req.id,
+                rpc::METHOD_NOT_FOUND,
+                format!("Method not found: {}", req.method),
+            );
+        }
+    };
+
+    let Some(queue_id) = queue_id else {
+        return Response::error(req.id, rpc::INVALID_PARAMS, "Failed to enqueue");
+    };
+
+    if !wait {
+        // Fire-and-forget: return immediately with queue ID
+        return Response::success(
             req.id,
-            rpc::METHOD_NOT_FOUND,
-            format!("Method not found: {}", req.method),
+            serde_json::json!({ "queue_id": queue_id, "status": "queued" }),
+        );
+    }
+
+    // Wait for completion: register a waiter and block until the item finishes
+    let rx = queue.wait_for(&queue_id).await;
+    match rx.await {
+        Ok(result) => Response::success(
+            req.id,
+            serde_json::json!({
+                "queue_id": queue_id,
+                "status": result.status,
+                "result": result.result,
+            }),
         ),
+        Err(_) => Response::error(req.id, -32000, "Queue item dropped before completion"),
     }
 }
 

--- a/crates/voice-daemon/src/socket.rs
+++ b/crates/voice-daemon/src/socket.rs
@@ -96,14 +96,16 @@ async fn handle_client(
 }
 
 async fn dispatch(req: rpc::Request, queue: &Arc<RequestQueue>, client_id: &str) -> Response {
+    use crate::queue::VoiceRequest;
+
     let wait = req
         .params
         .get("wait")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    // Enqueue the request
-    let queue_id = match req.method.as_str() {
+    // Build the voice request from params
+    let voice_req = match req.method.as_str() {
         "speak" => {
             let text = req.params.get("text").and_then(|v| v.as_str());
             let Some(text) = text else {
@@ -115,22 +117,16 @@ async fn dispatch(req: rpc::Request, queue: &Arc<RequestQueue>, client_id: &str)
                 .and_then(|v| v.as_str())
                 .map(String::from);
             let speed = req.params.get("speed").and_then(|v| v.as_f64());
-            Some(
-                queue
-                    .enqueue_speak(client_id.to_string(), text.to_string(), voice, speed)
-                    .await,
-            )
+            VoiceRequest::Speak {
+                text: text.to_string(),
+                voice,
+                speed,
+            }
         }
-
         "listen" => {
             let max_duration_ms = req.params.get("max_duration_ms").and_then(|v| v.as_u64());
-            Some(
-                queue
-                    .enqueue_listen(client_id.to_string(), max_duration_ms)
-                    .await,
-            )
+            VoiceRequest::Listen { max_duration_ms }
         }
-
         "converse" => {
             let text = req.params.get("text").and_then(|v| v.as_str());
             let Some(text) = text else {
@@ -141,23 +137,19 @@ async fn dispatch(req: rpc::Request, queue: &Arc<RequestQueue>, client_id: &str)
                 .get("voice")
                 .and_then(|v| v.as_str())
                 .map(String::from);
-            Some(
-                queue
-                    .enqueue_converse(client_id.to_string(), text.to_string(), voice)
-                    .await,
-            )
+            VoiceRequest::Converse {
+                text: text.to_string(),
+                voice,
+            }
         }
-
         "cancel" => {
             let count = queue.cancel_client(client_id).await;
             return Response::success(req.id, serde_json::json!({ "cancelled_count": count }));
         }
-
         "status" => {
             let state = queue.snapshot().await;
             return Response::success(req.id, serde_json::to_value(&state).unwrap());
         }
-
         _ => {
             return Response::error(
                 req.id,
@@ -167,20 +159,36 @@ async fn dispatch(req: rpc::Request, queue: &Arc<RequestQueue>, client_id: &str)
         }
     };
 
-    let Some(queue_id) = queue_id else {
-        return Response::error(req.id, rpc::INVALID_PARAMS, "Failed to enqueue");
-    };
-
     if !wait {
-        // Fire-and-forget: return immediately with queue ID
+        // Fire-and-forget: enqueue and return immediately
+        let queue_id = match voice_req {
+            VoiceRequest::Speak { text, voice, speed } => {
+                queue
+                    .enqueue_speak(client_id.to_string(), text, voice, speed)
+                    .await
+            }
+            VoiceRequest::Listen { max_duration_ms } => {
+                queue
+                    .enqueue_listen(client_id.to_string(), max_duration_ms)
+                    .await
+            }
+            VoiceRequest::Converse { text, voice } => {
+                queue
+                    .enqueue_converse(client_id.to_string(), text, voice)
+                    .await
+            }
+        };
         return Response::success(
             req.id,
             serde_json::json!({ "queue_id": queue_id, "status": "queued" }),
         );
     }
 
-    // Wait for completion: register a waiter and block until the item finishes
-    let rx = queue.wait_for(&queue_id).await;
+    // Wait mode: register waiter atomically with enqueue to prevent race
+    let (queue_id, rx) = queue
+        .enqueue_and_wait(client_id.to_string(), voice_req)
+        .await;
+
     match rx.await {
         Ok(result) => Response::success(
             req.id,

--- a/crates/voice-daemon/src/socket.rs
+++ b/crates/voice-daemon/src/socket.rs
@@ -1,70 +1,15 @@
 //! Unix socket server for the voice daemon.
 //!
-//! Listens on ~/.voice/daemon.sock. Speaks JSON-RPC 2.0 over
-//! newline-delimited streams, consistent with the MCP server protocol.
+//! Uses the voice-protocol frame codec (length-prefixed typed frames)
+//! instead of newline-delimited JSON.
 
 use crate::queue::RequestQueue;
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixListener;
 use uuid::Uuid;
-
-// ---------------------------------------------------------------------------
-// JSON-RPC types
-// ---------------------------------------------------------------------------
-
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)]
-struct JsonRpcRequest {
-    jsonrpc: Option<String>,
-    method: String,
-    #[serde(default)]
-    params: Value,
-    id: Option<Value>,
-}
-
-#[derive(Debug, Serialize)]
-struct JsonRpcResponse {
-    jsonrpc: &'static str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    result: Option<Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    error: Option<JsonRpcError>,
-    id: Option<Value>,
-}
-
-#[derive(Debug, Serialize)]
-struct JsonRpcError {
-    code: i32,
-    message: String,
-}
-
-impl JsonRpcResponse {
-    fn success(id: Option<Value>, result: Value) -> Self {
-        Self {
-            jsonrpc: "2.0",
-            result: Some(result),
-            error: None,
-            id,
-        }
-    }
-
-    fn error(id: Option<Value>, code: i32, message: String) -> Self {
-        Self {
-            jsonrpc: "2.0",
-            result: None,
-            error: Some(JsonRpcError { code, message }),
-            id,
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Socket path
-// ---------------------------------------------------------------------------
+use voice_protocol::frames::{read_frame, write_frame, Frame, FrameType};
+use voice_protocol::rpc::{self, Response};
 
 pub fn socket_path() -> PathBuf {
     let dir = dirs::home_dir()
@@ -73,10 +18,6 @@ pub fn socket_path() -> PathBuf {
     std::fs::create_dir_all(&dir).ok();
     dir.join("daemon.sock")
 }
-
-// ---------------------------------------------------------------------------
-// Server
-// ---------------------------------------------------------------------------
 
 pub async fn serve(queue: Arc<RequestQueue>) {
     let path = socket_path();
@@ -113,51 +54,53 @@ async fn handle_client(
     queue: Arc<RequestQueue>,
     client_id: String,
 ) {
-    let (reader, mut writer) = stream.into_split();
-    let mut lines = BufReader::new(reader).lines();
+    let (mut reader, mut writer) = stream.into_split();
 
-    while let Ok(Some(line)) = lines.next_line().await {
-        let line = line.trim().to_string();
-        if line.is_empty() {
-            continue;
-        }
-
-        let response = match serde_json::from_str::<JsonRpcRequest>(&line) {
-            Ok(req) => dispatch(req, &queue, &client_id).await,
-            Err(e) => JsonRpcResponse::error(None, -32700, format!("Parse error: {}", e)),
+    loop {
+        let frame = match read_frame(&mut reader).await {
+            Ok(Some(f)) => f,
+            Ok(None) => break, // EOF
+            Err(e) => {
+                eprintln!("voiced: read error ({}): {}", client_id, e);
+                break;
+            }
         };
 
-        let json = serde_json::to_string(&response).unwrap();
-        if writer
-            .write_all(format!("{}\n", json).as_bytes())
-            .await
-            .is_err()
-        {
-            break;
+        match frame.frame_type {
+            FrameType::Request => {
+                let response = match frame.json::<rpc::Request>() {
+                    Ok(req) => dispatch(req, &queue, &client_id).await,
+                    Err(e) => Response::error(
+                        None,
+                        rpc::PARSE_ERROR,
+                        format!("Invalid request JSON: {}", e),
+                    ),
+                };
+
+                let json = serde_json::to_vec(&response).unwrap();
+                let resp_frame = Frame::response(&json);
+                if write_frame(&mut writer, &resp_frame).await.is_err() {
+                    break;
+                }
+            }
+            other => {
+                eprintln!(
+                    "voiced: unexpected frame type {:?} from {}",
+                    other, client_id
+                );
+            }
         }
     }
 
     eprintln!("voiced: client disconnected ({})", client_id);
 }
 
-// ---------------------------------------------------------------------------
-// Method dispatch
-// ---------------------------------------------------------------------------
-
-async fn dispatch(
-    req: JsonRpcRequest,
-    queue: &Arc<RequestQueue>,
-    client_id: &str,
-) -> JsonRpcResponse {
+async fn dispatch(req: rpc::Request, queue: &Arc<RequestQueue>, client_id: &str) -> Response {
     match req.method.as_str() {
         "speak" => {
             let text = req.params.get("text").and_then(|v| v.as_str());
             let Some(text) = text else {
-                return JsonRpcResponse::error(
-                    req.id,
-                    -32602,
-                    "Missing required param: text".to_string(),
-                );
+                return Response::error(req.id, rpc::INVALID_PARAMS, "Missing param: text");
             };
             let voice = req
                 .params
@@ -170,7 +113,7 @@ async fn dispatch(
                 .enqueue_speak(client_id.to_string(), text.to_string(), voice, speed)
                 .await;
 
-            JsonRpcResponse::success(
+            Response::success(
                 req.id,
                 serde_json::json!({ "queue_id": queue_id, "status": "queued" }),
             )
@@ -178,12 +121,11 @@ async fn dispatch(
 
         "listen" => {
             let max_duration_ms = req.params.get("max_duration_ms").and_then(|v| v.as_u64());
-
             let queue_id = queue
                 .enqueue_listen(client_id.to_string(), max_duration_ms)
                 .await;
 
-            JsonRpcResponse::success(
+            Response::success(
                 req.id,
                 serde_json::json!({ "queue_id": queue_id, "status": "queued" }),
             )
@@ -192,11 +134,7 @@ async fn dispatch(
         "converse" => {
             let text = req.params.get("text").and_then(|v| v.as_str());
             let Some(text) = text else {
-                return JsonRpcResponse::error(
-                    req.id,
-                    -32602,
-                    "Missing required param: text".to_string(),
-                );
+                return Response::error(req.id, rpc::INVALID_PARAMS, "Missing param: text");
             };
             let voice = req
                 .params
@@ -208,7 +146,7 @@ async fn dispatch(
                 .enqueue_converse(client_id.to_string(), text.to_string(), voice)
                 .await;
 
-            JsonRpcResponse::success(
+            Response::success(
                 req.id,
                 serde_json::json!({ "queue_id": queue_id, "status": "queued" }),
             )
@@ -216,15 +154,19 @@ async fn dispatch(
 
         "cancel" => {
             let count = queue.cancel_client(client_id).await;
-            JsonRpcResponse::success(req.id, serde_json::json!({ "cancelled_count": count }))
+            Response::success(req.id, serde_json::json!({ "cancelled_count": count }))
         }
 
         "status" => {
             let state = queue.snapshot().await;
-            JsonRpcResponse::success(req.id, serde_json::to_value(&state).unwrap())
+            Response::success(req.id, serde_json::to_value(&state).unwrap())
         }
 
-        _ => JsonRpcResponse::error(req.id, -32601, format!("Method not found: {}", req.method)),
+        _ => Response::error(
+            req.id,
+            rpc::METHOD_NOT_FOUND,
+            format!("Method not found: {}", req.method),
+        ),
     }
 }
 

--- a/crates/voice-daemon/src/socket.rs
+++ b/crates/voice-daemon/src/socket.rs
@@ -1,29 +1,70 @@
 //! Unix socket server for the voice daemon.
 //!
-//! Listens on ~/.voice/daemon.sock. Each connection is a client session.
-//! Clients send newline-delimited JSON requests and get JSON responses.
+//! Listens on ~/.voice/daemon.sock. Speaks JSON-RPC 2.0 over
+//! newline-delimited streams, consistent with the MCP server protocol.
 
-use crate::queue::{RequestQueue, VoiceRequest};
+use crate::queue::RequestQueue;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixListener;
 use uuid::Uuid;
 
+// ---------------------------------------------------------------------------
+// JSON-RPC types
+// ---------------------------------------------------------------------------
+
 #[derive(Debug, Deserialize)]
-struct ClientRequest {
-    id: Option<String>,
-    #[serde(flatten)]
-    request: VoiceRequest,
+#[allow(dead_code)]
+struct JsonRpcRequest {
+    jsonrpc: Option<String>,
+    method: String,
+    #[serde(default)]
+    params: Value,
+    id: Option<Value>,
 }
 
 #[derive(Debug, Serialize)]
-struct QueuedResponse {
-    id: Option<String>,
-    queue_id: String,
-    status: String,
+struct JsonRpcResponse {
+    jsonrpc: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<JsonRpcError>,
+    id: Option<Value>,
 }
+
+#[derive(Debug, Serialize)]
+struct JsonRpcError {
+    code: i32,
+    message: String,
+}
+
+impl JsonRpcResponse {
+    fn success(id: Option<Value>, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            result: Some(result),
+            error: None,
+            id,
+        }
+    }
+
+    fn error(id: Option<Value>, code: i32, message: String) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            result: None,
+            error: Some(JsonRpcError { code, message }),
+            id,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Socket path
+// ---------------------------------------------------------------------------
 
 pub fn socket_path() -> PathBuf {
     let dir = dirs::home_dir()
@@ -33,10 +74,13 @@ pub fn socket_path() -> PathBuf {
     dir.join("daemon.sock")
 }
 
+// ---------------------------------------------------------------------------
+// Server
+// ---------------------------------------------------------------------------
+
 pub async fn serve(queue: Arc<RequestQueue>) {
     let path = socket_path();
 
-    // Remove stale socket
     if path.exists() {
         std::fs::remove_file(&path).ok();
     }
@@ -44,7 +88,7 @@ pub async fn serve(queue: Arc<RequestQueue>) {
     let listener = match UnixListener::bind(&path) {
         Ok(l) => l,
         Err(e) => {
-            eprintln!("Failed to bind {}: {}", path.display(), e);
+            eprintln!("voiced: failed to bind {}: {}", path.display(), e);
             return;
         }
     };
@@ -78,16 +122,14 @@ async fn handle_client(
             continue;
         }
 
-        let response = match serde_json::from_str::<ClientRequest>(&line) {
-            Ok(req) => handle_request(req, &queue, &client_id).await,
-            Err(e) => serde_json::to_string(&serde_json::json!({
-                "error": format!("parse error: {}", e)
-            }))
-            .unwrap(),
+        let response = match serde_json::from_str::<JsonRpcRequest>(&line) {
+            Ok(req) => dispatch(req, &queue, &client_id).await,
+            Err(e) => JsonRpcResponse::error(None, -32700, format!("Parse error: {}", e)),
         };
 
+        let json = serde_json::to_string(&response).unwrap();
         if writer
-            .write_all(format!("{}\n", response).as_bytes())
+            .write_all(format!("{}\n", json).as_bytes())
             .await
             .is_err()
         {
@@ -98,36 +140,91 @@ async fn handle_client(
     eprintln!("voiced: client disconnected ({})", client_id);
 }
 
-async fn handle_request(req: ClientRequest, queue: &Arc<RequestQueue>, client_id: &str) -> String {
-    let request_id = req.id.clone();
+// ---------------------------------------------------------------------------
+// Method dispatch
+// ---------------------------------------------------------------------------
 
-    match req.request {
-        VoiceRequest::Cancel => {
+async fn dispatch(
+    req: JsonRpcRequest,
+    queue: &Arc<RequestQueue>,
+    client_id: &str,
+) -> JsonRpcResponse {
+    match req.method.as_str() {
+        "speak" => {
+            let text = req.params.get("text").and_then(|v| v.as_str());
+            let Some(text) = text else {
+                return JsonRpcResponse::error(
+                    req.id,
+                    -32602,
+                    "Missing required param: text".to_string(),
+                );
+            };
+            let voice = req
+                .params
+                .get("voice")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            let speed = req.params.get("speed").and_then(|v| v.as_f64());
+
+            let queue_id = queue
+                .enqueue_speak(client_id.to_string(), text.to_string(), voice, speed)
+                .await;
+
+            JsonRpcResponse::success(
+                req.id,
+                serde_json::json!({ "queue_id": queue_id, "status": "queued" }),
+            )
+        }
+
+        "listen" => {
+            let max_duration_ms = req.params.get("max_duration_ms").and_then(|v| v.as_u64());
+
+            let queue_id = queue
+                .enqueue_listen(client_id.to_string(), max_duration_ms)
+                .await;
+
+            JsonRpcResponse::success(
+                req.id,
+                serde_json::json!({ "queue_id": queue_id, "status": "queued" }),
+            )
+        }
+
+        "converse" => {
+            let text = req.params.get("text").and_then(|v| v.as_str());
+            let Some(text) = text else {
+                return JsonRpcResponse::error(
+                    req.id,
+                    -32602,
+                    "Missing required param: text".to_string(),
+                );
+            };
+            let voice = req
+                .params
+                .get("voice")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+
+            let queue_id = queue
+                .enqueue_converse(client_id.to_string(), text.to_string(), voice)
+                .await;
+
+            JsonRpcResponse::success(
+                req.id,
+                serde_json::json!({ "queue_id": queue_id, "status": "queued" }),
+            )
+        }
+
+        "cancel" => {
             let count = queue.cancel_client(client_id).await;
-            serde_json::to_string(&serde_json::json!({
-                "id": request_id,
-                "status": "cancelled",
-                "cancelled_count": count,
-            }))
-            .unwrap()
+            JsonRpcResponse::success(req.id, serde_json::json!({ "cancelled_count": count }))
         }
-        VoiceRequest::Status => {
+
+        "status" => {
             let state = queue.snapshot().await;
-            serde_json::to_string(&serde_json::json!({
-                "id": request_id,
-                "state": state,
-            }))
-            .unwrap()
+            JsonRpcResponse::success(req.id, serde_json::to_value(&state).unwrap())
         }
-        request => {
-            let queue_id = queue.enqueue(client_id.to_string(), request).await;
-            serde_json::to_string(&QueuedResponse {
-                id: request_id,
-                queue_id,
-                status: "queued".to_string(),
-            })
-            .unwrap()
-        }
+
+        _ => JsonRpcResponse::error(req.id, -32601, format!("Method not found: {}", req.method)),
     }
 }
 

--- a/crates/voice-daemon/src/socket.rs
+++ b/crates/voice-daemon/src/socket.rs
@@ -1,0 +1,139 @@
+//! Unix socket server for the voice daemon.
+//!
+//! Listens on ~/.voice/daemon.sock. Each connection is a client session.
+//! Clients send newline-delimited JSON requests and get JSON responses.
+
+use crate::queue::{RequestQueue, VoiceRequest};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixListener;
+use uuid::Uuid;
+
+#[derive(Debug, Deserialize)]
+struct ClientRequest {
+    id: Option<String>,
+    #[serde(flatten)]
+    request: VoiceRequest,
+}
+
+#[derive(Debug, Serialize)]
+struct QueuedResponse {
+    id: Option<String>,
+    queue_id: String,
+    status: String,
+}
+
+pub fn socket_path() -> PathBuf {
+    let dir = dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join(".voice");
+    std::fs::create_dir_all(&dir).ok();
+    dir.join("daemon.sock")
+}
+
+pub async fn serve(queue: Arc<RequestQueue>) {
+    let path = socket_path();
+
+    // Remove stale socket
+    if path.exists() {
+        std::fs::remove_file(&path).ok();
+    }
+
+    let listener = match UnixListener::bind(&path) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("Failed to bind {}: {}", path.display(), e);
+            return;
+        }
+    };
+
+    eprintln!("voiced: listening on {}", path.display());
+
+    loop {
+        match listener.accept().await {
+            Ok((stream, _)) => {
+                let queue = queue.clone();
+                let client_id = Uuid::new_v4().to_string()[..8].to_string();
+                eprintln!("voiced: client connected ({})", client_id);
+                tokio::spawn(handle_client(stream, queue, client_id));
+            }
+            Err(e) => eprintln!("voiced: accept error: {}", e),
+        }
+    }
+}
+
+async fn handle_client(
+    stream: tokio::net::UnixStream,
+    queue: Arc<RequestQueue>,
+    client_id: String,
+) {
+    let (reader, mut writer) = stream.into_split();
+    let mut lines = BufReader::new(reader).lines();
+
+    while let Ok(Some(line)) = lines.next_line().await {
+        let line = line.trim().to_string();
+        if line.is_empty() {
+            continue;
+        }
+
+        let response = match serde_json::from_str::<ClientRequest>(&line) {
+            Ok(req) => handle_request(req, &queue, &client_id).await,
+            Err(e) => serde_json::to_string(&serde_json::json!({
+                "error": format!("parse error: {}", e)
+            }))
+            .unwrap(),
+        };
+
+        if writer
+            .write_all(format!("{}\n", response).as_bytes())
+            .await
+            .is_err()
+        {
+            break;
+        }
+    }
+
+    eprintln!("voiced: client disconnected ({})", client_id);
+}
+
+async fn handle_request(req: ClientRequest, queue: &Arc<RequestQueue>, client_id: &str) -> String {
+    let request_id = req.id.clone();
+
+    match req.request {
+        VoiceRequest::Cancel => {
+            let count = queue.cancel_client(client_id).await;
+            serde_json::to_string(&serde_json::json!({
+                "id": request_id,
+                "status": "cancelled",
+                "cancelled_count": count,
+            }))
+            .unwrap()
+        }
+        VoiceRequest::Status => {
+            let state = queue.snapshot().await;
+            serde_json::to_string(&serde_json::json!({
+                "id": request_id,
+                "state": state,
+            }))
+            .unwrap()
+        }
+        request => {
+            let queue_id = queue.enqueue(client_id.to_string(), request).await;
+            serde_json::to_string(&QueuedResponse {
+                id: request_id,
+                queue_id,
+                status: "queued".to_string(),
+            })
+            .unwrap()
+        }
+    }
+}
+
+pub fn cleanup() {
+    let path = socket_path();
+    if path.exists() {
+        std::fs::remove_file(&path).ok();
+    }
+}

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -300,10 +300,12 @@ fn listen(
 
     let max_ms = max_duration_ms.unwrap_or(60000);
 
-    // Play a ding to signal recording start
-    play_tone(880.0, 0.1);
-
     eprintln!("voiced: listening (max {}ms)...", max_ms);
+
+    // Play a ding to signal recording start
+    play_tone(880.0, 0.15);
+    // Brief pause so the ding finishes before mic opens
+    std::thread::sleep(std::time::Duration::from_millis(100));
 
     // Open mic
     let mic = MicrophoneBuilder::new()
@@ -322,50 +324,63 @@ fn listen(
     let recent_peak = Arc::new(AtomicU32::new(0));
     let stop = Arc::new(AtomicBool::new(false));
 
-    // Mic drain thread
+    // Mic drain thread — matches the CLI's start_mic_drain pattern:
+    // track local chunk_peak, publish + reset every 100 samples.
     let buf_clone = buffer.clone();
     let peak_clone = recent_peak.clone();
     let stop_clone = stop.clone();
     let mic_thread = std::thread::spawn(move || {
+        let ch = channels.max(1) as usize;
+        let mut chunk_peak: f32 = 0.0;
+        let mut sample_count = 0usize;
+
         for sample in mic.into_iter() {
             if stop_clone.load(Ordering::Relaxed) {
                 break;
             }
-            // Mix to mono
-            let mono = if channels > 1 {
-                sample / channels as f32
-            } else {
-                sample
-            };
-            let abs = mono.abs();
-            // Update peak (atomic float via u32 bits)
-            let current = f32::from_bits(peak_clone.load(Ordering::Relaxed));
-            if abs > current {
-                peak_clone.store(abs.to_bits(), Ordering::Relaxed);
+
+            let abs = sample.abs();
+            chunk_peak = chunk_peak.max(abs);
+            sample_count += 1;
+
+            // Multi-channel: take every ch-th sample (mono mix)
+            if ch == 1 {
+                buf_clone.lock().unwrap().push(sample);
+            } else if sample_count % ch == 0 {
+                buf_clone.lock().unwrap().push(sample);
             }
-            buf_clone.lock().unwrap().push(mono);
+
+            // Publish peak every ~100 samples, then reset
+            if sample_count % 100 == 0 {
+                peak_clone.store(chunk_peak.to_bits(), Ordering::Relaxed);
+                chunk_peak = 0.0;
+            }
         }
     });
 
-    // Calibrate noise floor (500ms)
+    // Calibrate noise floor — sample peak amplitude over 500ms.
+    // The mic may take a moment to warm up (especially Bluetooth).
     std::thread::sleep(std::time::Duration::from_millis(500));
-    let noise_floor = f32::from_bits(recent_peak.load(Ordering::Relaxed));
+    let noise_floor = f32::from_bits(recent_peak.swap(0f32.to_bits(), Ordering::Relaxed));
+    // Threshold must be well above noise to avoid false positives.
+    // Use the same heuristic as the CLI: max(noise * 3, 0.01)
     let threshold = (noise_floor * 3.0).max(0.01);
-    recent_peak.store(0f32.to_bits(), Ordering::Relaxed);
     eprintln!(
         "voiced: noise floor: {:.4}, threshold: {:.4}",
         noise_floor, threshold
     );
 
-    // Wait for speech, then silence
+    // VAD state machine: wait for speech, then stop after 2s of silence.
     let started = Instant::now();
     let max_dur = std::time::Duration::from_millis(max_ms);
     let silence_timeout = std::time::Duration::from_millis(2000);
     let mut speech_detected = false;
     let mut last_speech = Instant::now();
+    let mut consecutive_silent = 0u32;
 
     loop {
         if started.elapsed() > max_dur {
+            eprintln!("voiced: max duration reached");
             break;
         }
 
@@ -373,14 +388,21 @@ fn listen(
         let peak = f32::from_bits(recent_peak.swap(0f32.to_bits(), Ordering::Relaxed));
 
         if peak > threshold {
+            consecutive_silent = 0;
             if !speech_detected {
-                eprintln!("voiced: speech detected");
+                eprintln!("voiced: speech detected (peak: {:.4})", peak);
                 speech_detected = true;
             }
             last_speech = Instant::now();
-        } else if speech_detected && last_speech.elapsed() > silence_timeout {
-            eprintln!("voiced: silence detected, stopping");
-            break;
+        } else {
+            consecutive_silent += 1;
+            if speech_detected && last_speech.elapsed() > silence_timeout {
+                eprintln!(
+                    "voiced: silence for {:.1}s, stopping",
+                    last_speech.elapsed().as_secs_f32()
+                );
+                break;
+            }
         }
     }
 

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -1,0 +1,72 @@
+//! Queue worker — processes voice requests one at a time.
+//!
+//! Prototype: simulates TTS/STT with delays.
+//! Production: will call voice-tts and voice-stt crates.
+
+use crate::queue::{RequestQueue, VoiceRequest};
+use std::sync::Arc;
+
+pub async fn run(queue: Arc<RequestQueue>) {
+    eprintln!("voiced: worker ready");
+
+    loop {
+        queue.notify.notified().await;
+
+        while let Some(item) = queue.dequeue().await {
+            eprintln!(
+                "voiced: [{}/{}] {:?}",
+                item.id,
+                item.client_id,
+                short_desc(&item.request)
+            );
+
+            match &item.request {
+                VoiceRequest::Speak { text, .. } => {
+                    // TODO: voice-tts generate + rodio playback
+                    let words = text.split_whitespace().count();
+                    let ms = (words as u64 * 200).max(500);
+                    tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
+                    queue.complete(Some(format!("spoke {} words", words))).await;
+                }
+                VoiceRequest::Listen { .. } => {
+                    // TODO: voice-stt mic + transcribe
+                    tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
+                    queue
+                        .complete(Some("(simulated transcription)".to_string()))
+                        .await;
+                }
+                VoiceRequest::Converse { text, .. } => {
+                    // TODO: speak then listen
+                    let words = text.split_whitespace().count();
+                    let ms = (words as u64 * 200).max(500);
+                    tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
+                    tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
+                    queue
+                        .complete(Some("(simulated converse)".to_string()))
+                        .await;
+                }
+                VoiceRequest::Cancel | VoiceRequest::Status => {
+                    queue.complete(None).await;
+                }
+            }
+        }
+    }
+}
+
+fn short_desc(req: &VoiceRequest) -> String {
+    match req {
+        VoiceRequest::Speak { text, .. } => {
+            let preview: String = text.chars().take(50).collect();
+            format!("speak: {}", preview)
+        }
+        VoiceRequest::Listen { max_duration_ms } => {
+            format!("listen ({}ms)", max_duration_ms.unwrap_or(30000))
+        }
+        VoiceRequest::Converse { text, .. } => {
+            let preview: String = text.chars().take(50).collect();
+            format!("converse: {}", preview)
+        }
+        VoiceRequest::Cancel => "cancel".to_string(),
+        VoiceRequest::Status => "status".to_string(),
+    }
+}

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -14,10 +14,10 @@ pub async fn run(queue: Arc<RequestQueue>) {
 
         while let Some(item) = queue.dequeue().await {
             eprintln!(
-                "voiced: [{}/{}] {:?}",
+                "voiced: [{}/{}] {}",
                 item.id,
                 item.client_id,
-                short_desc(&item.request)
+                short(&item.request)
             );
 
             match &item.request {
@@ -45,15 +45,12 @@ pub async fn run(queue: Arc<RequestQueue>) {
                         .complete(Some("(simulated converse)".to_string()))
                         .await;
                 }
-                VoiceRequest::Cancel | VoiceRequest::Status => {
-                    queue.complete(None).await;
-                }
             }
         }
     }
 }
 
-fn short_desc(req: &VoiceRequest) -> String {
+fn short(req: &VoiceRequest) -> String {
     match req {
         VoiceRequest::Speak { text, .. } => {
             let preview: String = text.chars().take(50).collect();
@@ -66,7 +63,5 @@ fn short_desc(req: &VoiceRequest) -> String {
             let preview: String = text.chars().take(50).collect();
             format!("converse: {}", preview)
         }
-        VoiceRequest::Cancel => "cancel".to_string(),
-        VoiceRequest::Status => "status".to_string(),
     }
 }

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -1,12 +1,65 @@
 //! Queue worker — processes voice requests one at a time.
 //!
-//! Prototype: simulates TTS/STT with delays.
-//! Production: will call voice-tts and voice-stt crates.
+//! Owns the TTS model and audio output. Runs blocking GPU inference
+//! and audio playback on a dedicated thread via spawn_blocking.
 
 use crate::queue::{RequestQueue, VoiceRequest};
-use std::sync::Arc;
+use candle_core::Tensor;
+use rodio::{buffer::SamplesBuffer, DeviceSinkBuilder, Player};
+use std::collections::HashMap;
+use std::num::NonZero;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use voice_tts::KokoroModel;
+
+/// Shared TTS state — model, voices, config. Protected by a std::sync::Mutex
+/// (not tokio) because all access is from spawn_blocking threads.
+struct TtsState {
+    model: KokoroModel,
+    default_voice: Tensor,
+    default_voice_name: String,
+    voice_cache: HashMap<String, Tensor>,
+    speed: f32,
+    sample_rate: u32,
+    repo_id: String,
+}
+
+impl TtsState {
+    fn get_voice(&mut self, name: &str) -> Result<&Tensor, String> {
+        if !self.voice_cache.contains_key(name) {
+            let v = self
+                .model
+                .load_voice(name, Some(&self.repo_id))
+                .map_err(|e| format!("Failed to load voice '{}': {}", name, e))?;
+            self.voice_cache.insert(name.to_string(), v);
+        }
+        Ok(&self.voice_cache[name])
+    }
+}
 
 pub async fn run(queue: Arc<RequestQueue>) {
+    eprintln!("voiced: loading TTS model...");
+    let start = Instant::now();
+
+    // Load model on a blocking thread (heavy GPU init)
+    let tts = match tokio::task::spawn_blocking(|| init_tts()).await {
+        Ok(Ok(tts)) => Arc::new(Mutex::new(tts)),
+        Ok(Err(e)) => {
+            eprintln!("voiced: failed to load TTS model: {}", e);
+            eprintln!("voiced: running in simulation mode");
+            run_simulated(queue).await;
+            return;
+        }
+        Err(e) => {
+            eprintln!("voiced: TTS init panicked: {}", e);
+            return;
+        }
+    };
+
+    eprintln!(
+        "voiced: TTS model loaded in {:.1}s",
+        start.elapsed().as_secs_f32()
+    );
     eprintln!("voiced: worker ready");
 
     loop {
@@ -21,26 +74,194 @@ pub async fn run(queue: Arc<RequestQueue>) {
             );
 
             match &entry.request {
-                VoiceRequest::Speak { text, .. } => {
-                    // TODO: voice-tts generate + rodio playback
-                    let words = text.split_whitespace().count();
-                    let ms = (words as u64 * 200).max(500);
-                    tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
-                    queue.complete(Some(format!("spoke {} words", words))).await;
+                VoiceRequest::Speak { text, voice, speed } => {
+                    let text = text.clone();
+                    let voice = voice.clone();
+                    let speed = *speed;
+                    let tts = tts.clone();
+
+                    let result = tokio::task::spawn_blocking(move || {
+                        speak(&tts, &text, voice.as_deref(), speed)
+                    })
+                    .await;
+
+                    match result {
+                        Ok(Ok(msg)) => queue.complete(Some(msg)).await,
+                        Ok(Err(e)) => {
+                            eprintln!("voiced: speak error: {}", e);
+                            queue.fail(e).await;
+                        }
+                        Err(e) => {
+                            eprintln!("voiced: speak panicked: {}", e);
+                            queue.fail(format!("panic: {}", e)).await;
+                        }
+                    }
                 }
                 VoiceRequest::Listen { .. } => {
-                    // TODO: voice-stt mic + transcribe
-                    tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
+                    // TODO: voice-stt integration
+                    eprintln!("voiced: listen not yet implemented");
                     queue
-                        .complete(Some("(simulated transcription)".to_string()))
+                        .complete(Some("(listen not yet implemented)".to_string()))
                         .await;
                 }
-                VoiceRequest::Converse { text, .. } => {
-                    // TODO: speak then listen
+                VoiceRequest::Converse { text, voice } => {
+                    // Speak first, then listen (listen is stubbed for now)
+                    let text = text.clone();
+                    let voice = voice.clone();
+                    let tts = tts.clone();
+
+                    let speak_result = tokio::task::spawn_blocking(move || {
+                        speak(&tts, &text, voice.as_deref(), None)
+                    })
+                    .await;
+
+                    let spoke = match speak_result {
+                        Ok(Ok(msg)) => msg,
+                        Ok(Err(e)) => format!("speak error: {}", e),
+                        Err(e) => format!("panic: {}", e),
+                    };
+
+                    queue
+                        .complete(Some(format!(
+                            "spoke: {}, listen: (not yet implemented)",
+                            spoke
+                        )))
+                        .await;
+                }
+            }
+        }
+    }
+}
+
+const MODEL_REPO: &str = "prince-canuma/Kokoro-82M";
+
+fn init_tts() -> Result<TtsState, String> {
+    let model = voice_tts::load_model(MODEL_REPO).map_err(|e| format!("load_model: {}", e))?;
+    let sample_rate = model.sample_rate;
+
+    let default_voice_name = "af_heart".to_string();
+    let voice = model
+        .load_voice(&default_voice_name, Some(MODEL_REPO))
+        .map_err(|e| e.to_string())?;
+
+    let mut voice_cache = HashMap::new();
+    voice_cache.insert(default_voice_name.clone(), voice.clone());
+
+    Ok(TtsState {
+        model,
+        default_voice: voice,
+        default_voice_name,
+        voice_cache,
+        speed: 1.0,
+        sample_rate,
+        repo_id: MODEL_REPO.to_string(),
+    })
+}
+
+fn speak(
+    tts: &Arc<Mutex<TtsState>>,
+    text: &str,
+    voice_name: Option<&str>,
+    speed: Option<f64>,
+) -> Result<String, String> {
+    // G2P
+    let chunks =
+        voice_g2p::text_to_phoneme_chunks(text).map_err(|e| format!("G2P error: {}", e))?;
+
+    if chunks.is_empty() {
+        return Ok("(empty text)".to_string());
+    }
+
+    // Open audio output
+    let mut stream = DeviceSinkBuilder::open_default_sink().map_err(|e| format!("audio: {}", e))?;
+    stream.log_on_drop(false);
+    let player = Player::connect_new(stream.mixer());
+
+    let started = Instant::now();
+    let mut total_samples = 0usize;
+
+    {
+        let mut state = tts.lock().map_err(|e| format!("lock: {}", e))?;
+        let speed = speed.map(|s| s as f32).unwrap_or(state.speed);
+        let sample_rate = state.sample_rate;
+
+        let channels = NonZero::new(1u16).unwrap();
+        let rate = NonZero::new(sample_rate).unwrap();
+
+        for (i, phonemes) in chunks.iter().enumerate() {
+            if phonemes.is_empty() {
+                continue;
+            }
+
+            // Clone the voice tensor so we can release the borrow on state
+            // before passing &mut state.model to generate.
+            let voice = if let Some(name) = voice_name {
+                state.get_voice(name)?.clone()
+            } else {
+                state.default_voice.clone()
+            };
+
+            match voice_tts::generate(&mut state.model, phonemes, &voice, speed) {
+                Ok(audio) => {
+                    total_samples += audio.len();
+                    let source = SamplesBuffer::new(channels, rate, audio);
+                    player.append(source);
+                    if chunks.len() > 1 {
+                        eprintln!("voiced:   chunk {}/{} generated", i + 1, chunks.len());
+                    }
+                }
+                Err(e) => {
+                    return Err(format!("generate chunk {}: {}", i + 1, e));
+                }
+            }
+        }
+    }
+
+    // Wait for playback to finish (release the mutex while waiting)
+    while !player.empty() {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    let duration_ms = started.elapsed().as_millis();
+    let audio_ms = total_samples as u64 * 1000 / 24000;
+
+    Ok(format!(
+        "spoke {} chunks, {}ms audio in {}ms",
+        chunks.len(),
+        audio_ms,
+        duration_ms
+    ))
+}
+
+/// Fallback when TTS model can't load — simulate with delays.
+async fn run_simulated(queue: Arc<RequestQueue>) {
+    eprintln!("voiced: worker ready (simulation mode)");
+    loop {
+        queue.notify.notified().await;
+        while let Some(entry) = queue.dequeue().await {
+            eprintln!(
+                "voiced: [{}/{}] {} (simulated)",
+                entry.id,
+                entry.client_id,
+                short(&entry.request)
+            );
+            match &entry.request {
+                VoiceRequest::Speak { text, .. } => {
                     let words = text.split_whitespace().count();
                     let ms = (words as u64 * 200).max(500);
                     tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
+                    queue
+                        .complete(Some(format!("simulated {} words", words)))
+                        .await;
+                }
+                VoiceRequest::Listen { .. } => {
                     tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
+                    queue.complete(Some("(simulated listen)".to_string())).await;
+                }
+                VoiceRequest::Converse { text, .. } => {
+                    let words = text.split_whitespace().count();
+                    let ms = (words as u64 * 200).max(500);
+                    tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
                     queue
                         .complete(Some("(simulated converse)".to_string()))
                         .await;

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -12,15 +12,15 @@ pub async fn run(queue: Arc<RequestQueue>) {
     loop {
         queue.notify.notified().await;
 
-        while let Some(item) = queue.dequeue().await {
+        while let Some(entry) = queue.dequeue().await {
             eprintln!(
                 "voiced: [{}/{}] {}",
-                item.id,
-                item.client_id,
-                short(&item.request)
+                entry.id,
+                entry.client_id,
+                short(&entry.request)
             );
 
-            match &item.request {
+            match &entry.request {
                 VoiceRequest::Speak { text, .. } => {
                     // TODO: voice-tts generate + rodio playback
                     let words = text.split_whitespace().count();

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -68,10 +68,36 @@ pub async fn run(queue: Arc<RequestQueue>) {
         start.elapsed().as_secs_f32()
     );
 
-    // Lazily load STT model on first listen request
-    let stt: Arc<Mutex<Option<voice_stt::WhisperModel>>> = Arc::new(Mutex::new(None));
+    // Eagerly load STT model — daemon is long-lived, pay the cost once
+    eprintln!("voiced: loading STT model...");
+    let stt_start = Instant::now();
+    let stt: Arc<Mutex<Option<voice_stt::WhisperModel>>> = match tokio::task::spawn_blocking(|| {
+        voice_stt::load_model(STT_REPO).map_err(|e| format!("stt: {}", e))
+    })
+    .await
+    {
+        Ok(Ok(model)) => {
+            eprintln!(
+                "voiced: STT model loaded in {:.1}s",
+                stt_start.elapsed().as_secs_f32()
+            );
+            Arc::new(Mutex::new(Some(model)))
+        }
+        Ok(Err(e)) => {
+            eprintln!("voiced: STT model failed to load: {}", e);
+            eprintln!("voiced: listen/converse will be unavailable");
+            Arc::new(Mutex::new(None))
+        }
+        Err(e) => {
+            eprintln!("voiced: STT init panicked: {}", e);
+            Arc::new(Mutex::new(None))
+        }
+    };
 
-    eprintln!("voiced: worker ready");
+    eprintln!(
+        "voiced: all models ready ({:.1}s total)",
+        start.elapsed().as_secs_f32()
+    );
 
     loop {
         queue.notify.notified().await;

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -344,9 +344,7 @@ fn listen(
             sample_count += 1;
 
             // Multi-channel: take every ch-th sample (mono mix)
-            if ch == 1 {
-                buf_clone.lock().unwrap().push(sample);
-            } else if sample_count % ch == 0 {
+            if ch == 1 || sample_count % ch == 0 {
                 buf_clone.lock().unwrap().push(sample);
             }
 
@@ -376,7 +374,6 @@ fn listen(
     let silence_timeout = std::time::Duration::from_millis(2000);
     let mut speech_detected = false;
     let mut last_speech = Instant::now();
-    let mut consecutive_silent = 0u32;
 
     loop {
         if started.elapsed() > max_dur {
@@ -388,21 +385,17 @@ fn listen(
         let peak = f32::from_bits(recent_peak.swap(0f32.to_bits(), Ordering::Relaxed));
 
         if peak > threshold {
-            consecutive_silent = 0;
             if !speech_detected {
                 eprintln!("voiced: speech detected (peak: {:.4})", peak);
                 speech_detected = true;
             }
             last_speech = Instant::now();
-        } else {
-            consecutive_silent += 1;
-            if speech_detected && last_speech.elapsed() > silence_timeout {
-                eprintln!(
-                    "voiced: silence for {:.1}s, stopping",
-                    last_speech.elapsed().as_secs_f32()
-                );
-                break;
-            }
+        } else if speech_detected && last_speech.elapsed() > silence_timeout {
+            eprintln!(
+                "voiced: silence for {:.1}s, stopping",
+                last_speech.elapsed().as_secs_f32()
+            );
+            break;
         }
     }
 

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -1,22 +1,28 @@
 //! Queue worker — processes voice requests one at a time.
 //!
-//! Owns the TTS model and audio output. Runs blocking GPU inference
-//! and audio playback on a dedicated thread via spawn_blocking.
+//! Owns the TTS and STT models and audio hardware. Runs blocking GPU
+//! inference and audio I/O on dedicated threads via spawn_blocking.
 
 use crate::queue::{RequestQueue, VoiceRequest};
 use candle_core::Tensor;
+use rodio::microphone::MicrophoneBuilder;
 use rodio::{buffer::SamplesBuffer, DeviceSinkBuilder, Player};
 use std::collections::HashMap;
 use std::num::NonZero;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use voice_tts::KokoroModel;
 
-/// Shared TTS state — model, voices, config. Protected by a std::sync::Mutex
-/// (not tokio) because all access is from spawn_blocking threads.
+const MODEL_REPO: &str = "prince-canuma/Kokoro-82M";
+const STT_REPO: &str = "distil-whisper/distil-large-v3";
+
+// -- TTS state ---------------------------------------------------------------
+
 struct TtsState {
     model: KokoroModel,
     default_voice: Tensor,
+    #[allow(dead_code)]
     default_voice_name: String,
     voice_cache: HashMap<String, Tensor>,
     speed: f32,
@@ -37,12 +43,13 @@ impl TtsState {
     }
 }
 
+// -- Worker entry point -------------------------------------------------------
+
 pub async fn run(queue: Arc<RequestQueue>) {
     eprintln!("voiced: loading TTS model...");
     let start = Instant::now();
 
-    // Load model on a blocking thread (heavy GPU init)
-    let tts = match tokio::task::spawn_blocking(|| init_tts()).await {
+    let tts = match tokio::task::spawn_blocking(init_tts).await {
         Ok(Ok(tts)) => Arc::new(Mutex::new(tts)),
         Ok(Err(e)) => {
             eprintln!("voiced: failed to load TTS model: {}", e);
@@ -60,6 +67,10 @@ pub async fn run(queue: Arc<RequestQueue>) {
         "voiced: TTS model loaded in {:.1}s",
         start.elapsed().as_secs_f32()
     );
+
+    // Lazily load STT model on first listen request
+    let stt: Arc<Mutex<Option<voice_stt::WhisperModel>>> = Arc::new(Mutex::new(None));
+
     eprintln!("voiced: worker ready");
 
     loop {
@@ -97,43 +108,56 @@ pub async fn run(queue: Arc<RequestQueue>) {
                         }
                     }
                 }
-                VoiceRequest::Listen { .. } => {
-                    // TODO: voice-stt integration
-                    eprintln!("voiced: listen not yet implemented");
-                    queue
-                        .complete(Some("(listen not yet implemented)".to_string()))
-                        .await;
+                VoiceRequest::Listen { max_duration_ms } => {
+                    let max_ms = *max_duration_ms;
+                    let stt = stt.clone();
+
+                    let result = tokio::task::spawn_blocking(move || listen(&stt, max_ms)).await;
+
+                    match result {
+                        Ok(Ok(msg)) => queue.complete(Some(msg)).await,
+                        Ok(Err(e)) => {
+                            eprintln!("voiced: listen error: {}", e);
+                            queue.fail(e).await;
+                        }
+                        Err(e) => {
+                            eprintln!("voiced: listen panicked: {}", e);
+                            queue.fail(format!("panic: {}", e)).await;
+                        }
+                    }
                 }
                 VoiceRequest::Converse { text, voice } => {
-                    // Speak first, then listen (listen is stubbed for now)
                     let text = text.clone();
                     let voice = voice.clone();
                     let tts = tts.clone();
+                    let stt = stt.clone();
 
+                    // Speak
                     let speak_result = tokio::task::spawn_blocking(move || {
-                        speak(&tts, &text, voice.as_deref(), None)
+                        let spoke = speak(&tts, &text, voice.as_deref(), None)?;
+                        let heard = listen(&stt, None)?;
+                        Ok::<String, String>(format!("{}, {}", spoke, heard))
                     })
                     .await;
 
-                    let spoke = match speak_result {
-                        Ok(Ok(msg)) => msg,
-                        Ok(Err(e)) => format!("speak error: {}", e),
-                        Err(e) => format!("panic: {}", e),
-                    };
-
-                    queue
-                        .complete(Some(format!(
-                            "spoke: {}, listen: (not yet implemented)",
-                            spoke
-                        )))
-                        .await;
+                    match speak_result {
+                        Ok(Ok(msg)) => queue.complete(Some(msg)).await,
+                        Ok(Err(e)) => {
+                            eprintln!("voiced: converse error: {}", e);
+                            queue.fail(e).await;
+                        }
+                        Err(e) => {
+                            eprintln!("voiced: converse panicked: {}", e);
+                            queue.fail(format!("panic: {}", e)).await;
+                        }
+                    }
                 }
             }
         }
     }
 }
 
-const MODEL_REPO: &str = "prince-canuma/Kokoro-82M";
+// -- TTS init + speak ---------------------------------------------------------
 
 fn init_tts() -> Result<TtsState, String> {
     let model = voice_tts::load_model(MODEL_REPO).map_err(|e| format!("load_model: {}", e))?;
@@ -164,7 +188,6 @@ fn speak(
     voice_name: Option<&str>,
     speed: Option<f64>,
 ) -> Result<String, String> {
-    // G2P
     let chunks =
         voice_g2p::text_to_phoneme_chunks(text).map_err(|e| format!("G2P error: {}", e))?;
 
@@ -172,7 +195,6 @@ fn speak(
         return Ok("(empty text)".to_string());
     }
 
-    // Open audio output
     let mut stream = DeviceSinkBuilder::open_default_sink().map_err(|e| format!("audio: {}", e))?;
     stream.log_on_drop(false);
     let player = Player::connect_new(stream.mixer());
@@ -184,7 +206,6 @@ fn speak(
         let mut state = tts.lock().map_err(|e| format!("lock: {}", e))?;
         let speed = speed.map(|s| s as f32).unwrap_or(state.speed);
         let sample_rate = state.sample_rate;
-
         let channels = NonZero::new(1u16).unwrap();
         let rate = NonZero::new(sample_rate).unwrap();
 
@@ -193,8 +214,6 @@ fn speak(
                 continue;
             }
 
-            // Clone the voice tensor so we can release the borrow on state
-            // before passing &mut state.model to generate.
             let voice = if let Some(name) = voice_name {
                 state.get_voice(name)?.clone()
             } else {
@@ -210,21 +229,17 @@ fn speak(
                         eprintln!("voiced:   chunk {}/{} generated", i + 1, chunks.len());
                     }
                 }
-                Err(e) => {
-                    return Err(format!("generate chunk {}: {}", i + 1, e));
-                }
+                Err(e) => return Err(format!("generate chunk {}: {}", i + 1, e)),
             }
         }
     }
 
-    // Wait for playback to finish (release the mutex while waiting)
     while !player.empty() {
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
 
     let duration_ms = started.elapsed().as_millis();
     let audio_ms = total_samples as u64 * 1000 / 24000;
-
     Ok(format!(
         "spoke {} chunks, {}ms audio in {}ms",
         chunks.len(),
@@ -233,7 +248,177 @@ fn speak(
     ))
 }
 
-/// Fallback when TTS model can't load — simulate with delays.
+// -- STT listen ---------------------------------------------------------------
+
+fn ensure_stt(stt: &Arc<Mutex<Option<voice_stt::WhisperModel>>>) -> Result<(), String> {
+    let mut guard = stt.lock().map_err(|e| format!("stt lock: {}", e))?;
+    if guard.is_none() {
+        eprintln!("voiced: loading STT model ({})...", STT_REPO);
+        let start = Instant::now();
+        let model =
+            voice_stt::load_model(STT_REPO).map_err(|e| format!("stt load_model: {}", e))?;
+        eprintln!(
+            "voiced: STT model loaded in {:.1}s",
+            start.elapsed().as_secs_f32()
+        );
+        *guard = Some(model);
+    }
+    Ok(())
+}
+
+fn listen(
+    stt: &Arc<Mutex<Option<voice_stt::WhisperModel>>>,
+    max_duration_ms: Option<u64>,
+) -> Result<String, String> {
+    ensure_stt(stt)?;
+
+    let max_ms = max_duration_ms.unwrap_or(60000);
+
+    // Play a ding to signal recording start
+    play_tone(880.0, 0.1);
+
+    eprintln!("voiced: listening (max {}ms)...", max_ms);
+
+    // Open mic
+    let mic = MicrophoneBuilder::new()
+        .default_device()
+        .map_err(|e| format!("mic: no input device: {}", e))?
+        .default_config()
+        .map_err(|e| format!("mic: no config: {}", e))?
+        .open_stream()
+        .map_err(|e| format!("mic: open failed: {}", e))?;
+
+    let sample_rate = mic.config().sample_rate.get();
+    let channels = mic.config().channel_count.get();
+
+    // Record with VAD
+    let buffer: Arc<Mutex<Vec<f32>>> = Arc::new(Mutex::new(Vec::new()));
+    let recent_peak = Arc::new(AtomicU32::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+
+    // Mic drain thread
+    let buf_clone = buffer.clone();
+    let peak_clone = recent_peak.clone();
+    let stop_clone = stop.clone();
+    let mic_thread = std::thread::spawn(move || {
+        for sample in mic.into_iter() {
+            if stop_clone.load(Ordering::Relaxed) {
+                break;
+            }
+            // Mix to mono
+            let mono = if channels > 1 {
+                sample / channels as f32
+            } else {
+                sample
+            };
+            let abs = mono.abs();
+            // Update peak (atomic float via u32 bits)
+            let current = f32::from_bits(peak_clone.load(Ordering::Relaxed));
+            if abs > current {
+                peak_clone.store(abs.to_bits(), Ordering::Relaxed);
+            }
+            buf_clone.lock().unwrap().push(mono);
+        }
+    });
+
+    // Calibrate noise floor (500ms)
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    let noise_floor = f32::from_bits(recent_peak.load(Ordering::Relaxed));
+    let threshold = (noise_floor * 3.0).max(0.01);
+    recent_peak.store(0f32.to_bits(), Ordering::Relaxed);
+    eprintln!(
+        "voiced: noise floor: {:.4}, threshold: {:.4}",
+        noise_floor, threshold
+    );
+
+    // Wait for speech, then silence
+    let started = Instant::now();
+    let max_dur = std::time::Duration::from_millis(max_ms);
+    let silence_timeout = std::time::Duration::from_millis(2000);
+    let mut speech_detected = false;
+    let mut last_speech = Instant::now();
+
+    loop {
+        if started.elapsed() > max_dur {
+            break;
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        let peak = f32::from_bits(recent_peak.swap(0f32.to_bits(), Ordering::Relaxed));
+
+        if peak > threshold {
+            if !speech_detected {
+                eprintln!("voiced: speech detected");
+                speech_detected = true;
+            }
+            last_speech = Instant::now();
+        } else if speech_detected && last_speech.elapsed() > silence_timeout {
+            eprintln!("voiced: silence detected, stopping");
+            break;
+        }
+    }
+
+    stop.store(true, Ordering::Relaxed);
+    let _ = mic_thread.join();
+
+    // Play stop tone
+    play_tone(440.0, 0.1);
+
+    let samples = match Arc::try_unwrap(buffer) {
+        Ok(mutex) => mutex.into_inner().unwrap(),
+        Err(arc) => arc.lock().unwrap().clone(),
+    };
+
+    if samples.is_empty() || !speech_detected {
+        return Ok("(no speech detected)".to_string());
+    }
+
+    let duration_s = samples.len() as f32 / sample_rate as f32;
+    eprintln!("voiced: recorded {:.1}s, transcribing...", duration_s);
+
+    // Transcribe
+    let mut guard = stt.lock().map_err(|e| format!("stt lock: {}", e))?;
+    let model = guard.as_mut().ok_or("STT model not loaded")?;
+
+    let result = voice_stt::transcribe_audio(model, &samples, sample_rate)
+        .map_err(|e| format!("transcribe: {}", e))?;
+
+    let text = result.text.trim().to_string();
+    eprintln!("voiced: heard: {}", text);
+
+    Ok(format!("heard: {}", text))
+}
+
+/// Play a simple sine tone (for ding/dong feedback).
+fn play_tone(freq: f32, duration_secs: f32) {
+    let sample_rate = 24000u32;
+    let num_samples = (sample_rate as f32 * duration_secs) as usize;
+    let samples: Vec<f32> = (0..num_samples)
+        .map(|i| {
+            let t = i as f32 / sample_rate as f32;
+            let envelope = if t < 0.01 {
+                t / 0.01
+            } else {
+                (1.0 - (t - 0.01) / (duration_secs - 0.01)).max(0.0)
+            };
+            (2.0 * std::f32::consts::PI * freq * t).sin() * 0.3 * envelope
+        })
+        .collect();
+
+    if let Ok(mut stream) = DeviceSinkBuilder::open_default_sink() {
+        stream.log_on_drop(false);
+        let player = Player::connect_new(stream.mixer());
+        let channels = NonZero::new(1u16).unwrap();
+        let rate = NonZero::new(sample_rate).unwrap();
+        player.append(SamplesBuffer::new(channels, rate, samples));
+        while !player.empty() {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+}
+
+// -- Simulation fallback ------------------------------------------------------
+
 async fn run_simulated(queue: Arc<RequestQueue>) {
     eprintln!("voiced: worker ready (simulation mode)");
     loop {

--- a/crates/voice-protocol/Cargo.toml
+++ b/crates/voice-protocol/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "voice-protocol"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.85.0"
+description = "Wire protocol for the voice daemon: frames, RPC types, sync"
+license = "MIT"
+repository = "https://github.com/rgbkrk/voice"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { version = "1", features = ["io-util", "net"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["io-util", "rt", "macros"] }

--- a/crates/voice-protocol/Cargo.toml
+++ b/crates/voice-protocol/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/rgbkrk/voice"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { version = "1", features = ["io-util", "net"] }
+dirs = "6"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["io-util", "rt", "macros"] }

--- a/crates/voice-protocol/src/client.rs
+++ b/crates/voice-protocol/src/client.rs
@@ -87,14 +87,14 @@ impl DaemonClient {
         serde_json::from_slice::<Response>(payload).map_err(|e| format!("parse response: {}", e))
     }
 
-    /// Convenience: send a speak request.
+    /// Convenience: send a speak request. Blocks until playback completes.
     pub fn speak(
         &mut self,
         text: &str,
         voice: Option<&str>,
         speed: Option<f64>,
     ) -> Result<Response, String> {
-        let mut params = serde_json::json!({"text": text});
+        let mut params = serde_json::json!({"text": text, "wait": true});
         if let Some(v) = voice {
             params["voice"] = Value::String(v.to_string());
         }
@@ -104,18 +104,18 @@ impl DaemonClient {
         self.call("speak", params)
     }
 
-    /// Convenience: send a listen request.
+    /// Convenience: send a listen request. Blocks until transcription completes.
     pub fn listen(&mut self, max_duration_ms: Option<u64>) -> Result<Response, String> {
-        let mut params = serde_json::json!({});
+        let mut params = serde_json::json!({"wait": true});
         if let Some(ms) = max_duration_ms {
             params["max_duration_ms"] = serde_json::json!(ms);
         }
         self.call("listen", params)
     }
 
-    /// Convenience: send a converse request.
+    /// Convenience: send a converse request. Blocks until speak+listen completes.
     pub fn converse(&mut self, text: &str, voice: Option<&str>) -> Result<Response, String> {
-        let mut params = serde_json::json!({"text": text});
+        let mut params = serde_json::json!({"text": text, "wait": true});
         if let Some(v) = voice {
             params["voice"] = Value::String(v.to_string());
         }

--- a/crates/voice-protocol/src/client.rs
+++ b/crates/voice-protocol/src/client.rs
@@ -1,0 +1,134 @@
+//! Synchronous client for talking to the voice daemon.
+//!
+//! The MCP server is synchronous (no tokio runtime), so this client
+//! uses std::os::unix::net::UnixStream directly.
+
+use crate::frames::FrameType;
+use crate::rpc::{self, Response};
+use serde_json::Value;
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// A synchronous client connection to the voice daemon.
+pub struct DaemonClient {
+    stream: UnixStream,
+}
+
+/// Get the daemon socket path.
+pub fn daemon_socket_path() -> PathBuf {
+    let dir = dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join(".voice");
+    dir.join("daemon.sock")
+}
+
+/// Check if the daemon is running (socket exists and accepts connections).
+pub fn daemon_is_running() -> bool {
+    let path = daemon_socket_path();
+    if !path.exists() {
+        return false;
+    }
+    UnixStream::connect(&path).is_ok()
+}
+
+impl DaemonClient {
+    /// Connect to the daemon. Returns None if daemon isn't running.
+    pub fn connect() -> Option<Self> {
+        let path = daemon_socket_path();
+        let stream = UnixStream::connect(&path).ok()?;
+        stream
+            .set_read_timeout(Some(Duration::from_secs(120)))
+            .ok()?;
+        stream
+            .set_write_timeout(Some(Duration::from_secs(5)))
+            .ok()?;
+        Some(Self { stream })
+    }
+
+    /// Send a JSON-RPC request and get the response.
+    pub fn call(&mut self, method: &str, params: Value) -> Result<Response, String> {
+        let req = rpc::Request::new(method, params).with_id(1);
+        let json = serde_json::to_vec(&req).map_err(|e| format!("serialize: {}", e))?;
+
+        // Write frame: [4-byte length][1-byte type=Request][payload]
+        let total_len = (json.len() + 1) as u32;
+        self.stream
+            .write_all(&total_len.to_be_bytes())
+            .map_err(|e| format!("write len: {}", e))?;
+        self.stream
+            .write_all(&[FrameType::Request as u8])
+            .map_err(|e| format!("write type: {}", e))?;
+        self.stream
+            .write_all(&json)
+            .map_err(|e| format!("write payload: {}", e))?;
+        self.stream.flush().map_err(|e| format!("flush: {}", e))?;
+
+        // Read response frame
+        let mut len_buf = [0u8; 4];
+        self.stream
+            .read_exact(&mut len_buf)
+            .map_err(|e| format!("read len: {}", e))?;
+        let total_len = u32::from_be_bytes(len_buf) as usize;
+
+        let mut data = vec![0u8; total_len];
+        self.stream
+            .read_exact(&mut data)
+            .map_err(|e| format!("read payload: {}", e))?;
+
+        if data.is_empty() {
+            return Err("empty response".to_string());
+        }
+
+        let _frame_type = data[0]; // Should be Response (0x02)
+        let payload = &data[1..];
+
+        serde_json::from_slice::<Response>(payload).map_err(|e| format!("parse response: {}", e))
+    }
+
+    /// Convenience: send a speak request.
+    pub fn speak(
+        &mut self,
+        text: &str,
+        voice: Option<&str>,
+        speed: Option<f64>,
+    ) -> Result<Response, String> {
+        let mut params = serde_json::json!({"text": text});
+        if let Some(v) = voice {
+            params["voice"] = Value::String(v.to_string());
+        }
+        if let Some(s) = speed {
+            params["speed"] = serde_json::json!(s);
+        }
+        self.call("speak", params)
+    }
+
+    /// Convenience: send a listen request.
+    pub fn listen(&mut self, max_duration_ms: Option<u64>) -> Result<Response, String> {
+        let mut params = serde_json::json!({});
+        if let Some(ms) = max_duration_ms {
+            params["max_duration_ms"] = serde_json::json!(ms);
+        }
+        self.call("listen", params)
+    }
+
+    /// Convenience: send a converse request.
+    pub fn converse(&mut self, text: &str, voice: Option<&str>) -> Result<Response, String> {
+        let mut params = serde_json::json!({"text": text});
+        if let Some(v) = voice {
+            params["voice"] = Value::String(v.to_string());
+        }
+        self.call("converse", params)
+    }
+
+    /// Convenience: cancel all pending requests from this client.
+    pub fn cancel(&mut self) -> Result<Response, String> {
+        self.call("cancel", serde_json::json!({}))
+    }
+
+    /// Convenience: get daemon status.
+    pub fn status(&mut self) -> Result<Response, String> {
+        self.call("status", serde_json::json!({}))
+    }
+}

--- a/crates/voice-protocol/src/frames.rs
+++ b/crates/voice-protocol/src/frames.rs
@@ -1,0 +1,163 @@
+//! Frame codec: length-prefixed typed frames over async byte streams.
+
+use std::io;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+/// Frame types carried over the wire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FrameType {
+    /// JSON-RPC 2.0 request (client → daemon).
+    Request = 0x01,
+    /// JSON-RPC 2.0 response (daemon → client).
+    Response = 0x02,
+    /// Daemon-initiated event/notification (daemon → client).
+    Event = 0x03,
+    /// Automerge sync message (bidirectional, future).
+    Sync = 0x04,
+}
+
+impl FrameType {
+    pub fn from_byte(b: u8) -> Option<Self> {
+        match b {
+            0x01 => Some(Self::Request),
+            0x02 => Some(Self::Response),
+            0x03 => Some(Self::Event),
+            0x04 => Some(Self::Sync),
+            _ => None,
+        }
+    }
+}
+
+/// A typed frame with its payload.
+#[derive(Debug, Clone)]
+pub struct Frame {
+    pub frame_type: FrameType,
+    pub payload: Vec<u8>,
+}
+
+impl Frame {
+    pub fn request(json: &[u8]) -> Self {
+        Self {
+            frame_type: FrameType::Request,
+            payload: json.to_vec(),
+        }
+    }
+
+    pub fn response(json: &[u8]) -> Self {
+        Self {
+            frame_type: FrameType::Response,
+            payload: json.to_vec(),
+        }
+    }
+
+    pub fn event(json: &[u8]) -> Self {
+        Self {
+            frame_type: FrameType::Event,
+            payload: json.to_vec(),
+        }
+    }
+
+    /// Parse the payload as JSON.
+    pub fn json<T: serde::de::DeserializeOwned>(&self) -> Result<T, serde_json::Error> {
+        serde_json::from_slice(&self.payload)
+    }
+}
+
+/// Maximum frame payload size (1 MB).
+const MAX_FRAME_SIZE: u32 = 1_048_576;
+
+/// Write a frame to an async writer.
+pub async fn write_frame<W: AsyncWrite + Unpin>(writer: &mut W, frame: &Frame) -> io::Result<()> {
+    let payload_len = frame.payload.len() as u32 + 1; // +1 for frame type byte
+    writer.write_all(&payload_len.to_be_bytes()).await?;
+    writer.write_u8(frame.frame_type as u8).await?;
+    writer.write_all(&frame.payload).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Read a frame from an async reader. Returns None on EOF.
+pub async fn read_frame<R: AsyncRead + Unpin>(reader: &mut R) -> io::Result<Option<Frame>> {
+    // Read length prefix
+    let mut len_buf = [0u8; 4];
+    match reader.read_exact(&mut len_buf).await {
+        Ok(_) => {}
+        Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e),
+    }
+
+    let total_len = u32::from_be_bytes(len_buf);
+    if total_len == 0 || total_len > MAX_FRAME_SIZE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("frame too large: {} bytes", total_len),
+        ));
+    }
+
+    // Read frame type byte
+    let type_byte = reader.read_u8().await?;
+    let frame_type = FrameType::from_byte(type_byte).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unknown frame type: 0x{:02x}", type_byte),
+        )
+    })?;
+
+    // Read payload
+    let payload_len = (total_len - 1) as usize;
+    let mut payload = vec![0u8; payload_len];
+    reader.read_exact(&mut payload).await?;
+
+    Ok(Some(Frame {
+        frame_type,
+        payload,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::duplex;
+
+    #[tokio::test]
+    async fn test_roundtrip() {
+        let (mut client, mut server) = duplex(1024);
+
+        let request = Frame::request(b"{\"method\":\"speak\"}");
+        write_frame(&mut client, &request).await.unwrap();
+
+        let received = read_frame(&mut server).await.unwrap().unwrap();
+        assert_eq!(received.frame_type, FrameType::Request);
+        assert_eq!(received.payload, b"{\"method\":\"speak\"}");
+    }
+
+    #[tokio::test]
+    async fn test_multiple_frames() {
+        let (mut client, mut server) = duplex(4096);
+
+        let f1 = Frame::request(b"one");
+        let f2 = Frame::response(b"two");
+        let f3 = Frame::event(b"three");
+
+        write_frame(&mut client, &f1).await.unwrap();
+        write_frame(&mut client, &f2).await.unwrap();
+        write_frame(&mut client, &f3).await.unwrap();
+
+        let r1 = read_frame(&mut server).await.unwrap().unwrap();
+        let r2 = read_frame(&mut server).await.unwrap().unwrap();
+        let r3 = read_frame(&mut server).await.unwrap().unwrap();
+
+        assert_eq!(r1.frame_type, FrameType::Request);
+        assert_eq!(r2.frame_type, FrameType::Response);
+        assert_eq!(r3.frame_type, FrameType::Event);
+    }
+
+    #[tokio::test]
+    async fn test_eof_returns_none() {
+        let (client, mut server) = duplex(1024);
+        drop(client);
+        let result = read_frame(&mut server).await.unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/crates/voice-protocol/src/lib.rs
+++ b/crates/voice-protocol/src/lib.rs
@@ -1,0 +1,21 @@
+//! Wire protocol for the voice daemon.
+//!
+//! Defines frame types, RPC request/response types, and codec functions
+//! shared between the daemon, MCP server, CLI client, and Tauri UI.
+//!
+//! ## Wire format
+//!
+//! Length-prefixed frames over a byte stream (Unix socket or pipe):
+//!
+//! ```text
+//! [4 bytes: payload length (big-endian u32)] [1 byte: frame type] [N bytes: payload]
+//! ```
+//!
+//! Frame types:
+//! - `0x01` Request  — JSON-RPC 2.0 request
+//! - `0x02` Response — JSON-RPC 2.0 response
+//! - `0x03` Event    — daemon-initiated notification (state changes, progress)
+//! - `0x04` Sync     — reserved for automerge state sync (future)
+
+pub mod frames;
+pub mod rpc;

--- a/crates/voice-protocol/src/lib.rs
+++ b/crates/voice-protocol/src/lib.rs
@@ -17,5 +17,6 @@
 //! - `0x03` Event    — daemon-initiated notification (state changes, progress)
 //! - `0x04` Sync     — reserved for automerge state sync (future)
 
+pub mod client;
 pub mod frames;
 pub mod rpc;

--- a/crates/voice-protocol/src/rpc.rs
+++ b/crates/voice-protocol/src/rpc.rs
@@ -1,0 +1,148 @@
+//! JSON-RPC 2.0 request/response types for the voice daemon.
+//!
+//! These are the canonical definitions used by both the daemon and all clients
+//! (MCP server, CLI, Tauri UI).
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// JSON-RPC envelope
+// ---------------------------------------------------------------------------
+
+/// A JSON-RPC 2.0 request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Request {
+    pub jsonrpc: String,
+    pub method: String,
+    #[serde(default)]
+    pub params: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<Value>,
+}
+
+impl Request {
+    pub fn new(method: &str, params: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            method: method.to_string(),
+            params,
+            id: None,
+        }
+    }
+
+    pub fn with_id(mut self, id: impl Into<Value>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+}
+
+/// A JSON-RPC 2.0 response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Response {
+    pub jsonrpc: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<RpcError>,
+    pub id: Option<Value>,
+}
+
+impl Response {
+    pub fn success(id: Option<Value>, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            result: Some(result),
+            error: None,
+            id,
+        }
+    }
+
+    pub fn error(id: Option<Value>, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            result: None,
+            error: Some(RpcError {
+                code,
+                message: message.into(),
+            }),
+            id,
+        }
+    }
+
+    pub fn is_error(&self) -> bool {
+        self.error.is_some()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RpcError {
+    pub code: i32,
+    pub message: String,
+}
+
+// Standard JSON-RPC error codes
+pub const PARSE_ERROR: i32 = -32700;
+pub const INVALID_REQUEST: i32 = -32600;
+pub const METHOD_NOT_FOUND: i32 = -32601;
+pub const INVALID_PARAMS: i32 = -32602;
+
+// ---------------------------------------------------------------------------
+// Daemon event (server-initiated notification)
+// ---------------------------------------------------------------------------
+
+/// An event pushed from the daemon to connected clients.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Event {
+    /// Event type name.
+    pub event: String,
+    /// Event payload.
+    pub data: Value,
+}
+
+impl Event {
+    pub fn new(event: &str, data: Value) -> Self {
+        Self {
+            event: event.to_string(),
+            data,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Voice-specific types (shared between daemon and clients)
+// ---------------------------------------------------------------------------
+
+/// Status of a queued item.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ItemStatus {
+    Queued,
+    Processing,
+    Completed,
+    Failed,
+}
+
+/// A single item in the daemon's queue.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueueItem {
+    pub id: String,
+    pub client_id: String,
+    pub method: String,
+    pub status: ItemStatus,
+    pub created_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_preview: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<String>,
+}
+
+/// Snapshot of daemon state — returned by the `status` method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonState {
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current: Option<QueueItem>,
+    pub pending: Vec<QueueItem>,
+    pub recent: Vec<QueueItem>,
+}


### PR DESCRIPTION
## Summary

A voice daemon (`voiced`) that serializes TTS/STT requests from multiple clients through a Unix socket, preventing audio overlap when multiple Claude sessions use voice simultaneously.

### Architecture

```
Claude Session 1 (voice mcp) ─┐
Claude Session 2 (voice mcp) ─┼──→ ~/.voice/daemon.sock ──→ voiced ──→ 🔊
voice say "hello" (CLI) ───────┘         (queue)           (one model)
```

### New crates
- **voice-daemon** — the `voiced` binary: Unix socket server, request queue, TTS/STT worker
- **voice-protocol** — shared frame codec (length-prefixed typed frames) and JSON-RPC types, sync client

### Changes to existing code
- **voice-cli** — MCP server and CLI (say/converse/listen) detect daemon and delegate when available, falling back to local processing

### Key features
- One Kokoro TTS + Whisper STT model instance shared across all clients
- Sequential FIFO queue — no audio overlap
- `wait: true` mode — clients block until their request completes and get the actual result
- Launchd plist for auto-start at login
- Graceful fallback to local processing when daemon isn't running

### Commits (12)
1. Daemon skeleton — queue, socket, worker
2. JSON-RPC dispatch
3. voice-protocol crate — shared frame codec
4. Wire daemon to frame codec
5. Real TTS through the worker
6. STT (listen) through the worker
7. Eager model loading at startup
8. Fix VAD silence detection
9. MCP server delegates to daemon
10. Wait-for-completion mode
11. CLI say/converse/listen delegate to daemon
12. Clippy fixes

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --workspace` — all pass
- [x] `voiced` starts and loads both models
- [x] `voice say` delegates through daemon (instant, no model loading)
- [x] `voice mcp` speak/converse through daemon
- [x] Silence detection (VAD) works for listen
- [x] Multiple clients queue correctly, no overlap
- [ ] CI (may need voice-daemon excluded from workspace check since it has extra deps)