### PR TITLE
Add daemon TTS streaming surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7074,6 +7074,7 @@ dependencies = [
  "serde_json",
  "voice-g2p",
  "voice-protocol",
+ "voice-stream",
  "voice-stt",
  "voice-tts",
 ]
@@ -7094,6 +7095,7 @@ dependencies = [
  "uuid",
  "voice-g2p",
  "voice-protocol",
+ "voice-stream",
  "voice-stt",
  "voice-tts",
 ]
@@ -7135,6 +7137,14 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "voice-stream",
+]
+
+[[package]]
+name = "voice-stream"
+version = "0.1.0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ echo "The quick brown fox jumps over the lazy dog." | voice say
 # Save to file instead of playing
 voice say -o speech.wav "Good morning everyone."
 
+# Stream daemon TTS frames for bridge/WebRTC experiments
+voice stream --sample-rate 48000 --frame-ms 20 --raw-output speech.s16le "Good morning everyone."
+
 # Read from a file, strip markdown
 voice say --markdown -f blog-post.mdx
 
@@ -111,6 +114,28 @@ Options:
                      as you speak. Segments split on silence.
   -q, --quiet        Suppress progress output
   -h, --help         Print help
+```
+
+### `voice stream`
+
+Streams ordered PCM frames from a running `voiced` daemon. Use this for bridge
+and WebRTC experiments where clients need audio chunks instead of a completed
+WAV file.
+
+```
+Usage: voice stream [OPTIONS] [TEXT]...
+
+Options:
+  -f, --input-file <FILE>          Read text from a file (use - for stdin)
+  -v, --voice <VOICE>              Voice name [default: af_heart]
+  -s, --speed <SPEED>              Speech speed factor [default: 1.0]
+      --sample-rate <SAMPLE_RATE>  Target stream sample rate [default: 24000]
+      --frame-ms <FRAME_MS>        Target frame duration in milliseconds [default: 20]
+  -o, --raw-output <PATH>          Write raw signed 16-bit little-endian mono PCM
+      --json                       Print full JSON stream events
+      --markdown                   Strip markdown/MDX formatting before speaking
+      --sub <WORD=REPLACEMENT>     Word substitution (repeatable)
+      --sub-file <PATH>            Load substitutions from a file
 ```
 
 ### `voice transcribe`
@@ -187,6 +212,18 @@ When `detail` is `"full"`, `speak` emits `speak.progress` notifications with chu
 ```
 
 See [`examples/conversation.py`](examples/conversation.py) for a full speak/listen conversation loop.
+
+## Daemon TTS for Hermes and Streaming
+
+Run `voiced --tts-only` to keep Kokoro warm without eagerly loading STT. When the
+daemon is running, `voice say -o output.wav ...` uses the daemon `synthesize`
+RPC and waits until the WAV exists. This is the compatibility path for Hermes'
+command TTS provider and WhatsApp voice-note delivery.
+
+For lower-level streaming, `stream_speak` emits `tts.started`, `tts.audio`, and
+terminal `tts.ended` / `tts.error` / `tts.cancelled` events over the same daemon
+frame protocol. See [docs/streaming.md](docs/streaming.md) for the event schema
+and Hermes/WebRTC notes.
 
 ## LLM-friendly design
 

--- a/crates/voice-cli/Cargo.toml
+++ b/crates/voice-cli/Cargo.toml
@@ -35,4 +35,5 @@ ctrlc = "3.5.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 voice-protocol = { path = "../voice-protocol" }
+voice-stream = { path = "../voice-stream" }
 dirs = "5"

--- a/crates/voice-cli/README.md
+++ b/crates/voice-cli/README.md
@@ -44,6 +44,7 @@ voice say -v am_michael "How are you today?"
 voice say -f script.txt -o output.wav
 echo "Hello" | voice say
 voice say --markdown -f post.mdx
+voice stream --sample-rate 48000 --frame-ms 20 --raw-output output.s16le "Hello"
 
 # Speech-to-text from microphone
 voice listen
@@ -65,6 +66,7 @@ Usage: voice [OPTIONS] [COMMAND] [TEXT]...
 
 Commands:
   say         Speak text aloud (default when no subcommand given)
+  stream      Stream TTS audio chunks from the voice daemon
   listen      Record from microphone and transcribe (speech-to-text)
   transcribe  Transcribe a WAV audio file
   serve       Run as a JSON-RPC 2.0 server on stdin/stdout
@@ -91,6 +93,27 @@ Options:
       --markdown                 Strip markdown/MDX formatting before speaking
       --sub <WORD=REPLACEMENT>   Word substitution (repeatable)
       --sub-file <PATH>          Load substitutions from a file
