### PR TITLE
Improve voice daemon control surface

### DIFF
--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -42,6 +42,7 @@ macro_rules! info {
                   voice listen\n  \
                   voice listen --continuous\n  \
                   voice transcribe recording.wav\n  \
+                  voice daemon status\n  \
                   voice serve -v am_michael"
 )]
 struct Args {
@@ -77,6 +78,9 @@ enum Command {
 
     /// Run as an MCP (Model Context Protocol) server on stdin/stdout
     Mcp(ServeArgs),
+
+    /// Inspect and control a running voice daemon
+    Daemon(DaemonArgs),
 }
 
 #[derive(clap::Args, Debug)]
@@ -185,6 +189,81 @@ struct ServeArgs {
     /// Include Metal GPU memory stats (_mem) in MCP tool responses
     #[arg(long)]
     mem: bool,
+}
+
+#[derive(clap::Args, Debug)]
+struct DaemonArgs {
+    #[command(subcommand)]
+    command: Option<DaemonCommand>,
+}
+
+#[derive(clap::Subcommand, Debug)]
+enum DaemonCommand {
+    /// Show daemon queue state
+    Status {
+        /// Print the raw daemon status JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Print the daemon Unix socket path
+    Socket,
+
+    /// List voices known to the daemon
+    Voices {
+        /// Print the raw daemon voices JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Set the daemon default voice
+    SetVoice {
+        /// Voice name, e.g. af_heart or am_adam
+        voice: String,
+    },
+
+    /// Set the daemon default speech speed
+    SetSpeed {
+        /// Speech speed factor, between 0 and 5
+        speed: f64,
+    },
+
+    /// Cancel a queued item by queue ID
+    Cancel {
+        /// Queue item ID returned by daemon status or speak
+        queue_id: String,
+    },
+
+    /// Replay stored question or answer audio for a queue item
+    Replay {
+        /// Queue item ID returned by daemon status or converse
+        queue_id: String,
+
+        /// Which audio file to replay
+        #[arg(short, long, value_enum, default_value_t = ReplayPart::Question)]
+        part: ReplayPart,
+    },
+}
+
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+enum ReplayPart {
+    Question,
+    Answer,
+}
+
+impl ReplayPart {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Question => "question",
+            Self::Answer => "answer",
+        }
+    }
+}
+
+impl std::fmt::Display for ReplayPart {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 fn resolve_text(say: &SayArgs) -> Result<String, String> {
@@ -492,6 +571,9 @@ fn main() {
         Some(Command::Mcp(serve_args)) => {
             run_mcp(serve_args);
         }
+        Some(Command::Daemon(daemon_args)) => {
+            run_daemon(daemon_args);
+        }
         Some(Command::Say(say_args)) => {
             run_say(say_args);
         }
@@ -516,6 +598,178 @@ fn main() {
                 run_say(say_args);
             }
         }
+    }
+}
+
+fn run_daemon(args: DaemonArgs) {
+    let command = args
+        .command
+        .unwrap_or(DaemonCommand::Status { json: false });
+
+    match command {
+        DaemonCommand::Socket => {
+            println!("{}", voice_protocol::client::daemon_socket_path().display());
+        }
+        DaemonCommand::Status { json } => {
+            let mut daemon = connect_daemon_or_exit();
+            let result = daemon_response_or_exit(daemon.status());
+            if json {
+                println!("{}", serde_json::to_string_pretty(&result).unwrap());
+            } else {
+                print_daemon_status(&result);
+            }
+        }
+        DaemonCommand::Voices { json } => {
+            let mut daemon = connect_daemon_or_exit();
+            let result = daemon_response_or_exit(daemon.list_voices());
+            if json {
+                println!("{}", serde_json::to_string_pretty(&result).unwrap());
+            } else {
+                print_daemon_voices(&result);
+            }
+        }
+        DaemonCommand::SetVoice { voice } => {
+            let mut daemon = connect_daemon_or_exit();
+            let result = daemon_response_or_exit(daemon.set_voice(&voice));
+            let voice = result
+                .get("voice")
+                .and_then(|v| v.as_str())
+                .unwrap_or(&voice);
+            println!("voice: {voice}");
+        }
+        DaemonCommand::SetSpeed { speed } => {
+            let mut daemon = connect_daemon_or_exit();
+            let result = daemon_response_or_exit(daemon.set_speed(speed));
+            let speed = result
+                .get("speed")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(speed);
+            println!("speed: {speed}");
+        }
+        DaemonCommand::Cancel { queue_id } => {
+            let mut daemon = connect_daemon_or_exit();
+            let result = daemon_response_or_exit(daemon.cancel_item(&queue_id));
+            let cancelled = result
+                .get("cancelled")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            println!("cancelled: {cancelled}");
+        }
+        DaemonCommand::Replay { queue_id, part } => {
+            let mut daemon = connect_daemon_or_exit();
+            let result = daemon_response_or_exit(daemon.replay_audio(&queue_id, part.as_str()));
+            let duration = result
+                .get("duration_ms")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            println!(
+                "played {} audio for {} ({} ms)",
+                part.as_str(),
+                queue_id,
+                duration
+            );
+        }
+    }
+}
+
+fn connect_daemon_or_exit() -> voice_protocol::client::DaemonClient {
+    if let Some(daemon) = voice_protocol::client::DaemonClient::connect() {
+        return daemon;
+    }
+
+    let socket = voice_protocol::client::daemon_socket_path();
+    eprintln!("voice daemon: not running (socket: {})", socket.display());
+    eprintln!("start it with `voiced`");
+    std::process::exit(1);
+}
+
+fn daemon_response_or_exit(
+    result: Result<voice_protocol::rpc::Response, String>,
+) -> serde_json::Value {
+    match result {
+        Ok(resp) => {
+            if let Some(err) = resp.error {
+                eprintln!("voice daemon: {}", err.message);
+                std::process::exit(1);
+            }
+            resp.result.unwrap_or(serde_json::Value::Null)
+        }
+        Err(e) => {
+            eprintln!("voice daemon: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn print_daemon_status(result: &serde_json::Value) {
+    let status = result
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let pending = result
+        .get("pending")
+        .and_then(|v| v.as_array())
+        .map(|items| items.len())
+        .unwrap_or(0);
+    let recent = result
+        .get("recent")
+        .and_then(|v| v.as_array())
+        .map(|items| items.len())
+        .unwrap_or(0);
+
+    println!("status: {status}");
+    println!(
+        "socket: {}",
+        voice_protocol::client::daemon_socket_path().display()
+    );
+
+    match result.get("current").filter(|value| !value.is_null()) {
+        Some(current) => println!("current: {}", format_daemon_item(current)),
+        None => println!("current: none"),
+    }
+
+    println!("pending: {pending}");
+    println!("recent: {recent}");
+}
+
+fn format_daemon_item(item: &serde_json::Value) -> String {
+    let id = item.get("id").and_then(|v| v.as_str()).unwrap_or("unknown");
+    let method = item
+        .get("method")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let status = item
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+
+    if let Some(preview) = item.get("text_preview").and_then(|v| v.as_str()) {
+        format!("{id} {method} {status}: {preview}")
+    } else {
+        format!("{id} {method} {status}")
+    }
+}
+
+fn print_daemon_voices(result: &serde_json::Value) {
+    let current = result.get("current").and_then(|v| v.as_str()).unwrap_or("");
+    let voices = result
+        .get("voices")
+        .and_then(|v| v.as_array())
+        .map(|voices| voices.as_slice())
+        .unwrap_or(&[]);
+
+    for voice in voices {
+        let id = voice.get("id").and_then(|v| v.as_str()).unwrap_or("");
+        let name = voice.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        let language = voice.get("language").and_then(|v| v.as_str()).unwrap_or("");
+        let builtin = voice
+            .get("builtin")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let marker = if id == current { "*" } else { " " };
+        let source = if builtin { "builtin" } else { "download" };
+
+        println!("{marker} {id:<14} {name:<24} {language:<12} {source}");
     }
 }
 

--- a/crates/voice-cli/src/mcp.rs
+++ b/crates/voice-cli/src/mcp.rs
@@ -680,6 +680,7 @@ fn metal_memory_stats() -> MemStats {
 }
 
 /// Get process resident set size in bytes via mach task_info.
+#[cfg(target_os = "macos")]
 fn process_rss_bytes() -> u64 {
     use std::mem;
 
@@ -722,6 +723,11 @@ fn process_rss_bytes() -> u64 {
     } else {
         0
     }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn process_rss_bytes() -> u64 {
+    0
 }
 
 fn round1(v: f64) -> f64 {

--- a/crates/voice-daemon/src/main.rs
+++ b/crates/voice-daemon/src/main.rs
@@ -61,6 +61,18 @@ async fn main() {
         }
     };
 
+    // Persist an initial idle snapshot so file-watching clients can attach
+    // before the first queue transition.
+    {
+        let snapshot = queue.snapshot().await;
+        let mut am = automerge.lock().await;
+        am.update(&snapshot);
+        if let Err(e) = am.save() {
+            eprintln!("voiced: failed to save initial automerge state: {}", e);
+            std::process::exit(1);
+        }
+    }
+
     // Handle ctrl-c
     tokio::spawn({
         async move {

--- a/crates/voice-daemon/src/queue.rs
+++ b/crates/voice-daemon/src/queue.rs
@@ -5,6 +5,8 @@ use tokio::sync::{oneshot, Mutex, Notify};
 use uuid::Uuid;
 use voice_protocol::rpc::{DaemonState, ItemStatus, QueueItem};
 
+const CANCELLED_MESSAGE: &str = "Cancelled by user";
+
 /// What the worker will execute.
 #[derive(Debug, Clone)]
 pub enum VoiceRequest {
@@ -228,56 +230,59 @@ impl RequestQueue {
     }
 
     pub async fn cancel_client(&self, client_id: &str) -> usize {
-        let mut items = self.items.lock().await;
-        let before = items.len();
-        items.retain(|e| e.client_id != client_id);
-        before - items.len()
+        let mut cancelled = Vec::new();
+
+        {
+            let mut items = self.items.lock().await;
+            let mut index = 0;
+            while index < items.len() {
+                if items[index].client_id == client_id {
+                    cancelled.push(items.remove(index).unwrap());
+                } else {
+                    index += 1;
+                }
+            }
+        }
+
+        let count = cancelled.len();
+        for entry in cancelled {
+            self.cancel_entry(entry).await;
+        }
+        count
     }
 
     /// Cancel a specific queue item by ID.
     pub async fn cancel_item(&self, queue_id: &str) -> bool {
         // Check if it's the current item
-        {
+        let current_entry = {
             let mut current = self.current.lock().await;
             if let Some(entry) = current.as_ref() {
                 if entry.id == queue_id {
-                    // Mark as failed and move to recent
-                    let mut entry = current.take().unwrap();
-                    entry.status = ItemStatus::Failed;
-                    entry.result = Some("Cancelled by user".to_string());
-                    self.push_recent(entry).await;
-                    // Signal any waiting client
-                    self.signal_waiter(
-                        queue_id,
-                        CompletionResult {
-                            status: ItemStatus::Failed,
-                            result: Some("Cancelled by user".to_string()),
-                        },
-                    )
-                    .await;
-                    return true;
+                    current.take()
+                } else {
+                    None
                 }
+            } else {
+                None
             }
+        };
+
+        if let Some(entry) = current_entry {
+            self.cancel_entry(entry).await;
+            return true;
         }
 
         // Check pending queue
-        let mut items = self.items.lock().await;
-        if let Some(pos) = items.iter().position(|e| e.id == queue_id) {
-            let mut entry = items.remove(pos).unwrap();
-            let entry_id = entry.id.clone(); // Capture ID before moving entry
-            entry.status = ItemStatus::Failed;
-            entry.result = Some("Cancelled by user".to_string());
-            drop(items); // Release lock before calling push_recent
-            self.push_recent(entry).await;
-            // Signal any waiting client
-            self.signal_waiter(
-                &entry_id,
-                CompletionResult {
-                    status: ItemStatus::Failed,
-                    result: Some("Cancelled by user".to_string()),
-                },
-            )
-            .await;
+        let pending_entry = {
+            let mut items = self.items.lock().await;
+            items
+                .iter()
+                .position(|e| e.id == queue_id)
+                .and_then(|pos| items.remove(pos))
+        };
+
+        if let Some(entry) = pending_entry {
+            self.cancel_entry(entry).await;
             return true;
         }
 
@@ -334,6 +339,21 @@ impl RequestQueue {
         }
     }
 
+    async fn cancel_entry(&self, mut entry: QueueEntry) {
+        let id = entry.id.clone();
+        entry.status = ItemStatus::Failed;
+        entry.result = Some(CANCELLED_MESSAGE.to_string());
+        self.push_recent(entry).await;
+        self.signal_waiter(
+            &id,
+            CompletionResult {
+                status: ItemStatus::Failed,
+                result: Some(CANCELLED_MESSAGE.to_string()),
+            },
+        )
+        .await;
+    }
+
     /// Remove a completed item from the recent list by ID.
     pub async fn remove_recent(&self, id: &str) {
         self.recent.lock().await.retain(|item| item.id != id);
@@ -345,4 +365,55 @@ fn now_secs() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn cancel_client_moves_pending_items_to_recent_and_signals_waiters() {
+        let queue = RequestQueue::new();
+        let (queue_id, rx) = queue
+            .enqueue_and_wait(
+                "client-a".to_string(),
+                VoiceRequest::Speak {
+                    text: "hello".to_string(),
+                    voice: None,
+                    speed: None,
+                },
+            )
+            .await;
+
+        assert_eq!(queue.cancel_client("client-a").await, 1);
+
+        let result = rx.await.unwrap();
+        assert_eq!(result.status, ItemStatus::Failed);
+        assert_eq!(result.result.as_deref(), Some(CANCELLED_MESSAGE));
+
+        let snapshot = queue.snapshot().await;
+        assert!(snapshot.pending.is_empty());
+        assert_eq!(snapshot.recent.len(), 1);
+        assert_eq!(snapshot.recent[0].id, queue_id);
+        assert_eq!(snapshot.recent[0].status, ItemStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn cancel_item_signals_waiter_for_pending_item() {
+        let queue = RequestQueue::new();
+        let (queue_id, rx) = queue
+            .enqueue_and_wait(
+                "client-a".to_string(),
+                VoiceRequest::Listen {
+                    max_duration_ms: None,
+                },
+            )
+            .await;
+
+        assert!(queue.cancel_item(&queue_id).await);
+
+        let result = rx.await.unwrap();
+        assert_eq!(result.status, ItemStatus::Failed);
+        assert_eq!(result.result.as_deref(), Some(CANCELLED_MESSAGE));
+    }
 }

--- a/crates/voice-daemon/src/socket.rs
+++ b/crates/voice-daemon/src/socket.rs
@@ -13,11 +13,11 @@ use voice_protocol::frames::{read_frame, write_frame, Frame, FrameType};
 use voice_protocol::rpc::{self, Response};
 
 pub fn socket_path() -> PathBuf {
-    let dir = dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join(".voice");
-    std::fs::create_dir_all(&dir).ok();
-    dir.join("daemon.sock")
+    let path = voice_protocol::client::daemon_socket_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    path
 }
 
 pub async fn serve(
@@ -110,6 +110,18 @@ async fn handle_client(
     eprintln!("voiced: client disconnected ({})", client_id);
 }
 
+async fn sync_automerge(
+    queue: &Arc<RequestQueue>,
+    automerge: &Arc<tokio::sync::Mutex<crate::automerge_state::AutomergeState>>,
+) {
+    let snapshot = queue.snapshot().await;
+    let mut am = automerge.lock().await;
+    am.update(&snapshot);
+    if let Err(e) = am.save() {
+        eprintln!("voiced: failed to save automerge doc: {}", e);
+    }
+}
+
 async fn dispatch(
     req: rpc::Request,
     queue: &Arc<RequestQueue>,
@@ -119,63 +131,63 @@ async fn dispatch(
 ) -> Response {
     use crate::queue::VoiceRequest;
 
-    let wait = req
-        .params
-        .get("wait")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    if !(req.params.is_null() || req.params.is_object()) {
+        return Response::error(req.id, rpc::INVALID_PARAMS, "params must be an object");
+    }
+
+    let wait = match wait_param(&req) {
+        Ok(wait) => wait,
+        Err(resp) => return resp,
+    };
 
     // Build the voice request from params
     let voice_req = match req.method.as_str() {
         "speak" => {
-            let text = req.params.get("text").and_then(|v| v.as_str());
-            let Some(text) = text else {
-                return Response::error(req.id, rpc::INVALID_PARAMS, "Missing param: text");
+            let text = match required_string_param(&req, "text") {
+                Ok(text) => text,
+                Err(resp) => return resp,
             };
-            let voice = req
-                .params
-                .get("voice")
-                .and_then(|v| v.as_str())
-                .map(String::from);
-            let speed = req.params.get("speed").and_then(|v| v.as_f64());
-            VoiceRequest::Speak {
-                text: text.to_string(),
-                voice,
-                speed,
-            }
+            let voice = match optional_voice_param(&req) {
+                Ok(voice) => voice,
+                Err(resp) => return resp,
+            };
+            let speed = match optional_speed_param(&req) {
+                Ok(speed) => speed,
+                Err(resp) => return resp,
+            };
+            VoiceRequest::Speak { text, voice, speed }
         }
         "listen" => {
-            let max_duration_ms = req.params.get("max_duration_ms").and_then(|v| v.as_u64());
+            let max_duration_ms = match optional_duration_param(&req, "max_duration_ms") {
+                Ok(duration) => duration,
+                Err(resp) => return resp,
+            };
             VoiceRequest::Listen { max_duration_ms }
         }
         "converse" => {
-            let text = req.params.get("text").and_then(|v| v.as_str());
-            let Some(text) = text else {
-                return Response::error(req.id, rpc::INVALID_PARAMS, "Missing param: text");
+            let text = match required_string_param(&req, "text") {
+                Ok(text) => text,
+                Err(resp) => return resp,
             };
-            let voice = req
-                .params
-                .get("voice")
-                .and_then(|v| v.as_str())
-                .map(String::from);
-            VoiceRequest::Converse {
-                text: text.to_string(),
-                voice,
-            }
+            let voice = match optional_voice_param(&req) {
+                Ok(voice) => voice,
+                Err(resp) => return resp,
+            };
+            VoiceRequest::Converse { text, voice }
         }
         "replay_audio" => {
-            let queue_id = req.params.get("queue_id").and_then(|v| v.as_str());
-            let Some(queue_id) = queue_id else {
-                return Response::error(req.id, rpc::INVALID_PARAMS, "Missing param: queue_id");
+            let queue_id = match required_string_param(&req, "queue_id") {
+                Ok(queue_id) => queue_id,
+                Err(resp) => return resp,
             };
-            let part = req.params.get("part").and_then(|v| v.as_str());
-            let Some(part) = part else {
-                return Response::error(req.id, rpc::INVALID_PARAMS, "Missing param: part");
+            let part = match required_string_param(&req, "part") {
+                Ok(part) => part,
+                Err(resp) => return resp,
             };
 
-            let path = match part {
-                "question" => crate::audio_recorder::question_path(queue_id),
-                "answer" => crate::audio_recorder::answer_path(queue_id),
+            let path = match part.as_str() {
+                "question" => crate::audio_recorder::question_path(&queue_id),
+                "answer" => crate::audio_recorder::answer_path(&queue_id),
                 _ => {
                     return Response::error(
                         req.id,
@@ -233,26 +245,20 @@ async fn dispatch(
         }
         "cancel" => {
             let count = queue.cancel_client(client_id).await;
+            sync_automerge(queue, automerge).await;
             return Response::success(req.id, serde_json::json!({ "cancelled_count": count }));
         }
         "cancel_item" => {
-            let queue_id = req.params.get("queue_id").and_then(|v| v.as_str());
-            let Some(queue_id) = queue_id else {
-                return Response::error(req.id, rpc::INVALID_PARAMS, "Missing param: queue_id");
+            let queue_id = match required_string_param(&req, "queue_id") {
+                Ok(queue_id) => queue_id,
+                Err(resp) => return resp,
             };
 
             // Remove from queue (both pending and current)
-            let removed = queue.cancel_item(queue_id).await;
+            let removed = queue.cancel_item(&queue_id).await;
 
             if removed {
-                // Update Automerge state
-                let snapshot = queue.snapshot().await;
-                let mut am = automerge.lock().await;
-                am.update(&snapshot);
-                if let Err(e) = am.save() {
-                    eprintln!("voiced: failed to save automerge after cancel: {}", e);
-                }
-
+                sync_automerge(queue, automerge).await;
                 return Response::success(req.id, serde_json::json!({ "cancelled": true }));
             } else {
                 return Response::success(req.id, serde_json::json!({ "cancelled": false }));
@@ -263,25 +269,18 @@ async fn dispatch(
             return Response::success(req.id, serde_json::to_value(&state).unwrap());
         }
         "set_voice" => {
-            let voice = req.params.get("voice").and_then(|v| v.as_str());
-            let Some(voice) = voice else {
-                return Response::error(req.id, rpc::INVALID_PARAMS, "Missing param: voice");
+            let voice = match required_voice_param(&req) {
+                Ok(voice) => voice,
+                Err(resp) => return resp,
             };
-            config.set_voice_name(voice.to_string());
+            config.set_voice_name(voice.clone());
             return Response::success(req.id, serde_json::json!({ "voice": voice }));
         }
         "set_speed" => {
-            let speed = req.params.get("speed").and_then(|v| v.as_f64());
-            let Some(speed) = speed else {
-                return Response::error(req.id, rpc::INVALID_PARAMS, "Missing param: speed");
+            let speed = match required_speed_param(&req) {
+                Ok(speed) => speed,
+                Err(resp) => return resp,
             };
-            if speed <= 0.0 || speed > 5.0 {
-                return Response::error(
-                    req.id,
-                    rpc::INVALID_PARAMS,
-                    "Speed must be between 0 (exclusive) and 5 (inclusive)",
-                );
-            }
             config.set_speed(speed as f32);
             return Response::success(req.id, serde_json::json!({ "speed": speed }));
         }
@@ -334,6 +333,7 @@ async fn dispatch(
                     .await
             }
         };
+        sync_automerge(queue, automerge).await;
         return Response::success(
             req.id,
             serde_json::json!({ "queue_id": queue_id, "status": "queued" }),
@@ -344,6 +344,7 @@ async fn dispatch(
     let (queue_id, rx) = queue
         .enqueue_and_wait(client_id.to_string(), voice_req)
         .await;
+    sync_automerge(queue, automerge).await;
 
     match rx.await {
         Ok(result) => Response::success(
@@ -355,6 +356,125 @@ async fn dispatch(
             }),
         ),
         Err(_) => Response::error(req.id, -32000, "Queue item dropped before completion"),
+    }
+}
+
+fn wait_param(req: &rpc::Request) -> Result<bool, Response> {
+    match req.params.get("wait") {
+        Some(value) => value.as_bool().ok_or_else(|| {
+            Response::error(
+                req.id.clone(),
+                rpc::INVALID_PARAMS,
+                "param 'wait' must be a boolean",
+            )
+        }),
+        None => Ok(false),
+    }
+}
+
+fn required_string_param(req: &rpc::Request, name: &str) -> Result<String, Response> {
+    match req.params.get(name) {
+        Some(value) => match value.as_str() {
+            Some(text) if !text.trim().is_empty() => Ok(text.to_string()),
+            Some(_) => Err(Response::error(
+                req.id.clone(),
+                rpc::INVALID_PARAMS,
+                format!("param '{}' must not be empty", name),
+            )),
+            None => Err(Response::error(
+                req.id.clone(),
+                rpc::INVALID_PARAMS,
+                format!("param '{}' must be a string", name),
+            )),
+        },
+        None => Err(Response::error(
+            req.id.clone(),
+            rpc::INVALID_PARAMS,
+            format!("Missing param: {}", name),
+        )),
+    }
+}
+
+fn required_voice_param(req: &rpc::Request) -> Result<String, Response> {
+    let voice = required_string_param(req, "voice")?;
+    validate_voice(req, voice)
+}
+
+fn optional_voice_param(req: &rpc::Request) -> Result<Option<String>, Response> {
+    if req.params.get("voice").is_none() {
+        return Ok(None);
+    }
+    required_voice_param(req).map(Some)
+}
+
+fn validate_voice(req: &rpc::Request, voice: String) -> Result<String, Response> {
+    if voice_tts::catalog::ALL_VOICES
+        .iter()
+        .any(|v| v.id == voice.as_str())
+    {
+        Ok(voice)
+    } else {
+        Err(Response::error(
+            req.id.clone(),
+            rpc::INVALID_PARAMS,
+            format!("Unknown voice: {}", voice),
+        ))
+    }
+}
+
+fn required_speed_param(req: &rpc::Request) -> Result<f64, Response> {
+    match req.params.get("speed") {
+        Some(value) => match value.as_f64() {
+            Some(speed) => validate_speed(req, speed),
+            None => Err(Response::error(
+                req.id.clone(),
+                rpc::INVALID_PARAMS,
+                "param 'speed' must be a number",
+            )),
+        },
+        None => Err(Response::error(
+            req.id.clone(),
+            rpc::INVALID_PARAMS,
+            "Missing param: speed",
+        )),
+    }
+}
+
+fn optional_speed_param(req: &rpc::Request) -> Result<Option<f64>, Response> {
+    if req.params.get("speed").is_none() {
+        return Ok(None);
+    }
+    required_speed_param(req).map(Some)
+}
+
+fn validate_speed(req: &rpc::Request, speed: f64) -> Result<f64, Response> {
+    if speed.is_finite() && speed > 0.0 && speed <= 5.0 {
+        Ok(speed)
+    } else {
+        Err(Response::error(
+            req.id.clone(),
+            rpc::INVALID_PARAMS,
+            "Speed must be between 0 (exclusive) and 5 (inclusive)",
+        ))
+    }
+}
+
+fn optional_duration_param(req: &rpc::Request, name: &str) -> Result<Option<u64>, Response> {
+    match req.params.get(name) {
+        Some(value) => match value.as_u64() {
+            Some(duration) if duration > 0 => Ok(Some(duration)),
+            Some(_) => Err(Response::error(
+                req.id.clone(),
+                rpc::INVALID_PARAMS,
+                format!("param '{}' must be greater than 0", name),
+            )),
+            None => Err(Response::error(
+                req.id.clone(),
+                rpc::INVALID_PARAMS,
+                format!("param '{}' must be an unsigned integer", name),
+            )),
+        },
+        None => Ok(None),
     }
 }
 

--- a/crates/voice-protocol/src/client.rs
+++ b/crates/voice-protocol/src/client.rs
@@ -3,13 +3,14 @@
 //! The MCP server is synchronous (no tokio runtime), so this client
 //! uses std::os::unix::net::UnixStream directly.
 
-use crate::frames::FrameType;
+use crate::frames::{read_frame_sync, write_frame_sync, Frame, FrameType};
 use crate::rpc::{self, Response};
 use serde_json::Value;
-use std::io::{Read, Write};
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::time::Duration;
+
+const SOCKET_ENV: &str = "VOICE_DAEMON_SOCKET";
 
 /// A synchronous client connection to the voice daemon.
 pub struct DaemonClient {
@@ -18,10 +19,21 @@ pub struct DaemonClient {
 
 /// Get the daemon socket path.
 pub fn daemon_socket_path() -> PathBuf {
+    if let Ok(path) = std::env::var(SOCKET_ENV) {
+        if !path.trim().is_empty() {
+            return PathBuf::from(path);
+        }
+    }
+
     let dir = dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("/tmp"))
         .join(".voice");
     dir.join("daemon.sock")
+}
+
+/// Environment variable that overrides the daemon socket path.
+pub fn daemon_socket_env_var() -> &'static str {
+    SOCKET_ENV
 }
 
 /// Check if the daemon is running (socket exists and accepts connections).
@@ -52,39 +64,23 @@ impl DaemonClient {
         let req = rpc::Request::new(method, params).with_id(1);
         let json = serde_json::to_vec(&req).map_err(|e| format!("serialize: {}", e))?;
 
-        // Write frame: [4-byte length][1-byte type=Request][payload]
-        let total_len = (json.len() + 1) as u32;
-        self.stream
-            .write_all(&total_len.to_be_bytes())
-            .map_err(|e| format!("write len: {}", e))?;
-        self.stream
-            .write_all(&[FrameType::Request as u8])
-            .map_err(|e| format!("write type: {}", e))?;
-        self.stream
-            .write_all(&json)
-            .map_err(|e| format!("write payload: {}", e))?;
-        self.stream.flush().map_err(|e| format!("flush: {}", e))?;
+        write_frame_sync(&mut self.stream, &Frame::request(&json))
+            .map_err(|e| format!("write frame: {}", e))?;
 
-        // Read response frame
-        let mut len_buf = [0u8; 4];
-        self.stream
-            .read_exact(&mut len_buf)
-            .map_err(|e| format!("read len: {}", e))?;
-        let total_len = u32::from_be_bytes(len_buf) as usize;
+        let frame = read_frame_sync(&mut self.stream)
+            .map_err(|e| format!("read frame: {}", e))?
+            .ok_or_else(|| "connection closed before response".to_string())?;
 
-        let mut data = vec![0u8; total_len];
-        self.stream
-            .read_exact(&mut data)
-            .map_err(|e| format!("read payload: {}", e))?;
-
-        if data.is_empty() {
-            return Err("empty response".to_string());
+        if frame.frame_type != FrameType::Response {
+            return Err(format!(
+                "unexpected frame type {:?}; expected response",
+                frame.frame_type
+            ));
         }
 
-        let _frame_type = data[0]; // Should be Response (0x02)
-        let payload = &data[1..];
-
-        serde_json::from_slice::<Response>(payload).map_err(|e| format!("parse response: {}", e))
+        frame
+            .json::<Response>()
+            .map_err(|e| format!("parse response: {}", e))
     }
 
     /// Convenience: send a speak request. Returns immediately with queue_id (fire-and-forget).
@@ -130,5 +126,127 @@ impl DaemonClient {
     /// Convenience: get daemon status.
     pub fn status(&mut self) -> Result<Response, String> {
         self.call("status", serde_json::json!({}))
+    }
+
+    /// Convenience: set daemon default voice.
+    pub fn set_voice(&mut self, voice: &str) -> Result<Response, String> {
+        self.call("set_voice", serde_json::json!({ "voice": voice }))
+    }
+
+    /// Convenience: set daemon default speed.
+    pub fn set_speed(&mut self, speed: f64) -> Result<Response, String> {
+        self.call("set_speed", serde_json::json!({ "speed": speed }))
+    }
+
+    /// Convenience: list known voices and the current daemon default.
+    pub fn list_voices(&mut self) -> Result<Response, String> {
+        self.call("list_voices", serde_json::json!({}))
+    }
+
+    /// Convenience: cancel a specific queue item.
+    pub fn cancel_item(&mut self, queue_id: &str) -> Result<Response, String> {
+        self.call("cancel_item", serde_json::json!({ "queue_id": queue_id }))
+    }
+
+    /// Convenience: replay stored question or answer audio for a queue item.
+    pub fn replay_audio(&mut self, queue_id: &str, part: &str) -> Result<Response, String> {
+        self.call(
+            "replay_audio",
+            serde_json::json!({ "queue_id": queue_id, "part": part }),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frames::{write_frame_sync, Frame};
+    use crate::rpc::Response;
+    use std::io::Read;
+    use std::os::unix::net::UnixListener;
+    use std::sync::Mutex;
+    use std::thread;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn socket_path_uses_env_override() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let old = std::env::var(SOCKET_ENV).ok();
+        std::env::set_var(SOCKET_ENV, "/tmp/voice-test.sock");
+
+        assert_eq!(daemon_socket_path(), PathBuf::from("/tmp/voice-test.sock"));
+
+        match old {
+            Some(value) => std::env::set_var(SOCKET_ENV, value),
+            None => std::env::remove_var(SOCKET_ENV),
+        }
+    }
+
+    #[test]
+    fn call_rejects_non_response_frame() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("voice-protocol-test-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).unwrap();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 64];
+            let _ = stream.read(&mut buf).unwrap();
+            write_frame_sync(&mut stream, &Frame::event(b"{}")).unwrap();
+        });
+
+        let old = std::env::var(SOCKET_ENV).ok();
+        std::env::set_var(SOCKET_ENV, &path);
+
+        let mut client = DaemonClient::connect().unwrap();
+        let err = client.call("status", serde_json::json!({})).unwrap_err();
+
+        assert!(err.contains("unexpected frame type"));
+
+        match old {
+            Some(value) => std::env::set_var(SOCKET_ENV, value),
+            None => std::env::remove_var(SOCKET_ENV),
+        }
+        let _ = std::fs::remove_file(path);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn call_parses_response_frame() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "voice-protocol-test-ok-{}.sock",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).unwrap();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 128];
+            let _ = stream.read(&mut buf).unwrap();
+            let response =
+                Response::success(Some(1.into()), serde_json::json!({ "status": "idle" }));
+            let payload = serde_json::to_vec(&response).unwrap();
+            write_frame_sync(&mut stream, &Frame::response(&payload)).unwrap();
+        });
+
+        let old = std::env::var(SOCKET_ENV).ok();
+        std::env::set_var(SOCKET_ENV, &path);
+
+        let mut client = DaemonClient::connect().unwrap();
+        let response = client.call("status", serde_json::json!({})).unwrap();
+        assert_eq!(response.result.unwrap()["status"], "idle");
+
+        match old {
+            Some(value) => std::env::set_var(SOCKET_ENV, value),
+            None => std::env::remove_var(SOCKET_ENV),
+        }
+        let _ = std::fs::remove_file(path);
+        server.join().unwrap();
     }
 }

--- a/crates/voice-protocol/src/frames.rs
+++ b/crates/voice-protocol/src/frames.rs
@@ -1,6 +1,6 @@
 //! Frame codec: length-prefixed typed frames over async byte streams.
 
-use std::io;
+use std::io::{self, Read, Write};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 /// Frame types carried over the wire.
@@ -115,6 +115,52 @@ pub async fn read_frame<R: AsyncRead + Unpin>(reader: &mut R) -> io::Result<Opti
     }))
 }
 
+/// Write a frame to a blocking writer.
+pub fn write_frame_sync<W: Write>(writer: &mut W, frame: &Frame) -> io::Result<()> {
+    let payload_len = frame.payload.len() as u32 + 1; // +1 for frame type byte
+    writer.write_all(&payload_len.to_be_bytes())?;
+    writer.write_all(&[frame.frame_type as u8])?;
+    writer.write_all(&frame.payload)?;
+    writer.flush()?;
+    Ok(())
+}
+
+/// Read a frame from a blocking reader. Returns None on EOF.
+pub fn read_frame_sync<R: Read>(reader: &mut R) -> io::Result<Option<Frame>> {
+    let mut len_buf = [0u8; 4];
+    match reader.read_exact(&mut len_buf) {
+        Ok(()) => {}
+        Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e),
+    }
+
+    let total_len = u32::from_be_bytes(len_buf);
+    if total_len == 0 || total_len > MAX_FRAME_SIZE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("frame too large: {} bytes", total_len),
+        ));
+    }
+
+    let mut type_byte = [0u8; 1];
+    reader.read_exact(&mut type_byte)?;
+    let frame_type = FrameType::from_byte(type_byte[0]).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unknown frame type: 0x{:02x}", type_byte[0]),
+        )
+    })?;
+
+    let payload_len = (total_len - 1) as usize;
+    let mut payload = vec![0u8; payload_len];
+    reader.read_exact(&mut payload)?;
+
+    Ok(Some(Frame {
+        frame_type,
+        payload,
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -159,5 +205,18 @@ mod tests {
         drop(client);
         let result = read_frame(&mut server).await.unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_sync_roundtrip() {
+        let request = Frame::request(b"{\"method\":\"status\"}");
+        let mut bytes = Vec::new();
+
+        write_frame_sync(&mut bytes, &request).unwrap();
+
+        let mut cursor = std::io::Cursor::new(bytes);
+        let received = read_frame_sync(&mut cursor).unwrap().unwrap();
+        assert_eq!(received.frame_type, FrameType::Request);
+        assert_eq!(received.payload, b"{\"method\":\"status\"}");
     }
 }


### PR DESCRIPTION
## Summary
- add `voice daemon ...` commands for status, socket inspection, voice/speed config, cancellation, and replay
- share daemon socket handling through `voice-protocol`, including `VOICE_DAEMON_SOCKET` override support
- harden daemon/client RPC handling with stricter frame checks, parameter validation, immediate Automerge state sync, and cancellation waiter signaling
- gate macOS-only MCP memory stats so the CLI links on non-macOS hosts

## Tests
- `cargo test -p voice-protocol`
- `cargo test -p voice-daemon --all-targets`
- `cargo test -p voice --tests`
- `cargo run -p voice -- daemon socket`
- `cargo run -p voice -- daemon --help`