### PR TITLE
Local voicepack resolution: voice say -v <name> picks up ~/.cache/voice/voices/

### DIFF
--- a/crates/voice-cli/Cargo.toml
+++ b/crates/voice-cli/Cargo.toml
@@ -35,3 +35,4 @@ ctrlc = "3.5.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 voice-protocol = { path = "../voice-protocol" }
+dirs = "5"

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -431,7 +431,7 @@ fn collect_subs(
     }
 
     // Sort text subs by key length descending so "nteract.io" matches before "nteract"
-    text_subs.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+    text_subs.sort_by_key(|b| std::cmp::Reverse(b.0.len()));
 
     (text_subs, phoneme_overrides)
 }

--- a/crates/voice-cli/src/mcp.rs
+++ b/crates/voice-cli/src/mcp.rs
@@ -995,19 +995,17 @@ fn voice_list_voices(session: &Session, params: Value) -> Result<Value, RpcErr> 
                 .filter_map(|e| {
                     let path = e.path();
                     if path.extension().and_then(|x| x.to_str()) == Some("safetensors") {
-                        path.file_stem()
-                            .and_then(|s| s.to_str())
-                            .map(|id| {
-                                serde_json::json!({
-                                    "id": id,
-                                    "name": id,
-                                    "language": "custom",
-                                    "gender": "unknown",
-                                    "grade": "user",
-                                    "traits": [],
-                                    "status": "local",
-                                })
+                        path.file_stem().and_then(|s| s.to_str()).map(|id| {
+                            serde_json::json!({
+                                "id": id,
+                                "name": id,
+                                "language": "custom",
+                                "gender": "unknown",
+                                "grade": "user",
+                                "traits": [],
+                                "status": "local",
                             })
+                        })
                     } else {
                         None
                     }

--- a/crates/voice-cli/src/mcp.rs
+++ b/crates/voice-cli/src/mcp.rs
@@ -985,9 +985,40 @@ fn voice_set_speed(session: &mut Session, params: Value) -> Result<Value, RpcErr
 fn voice_list_voices(session: &Session, params: Value) -> Result<Value, RpcErr> {
     let show_all = params.get("all").and_then(|v| v.as_bool()).unwrap_or(false);
 
+    // Scan ~/.cache/voice/voices/ for user-local voicepacks.
+    let local_voices: Vec<Value> = dirs::home_dir()
+        .map(|h| h.join(".cache/voice/voices"))
+        .and_then(|dir| std::fs::read_dir(&dir).ok())
+        .map(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .filter_map(|e| {
+                    let path = e.path();
+                    if path.extension().and_then(|x| x.to_str()) == Some("safetensors") {
+                        path.file_stem()
+                            .and_then(|s| s.to_str())
+                            .map(|id| {
+                                serde_json::json!({
+                                    "id": id,
+                                    "name": id,
+                                    "language": "custom",
+                                    "gender": "unknown",
+                                    "grade": "user",
+                                    "traits": [],
+                                    "status": "local",
+                                })
+                            })
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
     if show_all {
-        // Full catalog with availability status
-        let voices: Vec<Value> = voice_tts::catalog::ALL_VOICES
+        // Full catalog with availability status + local voices
+        let mut voices: Vec<Value> = voice_tts::catalog::ALL_VOICES
             .iter()
             .map(|v| {
                 let builtin = voice_tts::catalog::is_builtin(v.id);
@@ -1010,10 +1041,11 @@ fn voice_list_voices(session: &Session, params: Value) -> Result<Value, RpcErr> 
                 })
             })
             .collect();
+        voices.extend(local_voices);
         Ok(serde_json::json!({ "voices": voices }))
     } else {
-        // Quick: just builtin voices with metadata
-        let voices: Vec<Value> = voice_tts::catalog::ALL_VOICES
+        // Quick: builtin voices + local voices
+        let mut voices: Vec<Value> = voice_tts::catalog::ALL_VOICES
             .iter()
             .filter(|v| voice_tts::catalog::is_builtin(v.id))
             .map(|v| {
@@ -1028,6 +1060,7 @@ fn voice_list_voices(session: &Session, params: Value) -> Result<Value, RpcErr> 
                 })
             })
             .collect();
+        voices.extend(local_voices);
         Ok(serde_json::json!({ "voices": voices }))
     }
 }

--- a/crates/voice-tts/Cargo.toml
+++ b/crates/voice-tts/Cargo.toml
@@ -17,3 +17,4 @@ serde_json = { workspace = true }
 hf-hub = { workspace = true }
 hound = { workspace = true }
 thiserror = { workspace = true }
+dirs = "5"

--- a/crates/voice-tts/src/lib.rs
+++ b/crates/voice-tts/src/lib.rs
@@ -88,7 +88,9 @@ pub fn load_voice(voice_name: &str, repo_id: Option<&str>, device: &Device) -> R
 
     // (2) User-local voice cache
     if let Some(home) = dirs::home_dir() {
-        let local = home.join(".cache/voice/voices").join(format!("{voice_name}.safetensors"));
+        let local = home
+            .join(".cache/voice/voices")
+            .join(format!("{voice_name}.safetensors"));
         if local.is_file() {
             let data = std::fs::read(&local)?;
             return load_voice_from_bytes(&data, device);

--- a/crates/voice-tts/src/lib.rs
+++ b/crates/voice-tts/src/lib.rs
@@ -72,13 +72,35 @@ impl KokoroModel {
 }
 
 /// Load a voice embedding by name, using the model's device.
+///
+/// Resolution order:
+///   1. If `voice_name` points to an existing file, load that safetensors.
+///   2. If `~/.cache/voice/voices/{voice_name}.safetensors` exists, load it.
+///   3. If `voice_name` matches a builtin embedded voice, use that.
+///   4. Fall back to downloading from HuggingFace.
 pub fn load_voice(voice_name: &str, repo_id: Option<&str>, device: &Device) -> Result<Tensor> {
-    // Try builtin first
+    // (1) Direct file path
+    let as_path = Path::new(voice_name);
+    if as_path.is_file() {
+        let data = std::fs::read(as_path)?;
+        return load_voice_from_bytes(&data, device);
+    }
+
+    // (2) User-local voice cache
+    if let Some(home) = dirs::home_dir() {
+        let local = home.join(".cache/voice/voices").join(format!("{voice_name}.safetensors"));
+        if local.is_file() {
+            let data = std::fs::read(&local)?;
+            return load_voice_from_bytes(&data, device);
+        }
+    }
+
+    // (3) Builtin embedded voice
     if let Some(data) = builtin::get_builtin_voice_bytes(voice_name) {
         return load_voice_from_bytes(data, device);
     }
 
-    // Download from HF
+    // (4) Download from HF
     let repo_id = repo_id.unwrap_or(DEFAULT_REPO);
     let api = Api::new().map_err(|e| VoicersError::Hub(e.to_string()))?;
     let repo = api.model(repo_id.to_string());


### PR DESCRIPTION
## Summary
- `load_voice` resolves in order: absolute path, `~/.cache/voice/voices/{name}.safetensors`, builtin, HF hub
- `list_voices` (MCP) includes derived voicepacks from the local cache in both quick and `--all` modes
- Enables per-user voicepack experimentation without republishing

## Why
Working on voice-forge produces derived Kokoro voicepacks — research outputs, custom voices, variants. Before this, the only way to use one was to publish it to HuggingFace or point at an absolute path. Both are clunky for iteration.

This lets you drop any `name.safetensors` into `~/.cache/voice/voices/` and use it as `voice say -v name ...` exactly like a built-in voice. MCP clients see them in `list_voices` too.

Already in active use across the voice-forge Millie iteration loop.

## Test plan
- [ ] `voice say -v af_heart "test"` still works (HF path unchanged)
- [ ] Drop a .safetensors into `~/.cache/voice/voices/`, run `voice say -v <name>`, expect load from local
- [ ] `voice mcp` then `list_voices` returns local voices alongside HF voices
- [ ] `voice say -v /abs/path/voice.safetensors` works (explicit path)
- [ ] Missing voice still returns the existing "not found" error with suggestions