+```
+
+### `voice stream`
+
+Requires a running `voiced` daemon. Emits ordered signed 16-bit little-endian
+mono PCM frames as compact summaries or full JSON events.
+
+```
+Usage: voice stream [OPTIONS] [TEXT]...
+
+Options:
+  -f, --input-file <FILE>          Read text from a file (use - for stdin)
+  -v, --voice <VOICE>              Voice name [default: af_heart]
+  -s, --speed <SPEED>              Speech speed factor [default: 1.0]
+      --sample-rate <SAMPLE_RATE>  Target stream sample rate [default: 24000]
+      --frame-ms <FRAME_MS>        Target frame duration in milliseconds [default: 20]
+  -o, --raw-output <PATH>          Write raw signed 16-bit little-endian mono PCM
+      --json                       Print full JSON stream events
+      --markdown                   Strip markdown/MDX formatting before speaking
+      --sub <WORD=REPLACEMENT>     Word substitution (repeatable)
+      --sub-file <PATH>            Load substitutions from a file
 ```
 
 ### `voice listen`

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -39,6 +39,7 @@ macro_rules! info {
                   voice say -f speech.txt -o output.wav\n  \
                   voice say --phonemes \"hɛloʊ wɜːld\"\n  \
                   voice say --markdown -f post.mdx\n  \
+                  voice stream --json \"Hello world\"\n  \
                   voice listen\n  \
                   voice listen --continuous\n  \
                   voice transcribe recording.wav\n  \
@@ -63,6 +64,9 @@ struct Args {
 enum Command {
     /// Speak text aloud (default when no subcommand given)
     Say(SayArgs),
+
+    /// Stream TTS audio chunks from the voice daemon
+    Stream(StreamArgs),
 
     /// Speak text aloud, then listen for a response (speak + listen in one shot)
     Converse(ConverseArgs),
@@ -108,6 +112,54 @@ struct SayArgs {
     /// Speech speed factor (1.0 = normal)
     #[arg(short, long, default_value = "1.0")]
     speed: f32,
+
+    /// Strip markdown/MDX formatting before speaking
+    #[arg(long)]
+    markdown: bool,
+
+    /// Word substitutions (pre-processing), e.g. --sub nteract=enteract
+    #[arg(long = "sub", value_name = "WORD=REPLACEMENT")]
+    subs: Vec<String>,
+
+    /// Load substitutions from a file (one WORD=REPLACEMENT per line, # comments).
+    /// If not set, .voice-subs is auto-discovered from the working directory upward.
+    #[arg(long = "sub-file", value_name = "PATH")]
+    sub_file: Option<PathBuf>,
+}
+
+#[derive(clap::Args, Debug)]
+struct StreamArgs {
+    /// Text to stream
+    #[arg(trailing_var_arg = true)]
+    text: Vec<String>,
+
+    /// Read text from a file (use - for stdin)
+    #[arg(short = 'f', long = "input-file")]
+    input_file: Option<PathBuf>,
+
+    /// Voice name (e.g. af_heart, am_adam)
+    #[arg(short, long, default_value = "af_heart")]
+    voice: String,
+
+    /// Speech speed factor (1.0 = normal)
+    #[arg(short, long, default_value = "1.0")]
+    speed: f32,
+
+    /// Target stream sample rate
+    #[arg(long = "sample-rate", default_value = "24000")]
+    sample_rate: u32,
+
+    /// Target stream frame duration in milliseconds
+    #[arg(long = "frame-ms", default_value = "20")]
+    frame_ms: u32,
+
+    /// Write raw signed 16-bit little-endian mono PCM to this path
+    #[arg(short = 'o', long = "raw-output")]
+    raw_output: Option<PathBuf>,
+
+    /// Print full JSON stream events instead of compact summaries
+    #[arg(long)]
+    json: bool,
 
     /// Strip markdown/MDX formatting before speaking
     #[arg(long)]
@@ -297,6 +349,44 @@ fn resolve_text(say: &SayArgs) -> Result<String, String> {
     }
 
     // Fall back to stdin if it's not a TTY
+    if io::stdin().is_terminal() {
+        return Err("No text provided. Pass text as arguments, use -f, or pipe to stdin.".into());
+    }
+
+    let mut buf = String::new();
+    io::stdin()
+        .read_to_string(&mut buf)
+        .map_err(|e| format!("Failed to read stdin: {e}"))?;
+    let text = buf.trim().to_string();
+    if text.is_empty() {
+        return Err("No text provided on stdin".into());
+    }
+    Ok(text)
+}
+
+fn resolve_stream_text(stream: &StreamArgs) -> Result<String, String> {
+    if let Some(path) = &stream.input_file {
+        let text = if path.to_str() == Some("-") {
+            let mut buf = String::new();
+            io::stdin()
+                .read_to_string(&mut buf)
+                .map_err(|e| format!("Failed to read stdin: {e}"))?;
+            buf
+        } else {
+            std::fs::read_to_string(path)
+                .map_err(|e| format!("Failed to read {}: {e}", path.display()))?
+        };
+        let text = text.trim().to_string();
+        if text.is_empty() {
+            return Err("Input file is empty".into());
+        }
+        return Ok(text);
+    }
+
+    if !stream.text.is_empty() {
+        return Ok(stream.text.join(" "));
+    }
+
     if io::stdin().is_terminal() {
         return Err("No text provided. Pass text as arguments, use -f, or pipe to stdin.".into());
     }
@@ -519,6 +609,27 @@ fn collect_subs(
     (text_subs, phoneme_overrides)
 }
 
+fn preprocess_daemon_text(
+    text: String,
+    markdown: bool,
+    cli_subs: &[String],
+    sub_file: Option<PathBuf>,
+) -> String {
+    let text = if markdown {
+        strip_markdown(&text)
+    } else {
+        text
+    };
+    let text = apply_tech_subs(&text);
+    let sub_file = sub_file.or_else(find_sub_file);
+    let (subs, _phoneme_overrides) = collect_subs(cli_subs, sub_file.as_deref());
+    if subs.is_empty() {
+        text
+    } else {
+        apply_substitutions(&text, &subs)
+    }
+}
+
 fn main() {
     // Ctrl+C: set flag for cooperative cancellation. The generation loops
     // check this between chunks and exit cleanly, letting the current
@@ -576,6 +687,9 @@ fn main() {
         }
         Some(Command::Say(say_args)) => {
             run_say(say_args);
+        }
+        Some(Command::Stream(stream_args)) => {
+            run_stream(stream_args);
         }
         None => {
             // Backward compatibility: `voice Hello world` = `voice say Hello world`
@@ -827,8 +941,10 @@ fn run_mcp(serve_args: ServeArgs) {
 }
 
 fn run_say(say_args: SayArgs) {
-    // If the daemon is running and we're not writing to a file, delegate to it.
-    if say_args.output.is_none() {
+    // If the daemon is running, delegate normal playback and file synthesis to it.
+    // `--phonemes` stays local because the daemon RPC accepts text and runs its
+    // own G2P pipeline.
+    if say_args.phonemes.is_none() {
         if let Some(mut daemon) = voice_protocol::client::DaemonClient::connect() {
             let text = match resolve_text(&say_args) {
                 Ok(t) => t,
@@ -837,22 +953,42 @@ fn run_say(say_args: SayArgs) {
                     std::process::exit(1);
                 }
             };
-            // Apply the same preprocessing the local path uses
-            let text = if say_args.markdown {
-                strip_markdown(&text)
+            let text = preprocess_daemon_text(
+                text,
+                say_args.markdown,
+                &say_args.subs,
+                say_args.sub_file.clone(),
+            );
+
+            let daemon_result = if let Some(output_path) = &say_args.output {
+                daemon.synthesize(
+                    &text,
+                    &output_path.to_string_lossy(),
+                    Some(&say_args.voice),
+                    Some(say_args.speed as f64),
+                )
             } else {
-                text
+                daemon.speak(&text, Some(&say_args.voice), Some(say_args.speed as f64))
             };
-            let text = apply_tech_subs(&text);
-            let sub_file = say_args.sub_file.clone().or_else(find_sub_file);
-            let (subs, _phoneme_overrides) = collect_subs(&say_args.subs, sub_file.as_deref());
-            let text = if subs.is_empty() {
-                text
-            } else {
-                apply_substitutions(&text, &subs)
-            };
-            match daemon.speak(&text, Some(&say_args.voice), Some(say_args.speed as f64)) {
-                Ok(_resp) => return,
+
+            match daemon_result {
+                Ok(resp) if resp.error.is_none() => {
+                    let failed = resp
+                        .result
+                        .as_ref()
+                        .and_then(|r| r.get("status"))
+                        .and_then(|s| s.as_str())
+                        == Some("failed");
+                    if !failed {
+                        return;
+                    }
+                    eprintln!("Daemon synthesis failed, falling back to local");
+                }
+                Ok(resp) => {
+                    if let Some(err) = resp.error {
+                        eprintln!("Daemon error: {}, falling back to local", err.message);
+                    }
+                }
                 Err(e) => {
                     eprintln!("Daemon error: {e}, falling back to local");
                 }
@@ -945,6 +1081,136 @@ fn run_say(say_args: SayArgs) {
             say_args.speed,
             sample_rate,
         );
+    }
+}
+
+fn run_stream(stream_args: StreamArgs) {
+    let text = match resolve_stream_text(&stream_args) {
+        Ok(t) => t,
+        Err(msg) => {
+            eprintln!("Error: {msg}");
+            std::process::exit(1);
+        }
+    };
+    let text = preprocess_daemon_text(
+        text,
+        stream_args.markdown,
+        &stream_args.subs,
+        stream_args.sub_file.clone(),
+    );
+
+    let mut raw_writer = stream_args.raw_output.as_ref().map(|path| {
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent).unwrap_or_else(|e| {
+                    eprintln!("Failed to create {}: {e}", parent.display());
+                    std::process::exit(1);
+                });
+            }
+        }
+        std::fs::File::create(path).unwrap_or_else(|e| {
+            eprintln!("Failed to create {}: {e}", path.display());
+            std::process::exit(1);
+        })
+    });
+
+    let mut daemon = connect_daemon_or_exit();
+    let mut terminal_error: Option<String> = None;
+    let mut frame_count = 0u64;
+
+    let result = daemon.stream_speak(
+        &text,
+        Some(&stream_args.voice),
+        Some(stream_args.speed as f64),
+        Some(stream_args.sample_rate),
+        Some(stream_args.frame_ms),
+        |event| {
+            if stream_args.json {
+                println!("{}", serde_json::to_string(&event).unwrap());
+            }
+
+            match event {
+                voice_stream::TtsStreamEvent::Started { metadata } => {
+                    if !stream_args.json {
+                        println!(
+                            "started stream={} rate={}Hz frame={}ms encoding={:?}",
+                            metadata.stream_id,
+                            metadata.sample_rate,
+                            metadata.frame_ms,
+                            metadata.encoding
+                        );
+                    }
+                }
+                voice_stream::TtsStreamEvent::Audio { frame } => {
+                    frame_count += 1;
+                    if let Some(file) = raw_writer.as_mut() {
+                        file.write_all(&frame.payload_le_bytes())
+                            .map_err(|e| format!("write raw PCM: {e}"))?;
+                    }
+                    if !stream_args.json {
+                        println!(
+                            "audio seq={} samples={} padding={}",
+                            frame.sequence, frame.sample_count, frame.padding_samples
+                        );
+                    }
+                }
+                voice_stream::TtsStreamEvent::Ended(end) => {
+                    if !stream_args.json {
+                        println!(
+                            "ended stream={} frames={} samples={} duration_ms={}",
+                            end.stream_id, end.frames, end.samples, end.duration_ms
+                        );
+                    }
+                }
+                voice_stream::TtsStreamEvent::Error(err) => {
+                    terminal_error = Some(err.message.clone());
+                    if !stream_args.json {
+                        println!("error stream={}: {}", err.stream_id, err.message);
+                    }
+                }
+                voice_stream::TtsStreamEvent::Cancelled(cancelled) => {
+                    terminal_error = Some(cancelled.reason.clone());
+                    if !stream_args.json {
+                        println!(
+                            "cancelled stream={}: {}",
+                            cancelled.stream_id, cancelled.reason
+                        );
+                    }
+                }
+            }
+
+            Ok(())
+        },
+    );
+
+    match result {
+        Ok(resp) => {
+            if let Some(err) = resp.error {
+                eprintln!("voice daemon: {}", err.message);
+                std::process::exit(1);
+            }
+        }
+        Err(e) => {
+            eprintln!("voice daemon stream: {e}");
+            std::process::exit(1);
+        }
+    }
+
+    if let Some(err) = terminal_error {
+        eprintln!("voice stream failed: {err}");
+        std::process::exit(1);
+    }
+
+    if let Some(mut file) = raw_writer {
+        file.flush().unwrap_or_else(|e| {
+            eprintln!("Failed to flush raw output: {e}");
+            std::process::exit(1);
+        });
+    }
+
+    if frame_count == 0 {
+        eprintln!("voice stream produced no audio frames");
+        std::process::exit(1);
     }
 }
 

--- a/crates/voice-daemon/Cargo.toml
+++ b/crates/voice-daemon/Cargo.toml
@@ -21,6 +21,7 @@ voice-protocol = { path = "../voice-protocol" }
 voice-tts = { path = "../voice-tts" }
 voice-stt = { path = "../voice-stt" }
 voice-g2p = { path = "../voice-g2p" }
+voice-stream = { path = "../voice-stream" }
 candle-core = { workspace = true }
 rodio = { version = "0.22", features = ["experimental"] }
 hound = { workspace = true }

--- a/crates/voice-daemon/src/main.rs
+++ b/crates/voice-daemon/src/main.rs
@@ -6,6 +6,7 @@
 //! Usage:
 //!   voiced              # start the daemon
 //!   voiced --status     # print daemon state and exit
+//!   voiced --tts-only   # start without eagerly loading STT/microphone path
 
 mod audio_recorder;
 mod automerge_state;
@@ -32,7 +33,12 @@ async fn main() {
         return;
     }
 
+    let tts_only = args.iter().any(|a| a == "--tts-only");
+
     eprintln!("voiced: starting voice daemon");
+    if tts_only {
+        eprintln!("voiced: TTS-only mode enabled (STT loads only if listen/converse is requested)");
+    }
 
     // Check if another instance is already running
     let sock_path = socket::socket_path();
@@ -88,7 +94,7 @@ async fn main() {
     let worker_config = config.clone();
     let worker_automerge = automerge.clone();
     tokio::spawn(async move {
-        worker::run(worker_queue, worker_config, worker_automerge).await;
+        worker::run(worker_queue, worker_config, worker_automerge, tts_only).await;
     });
 
     // Start cleanup task

--- a/crates/voice-daemon/src/queue.rs
+++ b/crates/voice-daemon/src/queue.rs
@@ -1,11 +1,26 @@
 //! Request queue for serializing voice operations.
 
 use std::collections::{HashMap, VecDeque};
-use tokio::sync::{oneshot, Mutex, Notify};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use tokio::sync::{mpsc, oneshot, Mutex, Notify};
 use uuid::Uuid;
 use voice_protocol::rpc::{DaemonState, ItemStatus, QueueItem};
+use voice_stream::TtsStreamEvent;
 
 const CANCELLED_MESSAGE: &str = "Cancelled by user";
+
+/// Parameters for a daemon TTS stream request.
+#[derive(Debug, Clone)]
+pub struct StreamSpeakRequest {
+    pub text: String,
+    pub stream_id: String,
+    pub voice: Option<String>,
+    pub speed: Option<f64>,
+    pub sample_rate: u32,
+    pub frame_ms: u32,
+    pub event_tx: mpsc::Sender<TtsStreamEvent>,
+}
 
 /// What the worker will execute.
 #[derive(Debug, Clone)]
@@ -15,6 +30,15 @@ pub enum VoiceRequest {
         voice: Option<String>,
         speed: Option<f64>,
     },
+    /// Generate speech audio into a file without opening audio output.
+    Synthesize {
+        text: String,
+        output_path: String,
+        voice: Option<String>,
+        speed: Option<f64>,
+    },
+    /// Generate speech audio as ordered stream events.
+    StreamSpeak(StreamSpeakRequest),
     Listen {
         max_duration_ms: Option<u64>,
     },
@@ -28,6 +52,8 @@ impl VoiceRequest {
     pub fn method(&self) -> &str {
         match self {
             Self::Speak { .. } => "speak",
+            Self::Synthesize { .. } => "synthesize",
+            Self::StreamSpeak(_) => "stream_speak",
             Self::Listen { .. } => "listen",
             Self::Converse { .. } => "converse",
         }
@@ -35,11 +61,26 @@ impl VoiceRequest {
 
     pub fn text_preview(&self) -> Option<String> {
         match self {
-            Self::Speak { text, .. } | Self::Converse { text, .. } => {
+            Self::Speak { text, .. }
+            | Self::Synthesize { text, .. }
+            | Self::Converse { text, .. } => {
                 let preview: String = text.chars().take(80).collect();
                 Some(preview)
             }
+            Self::StreamSpeak(request) => {
+                let preview: String = request.text.chars().take(80).collect();
+                Some(preview)
+            }
             Self::Listen { .. } => None,
+        }
+    }
+
+    fn notify_cancelled(&self) {
+        if let Self::StreamSpeak(request) = self {
+            let _ = request.event_tx.try_send(TtsStreamEvent::cancelled(
+                request.stream_id.clone(),
+                CANCELLED_MESSAGE,
+            ));
         }
     }
 }
@@ -56,6 +97,7 @@ pub struct QueueEntry {
     pub completed_at: Option<u64>,
     pub repo: Option<String>,
     pub auto_clear_at: Option<u64>,
+    pub cancelled: Arc<AtomicBool>,
 }
 
 impl QueueEntry {
@@ -113,6 +155,35 @@ impl RequestQueue {
             .await
     }
 
+    pub async fn enqueue_synthesize(
+        &self,
+        client_id: String,
+        text: String,
+        output_path: String,
+        voice: Option<String>,
+        speed: Option<f64>,
+    ) -> String {
+        self.enqueue(
+            client_id,
+            VoiceRequest::Synthesize {
+                text,
+                output_path,
+                voice,
+                speed,
+            },
+        )
+        .await
+    }
+
+    pub async fn enqueue_stream_speak(
+        &self,
+        client_id: String,
+        request: StreamSpeakRequest,
+    ) -> String {
+        self.enqueue(client_id, VoiceRequest::StreamSpeak(request))
+            .await
+    }
+
     pub async fn enqueue_listen(&self, client_id: String, max_duration_ms: Option<u64>) -> String {
         self.enqueue(client_id, VoiceRequest::Listen { max_duration_ms })
             .await
@@ -140,6 +211,7 @@ impl RequestQueue {
             completed_at: None,
             repo: None,
             auto_clear_at: None,
+            cancelled: Arc::new(AtomicBool::new(false)),
         };
         self.items.lock().await.push_back(entry);
         self.notify.notify_one();
@@ -170,6 +242,7 @@ impl RequestQueue {
             completed_at: None,
             repo: None,
             auto_clear_at: None,
+            cancelled: Arc::new(AtomicBool::new(false)),
         };
         self.items.lock().await.push_back(entry);
         self.notify.notify_one();
@@ -231,6 +304,18 @@ impl RequestQueue {
 
     pub async fn cancel_client(&self, client_id: &str) -> usize {
         let mut cancelled = Vec::new();
+
+        {
+            let mut current = self.current.lock().await;
+            if current
+                .as_ref()
+                .is_some_and(|entry| entry.client_id == client_id)
+            {
+                if let Some(entry) = current.take() {
+                    cancelled.push(entry);
+                }
+            }
+        }
 
         {
             let mut items = self.items.lock().await;
@@ -309,6 +394,8 @@ impl RequestQueue {
         let status = match &current {
             Some(item) => match item.method.as_str() {
                 "speak" => "speaking",
+                "synthesize" => "synthesizing",
+                "stream_speak" => "streaming",
                 "listen" => "listening",
                 "converse" => "conversing",
                 _ => "idle",
@@ -341,6 +428,8 @@ impl RequestQueue {
 
     async fn cancel_entry(&self, mut entry: QueueEntry) {
         let id = entry.id.clone();
+        entry.cancelled.store(true, Ordering::SeqCst);
+        entry.request.notify_cancelled();
         entry.status = ItemStatus::Failed;
         entry.result = Some(CANCELLED_MESSAGE.to_string());
         self.push_recent(entry).await;
@@ -411,6 +500,31 @@ mod tests {
             .await;
 
         assert!(queue.cancel_item(&queue_id).await);
+
+        let result = rx.await.unwrap();
+        assert_eq!(result.status, ItemStatus::Failed);
+        assert_eq!(result.result.as_deref(), Some(CANCELLED_MESSAGE));
+    }
+
+    #[tokio::test]
+    async fn cancel_item_sets_current_cancellation_flag() {
+        let queue = RequestQueue::new();
+        let (queue_id, rx) = queue
+            .enqueue_and_wait(
+                "client-a".to_string(),
+                VoiceRequest::Speak {
+                    text: "hello".to_string(),
+                    voice: None,
+                    speed: None,
+                },
+            )
+            .await;
+
+        let entry = queue.dequeue().await.unwrap();
+        let cancelled = entry.cancelled.clone();
+
+        assert!(queue.cancel_item(&queue_id).await);
+        assert!(cancelled.load(Ordering::SeqCst));
 
         let result = rx.await.unwrap();
         assert_eq!(result.status, ItemStatus::Failed);

--- a/crates/voice-daemon/src/socket.rs
+++ b/crates/voice-daemon/src/socket.rs
@@ -4,13 +4,14 @@
 //! instead of newline-delimited JSON.
 
 use crate::config::DaemonConfig;
-use crate::queue::RequestQueue;
+use crate::queue::{RequestQueue, StreamSpeakRequest};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::net::UnixListener;
 use uuid::Uuid;
 use voice_protocol::frames::{read_frame, write_frame, Frame, FrameType};
 use voice_protocol::rpc::{self, Response};
+use voice_stream::{TtsStreamEvent, DEFAULT_FRAME_MS};
 
 pub fn socket_path() -> PathBuf {
     let path = voice_protocol::client::daemon_socket_path();
@@ -82,22 +83,39 @@ async fn handle_client(
         };
 
         match frame.frame_type {
-            FrameType::Request => {
-                let response = match frame.json::<rpc::Request>() {
-                    Ok(req) => dispatch(req, &queue, &config, &client_id, &automerge).await,
-                    Err(e) => Response::error(
+            FrameType::Request => match frame.json::<rpc::Request>() {
+                Ok(req) if req.method == "stream_speak" => {
+                    if dispatch_stream_speak(
+                        req,
+                        &queue,
+                        &config,
+                        &client_id,
+                        &automerge,
+                        &mut writer,
+                    )
+                    .await
+                    .is_err()
+                    {
+                        break;
+                    }
+                }
+                Ok(req) => {
+                    let response = dispatch(req, &queue, &config, &client_id, &automerge).await;
+                    if write_response(&mut writer, &response).await.is_err() {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    let response = Response::error(
                         None,
                         rpc::PARSE_ERROR,
                         format!("Invalid request JSON: {}", e),
-                    ),
-                };
-
-                let json = serde_json::to_vec(&response).unwrap();
-                let resp_frame = Frame::response(&json);
-                if write_frame(&mut writer, &resp_frame).await.is_err() {
-                    break;
+                    );
+                    if write_response(&mut writer, &response).await.is_err() {
+                        break;
+                    }
                 }
-            }
+            },
             other => {
                 eprintln!(
                     "voiced: unexpected frame type {:?} from {}",
@@ -108,6 +126,103 @@ async fn handle_client(
     }
 
     eprintln!("voiced: client disconnected ({})", client_id);
+}
+
+async fn write_response(
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+    response: &Response,
+) -> std::io::Result<()> {
+    let json = serde_json::to_vec(response).unwrap();
+    write_frame(writer, &Frame::response(&json)).await
+}
+
+async fn write_stream_event(
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+    event: &TtsStreamEvent,
+) -> std::io::Result<()> {
+    let envelope = rpc::Event::new(event.event_name(), serde_json::to_value(event).unwrap());
+    let json = serde_json::to_vec(&envelope).unwrap();
+    write_frame(writer, &Frame::event(&json)).await
+}
+
+async fn dispatch_stream_speak(
+    req: rpc::Request,
+    queue: &Arc<RequestQueue>,
+    config: &Arc<DaemonConfig>,
+    client_id: &str,
+    automerge: &Arc<tokio::sync::Mutex<crate::automerge_state::AutomergeState>>,
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+) -> std::io::Result<()> {
+    if !(req.params.is_null() || req.params.is_object()) {
+        let response = Response::error(req.id, rpc::INVALID_PARAMS, "params must be an object");
+        return write_response(writer, &response).await;
+    }
+
+    let text = match required_string_param(&req, "text") {
+        Ok(text) => text,
+        Err(resp) => return write_response(writer, &resp).await,
+    };
+    let voice = match optional_voice_param(&req) {
+        Ok(voice) => voice,
+        Err(resp) => return write_response(writer, &resp).await,
+    };
+    let speed = match optional_speed_param(&req) {
+        Ok(speed) => speed,
+        Err(resp) => return write_response(writer, &resp).await,
+    };
+    let sample_rate = match optional_u32_param(&req, "sample_rate", 8_000, 96_000) {
+        Ok(rate) => rate.unwrap_or(24_000),
+        Err(resp) => return write_response(writer, &resp).await,
+    };
+    let frame_ms = match optional_u32_param(&req, "frame_ms", 5, 100) {
+        Ok(frame_ms) => frame_ms.unwrap_or(DEFAULT_FRAME_MS),
+        Err(resp) => return write_response(writer, &resp).await,
+    };
+
+    let stream_id = Uuid::new_v4().to_string();
+    let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<TtsStreamEvent>(16);
+    let queue_id = queue
+        .enqueue_stream_speak(
+            client_id.to_string(),
+            StreamSpeakRequest {
+                text,
+                stream_id: stream_id.clone(),
+                voice: voice.or_else(|| Some(config.get_voice_name())),
+                speed: speed.or_else(|| Some(config.get_speed() as f64)),
+                sample_rate,
+                frame_ms,
+                event_tx,
+            },
+        )
+        .await;
+    sync_automerge(queue, automerge).await;
+
+    let response = Response::success(
+        req.id,
+        serde_json::json!({
+            "queue_id": queue_id,
+            "stream_id": stream_id,
+            "status": "queued",
+        }),
+    );
+    write_response(writer, &response).await?;
+
+    let mut saw_terminal = false;
+    while let Some(event) = event_rx.recv().await {
+        let terminal = event.is_terminal();
+        write_stream_event(writer, &event).await?;
+        if terminal {
+            saw_terminal = true;
+            break;
+        }
+    }
+
+    if !saw_terminal {
+        let event = TtsStreamEvent::error(stream_id, "stream closed before terminal event");
+        write_stream_event(writer, &event).await?;
+    }
+
+    Ok(())
 }
 
 async fn sync_automerge(
@@ -156,6 +271,30 @@ async fn dispatch(
                 Err(resp) => return resp,
             };
             VoiceRequest::Speak { text, voice, speed }
+        }
+        "synthesize" => {
+            let text = match required_string_param(&req, "text") {
+                Ok(text) => text,
+                Err(resp) => return resp,
+            };
+            let output_path = match required_string_param(&req, "output_path") {
+                Ok(output_path) => output_path,
+                Err(resp) => return resp,
+            };
+            let voice = match optional_voice_param(&req) {
+                Ok(voice) => voice,
+                Err(resp) => return resp,
+            };
+            let speed = match optional_speed_param(&req) {
+                Ok(speed) => speed,
+                Err(resp) => return resp,
+            };
+            VoiceRequest::Synthesize {
+                text,
+                output_path,
+                voice,
+                speed,
+            }
         }
         "listen" => {
             let max_duration_ms = match optional_duration_param(&req, "max_duration_ms") {
@@ -322,6 +461,19 @@ async fn dispatch(
                     .enqueue_speak(client_id.to_string(), text, voice, speed)
                     .await
             }
+            VoiceRequest::Synthesize {
+                text,
+                output_path,
+                voice,
+                speed,
+            } => {
+                queue
+                    .enqueue_synthesize(client_id.to_string(), text, output_path, voice, speed)
+                    .await
+            }
+            VoiceRequest::StreamSpeak(_) => {
+                unreachable!("stream_speak is handled before dispatch")
+            }
             VoiceRequest::Listen { max_duration_ms } => {
                 queue
                     .enqueue_listen(client_id.to_string(), max_duration_ms)
@@ -368,7 +520,7 @@ fn wait_param(req: &rpc::Request) -> Result<bool, Response> {
                 "param 'wait' must be a boolean",
             )
         }),
-        None => Ok(false),
+        None => Ok(req.method == "synthesize"),
     }
 }
 
@@ -467,6 +619,30 @@ fn optional_duration_param(req: &rpc::Request, name: &str) -> Result<Option<u64>
                 req.id.clone(),
                 rpc::INVALID_PARAMS,
                 format!("param '{}' must be greater than 0", name),
+            )),
+            None => Err(Response::error(
+                req.id.clone(),
+                rpc::INVALID_PARAMS,
+                format!("param '{}' must be an unsigned integer", name),
+            )),
+        },
+        None => Ok(None),
+    }
+}
+
+fn optional_u32_param(
+    req: &rpc::Request,
+    name: &str,
+    min: u32,
+    max: u32,
+) -> Result<Option<u32>, Response> {
+    match req.params.get(name) {
+        Some(value) => match value.as_u64() {
+            Some(raw) if raw >= min as u64 && raw <= max as u64 => Ok(Some(raw as u32)),
+            Some(_) => Err(Response::error(
+                req.id.clone(),
+                rpc::INVALID_PARAMS,
+                format!("param '{}' must be between {} and {}", name, min, max),
             )),
             None => Err(Response::error(
                 req.id.clone(),

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -12,6 +12,9 @@ use std::num::NonZero;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
+use voice_stream::{
+    resample_linear, AudioEncoding, Packetizer, StreamEnded, StreamMetadata, TtsStreamEvent,
+};
 use voice_tts::KokoroModel;
 
 use crate::audio_recorder;
@@ -30,6 +33,17 @@ struct TtsState {
     speed: f32,
     sample_rate: u32,
     repo_id: String,
+}
+
+struct StreamSpeakJob {
+    text: String,
+    stream_id: String,
+    voice_name: Option<String>,
+    speed: Option<f64>,
+    sample_rate: u32,
+    frame_ms: u32,
+    event_tx: tokio::sync::mpsc::Sender<TtsStreamEvent>,
+    cancelled: Arc<AtomicBool>,
 }
 
 impl TtsState {
@@ -63,6 +77,7 @@ pub async fn run(
     queue: Arc<RequestQueue>,
     config: Arc<crate::config::DaemonConfig>,
     automerge: Arc<tokio::sync::Mutex<crate::automerge_state::AutomergeState>>,
+    tts_only: bool,
 ) {
     eprintln!("voiced: loading TTS model...");
     let start = Instant::now();
@@ -86,29 +101,34 @@ pub async fn run(
         start.elapsed().as_secs_f32()
     );
 
-    // Eagerly load STT model — daemon is long-lived, pay the cost once
-    eprintln!("voiced: loading STT model...");
-    let stt_start = Instant::now();
-    let stt: Arc<Mutex<Option<voice_stt::WhisperModel>>> = match tokio::task::spawn_blocking(|| {
-        voice_stt::load_model(STT_REPO).map_err(|e| format!("stt: {}", e))
-    })
-    .await
-    {
-        Ok(Ok(model)) => {
-            eprintln!(
-                "voiced: STT model loaded in {:.1}s",
-                stt_start.elapsed().as_secs_f32()
-            );
-            Arc::new(Mutex::new(Some(model)))
-        }
-        Ok(Err(e)) => {
-            eprintln!("voiced: STT model failed to load: {}", e);
-            eprintln!("voiced: listen/converse will be unavailable");
-            Arc::new(Mutex::new(None))
-        }
-        Err(e) => {
-            eprintln!("voiced: STT init panicked: {}", e);
-            Arc::new(Mutex::new(None))
+    let stt: Arc<Mutex<Option<voice_stt::WhisperModel>>> = if tts_only {
+        eprintln!("voiced: skipping eager STT load (TTS-only mode)");
+        Arc::new(Mutex::new(None))
+    } else {
+        // Eagerly load STT model — daemon is long-lived, pay the cost once
+        eprintln!("voiced: loading STT model...");
+        let stt_start = Instant::now();
+        match tokio::task::spawn_blocking(|| {
+            voice_stt::load_model(STT_REPO).map_err(|e| format!("stt: {}", e))
+        })
+        .await
+        {
+            Ok(Ok(model)) => {
+                eprintln!(
+                    "voiced: STT model loaded in {:.1}s",
+                    stt_start.elapsed().as_secs_f32()
+                );
+                Arc::new(Mutex::new(Some(model)))
+            }
+            Ok(Err(e)) => {
+                eprintln!("voiced: STT model failed to load: {}", e);
+                eprintln!("voiced: listen/converse will be unavailable");
+                Arc::new(Mutex::new(None))
+            }
+            Err(e) => {
+                eprintln!("voiced: STT init panicked: {}", e);
+                Arc::new(Mutex::new(None))
+            }
         }
     };
 
@@ -137,9 +157,17 @@ pub async fn run(
                     let speed = speed.or_else(|| Some(config.get_speed() as f64));
                     let tts = tts.clone();
                     let queue_id = entry.id.clone();
+                    let cancelled = entry.cancelled.clone();
 
                     let result = tokio::task::spawn_blocking(move || {
-                        speak(&tts, &text, voice.as_deref(), speed, Some(&queue_id))
+                        speak(
+                            &tts,
+                            &text,
+                            voice.as_deref(),
+                            speed,
+                            Some(&queue_id),
+                            &cancelled,
+                        )
                     })
                     .await;
 
@@ -155,6 +183,83 @@ pub async fn run(
                         }
                         Err(e) => {
                             eprintln!("voiced: speak panicked: {}", e);
+                            queue.fail(format!("panic: {}", e)).await;
+                            sync_automerge(&queue, &automerge).await;
+                        }
+                    }
+                }
+                VoiceRequest::Synthesize {
+                    text,
+                    output_path,
+                    voice,
+                    speed,
+                } => {
+                    let text = text.clone();
+                    let output_path = output_path.clone();
+                    let voice = voice.clone().or_else(|| Some(config.get_voice_name()));
+                    let speed = speed.or_else(|| Some(config.get_speed() as f64));
+                    let tts = tts.clone();
+                    let cancelled = entry.cancelled.clone();
+
+                    let result = tokio::task::spawn_blocking(move || {
+                        synthesize_to_file(
+                            &tts,
+                            &text,
+                            &output_path,
+                            voice.as_deref(),
+                            speed,
+                            &cancelled,
+                        )
+                    })
+                    .await;
+
+                    match result {
+                        Ok(Ok(msg)) => {
+                            queue.complete(Some(msg), None).await;
+                            sync_automerge(&queue, &automerge).await;
+                        }
+                        Ok(Err(e)) => {
+                            eprintln!("voiced: synthesize error: {}", e);
+                            queue.fail(e).await;
+                            sync_automerge(&queue, &automerge).await;
+                        }
+                        Err(e) => {
+                            eprintln!("voiced: synthesize panicked: {}", e);
+                            queue.fail(format!("panic: {}", e)).await;
+                            sync_automerge(&queue, &automerge).await;
+                        }
+                    }
+                }
+                VoiceRequest::StreamSpeak(request) => {
+                    let job = StreamSpeakJob {
+                        text: request.text.clone(),
+                        stream_id: request.stream_id.clone(),
+                        voice_name: request
+                            .voice
+                            .clone()
+                            .or_else(|| Some(config.get_voice_name())),
+                        speed: request.speed.or_else(|| Some(config.get_speed() as f64)),
+                        sample_rate: request.sample_rate,
+                        frame_ms: request.frame_ms,
+                        event_tx: request.event_tx.clone(),
+                        cancelled: entry.cancelled.clone(),
+                    };
+                    let tts = tts.clone();
+
+                    let result = tokio::task::spawn_blocking(move || stream_speak(&tts, job)).await;
+
+                    match result {
+                        Ok(Ok(msg)) => {
+                            queue.complete(Some(msg), None).await;
+                            sync_automerge(&queue, &automerge).await;
+                        }
+                        Ok(Err(e)) => {
+                            eprintln!("voiced: stream_speak error: {}", e);
+                            queue.fail(e).await;
+                            sync_automerge(&queue, &automerge).await;
+                        }
+                        Err(e) => {
+                            eprintln!("voiced: stream_speak panicked: {}", e);
                             queue.fail(format!("panic: {}", e)).await;
                             sync_automerge(&queue, &automerge).await;
                         }
@@ -193,6 +298,7 @@ pub async fn run(
                     let tts = tts.clone();
                     let stt = stt.clone();
                     let queue_id = entry.id.clone(); // Capture for audio recording
+                    let cancelled = entry.cancelled.clone();
 
                     // Speak then listen, return combined JSON
                     let speak_result = tokio::task::spawn_blocking(move || {
@@ -202,6 +308,7 @@ pub async fn run(
                             voice.as_deref(),
                             default_speed,
                             Some(&queue_id),
+                            &cancelled,
                         )?;
                         let heard_json = listen(&stt, None, Some(&queue_id))?; // Pass queue_id for answer recording
                                                                                // Parse both results and combine into the converse format
@@ -272,6 +379,7 @@ fn speak(
     voice_name: Option<&str>,
     speed: Option<f64>,
     queue_id: Option<&str>,
+    cancelled: &Arc<AtomicBool>,
 ) -> Result<String, String> {
     let chunks =
         voice_g2p::text_to_phoneme_chunks(text).map_err(|e| format!("G2P error: {}", e))?;
@@ -296,6 +404,9 @@ fn speak(
         let rate = NonZero::new(sample_rate).unwrap();
 
         for (i, phonemes) in chunks.iter().enumerate() {
+            if cancelled.load(Ordering::SeqCst) {
+                return Err("Cancelled by user".to_string());
+            }
             if phonemes.is_empty() {
                 continue;
             }
@@ -342,6 +453,248 @@ fn speak(
         "chunks": chunks.len(),
     })
     .to_string())
+}
+
+fn synthesize_to_file(
+    tts: &Arc<Mutex<TtsState>>,
+    text: &str,
+    output_path: &str,
+    voice_name: Option<&str>,
+    speed: Option<f64>,
+    cancelled: &Arc<AtomicBool>,
+) -> Result<String, String> {
+    let chunks =
+        voice_g2p::text_to_phoneme_chunks(text).map_err(|e| format!("G2P error: {}", e))?;
+
+    let started = Instant::now();
+    let mut all_samples: Vec<f32> = Vec::new();
+    let sample_rate: u32;
+    let speed_used: f32;
+
+    {
+        let mut state = tts.lock().map_err(|e| format!("lock: {}", e))?;
+        speed_used = speed.map(|s| s as f32).unwrap_or(state.speed);
+        sample_rate = state.sample_rate;
+
+        for (i, phonemes) in chunks.iter().enumerate() {
+            if cancelled.load(Ordering::SeqCst) {
+                return Err("Cancelled by user".to_string());
+            }
+            if phonemes.is_empty() {
+                continue;
+            }
+
+            let voice = if let Some(name) = voice_name {
+                state.get_voice(name)?.clone()
+            } else {
+                state.default_voice.clone()
+            };
+
+            match voice_tts::generate(&mut state.model, phonemes, &voice, speed_used) {
+                Ok(audio) => {
+                    all_samples.extend_from_slice(&audio);
+                    if chunks.len() > 1 {
+                        eprintln!("voiced:   chunk {}/{} synthesized", i + 1, chunks.len());
+                    }
+                }
+                Err(e) => return Err(format!("generate chunk {}: {}", i + 1, e)),
+            }
+        }
+    }
+
+    if cancelled.load(Ordering::SeqCst) {
+        return Err("Cancelled by user".to_string());
+    }
+
+    let path = std::path::Path::new(output_path);
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("create output dir {}: {}", parent.display(), e))?;
+        }
+    }
+
+    audio_recorder::save_wav(path, &all_samples, sample_rate)?;
+
+    Ok(serde_json::json!({
+        "output_path": output_path,
+        "duration_ms": started.elapsed().as_millis() as u64,
+        "chunks": chunks.len(),
+        "samples": all_samples.len(),
+        "sample_rate": sample_rate,
+        "voice": voice_name,
+        "speed": speed_used,
+    })
+    .to_string())
+}
+
+fn stream_speak(tts: &Arc<Mutex<TtsState>>, job: StreamSpeakJob) -> Result<String, String> {
+    let StreamSpeakJob {
+        text,
+        stream_id,
+        voice_name,
+        speed,
+        sample_rate,
+        frame_ms,
+        event_tx,
+        cancelled,
+    } = job;
+
+    let started = Instant::now();
+    let chunks = match voice_g2p::text_to_phoneme_chunks(&text) {
+        Ok(chunks) => chunks,
+        Err(e) => {
+            let msg = format!("G2P error: {}", e);
+            let _ = send_stream_event(
+                &event_tx,
+                TtsStreamEvent::error(stream_id.clone(), msg.clone()),
+                &cancelled,
+            );
+            return Err(msg);
+        }
+    };
+
+    let init_result: Result<(Tensor, u32, f32, Option<String>), String> = {
+        let mut state = tts.lock().map_err(|e| format!("lock: {}", e))?;
+        let voice_tensor = if let Some(name) = voice_name.as_deref() {
+            state.get_voice(name)?.clone()
+        } else {
+            state.default_voice.clone()
+        };
+        Ok((
+            voice_tensor,
+            state.sample_rate,
+            speed.map(|s| s as f32).unwrap_or(state.speed),
+            voice_name
+                .clone()
+                .or_else(|| Some(state.default_voice_name.clone())),
+        ))
+    };
+    let (voice_tensor, source_sample_rate, speed_used, resolved_voice) = match init_result {
+        Ok(result) => result,
+        Err(e) => {
+            let _ = send_stream_event(
+                &event_tx,
+                TtsStreamEvent::error(stream_id.clone(), e.clone()),
+                &cancelled,
+            );
+            return Err(e);
+        }
+    };
+
+    let output_sample_rate = sample_rate.max(1);
+    let frame_ms = frame_ms.max(1);
+    let metadata = StreamMetadata {
+        stream_id: stream_id.clone(),
+        sample_rate: output_sample_rate,
+        source_sample_rate,
+        channels: 1,
+        encoding: AudioEncoding::PcmS16Le,
+        frame_ms,
+        voice: resolved_voice.clone(),
+        speed: speed_used,
+        total_phoneme_chunks: chunks.len(),
+    };
+    send_stream_event(&event_tx, TtsStreamEvent::Started { metadata }, &cancelled)?;
+
+    let mut packetizer = Packetizer::new(stream_id.clone(), output_sample_rate, frame_ms);
+
+    for (i, phonemes) in chunks.iter().enumerate() {
+        if cancelled.load(Ordering::SeqCst) {
+            send_stream_event(
+                &event_tx,
+                TtsStreamEvent::cancelled(stream_id.clone(), "Cancelled by user"),
+                &cancelled,
+            )
+            .ok();
+            return Err("Cancelled by user".to_string());
+        }
+        if phonemes.is_empty() {
+            continue;
+        }
+
+        let audio_result: Result<Vec<f32>, String> = {
+            let mut state = tts.lock().map_err(|e| format!("lock: {}", e))?;
+            voice_tts::generate(&mut state.model, phonemes, &voice_tensor, speed_used)
+                .map_err(|e| format!("generate chunk {}: {}", i + 1, e))
+        };
+        let audio = match audio_result {
+            Ok(audio) => audio,
+            Err(e) => {
+                let _ = send_stream_event(
+                    &event_tx,
+                    TtsStreamEvent::error(stream_id.clone(), e.clone()),
+                    &cancelled,
+                );
+                return Err(e);
+            }
+        };
+
+        let audio = if output_sample_rate == source_sample_rate {
+            audio
+        } else {
+            resample_linear(&audio, source_sample_rate, output_sample_rate)
+        };
+
+        for frame in packetizer.push_samples(i as u32, &audio) {
+            send_stream_event(&event_tx, TtsStreamEvent::Audio { frame }, &cancelled)?;
+        }
+
+        if chunks.len() > 1 {
+            eprintln!(
+                "voiced:   stream chunk {}/{} generated",
+                i + 1,
+                chunks.len()
+            );
+        }
+    }
+
+    if let Some(frame) = packetizer.finish(chunks.len().saturating_sub(1) as u32) {
+        send_stream_event(&event_tx, TtsStreamEvent::Audio { frame }, &cancelled)?;
+    }
+
+    let samples = packetizer.samples_emitted();
+    let duration_ms = if output_sample_rate == 0 {
+        0
+    } else {
+        samples.saturating_mul(1_000) / output_sample_rate as u64
+    };
+    let ended = StreamEnded {
+        stream_id: stream_id.clone(),
+        frames: packetizer.frames_emitted(),
+        samples,
+        duration_ms,
+        elapsed_ms: started.elapsed().as_millis() as u64,
+    };
+    send_stream_event(&event_tx, TtsStreamEvent::Ended(ended), &cancelled)?;
+
+    Ok(serde_json::json!({
+        "stream_id": stream_id,
+        "duration_ms": duration_ms,
+        "elapsed_ms": started.elapsed().as_millis() as u64,
+        "chunks": chunks.len(),
+        "frames": packetizer.frames_emitted(),
+        "samples": samples,
+        "sample_rate": output_sample_rate,
+        "source_sample_rate": source_sample_rate,
+        "frame_ms": frame_ms,
+        "voice": resolved_voice,
+        "speed": speed_used,
+    })
+    .to_string())
+}
+
+fn send_stream_event(
+    event_tx: &tokio::sync::mpsc::Sender<TtsStreamEvent>,
+    event: TtsStreamEvent,
+    cancelled: &Arc<AtomicBool>,
+) -> Result<(), String> {
+    if cancelled.load(Ordering::SeqCst) && !event.is_terminal() {
+        return Err("Cancelled by user".to_string());
+    }
+    event_tx
+        .blocking_send(event)
+        .map_err(|_| "stream receiver closed".to_string())
 }
 
 // -- STT listen ---------------------------------------------------------------
@@ -578,6 +931,77 @@ async fn run_simulated(
                         .await;
                     sync_automerge(&queue, &automerge).await;
                 }
+                VoiceRequest::Synthesize {
+                    text, output_path, ..
+                } => {
+                    let words = text.split_whitespace().count();
+                    let ms = (words as u64 * 50).max(100);
+                    tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
+                    let path = std::path::Path::new(output_path);
+                    if let Some(parent) = path.parent() {
+                        let _ = std::fs::create_dir_all(parent);
+                    }
+                    let _ = audio_recorder::save_wav(path, &[], 24_000);
+                    queue
+                        .complete(
+                            Some(
+                                serde_json::json!({
+                                    "output_path": output_path,
+                                    "duration_ms": ms,
+                                    "chunks": 0,
+                                    "samples": 0,
+                                    "sample_rate": 24000,
+                                    "simulated": true,
+                                })
+                                .to_string(),
+                            ),
+                            None,
+                        )
+                        .await;
+                    sync_automerge(&queue, &automerge).await;
+                }
+                VoiceRequest::StreamSpeak(request) => {
+                    let words = request.text.split_whitespace().count();
+                    let sample_rate = request.sample_rate;
+                    let frame_ms = request.frame_ms;
+                    let samples = (sample_rate as usize / 10).max(1);
+                    let metadata = StreamMetadata {
+                        stream_id: request.stream_id.clone(),
+                        sample_rate,
+                        source_sample_rate: sample_rate,
+                        channels: 1,
+                        encoding: AudioEncoding::PcmS16Le,
+                        frame_ms,
+                        voice: None,
+                        speed: 1.0,
+                        total_phoneme_chunks: 1,
+                    };
+                    let _ = request
+                        .event_tx
+                        .send(TtsStreamEvent::Started { metadata })
+                        .await;
+                    let mut packetizer =
+                        Packetizer::new(request.stream_id.clone(), sample_rate, frame_ms);
+                    for frame in packetizer.push_samples(0, &vec![0.0; samples]) {
+                        let _ = request.event_tx.send(TtsStreamEvent::Audio { frame }).await;
+                    }
+                    if let Some(frame) = packetizer.finish(0) {
+                        let _ = request.event_tx.send(TtsStreamEvent::Audio { frame }).await;
+                    }
+                    let ended = StreamEnded {
+                        stream_id: request.stream_id.clone(),
+                        frames: packetizer.frames_emitted(),
+                        samples: packetizer.samples_emitted(),
+                        duration_ms: packetizer.samples_emitted().saturating_mul(1_000)
+                            / sample_rate.max(1) as u64,
+                        elapsed_ms: words as u64,
+                    };
+                    let _ = request.event_tx.send(TtsStreamEvent::Ended(ended)).await;
+                    queue
+                        .complete(Some("simulated stream".to_string()), None)
+                        .await;
+                    sync_automerge(&queue, &automerge).await;
+                }
                 VoiceRequest::Listen { .. } => {
                     tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
                     queue
@@ -605,6 +1029,16 @@ fn short(req: &VoiceRequest) -> String {
             let preview: String = text.chars().take(50).collect();
             format!("speak: {}", preview)
         }
+        VoiceRequest::Synthesize {
+            text, output_path, ..
+        } => {
+            let preview: String = text.chars().take(50).collect();
+            format!("synthesize: {} -> {}", preview, output_path)
+        }
+        VoiceRequest::StreamSpeak(request) => {
+            let preview: String = request.text.chars().take(50).collect();
+            format!("stream_speak: {}", preview)
+        }
         VoiceRequest::Listen { max_duration_ms } => {
             format!("listen ({}ms)", max_duration_ms.unwrap_or(30000))
         }
@@ -612,5 +1046,126 @@ fn short(req: &VoiceRequest) -> String {
             let preview: String = text.chars().take(50).collect();
             format!("converse: {}", preview)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::automerge_state::AutomergeState;
+    use crate::queue::CompletionResult;
+    use voice_protocol::rpc::ItemStatus;
+
+    async fn start_simulated_worker() -> (Arc<RequestQueue>, tokio::task::JoinHandle<()>) {
+        let queue = Arc::new(RequestQueue::new());
+        let automerge = Arc::new(tokio::sync::Mutex::new(AutomergeState::new()));
+        let handle = tokio::spawn(run_simulated(queue.clone(), automerge));
+        tokio::task::yield_now().await;
+        (queue, handle)
+    }
+
+    async fn await_completion(
+        rx: tokio::sync::oneshot::Receiver<CompletionResult>,
+    ) -> CompletionResult {
+        tokio::time::timeout(std::time::Duration::from_secs(2), rx)
+            .await
+            .expect("simulated worker timed out")
+            .expect("completion channel closed")
+    }
+
+    #[tokio::test]
+    async fn simulated_synthesize_writes_wav_and_completes() {
+        let (queue, worker) = start_simulated_worker().await;
+        let output_path = std::env::temp_dir().join(format!(
+            "voice-daemon-simulated-synth-{}-{}.wav",
+            std::process::id(),
+            unique_suffix()
+        ));
+
+        let (_queue_id, rx) = queue
+            .enqueue_and_wait(
+                "test-client".to_string(),
+                VoiceRequest::Synthesize {
+                    text: "hello from simulated synthesis".to_string(),
+                    output_path: output_path.to_string_lossy().to_string(),
+                    voice: None,
+                    speed: None,
+                },
+            )
+            .await;
+
+        let result = await_completion(rx).await;
+        assert_eq!(result.status, ItemStatus::Completed);
+        let result_json: serde_json::Value =
+            serde_json::from_str(result.result.as_deref().unwrap()).unwrap();
+        assert_eq!(
+            result_json.get("simulated").and_then(|v| v.as_bool()),
+            Some(true)
+        );
+        assert!(output_path.exists(), "simulated synth should create WAV");
+
+        let (_samples, sample_rate) = audio_recorder::read_wav(&output_path).unwrap();
+        assert_eq!(sample_rate, 24_000);
+
+        let _ = std::fs::remove_file(output_path);
+        worker.abort();
+    }
+
+    #[tokio::test]
+    async fn simulated_stream_emits_started_audio_and_ended_events() {
+        let (queue, worker) = start_simulated_worker().await;
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(16);
+        let stream_id = format!("stream-{}", unique_suffix());
+
+        let (_queue_id, completion_rx) = queue
+            .enqueue_and_wait(
+                "test-client".to_string(),
+                VoiceRequest::StreamSpeak(crate::queue::StreamSpeakRequest {
+                    text: "hello from simulated stream".to_string(),
+                    stream_id: stream_id.clone(),
+                    voice: None,
+                    speed: None,
+                    sample_rate: 48_000,
+                    frame_ms: 20,
+                    event_tx,
+                }),
+            )
+            .await;
+
+        let mut event_names = Vec::new();
+        loop {
+            let event = tokio::time::timeout(std::time::Duration::from_secs(2), event_rx.recv())
+                .await
+                .expect("timed out waiting for stream event")
+                .expect("stream event channel closed");
+            let terminal = event.is_terminal();
+            if let TtsStreamEvent::Audio { frame } = &event {
+                assert_eq!(frame.sample_rate, 48_000);
+                assert_eq!(frame.frame_ms, 20);
+                assert_eq!(frame.sample_count, 960);
+                assert_eq!(frame.timestamp_ms, frame.sequence * 20);
+            }
+            event_names.push(event.event_name().to_string());
+            if terminal {
+                break;
+            }
+        }
+
+        assert_eq!(event_names.first().map(String::as_str), Some("tts.started"));
+        assert!(event_names.iter().any(|event| event == "tts.audio"));
+        assert_eq!(event_names.last().map(String::as_str), Some("tts.ended"));
+
+        let result = await_completion(completion_rx).await;
+        assert_eq!(result.status, ItemStatus::Completed);
+        assert_eq!(result.result.as_deref(), Some("simulated stream"));
+
+        worker.abort();
+    }
+
+    fn unique_suffix() -> u128 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
     }
 }

--- a/crates/voice-kokoro/src/istftnet.rs
+++ b/crates/voice-kokoro/src/istftnet.rs
@@ -889,12 +889,12 @@ fn reflection_pad_1d(x: &Tensor, pad: usize) -> Result<Tensor> {
     // Left pad: reflect indices [pad, pad-1, ..., 1]
     let mut parts = Vec::new();
     if pad > 0 {
-        let left = x.narrow(1, 1, pad)?.flip(&[1])?;
+        let left = x.narrow(1, 1, pad)?.contiguous()?.flip(&[1])?;
         parts.push(left);
     }
     parts.push(x.clone());
     if pad > 0 {
-        let right = x.narrow(1, l - pad - 1, pad)?.flip(&[1])?;
+        let right = x.narrow(1, l - pad - 1, pad)?.contiguous()?.flip(&[1])?;
         parts.push(right);
     }
     Tensor::cat(&parts, 1)
@@ -906,12 +906,15 @@ fn reflection_pad_1d_channels(x: &Tensor, pad_left: usize, pad_right: usize) -> 
     let mut parts = Vec::new();
 
     if pad_left > 0 {
-        let left = x.narrow(2, 1, pad_left)?.flip(&[2])?;
+        let left = x.narrow(2, 1, pad_left)?.contiguous()?.flip(&[2])?;
         parts.push(left);
     }
     parts.push(x.clone());
     if pad_right > 0 {
-        let right = x.narrow(2, t - pad_right - 1, pad_right)?.flip(&[2])?;
+        let right = x
+            .narrow(2, t - pad_right - 1, pad_right)?
+            .contiguous()?
+            .flip(&[2])?;
         parts.push(right);
     }
     Tensor::cat(&parts, 2)

--- a/crates/voice-protocol/Cargo.toml
+++ b/crates/voice-protocol/Cargo.toml
@@ -12,6 +12,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { version = "1", features = ["io-util", "net"] }
 dirs = "6"
+voice-stream = { path = "../voice-stream" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["io-util", "rt", "macros"] }

--- a/crates/voice-protocol/src/client.rs
+++ b/crates/voice-protocol/src/client.rs
@@ -9,6 +9,7 @@ use serde_json::Value;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::time::Duration;
+use voice_stream::TtsStreamEvent;
 
 const SOCKET_ENV: &str = "VOICE_DAEMON_SOCKET";
 
@@ -100,6 +101,109 @@ impl DaemonClient {
         self.call("speak", params)
     }
 
+    /// Convenience: synthesize text to a WAV file via the daemon and wait for completion.
+    pub fn synthesize(
+        &mut self,
+        text: &str,
+        output_path: &str,
+        voice: Option<&str>,
+        speed: Option<f64>,
+    ) -> Result<Response, String> {
+        let mut params = serde_json::json!({
+            "text": text,
+            "output_path": output_path,
+            "wait": true,
+        });
+        if let Some(v) = voice {
+            params["voice"] = Value::String(v.to_string());
+        }
+        if let Some(s) = speed {
+            params["speed"] = serde_json::json!(s);
+        }
+        self.call("synthesize", params)
+    }
+
+    /// Stream TTS audio from the daemon.
+    ///
+    /// The daemon first returns a normal JSON-RPC response containing
+    /// `queue_id` and `stream_id`, then pushes `tts.*` event frames on the
+    /// same connection until an ended/error/cancelled event arrives.
+    pub fn stream_speak<F>(
+        &mut self,
+        text: &str,
+        voice: Option<&str>,
+        speed: Option<f64>,
+        sample_rate: Option<u32>,
+        frame_ms: Option<u32>,
+        mut on_event: F,
+    ) -> Result<Response, String>
+    where
+        F: FnMut(TtsStreamEvent) -> Result<(), String>,
+    {
+        let mut params = serde_json::json!({ "text": text });
+        if let Some(v) = voice {
+            params["voice"] = Value::String(v.to_string());
+        }
+        if let Some(s) = speed {
+            params["speed"] = serde_json::json!(s);
+        }
+        if let Some(rate) = sample_rate {
+            params["sample_rate"] = serde_json::json!(rate);
+        }
+        if let Some(ms) = frame_ms {
+            params["frame_ms"] = serde_json::json!(ms);
+        }
+
+        let req = rpc::Request::new("stream_speak", params).with_id(1);
+        let json = serde_json::to_vec(&req).map_err(|e| format!("serialize: {}", e))?;
+
+        write_frame_sync(&mut self.stream, &Frame::request(&json))
+            .map_err(|e| format!("write frame: {}", e))?;
+
+        let frame = read_frame_sync(&mut self.stream)
+            .map_err(|e| format!("read frame: {}", e))?
+            .ok_or_else(|| "connection closed before stream response".to_string())?;
+        if frame.frame_type != FrameType::Response {
+            return Err(format!(
+                "unexpected frame type {:?}; expected stream response",
+                frame.frame_type
+            ));
+        }
+
+        let response = frame
+            .json::<Response>()
+            .map_err(|e| format!("parse response: {}", e))?;
+        if response.error.is_some() {
+            return Ok(response);
+        }
+
+        loop {
+            let frame = read_frame_sync(&mut self.stream)
+                .map_err(|e| format!("read stream frame: {}", e))?
+                .ok_or_else(|| "connection closed before stream finished".to_string())?;
+
+            if frame.frame_type != FrameType::Event {
+                return Err(format!(
+                    "unexpected frame type {:?}; expected stream event",
+                    frame.frame_type
+                ));
+            }
+
+            let event = frame
+                .json::<rpc::Event>()
+                .map_err(|e| format!("parse event envelope: {}", e))?;
+            let stream_event: TtsStreamEvent = serde_json::from_value(event.data)
+                .map_err(|e| format!("parse stream event: {}", e))?;
+            let terminal = stream_event.is_terminal();
+            on_event(stream_event)?;
+            if terminal {
+                break;
+            }
+        }
+
+        Ok(response)
+    }
+
     /// Convenience: send a listen request. Blocks until transcription completes.
     pub fn listen(&mut self, max_duration_ms: Option<u64>) -> Result<Response, String> {
         let mut params = serde_json::json!({"wait": true});
@@ -160,12 +264,13 @@ impl DaemonClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::frames::{write_frame_sync, Frame};
-    use crate::rpc::Response;
+    use crate::frames::{read_frame_sync, write_frame_sync, Frame};
+    use crate::rpc::{Event, Response};
     use std::io::Read;
     use std::os::unix::net::UnixListener;
     use std::sync::Mutex;
     use std::thread;
+    use voice_stream::{AudioEncoding, StreamEnded, StreamMetadata, TtsStreamEvent};
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -241,6 +346,90 @@ mod tests {
         let mut client = DaemonClient::connect().unwrap();
         let response = client.call("status", serde_json::json!({})).unwrap();
         assert_eq!(response.result.unwrap()["status"], "idle");
+
+        match old {
+            Some(value) => std::env::set_var(SOCKET_ENV, value),
+            None => std::env::remove_var(SOCKET_ENV),
+        }
+        let _ = std::fs::remove_file(path);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn stream_speak_reads_events_until_terminal() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "voice-protocol-stream-test-{}.sock",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).unwrap();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let _ = read_frame_sync(&mut stream).unwrap().unwrap();
+
+            let response = Response::success(
+                Some(serde_json::json!(1)),
+                serde_json::json!({
+                    "queue_id": "q",
+                    "stream_id": "s",
+                    "status": "queued",
+                }),
+            );
+            write_frame_sync(
+                &mut stream,
+                &Frame::response(&serde_json::to_vec(&response).unwrap()),
+            )
+            .unwrap();
+
+            let started = TtsStreamEvent::Started {
+                metadata: StreamMetadata {
+                    stream_id: "s".to_string(),
+                    sample_rate: 24_000,
+                    source_sample_rate: 24_000,
+                    channels: 1,
+                    encoding: AudioEncoding::PcmS16Le,
+                    frame_ms: 20,
+                    voice: Some("af_heart".to_string()),
+                    speed: 1.0,
+                    total_phoneme_chunks: 1,
+                },
+            };
+            let ended = TtsStreamEvent::Ended(StreamEnded {
+                stream_id: "s".to_string(),
+                frames: 0,
+                samples: 0,
+                duration_ms: 0,
+                elapsed_ms: 1,
+            });
+
+            for event in [started, ended] {
+                let envelope =
+                    Event::new(event.event_name(), serde_json::to_value(&event).unwrap());
+                write_frame_sync(
+                    &mut stream,
+                    &Frame::event(&serde_json::to_vec(&envelope).unwrap()),
+                )
+                .unwrap();
+            }
+        });
+
+        let old = std::env::var(SOCKET_ENV).ok();
+        std::env::set_var(SOCKET_ENV, &path);
+
+        let mut client = DaemonClient::connect().unwrap();
+        let mut events = Vec::new();
+        let response = client
+            .stream_speak("hello", None, None, None, None, |event| {
+                events.push(event.event_name().to_string());
+                Ok(())
+            })
+            .unwrap();
+
+        assert!(response.error.is_none());
+        assert_eq!(events, vec!["tts.started", "tts.ended"]);
 
         match old {
             Some(value) => std::env::set_var(SOCKET_ENV, value),

--- a/crates/voice-stream/Cargo.toml
+++ b/crates/voice-stream/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "voice-stream"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.85.0"
+description = "Transport-neutral streaming audio events for voice"
+license = "MIT"
+repository = "https://github.com/rgbkrk/voice"
+
+[dependencies]
+serde = { workspace = true }

--- a/crates/voice-stream/src/lib.rs
+++ b/crates/voice-stream/src/lib.rs
@@ -1,0 +1,287 @@
+//! Transport-neutral streaming audio events.
+//!
+//! The daemon and clients use these types to describe TTS as ordered audio
+//! frames instead of only completed files or local playback. The payload is
+//! signed 16-bit mono PCM so it can be written directly to a raw stream,
+//! wrapped in WAV, or fed to an Opus/WebRTC adapter.
+
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_FRAME_MS: u32 = 20;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AudioEncoding {
+    PcmS16Le,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StreamMetadata {
+    pub stream_id: String,
+    pub sample_rate: u32,
+    pub source_sample_rate: u32,
+    pub channels: u16,
+    pub encoding: AudioEncoding,
+    pub frame_ms: u32,
+    pub voice: Option<String>,
+    pub speed: f32,
+    pub total_phoneme_chunks: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AudioFrame {
+    pub stream_id: String,
+    pub sequence: u64,
+    pub chunk_index: u32,
+    pub offset_samples: u64,
+    pub timestamp_ms: u64,
+    pub sample_rate: u32,
+    pub channels: u16,
+    pub encoding: AudioEncoding,
+    pub frame_ms: u32,
+    pub sample_count: usize,
+    pub padding_samples: usize,
+    pub samples: Vec<i16>,
+}
+
+impl AudioFrame {
+    pub fn payload_le_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(self.samples.len() * 2);
+        for sample in &self.samples {
+            bytes.extend_from_slice(&sample.to_le_bytes());
+        }
+        bytes
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StreamEnded {
+    pub stream_id: String,
+    pub frames: u64,
+    pub samples: u64,
+    pub duration_ms: u64,
+    pub elapsed_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StreamError {
+    pub stream_id: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StreamCancelled {
+    pub stream_id: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TtsStreamEvent {
+    Started { metadata: StreamMetadata },
+    Audio { frame: AudioFrame },
+    Ended(StreamEnded),
+    Error(StreamError),
+    Cancelled(StreamCancelled),
+}
+
+impl TtsStreamEvent {
+    pub fn event_name(&self) -> &'static str {
+        match self {
+            Self::Started { .. } => "tts.started",
+            Self::Audio { .. } => "tts.audio",
+            Self::Ended(_) => "tts.ended",
+            Self::Error(_) => "tts.error",
+            Self::Cancelled(_) => "tts.cancelled",
+        }
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Ended(_) | Self::Error(_) | Self::Cancelled(_))
+    }
+
+    pub fn cancelled(stream_id: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::Cancelled(StreamCancelled {
+            stream_id: stream_id.into(),
+            reason: reason.into(),
+        })
+    }
+
+    pub fn error(stream_id: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::Error(StreamError {
+            stream_id: stream_id.into(),
+            message: message.into(),
+        })
+    }
+}
+
+/// Fixed-duration packetizer for mono f32 PCM.
+///
+/// `push_samples` emits only full frames. `finish` emits the remaining tail,
+/// padded with silence to a full frame, which keeps the output Opus-friendly.
+#[derive(Debug, Clone)]
+pub struct Packetizer {
+    stream_id: String,
+    sample_rate: u32,
+    channels: u16,
+    frame_ms: u32,
+    samples_per_frame: usize,
+    next_sequence: u64,
+    offset_samples: u64,
+    pending: Vec<f32>,
+}
+
+impl Packetizer {
+    pub fn new(stream_id: impl Into<String>, sample_rate: u32, frame_ms: u32) -> Self {
+        let sample_rate = sample_rate.max(1);
+        let frame_ms = frame_ms.max(1);
+        let samples_per_frame = ((sample_rate as u64 * frame_ms as u64) / 1_000).max(1) as usize;
+        Self {
+            stream_id: stream_id.into(),
+            sample_rate,
+            channels: 1,
+            frame_ms,
+            samples_per_frame,
+            next_sequence: 0,
+            offset_samples: 0,
+            pending: Vec::new(),
+        }
+    }
+
+    pub fn samples_per_frame(&self) -> usize {
+        self.samples_per_frame
+    }
+
+    pub fn frames_emitted(&self) -> u64 {
+        self.next_sequence
+    }
+
+    pub fn samples_emitted(&self) -> u64 {
+        self.offset_samples
+    }
+
+    pub fn push_samples(&mut self, chunk_index: u32, samples: &[f32]) -> Vec<AudioFrame> {
+        self.pending.extend_from_slice(samples);
+        let mut frames = Vec::new();
+
+        while self.pending.len() >= self.samples_per_frame {
+            let frame_samples: Vec<f32> = self.pending.drain(..self.samples_per_frame).collect();
+            frames.push(self.make_frame(chunk_index, frame_samples, 0));
+        }
+
+        frames
+    }
+
+    pub fn finish(&mut self, chunk_index: u32) -> Option<AudioFrame> {
+        if self.pending.is_empty() {
+            return None;
+        }
+
+        let padding = self.samples_per_frame - self.pending.len();
+        let mut frame_samples = std::mem::take(&mut self.pending);
+        frame_samples.resize(self.samples_per_frame, 0.0);
+        Some(self.make_frame(chunk_index, frame_samples, padding))
+    }
+
+    fn make_frame(
+        &mut self,
+        chunk_index: u32,
+        samples: Vec<f32>,
+        padding_samples: usize,
+    ) -> AudioFrame {
+        let sequence = self.next_sequence;
+        let offset_samples = self.offset_samples;
+        self.next_sequence += 1;
+        self.offset_samples += samples.len() as u64;
+
+        AudioFrame {
+            stream_id: self.stream_id.clone(),
+            sequence,
+            chunk_index,
+            offset_samples,
+            timestamp_ms: offset_samples.saturating_mul(1_000) / self.sample_rate as u64,
+            sample_rate: self.sample_rate,
+            channels: self.channels,
+            encoding: AudioEncoding::PcmS16Le,
+            frame_ms: self.frame_ms,
+            sample_count: samples.len(),
+            padding_samples,
+            samples: samples.into_iter().map(f32_to_i16).collect(),
+        }
+    }
+}
+
+pub fn f32_to_i16(sample: f32) -> i16 {
+    let clamped = sample.clamp(-1.0, 1.0);
+    if clamped >= 0.0 {
+        (clamped * i16::MAX as f32).round() as i16
+    } else {
+        (clamped * 32768.0).round() as i16
+    }
+}
+
+pub fn resample_linear(samples: &[f32], source_rate: u32, target_rate: u32) -> Vec<f32> {
+    if samples.is_empty() || source_rate == 0 || target_rate == 0 {
+        return Vec::new();
+    }
+    if source_rate == target_rate {
+        return samples.to_vec();
+    }
+    if samples.len() == 1 {
+        return vec![samples[0]];
+    }
+
+    let output_len =
+        (samples.len() as u64 * target_rate as u64).div_ceil(source_rate as u64) as usize;
+    let scale = source_rate as f64 / target_rate as f64;
+
+    (0..output_len)
+        .map(|i| {
+            let pos = i as f64 * scale;
+            let left = pos.floor() as usize;
+            let right = (left + 1).min(samples.len() - 1);
+            let frac = (pos - left as f64) as f32;
+            samples[left] * (1.0 - frac) + samples[right] * frac
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn packetizer_emits_full_frames_and_pads_tail() {
+        let mut packetizer = Packetizer::new("s", 24_000, 20);
+        assert_eq!(packetizer.samples_per_frame(), 480);
+
+        let frames = packetizer.push_samples(0, &vec![0.25; 1_000]);
+        assert_eq!(frames.len(), 2);
+        assert_eq!(frames[0].sequence, 0);
+        assert_eq!(frames[0].offset_samples, 0);
+        assert_eq!(frames[1].sequence, 1);
+        assert_eq!(frames[1].offset_samples, 480);
+        assert_eq!(frames[1].timestamp_ms, 20);
+
+        let tail = packetizer.finish(0).unwrap();
+        assert_eq!(tail.sequence, 2);
+        assert_eq!(tail.sample_count, 480);
+        assert_eq!(tail.padding_samples, 440);
+    }
+
+    #[test]
+    fn converts_f32_to_i16_with_clamping() {
+        assert_eq!(f32_to_i16(0.0), 0);
+        assert_eq!(f32_to_i16(1.0), 32767);
+        assert_eq!(f32_to_i16(-1.0), -32768);
+        assert_eq!(f32_to_i16(2.0), 32767);
+        assert_eq!(f32_to_i16(-2.0), -32768);
+    }
+
+    #[test]
+    fn resample_linear_doubles_sample_count() {
+        let out = resample_linear(&[0.0, 1.0, 0.0], 24_000, 48_000);
+        assert_eq!(out.len(), 6);
+        assert!((out[1] - 0.5).abs() < 0.001);
+    }
+}

--- a/crates/voice-tray/src-tauri/main.rs
+++ b/crates/voice-tray/src-tauri/main.rs
@@ -83,6 +83,9 @@ fn main() {
                 tray.on_tray_icon_event(move |_tray, event| {
                     info!("Tray icon event: {:?}", event);
                     if let tauri::tray::TrayIconEvent::Click { button, rect, .. } = event {
+                        #[cfg(not(target_os = "macos"))]
+                        let _ = &rect;
+
                         if button == MouseButton::Left {
                             if let Some(window) = window_handle.get_webview_window("main") {
                                 let is_visible = window.is_visible().unwrap_or(false);

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -1,0 +1,109 @@
+# Streaming TTS
+
+`voice` exposes two daemon-backed TTS surfaces:
+
+- `synthesize`: write a completed WAV file. This is the compatibility path for
+  tools that expect `{input_path} -> {output_path}`, including Hermes command
+  TTS providers.
+- `stream_speak`: emit ordered audio events over the daemon socket. This is the
+  transport-neutral path for WebRTC, voice bridges, or any client that wants
+  audio before a final file exists.
+
+## Hermes / WhatsApp
+
+Hermes' current WhatsApp path sends local media files to the WhatsApp bridge.
+The bridge reads the completed file and converts non-Opus audio to OGG/Opus for
+native `ptt` voice-note delivery. Use daemon synthesis for that path:
+
+```yaml
+tts:
+  provider: kokoro
+  providers:
+    kokoro:
+      type: command
+      command: /path/to/voice say --input-file {input_path} --output {output_path} --voice {voice} --speed {speed}
+      output_format: wav
+      voice: af_heart
+      speed: 1.0
+      timeout: 180
+      max_text_length: 2000
+```
+
+Run the daemon first so the Kokoro model stays resident:
+
+```bash
+voiced --tts-only
+```
+
+`voice say -o ...` falls back to local synthesis if the daemon is unavailable,
+so the same command still works outside Hermes.
+
+The repository also includes `examples/hermes-command-tts.sh`, which matches
+Hermes' command-provider argument order:
+
+```yaml
+command: /path/to/voice/examples/hermes-command-tts.sh {input_path} {output_path} {voice} {speed}
+```
+
+Set `VOICE_BIN=/path/to/voice` if `voice` is not on `PATH`.
+
+## CLI Smoke Test
+
+Use `voice stream` to inspect the streaming event flow:
+
+```bash
+voice stream "Hello from the stream"
+voice stream --json "Hello from the stream"
+voice stream --sample-rate 48000 --frame-ms 20 --raw-output reply.s16le "Hello"
+```
+
+The raw output is signed 16-bit little-endian mono PCM with no container header.
+Use the event metadata for sample rate, frame duration, and stream ID.
+
+## Daemon Protocol
+
+Send a JSON-RPC request in a `Request` frame:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "stream_speak",
+  "params": {
+    "text": "Hello",
+    "voice": "af_heart",
+    "speed": 1.0,
+    "sample_rate": 48000,
+    "frame_ms": 20
+  },
+  "id": 1
+}
+```
+
+The daemon replies with a normal JSON-RPC `Response` frame:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "queue_id": "abcd1234",
+    "stream_id": "...",
+    "status": "queued"
+  },
+  "id": 1
+}
+```
+
+It then emits `Event` frames until a terminal event:
+
+- `tts.started`: stream metadata, sample rate, encoding, frame duration, voice,
+  speed, and total phoneme chunks.
+- `tts.audio`: one ordered PCM frame with `sequence`, `offset_samples`,
+  `sample_count`, `padding_samples`, and `samples`.
+- `tts.ended`: frame count, sample count, audio duration, and elapsed synthesis
+  time.
+- `tts.error`: terminal failure with a message.
+- `tts.cancelled`: terminal cancellation with a reason.
+
+Audio frames are fixed-duration PCM packets. The last frame is padded with
+silence when needed so clients can feed frames directly into an Opus encoder.
+Use `sample_rate: 48000` and `frame_ms: 20` for a WebRTC-friendly stream.

--- a/examples/hermes-command-tts.sh
+++ b/examples/hermes-command-tts.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+text_file="${1:?text file required}"
+out_file="${2:?output file required}"
+voice="${3:-af_heart}"
+speed="${4:-1.0}"
+voice_bin="${VOICE_BIN:-voice}"
+
+exec "$voice_bin" say \
+  --input-file "$text_file" \
+  --output "$out_file" \
+  --voice "$voice" \
+  --speed "$speed"


### PR DESCRIPTION
## Summary
- add a voice-stream crate for stream metadata, PCM16 audio frames, packetization, cancellation/error events, and simple resampling
- add daemon stream_speak and synthesize RPCs, queue cancellation signaling, and a CLI voice stream command
- wire daemon-backed voice say --output for Hermes-style command providers, with docs and an example shim
- fix Kokoro reflection padding on CPU by making sliced tensors contiguous before flip/index_select
- keep workspace Clippy clean, including a small existing tray unused-binding cleanup

## Local deployment
- built release voice/voiced binaries
- symlinked ~/.local/bin/voice and ~/.local/bin/voiced to this worktree's release binaries
- installed and enabled ~/.config/systemd/user/voice-daemon.service running voiced --tts-only
- verified ~/.hermes/config.yaml provider kokoro still calls /home/ubuntu/projects/kokoro-hermes-tts/kokoro-hermes-tts {input_path} {output_path} {voice} {speed}
- verified the Hermes shim now produces WAV through Rust daemon synthesis without Python fallback

## Verification
- cargo fmt
- git diff --check
- cargo clippy --workspace -- -D warnings
- cargo build --release -p voice -p voice-daemon
- cargo test -p voice-stream -p voice-protocol -p voice-daemon -p voice --tests
- cargo test -p voice-kokoro --lib
- cargo check --workspace
- /home/ubuntu/projects/kokoro-hermes-tts/kokoro-hermes-tts input.txt output.wav af_heart 1.0
- voice stream --sample-rate 48000 --frame-ms 20 --raw-output out.pcm 'Streaming smoke test for WhatsApp transport.'