### PR TITLE
fix: support CPU Kokoro TTS builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7116,7 +7116,6 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "candle-core",
- "candle-metal-kernels",
  "candle-nn",
  "candle-transformers",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,9 @@ exclude = ["crates/src-tauri"]
 resolver = "2"
 
 [workspace.dependencies]
-candle-core = { version = "0.10", features = ["metal"] }
-candle-nn = { version = "0.10", features = ["metal"] }
+candle-core = { version = "0.10" }
+candle-nn = { version = "0.10" }
 candle-transformers = { version = "0.10" }
-candle-metal-kernels = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/voice-kokoro/Cargo.toml
+++ b/crates/voice-kokoro/Cargo.toml
@@ -11,13 +11,16 @@ repository = "https://github.com/rgbkrk/voice"
 candle-core = { workspace = true }
 candle-nn = { workspace = true }
 candle-transformers = { workspace = true }
-candle-metal-kernels = { workspace = true }
 half = { version = "2", features = ["num-traits"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 hf-hub = { workspace = true }
 safetensors = { workspace = true }
 thiserror = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+candle-core = { workspace = true, features = ["metal"] }
+candle-nn = { workspace = true, features = ["metal"] }
 
 [dev-dependencies]
 hound = "3"
@@ -29,5 +32,5 @@ name = "generate"
 required-features = ["metal"]
 
 [features]
-default = ["metal"]
+default = []
 metal = []

--- a/crates/voice-tts/Cargo.toml
+++ b/crates/voice-tts/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/rgbkrk/voice"
 
 [dependencies]
-voice-kokoro = { path = "../voice-kokoro" }
+voice-kokoro = { path = "../voice-kokoro", default-features = false }
 candle-core = { workspace = true }
 candle-nn = { workspace = true }
 safetensors = { workspace = true }
@@ -18,3 +18,11 @@ hf-hub = { workspace = true }
 hound = { workspace = true }
 thiserror = { workspace = true }
 dirs = "5"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+candle-core = { workspace = true, features = ["metal"] }
+candle-nn = { workspace = true, features = ["metal"] }
+
+[features]
+default = []
+metal = ["voice-kokoro/metal"]

--- a/crates/voice-tts/src/lib.rs
+++ b/crates/voice-tts/src/lib.rs
@@ -20,10 +20,31 @@ pub struct KokoroModel {
     pub sample_rate: u32,
 }
 
+/// Return the default inference device for TTS.
+///
+/// On macOS this preserves the existing Apple Silicon Metal path. All other
+/// builds use Candle's CPU backend, which keeps Kokoro usable on Linux hosts
+/// with no GPU.
+pub fn default_tts_device() -> Result<Device> {
+    #[cfg(target_os = "macos")]
+    {
+        Device::new_metal(0).map_err(|e| VoicersError::Model(e.to_string()))
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        Ok(Device::Cpu)
+    }
+}
+
 /// Load a Kokoro TTS model from a HuggingFace repo or local path.
 pub fn load_model(path_or_repo: &str) -> Result<KokoroModel> {
-    let device = Device::new_metal(0).map_err(|e| VoicersError::Model(e.to_string()))?;
+    let device = default_tts_device()?;
+    load_model_on_device(path_or_repo, device)
+}
 
+/// Load a Kokoro TTS model on an explicitly supplied Candle device.
+pub fn load_model_on_device(path_or_repo: &str, device: Device) -> Result<KokoroModel> {
     let (config_path, weights_path) = if Path::new(path_or_repo).exists() {
         let dir = PathBuf::from(path_or_repo);
         (dir.join("config.json"), find_safetensors(&dir)?)


### PR DESCRIPTION
## Summary
- stop enabling Candle Metal unconditionally at the workspace level
- keep Metal enabled for macOS targets while allowing Linux CPU builds
- add `voice_tts::default_tts_device()` and `load_model_on_device()` so callers can use the default platform device or provide one explicitly

## Notes
This is intentionally the CPU/headless enablement slice. On this Linux host, `voice-kokoro` and `voice-tts` now check without pulling Apple-only `objc2`/Metal dependencies. The default device selection is currently target-based: macOS uses Metal, non-macOS uses CPU. It does not yet do runtime GPU probing or env-var device overrides.

A follow-up stacked PR can tackle the daemon/file-synthesis path separately.

## Test Plan
- [x] `git diff --check`
- [x] `cargo fmt --check`
- [x] `cargo check -p voice-kokoro --lib`
- [x] `cargo check -p voice-tts`
- [x] `cargo check -p voice-tts --features metal`
- [x] `cargo check -p voice-kokoro --tests`

Known follow-up: `cargo check -p voice-daemon` and `cargo check -p voice --no-default-features` still hit Linux ALSA development dependencies through playback/audio-output crates. That appears separate from the Metal/CPU backend issue and is a good candidate for the daemon/headless stacked PR.