### PR TITLE
Add set_voice, set_speed, list_voices to daemon

### DIFF
--- a/crates/voice-cli/src/mcp.rs
+++ b/crates/voice-cli/src/mcp.rs
@@ -539,24 +539,51 @@ fn handle_tools_call(
                 Some(daemon.converse(&text, arguments.get("voice").and_then(|v| v.as_str())))
             }
             "cancel" => Some(daemon.cancel()),
+            "set_voice" => {
+                let voice = arguments
+                    .get("voice")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                Some(daemon.call("set_voice", serde_json::json!({"voice": voice})))
+            }
+            "set_speed" => {
+                let speed = arguments
+                    .get("speed")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(1.0);
+                Some(daemon.call("set_speed", serde_json::json!({"speed": speed})))
+            }
+            "list_voices" => Some(daemon.call("list_voices", serde_json::json!({}))),
             _ => None,
         };
 
         if let Some(result) = daemon_result {
             return match result {
                 Ok(resp) => {
-                    // The daemon returns {result: {queue_id, status, result: "<json string>"}}
-                    // Extract the inner result JSON string and use it as the MCP content.
-                    let inner = resp
+                    // For queued ops (speak/listen/converse), the daemon returns
+                    // {result: {queue_id, status, result: "<json string>"}}.
+                    // For config ops (set_voice/set_speed/list_voices), the daemon
+                    // returns the result directly in resp.result.
+                    let text = if let Some(inner) = resp
                         .result
                         .as_ref()
                         .and_then(|r| r.get("result"))
                         .and_then(|v| v.as_str())
-                        .unwrap_or("{}");
+                    {
+                        // Queued op: extract the worker's JSON result string
+                        inner.to_string()
+                    } else if let Some(r) = &resp.result {
+                        // Config op: serialize the whole result
+                        serde_json::to_string(r).unwrap_or_else(|_| "{}".to_string())
+                    } else if let Some(e) = &resp.error {
+                        format!("daemon error: {}", e.message)
+                    } else {
+                        "{}".to_string()
+                    };
                     Response::success(
                         id,
                         serde_json::json!({
-                            "content": [{ "type": "text", "text": inner }]
+                            "content": [{ "type": "text", "text": text }]
                         }),
                     )
                 }

--- a/crates/voice-daemon/src/config.rs
+++ b/crates/voice-daemon/src/config.rs
@@ -1,0 +1,36 @@
+//! Shared daemon configuration — voice, speed, etc.
+//!
+//! Accessible from both the socket handler (for set_voice/set_speed/list_voices)
+//! and the worker (for reading current defaults).
+
+use std::sync::Mutex;
+
+pub struct DaemonConfig {
+    pub voice_name: Mutex<String>,
+    pub speed: Mutex<f32>,
+}
+
+impl DaemonConfig {
+    pub fn new() -> Self {
+        Self {
+            voice_name: Mutex::new("af_heart".to_string()),
+            speed: Mutex::new(1.0),
+        }
+    }
+
+    pub fn get_voice_name(&self) -> String {
+        self.voice_name.lock().unwrap().clone()
+    }
+
+    pub fn set_voice_name(&self, name: String) {
+        *self.voice_name.lock().unwrap() = name;
+    }
+
+    pub fn get_speed(&self) -> f32 {
+        *self.speed.lock().unwrap()
+    }
+
+    pub fn set_speed(&self, speed: f32) {
+        *self.speed.lock().unwrap() = speed;
+    }
+}

--- a/crates/voice-daemon/src/main.rs
+++ b/crates/voice-daemon/src/main.rs
@@ -7,10 +7,12 @@
 //!   voiced              # start the daemon
 //!   voiced --status     # print daemon state and exit
 
+mod config;
 mod queue;
 mod socket;
 mod worker;
 
+use config::DaemonConfig;
 use queue::RequestQueue;
 use std::sync::Arc;
 use voice_protocol::frames::{read_frame, write_frame, Frame, FrameType};
@@ -43,6 +45,7 @@ async fn main() {
     }
 
     let queue = Arc::new(RequestQueue::new());
+    let config = Arc::new(DaemonConfig::new());
 
     // Handle ctrl-c
     tokio::spawn({
@@ -56,11 +59,12 @@ async fn main() {
 
     // Start worker and socket server concurrently
     let worker_queue = queue.clone();
+    let worker_config = config.clone();
     tokio::spawn(async move {
-        worker::run(worker_queue).await;
+        worker::run(worker_queue, worker_config).await;
     });
 
-    socket::serve(queue).await;
+    socket::serve(queue, config).await;
 }
 
 async fn print_status() {

--- a/crates/voice-daemon/src/socket.rs
+++ b/crates/voice-daemon/src/socket.rs
@@ -3,6 +3,7 @@
 //! Uses the voice-protocol frame codec (length-prefixed typed frames)
 //! instead of newline-delimited JSON.
 
+use crate::config::DaemonConfig;
 use crate::queue::RequestQueue;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -19,7 +20,7 @@ pub fn socket_path() -> PathBuf {
     dir.join("daemon.sock")
 }
 
-pub async fn serve(queue: Arc<RequestQueue>) {
+pub async fn serve(queue: Arc<RequestQueue>, config: Arc<DaemonConfig>) {
     let path = socket_path();
 
     if path.exists() {
@@ -40,9 +41,10 @@ pub async fn serve(queue: Arc<RequestQueue>) {
         match listener.accept().await {
             Ok((stream, _)) => {
                 let queue = queue.clone();
+                let config = config.clone();
                 let client_id = Uuid::new_v4().to_string()[..8].to_string();
                 eprintln!("voiced: client connected ({})", client_id);
-                tokio::spawn(handle_client(stream, queue, client_id));
+                tokio::spawn(handle_client(stream, queue, config, client_id));
             }
             Err(e) => eprintln!("voiced: accept error: {}", e),
         }
@@ -52,6 +54,7 @@ pub async fn serve(queue: Arc<RequestQueue>) {
 async fn handle_client(
     stream: tokio::net::UnixStream,
     queue: Arc<RequestQueue>,
+    config: Arc<DaemonConfig>,
     client_id: String,
 ) {
     let (mut reader, mut writer) = stream.into_split();
@@ -69,7 +72,7 @@ async fn handle_client(
         match frame.frame_type {
             FrameType::Request => {
                 let response = match frame.json::<rpc::Request>() {
-                    Ok(req) => dispatch(req, &queue, &client_id).await,
+                    Ok(req) => dispatch(req, &queue, &config, &client_id).await,
                     Err(e) => Response::error(
                         None,
                         rpc::PARSE_ERROR,
@@ -95,7 +98,12 @@ async fn handle_client(
     eprintln!("voiced: client disconnected ({})", client_id);
 }
 
-async fn dispatch(req: rpc::Request, queue: &Arc<RequestQueue>, client_id: &str) -> Response {
+async fn dispatch(
+    req: rpc::Request,
+    queue: &Arc<RequestQueue>,
+    config: &Arc<DaemonConfig>,
+    client_id: &str,
+) -> Response {
     use crate::queue::VoiceRequest;
 
     let wait = req
@@ -149,6 +157,50 @@ async fn dispatch(req: rpc::Request, queue: &Arc<RequestQueue>, client_id: &str)
         "status" => {
             let state = queue.snapshot().await;
             return Response::success(req.id, serde_json::to_value(&state).unwrap());
+        }
+        "set_voice" => {
+            let voice = req.params.get("voice").and_then(|v| v.as_str());
+            let Some(voice) = voice else {
+                return Response::error(req.id, rpc::INVALID_PARAMS, "Missing param: voice");
+            };
+            config.set_voice_name(voice.to_string());
+            return Response::success(req.id, serde_json::json!({ "voice": voice }));
+        }
+        "set_speed" => {
+            let speed = req.params.get("speed").and_then(|v| v.as_f64());
+            let Some(speed) = speed else {
+                return Response::error(req.id, rpc::INVALID_PARAMS, "Missing param: speed");
+            };
+            if speed <= 0.0 || speed > 5.0 {
+                return Response::error(
+                    req.id,
+                    rpc::INVALID_PARAMS,
+                    "Speed must be between 0 (exclusive) and 5 (inclusive)",
+                );
+            }
+            config.set_speed(speed as f32);
+            return Response::success(req.id, serde_json::json!({ "speed": speed }));
+        }
+        "list_voices" => {
+            let voices: Vec<serde_json::Value> = voice_tts::catalog::ALL_VOICES
+                .iter()
+                .map(|v| {
+                    let builtin = voice_tts::catalog::is_builtin(v.id);
+                    serde_json::json!({
+                        "id": v.id,
+                        "name": v.name,
+                        "language": v.language,
+                        "gender": v.gender,
+                        "traits": v.traits,
+                        "builtin": builtin,
+                    })
+                })
+                .collect();
+            let current = config.get_voice_name();
+            return Response::success(
+                req.id,
+                serde_json::json!({ "voices": voices, "current": current }),
+            );
         }
         _ => {
             return Response::error(

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -45,7 +45,7 @@ impl TtsState {
 
 // -- Worker entry point -------------------------------------------------------
 
-pub async fn run(queue: Arc<RequestQueue>) {
+pub async fn run(queue: Arc<RequestQueue>, config: Arc<crate::config::DaemonConfig>) {
     eprintln!("voiced: loading TTS model...");
     let start = Instant::now();
 
@@ -113,8 +113,9 @@ pub async fn run(queue: Arc<RequestQueue>) {
             match &entry.request {
                 VoiceRequest::Speak { text, voice, speed } => {
                     let text = text.clone();
-                    let voice = voice.clone();
-                    let speed = *speed;
+                    // Use daemon config defaults when request doesn't specify
+                    let voice = voice.clone().or_else(|| Some(config.get_voice_name()));
+                    let speed = speed.or_else(|| Some(config.get_speed() as f64));
                     let tts = tts.clone();
 
                     let result = tokio::task::spawn_blocking(move || {
@@ -154,13 +155,14 @@ pub async fn run(queue: Arc<RequestQueue>) {
                 }
                 VoiceRequest::Converse { text, voice } => {
                     let text = text.clone();
-                    let voice = voice.clone();
+                    let voice = voice.clone().or_else(|| Some(config.get_voice_name()));
+                    let default_speed = Some(config.get_speed() as f64);
                     let tts = tts.clone();
                     let stt = stt.clone();
 
                     // Speak then listen, return combined JSON
                     let speak_result = tokio::task::spawn_blocking(move || {
-                        let spoke_json = speak(&tts, &text, voice.as_deref(), None)?;
+                        let spoke_json = speak(&tts, &text, voice.as_deref(), default_speed)?;
                         let heard_json = listen(&stt, None)?;
                         // Parse both results and combine into the converse format
                         let spoke: serde_json::Value =


### PR DESCRIPTION
## Summary

Voice config methods forwarded through the daemon:

- **set_voice**: changes default voice for all subsequent requests
- **set_speed**: changes default speed (0.0-5.0)
- **list_voices**: returns full catalog with current selection

These are handled directly by the socket dispatcher (not queued) since they're instant state changes. Shared `DaemonConfig` struct accessible from both socket handler and worker.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --workspace` — all pass