### PR TITLE
Support CPU STT on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # voice
 
-Rust TTS & STT on Apple Silicon, powered by [candle](https://github.com/huggingface/candle) with Metal GPU acceleration. Ships the [Kokoro](https://huggingface.co/prince-canuma/Kokoro-82M) 82M-parameter TTS model with a full English G2P pipeline, and [Whisper](https://huggingface.co/distil-whisper/distil-large-v3) for speech-to-text.
+Rust TTS & STT powered by [candle](https://github.com/huggingface/candle), with Metal GPU acceleration on Apple Silicon and CPU fallback on Linux. Ships the [Kokoro](https://huggingface.co/prince-canuma/Kokoro-82M) 82M-parameter TTS model with a full English G2P pipeline, and [Whisper](https://huggingface.co/distil-whisper/distil-large-v3) for speech-to-text.
 
 Faster time-to-first-speech than macOS `say`, with dramatically better audio quality. STT runs at ~50× real-time on Apple Silicon.
 
@@ -162,14 +162,14 @@ Options:
 
 ## Speech-to-text
 
-STT uses [distil-whisper](https://huggingface.co/distil-whisper/distil-large-v3) models running on Metal GPU via candle — knowledge-distilled versions of OpenAI's Whisper optimized for fast on-device transcription.
+STT uses [distil-whisper](https://huggingface.co/distil-whisper/distil-large-v3) models via candle — knowledge-distilled versions of OpenAI's Whisper optimized for fast on-device transcription. On macOS, STT runs on Metal by default. On Linux and other non-macOS hosts, STT runs on CPU.
 
 | Model | Repo ID | Params | Notes |
 |-------|---------|--------|-------|
 | Distil Large v3 | `distil-whisper/distil-large-v3` | 756M | Multilingual (default) |
 | Distil Medium English | `distil-whisper/distil-medium.en` | 394M | English-only, faster |
 
-Performance is ~50× real-time on Apple Silicon (a 10-second recording transcribes in ~200ms). Configs and tokenizers for known models are embedded in the binary.
+Performance is ~50× real-time on Apple Silicon (a 10-second recording transcribes in ~200ms). CPU transcription is supported for portability but is much slower; use `distil-whisper/distil-medium.en` for faster CPU experiments. Configs and tokenizers for known models are embedded in the binary.
 
 **Adaptive noise floor**: Before recording, `voice listen` calibrates against ambient noise for ~500ms, then sets a silence threshold relative to the noise floor. This avoids false triggers in noisy environments and missed speech in quiet ones. A **ding** sound plays when the mic is ready.
 
@@ -375,14 +375,14 @@ fn main() -> voice_stt::Result<()> {
 
 ### STT: Whisper (distil-large-v3 / distil-medium.en)
 
-- **GPU mel spectrogram**: Preprocessing runs on Metal GPU via candle
+- **Mel spectrogram**: Preprocessing runs on Metal GPU via candle on macOS, with CPU mel preprocessing on CPU-only hosts
 - **Encoder-decoder transformer**: Standard Whisper architecture with knowledge distillation for faster inference
 - **Greedy decode with KV cache**: Encoder output is computed once, then cached cross-attention keys/values are reused across all decoder steps
 - **Embedded configs**: Tokenizers and model configs for known distil-whisper models are built into the binary
 
 ## Requirements
 
-- macOS with Apple Silicon (Metal GPU acceleration)
+- macOS with Apple Silicon for Metal acceleration, or Linux/other hosts with CPU inference
 - Rust 1.85+
 - Git LFS (`brew install git-lfs && git lfs install`)
 - Xcode command line tools

--- a/crates/voice-stt/README.md
+++ b/crates/voice-stt/README.md
@@ -1,15 +1,18 @@
 # voice-stt
 
-Speech-to-text on Apple Silicon, powered by [MLX](https://github.com/oxiglade/mlx-rs). Ships with [Moonshine](https://huggingface.co/UsefulSensors/moonshine-tiny) support — a compact encoder-decoder transformer designed for on-device speech recognition.
+Speech-to-text on candle using Whisper / distil-whisper models. Uses Metal on
+macOS when available and CPU on Linux or other non-macOS hosts.
 
 ## Install
 
 ```toml
 [dependencies]
-voice-stt = "0.1"
+voice-stt = "0.2"
 ```
 
-> **Note:** Requires macOS with Apple Silicon (MLX requirement). Model weights (~108-246MB) are downloaded from HuggingFace Hub on first run and cached locally.
+Model configs and tokenizers for known distil-whisper models are embedded in the
+binary. Model weights are downloaded from HuggingFace Hub on first use and cached
+locally.
 
 ## Usage
 
@@ -17,71 +20,68 @@ voice-stt = "0.1"
 
 ```rust
 fn main() -> voice_stt::Result<()> {
-    let mut model = voice_stt::load_model("UsefulSensors/moonshine-tiny")?;
+    let mut model = voice_stt::load_model("distil-whisper/distil-large-v3")?;
     let result = voice_stt::transcribe(&mut model, "audio.wav")?;
     println!("{}", result.text);
     Ok(())
 }
 ```
 
-### Transcribe raw audio samples
+### Force CPU
 
 ```rust
 fn main() -> voice_stt::Result<()> {
-    let mut model = voice_stt::load_model("UsefulSensors/moonshine-base")?;
-    let tokenizer = voice_stt::load_tokenizer("UsefulSensors/moonshine-base")?;
-
-    let samples: Vec<f32> = /* 16kHz mono f32 samples */;
-    let result = voice_stt::transcribe_audio_with_tokenizer(
-        &mut model, &samples, 16000, &tokenizer
+    let mut model = voice_stt::load_model_on_device(
+        "distil-whisper/distil-medium.en",
+        candle_core::Device::Cpu,
     )?;
+    let samples: Vec<f32> = vec![0.0; 16_000];
+    let result = voice_stt::transcribe_audio(&mut model, &samples, 16_000)?;
     println!("{}", result.text);
     Ok(())
 }
 ```
 
-Audio at any sample rate is automatically resampled to 16kHz using a high-quality sinc resampler.
+Audio at any sample rate is automatically resampled to 16kHz using a high-quality
+sinc resampler, with linear interpolation as a fallback for very short inputs.
 
 ## Supported Models
 
-| Model | Repo ID | Params | Size | Notes |
-|-------|---------|--------|------|-------|
-| Moonshine Tiny | `UsefulSensors/moonshine-tiny` | 27M | 108MB | Fast, embedded config + tokenizer |
-| Moonshine Base | `UsefulSensors/moonshine-base` | 61M | 246MB | Better accuracy for real mic audio |
+| Model | Repo ID | Params | Notes |
+|-------|---------|--------|-------|
+| Distil Large v3 | `distil-whisper/distil-large-v3` | 756M | Multilingual, default in the CLI |
+| Distil Medium English | `distil-whisper/distil-medium.en` | 394M | English-only, better for CPU experiments |
 
 ## Performance
 
-On Apple Silicon (cached model):
-
-| Audio Length | Transcription Time | RTF |
-|-------------|-------------------|-----|
-| 3s | ~60ms | 0.02× (50× real-time) |
-| 9s | ~100ms | 0.01× (89× real-time) |
-| 17s | ~200ms | 0.01× |
+On Apple Silicon with Metal, transcription is roughly 50x real-time for short
+voice-command audio. CPU inference is supported for portability and testing, but
+is substantially slower; use the medium English model for practical CPU smoke
+tests.
 
 ## Architecture
 
-Moonshine uses a **learned audio frontend** instead of mel spectrograms — raw 16kHz audio goes directly into the encoder:
+Whisper uses mel-spectrogram preprocessing followed by an encoder-decoder
+transformer:
 
-- **Encoder**: Three Conv1d layers (384× total downsampling) → transformer layers with partial RoPE
-- **Decoder**: Token embedding → transformer layers with causal self-attention + cross-attention + SwiGLU MLP
-- **Output**: Tied embedding projection → greedy autoregressive decoding with KV cache
-
-The Moonshine-tiny config and tokenizer are embedded in the binary for instant startup. Model weights are downloaded from HuggingFace on first use.
+- **Mel frontend**: Metal-accelerated on macOS, CPU fallback elsewhere.
+- **Encoder-decoder transformer**: candle-transformers Whisper backend.
+- **Greedy decode with KV cache**: encoder output is computed once, then cached
+  cross-attention keys/values are reused across decoder steps.
+- **Embedded metadata**: configs and tokenizers for known distil-whisper models
+  are compiled into the binary.
 
 ## Features
 
-- **High-quality resampling**: Sinc interpolation via [rubato](https://crates.io/crates/rubato) — accepts audio at any sample rate
-- **WAV loading**: 16-bit integer and 32-bit float WAV files, with automatic mono mixdown
-- **Embedded tokenizer**: SentencePiece BPE tokenizer compiled into the binary (no filesystem access needed)
-- **HuggingFace Hub**: Automatic model download and caching via [hf-hub](https://crates.io/crates/hf-hub)
-- **Weight sanitization**: Loads HuggingFace safetensors directly, handles PyTorch→MLX conv weight transposition
+- **High-quality resampling**: Sinc interpolation via [rubato](https://crates.io/crates/rubato).
+- **WAV loading**: 16-bit integer and 32-bit float WAV files, with automatic mono mixdown.
+- **HuggingFace Hub**: Automatic model weight download and caching via `hf-hub`.
+- **Portable inference**: Metal by default on macOS, CPU by default elsewhere.
 
 ## Requirements
 
-- macOS with Apple Silicon
 - Rust 1.85+
-- Xcode command line tools (for MLX Metal compilation)
+- macOS with Apple Silicon for fast Metal inference, or a CPU-only host for slower portable inference
 
 ## License
 

--- a/crates/voice-stt/src/lib.rs
+++ b/crates/voice-stt/src/lib.rs
@@ -1,4 +1,4 @@
-//! Speech-to-text library backed by candle + Metal, using Whisper.
+//! Speech-to-text library backed by candle, using Whisper.
 //!
 //! # Quick start
 //!
@@ -48,9 +48,26 @@ pub struct WhisperModel {
     decoder: voice_whisper::WhisperDecoder,
 }
 
+/// Return the default inference device for STT.
+///
+/// On macOS this preserves the existing Apple Silicon Metal path. All other
+/// builds use Candle's CPU backend, which keeps Whisper usable on Linux hosts
+/// with no GPU.
+pub fn default_stt_device() -> Result<Device> {
+    #[cfg(target_os = "macos")]
+    {
+        Device::new_metal(0).map_err(|e| SttError::Model(e.to_string()))
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        Ok(Device::Cpu)
+    }
+}
+
 /// Load a Whisper model from a HuggingFace repo or local path.
 ///
-/// Creates a Metal GPU device and loads the model weights via mmap.
+/// Creates the default STT device and loads the model weights via mmap.
 ///
 /// # Examples
 ///
@@ -58,8 +75,12 @@ pub struct WhisperModel {
 /// let mut model = voice_stt::load_model("distil-whisper/distil-medium.en").unwrap();
 /// ```
 pub fn load_model(path_or_repo: &str) -> Result<WhisperModel> {
-    let device = Device::new_metal(0).map_err(|e| SttError::Model(e.to_string()))?;
+    let device = default_stt_device()?;
+    load_model_on_device(path_or_repo, device)
+}
 
+/// Load a Whisper model on an explicitly supplied Candle device.
+pub fn load_model_on_device(path_or_repo: &str, device: Device) -> Result<WhisperModel> {
     // Use embedded config/tokenizer when available (zero network fetch).
     // Only the weights need downloading from HuggingFace.
     let config: voice_whisper::Config = if let Some(result) = builtin::config_for_repo(path_or_repo)
@@ -372,7 +393,35 @@ pub fn resample_linear(samples: &[f32], from_rate: u32, to_rate: u32) -> Vec<f32
 #[cfg(test)]
 mod tests {
     use super::*;
+    use candle_core::Device;
     use std::f32::consts::PI;
+
+    #[test]
+    fn test_default_stt_device_is_cpu_on_non_macos() {
+        let device = default_stt_device().unwrap();
+
+        #[cfg(target_os = "macos")]
+        assert!(
+            matches!(device, Device::Metal(_)),
+            "macOS should keep using Metal by default"
+        );
+
+        #[cfg(not(target_os = "macos"))]
+        assert!(
+            matches!(device, Device::Cpu),
+            "non-macOS STT should default to CPU"
+        );
+    }
+
+    #[test]
+    #[ignore = "downloads Whisper weights and runs CPU inference"]
+    fn test_cpu_model_transcribes_silence_smoke() {
+        let mut model =
+            load_model_on_device("distil-whisper/distil-medium.en", Device::Cpu).unwrap();
+        let samples = vec![0.0f32; 16_000];
+        let result = transcribe_audio(&mut model, &samples, 16_000).unwrap();
+        assert_eq!(result.sample_rate, 16_000);
+    }
 
     #[test]
     fn test_resample_identity() {

--- a/crates/voice-whisper/src/decoder.rs
+++ b/crates/voice-whisper/src/decoder.rs
@@ -27,14 +27,12 @@ pub struct DecodingResult {
 /// Whisper decoder wrapping the model, tokenizer, and mel filters.
 ///
 /// Handles greedy autoregressive decoding with KV-caching.
-/// Includes a GPU mel spectrogram processor for Metal-accelerated
-/// audio preprocessing.
 pub struct WhisperDecoder {
     model: m::model::Whisper,
     config: Config,
     device: Device,
     mel_filters: Vec<f32>,
-    gpu_mel: crate::mel::GpuMelSpec,
+    mel_backend: MelBackend,
     tokenizer: Tokenizer,
     suppress_tokens: Tensor,
     sot_token: u32,
@@ -43,6 +41,11 @@ pub struct WhisperDecoder {
     no_speech_token: u32,
     no_timestamps_token: u32,
     language_token: Option<u32>,
+}
+
+enum MelBackend {
+    Cpu,
+    Gpu(crate::mel::GpuMelSpec),
 }
 
 impl WhisperDecoder {
@@ -81,15 +84,17 @@ impl WhisperDecoder {
             .collect();
         let suppress_tokens = Tensor::new(suppress_tokens.as_slice(), &device)?;
 
-        // Build GPU mel spectrogram processor
-        let gpu_mel = crate::mel::GpuMelSpec::new(&config, &mel_filters, &device)?;
+        let mel_backend = match &device {
+            Device::Cpu => MelBackend::Cpu,
+            _ => MelBackend::Gpu(crate::mel::GpuMelSpec::new(&config, &mel_filters, &device)?),
+        };
 
         Ok(Self {
             model,
             config,
             device,
             mel_filters,
-            gpu_mel,
+            mel_backend,
             tokenizer,
             suppress_tokens,
             sot_token,
@@ -119,11 +124,15 @@ impl WhisperDecoder {
     /// Transcribe PCM audio samples (mono, 16kHz f32).
     ///
     /// Supports audio of any length via chunking. The mel spectrogram is
-    /// computed on GPU, then processed in 30-second windows. Each chunk
+    /// computed on the configured device, then processed in 30-second windows. Each chunk
     /// is decoded independently and results are concatenated.
     pub fn transcribe(&mut self, samples: &[f32]) -> candle_core::Result<DecodingResult> {
-        // Compute full mel spectrogram on GPU
-        let mel = self.gpu_mel.compute(samples)?;
+        let mel = match &self.mel_backend {
+            MelBackend::Cpu => {
+                crate::mel::pcm_to_mel(&self.config, samples, &self.mel_filters, &self.device)?
+            }
+            MelBackend::Gpu(gpu_mel) => gpu_mel.compute(samples)?,
+        };
         let (_, _, total_frames) = mel.dims3()?;
 
         let max_chunk_frames = m::N_FRAMES; // 3000 = 30s worth of frames

--- a/crates/voice-whisper/src/mel.rs
+++ b/crates/voice-whisper/src/mel.rs
@@ -193,3 +193,53 @@ impl GpuMelSpec {
         Ok(mel)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config(num_mel_bins: usize) -> Config {
+        Config {
+            num_mel_bins,
+            max_source_positions: 1500,
+            d_model: 384,
+            encoder_attention_heads: 6,
+            encoder_layers: 1,
+            vocab_size: 128,
+            max_target_positions: 448,
+            decoder_attention_heads: 6,
+            decoder_layers: 1,
+            suppress_tokens: vec![],
+        }
+    }
+
+    #[test]
+    fn cpu_mel_has_whisper_shape() {
+        let config = test_config(80);
+        let filters = load_mel_filters(&config).unwrap();
+        let samples = vec![0.0f32; 16_000];
+
+        let mel = pcm_to_mel(&config, &samples, &filters, &Device::Cpu).unwrap();
+        let (batch, bins, frames) = mel.dims3().unwrap();
+
+        assert_eq!(batch, 1);
+        assert_eq!(bins, 80);
+        assert!(frames > 0);
+        assert!(matches!(mel.device(), Device::Cpu));
+    }
+
+    #[test]
+    fn mel_filter_loader_supports_known_whisper_bin_counts() {
+        assert_eq!(load_mel_filters(&test_config(80)).unwrap().len(), 80 * 201);
+        assert_eq!(
+            load_mel_filters(&test_config(128)).unwrap().len(),
+            128 * 201
+        );
+    }
+
+    #[test]
+    fn mel_filter_loader_rejects_unknown_bin_counts() {
+        let err = load_mel_filters(&test_config(96)).unwrap_err();
+        assert!(err.contains("unsupported num_mel_bins"));
+    }
+}


### PR DESCRIPTION
## Summary
- make `voice_stt::load_model` choose Metal on macOS and CPU elsewhere
- add `voice_stt::load_model_on_device` for explicit device selection and tests
- make Whisper decoding use CPU mel preprocessing on `Device::Cpu`, keeping the existing GPU mel path for accelerator devices
- update STT docs to reflect current Whisper/Candle support instead of the stale Moonshine/MLX text

Closes #84

## Tests
- `cargo fmt`
- `cargo test -p voice-whisper -p voice-stt --lib`
- `cargo clippy --workspace -- -D warnings`
- `cargo check --workspace`

## Notes
- I verified locally that the patched CLI gets past the previous Linux failure and loads `distil-whisper` on CPU.
- Full CPU decoding with the large/medium models is slow on this host, so the real-model smoke is included as an ignored test rather than run in normal CI.
