### PR TITLE
Add --duration flag to voice converse, default 30s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7066,6 +7066,7 @@ dependencies = [
  "candle-core",
  "clap",
  "ctrlc",
+ "dirs 5.0.1",
  "hound",
  "pulldown-cmark",
  "rodio",
@@ -7182,6 +7183,7 @@ version = "0.3.0"
 dependencies = [
  "candle-core",
  "candle-nn",
+ "dirs 5.0.1",
  "hf-hub",
  "hound",
  "safetensors 0.6.2",

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -133,6 +133,10 @@ struct ConverseArgs {
     #[arg(short, long, default_value = "1.0")]
     speed: f32,
 
+    /// Max listen duration in seconds (after speaking)
+    #[arg(short, long, default_value = "30")]
+    duration: u64,
+
     /// Strip markdown/MDX formatting before speaking
     #[arg(long)]
     markdown: bool,
@@ -780,11 +784,11 @@ fn run_converse(args: ConverseArgs) {
     // Listen for response (VAD auto-stop — no Enter key needed)
     if let Some(result) = listen::listen_and_transcribe_vad(
         &mut stt_model,
-        15_000, // max_duration_ms
-        1_500,  // silence_timeout_ms
-        0.01,   // silence_threshold
-        3.0,    // noise_multiplier
-        300,    // calibration_ms
+        args.duration * 1_000, // max_duration_ms
+        1_500,                 // silence_timeout_ms
+        0.01,                  // silence_threshold
+        3.0,                   // noise_multiplier
+        300,                   // calibration_ms
     ) {
         println!("{}", result.text);
         if !QUIET.load(std::sync::atomic::Ordering::Relaxed) {


### PR DESCRIPTION
## Summary

- Adds `-d / --duration` flag to `voice converse` for configuring the listen window in seconds
- Bumps default from 15s to 30s so longer responses aren't cut off
- `voice converse -d 60 "Tell me a story"` for a 60s listen window

## Test plan

- [x] `voice converse --help` shows the new flag with default 30
- [ ] `voice converse "repeat after me"` listens for up to 30s
- [ ] `voice converse -d 5 "say something short"` cuts off at 5s