### PR TITLE
Fix tray toggle and X button UX

### DIFF
--- a/crates/voice-tray/src-tauri/commands.rs
+++ b/crates/voice-tray/src-tauri/commands.rs
@@ -62,9 +62,9 @@ pub fn toggle_window(window: tauri::Window) -> Result<(), String> {
     Ok(())
 }
 
-/// Quit the application.
+/// Hide the window (for tray apps, this is the "close" behavior).
 #[tauri::command]
-pub fn quit_app() {
-    log::info!("Quit requested from UI");
-    std::process::exit(0);
+pub fn hide_window(window: tauri::Window) -> Result<(), String> {
+    log::info!("Hide window requested from UI");
+    window.hide().map_err(|e| e.to_string())
 }

--- a/crates/voice-tray/src-tauri/main.rs
+++ b/crates/voice-tray/src-tauri/main.rs
@@ -78,80 +78,87 @@ fn main() {
 
                 use tauri::tray::MouseButton;
 
-                // Handle direct tray click to show window (always show, never toggle)
+                // Handle direct tray click to toggle window visibility
                 let window_handle = app.handle().clone();
                 tray.on_tray_icon_event(move |_tray, event| {
                     info!("Tray icon event: {:?}", event);
                     if let tauri::tray::TrayIconEvent::Click { button, rect, .. } = event {
                         if button == MouseButton::Left {
                             if let Some(window) = window_handle.get_webview_window("main") {
-                                info!("Left click on tray, showing window");
+                                let is_visible = window.is_visible().unwrap_or(false);
+                                info!("Left click on tray, window visible: {}", is_visible);
 
-                                #[cfg(target_os = "macos")]
-                                {
-                                    use tauri::{PhysicalPosition, Position, Size};
-
-                                    // Extract physical position and size from the rect
-                                    if let (Position::Physical(pos), Size::Physical(size)) =
-                                        (&rect.position, &rect.size)
+                                if is_visible {
+                                    info!("Hiding window");
+                                    let _ = window.hide();
+                                } else {
+                                    info!("Showing window");
+                                    #[cfg(target_os = "macos")]
                                     {
-                                        let tray_x = pos.x;
-                                        let tray_y = pos.y;
-                                        let tray_width = size.width;
-                                        let tray_height = size.height;
+                                        use tauri::{PhysicalPosition, Position, Size};
 
-                                        info!(
-                                            "Tray icon rect: x={}, y={}, width={}, height={}",
-                                            tray_x, tray_y, tray_width, tray_height
-                                        );
-
-                                        // Position window below the tray icon
-                                        // Window width is 400px, so center it under the tray icon
-                                        let window_x =
-                                            (tray_x + tray_width as i32 / 2 - 200).max(0);
-                                        let window_y = tray_y + tray_height as i32 + 5; // 5px gap
-
-                                        info!(
-                                            "Positioning window at physical: x={}, y={}",
-                                            window_x, window_y
-                                        );
-
-                                        if let Err(e) = window
-                                            .set_position(PhysicalPosition::new(window_x, window_y))
+                                        // Extract physical position and size from the rect
+                                        if let (Position::Physical(pos), Size::Physical(size)) =
+                                            (&rect.position, &rect.size)
                                         {
-                                            error!("Failed to set window position: {}", e);
+                                            let tray_x = pos.x;
+                                            let tray_y = pos.y;
+                                            let tray_width = size.width;
+                                            let tray_height = size.height;
+
+                                            info!(
+                                                "Tray icon rect: x={}, y={}, width={}, height={}",
+                                                tray_x, tray_y, tray_width, tray_height
+                                            );
+
+                                            // Position window below the tray icon
+                                            // Window width is 400px, so center it under the tray icon
+                                            let window_x =
+                                                (tray_x + tray_width as i32 / 2 - 200).max(0);
+                                            let window_y = tray_y + tray_height as i32 + 5; // 5px gap
+
+                                            info!(
+                                                "Positioning window at physical: x={}, y={}",
+                                                window_x, window_y
+                                            );
+
+                                            if let Err(e) = window
+                                                .set_position(PhysicalPosition::new(window_x, window_y))
+                                            {
+                                                error!("Failed to set window position: {}", e);
+                                            }
+                                        } else {
+                                            warn!(
+                                                "Tray rect not in physical coordinates, using fallback"
+                                            );
+                                            // Fallback positioning
+                                            let _ = window.set_position(PhysicalPosition::new(100, 40));
                                         }
-                                    } else {
-                                        warn!(
-                                            "Tray rect not in physical coordinates, using fallback"
-                                        );
-                                        // Fallback positioning
-                                        let _ = window.set_position(PhysicalPosition::new(100, 40));
+
+                                        // Show and focus the window
+                                        if let Err(e) = window.show() {
+                                            error!("Error showing window: {}", e);
+                                        }
+                                        if let Err(e) = window.set_focus() {
+                                            error!("Error focusing window: {}", e);
+                                        }
+
+                                        // Track show time
+                                        *last_show.lock().unwrap() = Instant::now();
                                     }
 
-                                    // Show and focus the window
-                                    if let Err(e) = window.show() {
-                                        error!("Error showing window: {}", e);
-                                    }
-                                    if let Err(e) = window.set_focus() {
-                                        error!("Error focusing window: {}", e);
-                                    }
+                                    #[cfg(not(target_os = "macos"))]
+                                    {
+                                        if let Err(e) = window.show() {
+                                            error!("Error showing window: {}", e);
+                                        }
+                                        if let Err(e) = window.set_focus() {
+                                            error!("Error focusing window: {}", e);
+                                        }
 
-                                    // Track show time
-                                    *last_show.lock().unwrap() = Instant::now();
-                                }
-
-                                #[cfg(not(target_os = "macos"))]
-                                {
-                                    if let Err(e) = window.show() {
-                                        error!("Error showing window: {}", e);
+                                        // Track show time
+                                        *last_show.lock().unwrap() = Instant::now();
                                     }
-                                    if let Err(e) = window.set_focus() {
-                                        error!("Error focusing window: {}", e);
-                                    }
-
-                                    // Track show time
-                                    *last_show.lock().unwrap() = Instant::now();
                                 }
                             }
                         }
@@ -243,7 +250,7 @@ fn main() {
             commands::cancel_item,
             commands::is_daemon_running,
             commands::toggle_window,
-            commands::quit_app,
+            commands::hide_window,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/crates/voice-tray/src/components/QueuePanel.tsx
+++ b/crates/voice-tray/src/components/QueuePanel.tsx
@@ -7,8 +7,8 @@ import { invoke } from "@tauri-apps/api/core";
 export default function QueuePanel() {
   const queueState = useAppStore((s) => s.queueState);
 
-  const handleQuit = async () => {
-    await invoke("quit_app");
+  const handleClose = async () => {
+    await invoke("hide_window");
   };
 
   if (!queueState) {
@@ -34,9 +34,9 @@ export default function QueuePanel() {
           </p>
         </div>
         <button
-          onClick={handleQuit}
+          onClick={handleClose}
           className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded transition-colors"
-          title="Quit Application"
+          title="Close"
         >
           <X className="w-4 h-4" />
         </button>


### PR DESCRIPTION
## Summary

Fixes two UX issues reported after testing the tray app:
1. Unable to hide window by clicking tray icon
2. X button quits entire app instead of just hiding window

## Changes

### Restored Tray Icon Toggle
- **Before**: Tray click always showed window (couldn't hide via tray)
- **After**: Tray click toggles visibility (show if hidden, hide if visible)
- Blur grace period (300ms) prevents click-and-hold requirement

### Changed X Button Behavior
- **Before**: X button called `quit_app` → exits entire process
- **After**: X button calls `hide_window` → hides window, keeps tray running
- Renamed command: `quit_app` → `hide_window`
- Updated button title: "Quit Application" → "Close"

## Standard Tray App UX

✅ X button hides window (app stays running in tray)
✅ Tray icon click toggles window visibility
✅ Clicking outside window hides it (after grace period)
✅ App quits via system force quit or explicit quit command

## Test Plan
- [x] Built and installed locally
- [x] Tray icon toggles window on click
- [x] X button hides window (app stays running)
- [x] Blur after grace period still works
- [ ] User verification

## User Feedback

> "Ironically I can't hide the window now by clicking the tray icon now. The "x" causes it to exit (and I clicked that thinking it would dismiss and stay alive). UX whoopsie"

Both issues now fixed.