### PR TITLE
Fix G2P hyphen compound boundaries

### DIFF
--- a/crates/voice-g2p/src/lib.rs
+++ b/crates/voice-g2p/src/lib.rs
@@ -264,18 +264,20 @@ impl G2P {
         }
 
         if should_fallback {
-            let merged = merge_tokens(group, None);
-            if let Some((ps, rating)) = self.fallback.convert_word(&merged.text) {
-                group[0].phonemes = Some(ps);
-                group[0].underscore.rating = Some(rating);
-                for j in 1..group.len() {
-                    group[j].phonemes = Some(String::new());
-                    group[j].underscore.rating = group[0].underscore.rating;
+            for tk in group.iter_mut() {
+                if tk.phonemes.is_some() {
+                    continue;
+                }
+                if tk.text.chars().all(|c| SUBTOKEN_JUNKS.contains(c)) {
+                    tk.phonemes = Some(String::new());
+                    tk.underscore.rating = Some(3);
+                } else {
+                    self.resolve_single_token(tk, ctx);
                 }
             }
-        } else {
-            Self::resolve_tokens(group);
         }
+
+        Self::resolve_tokens(group);
     }
 
     /// Update TokenContext based on resolved phonemes and token.
@@ -656,6 +658,42 @@ mod tests {
             result.contains(' '),
             "Expected space between words in: {}",
             result
+        );
+    }
+
+    #[test]
+    fn test_g2p_hyphen_compound_preserves_word_boundary() {
+        let g2p = G2P::new();
+        let result = g2p.convert("cat-dog").unwrap();
+        assert!(
+            result.contains(' '),
+            "Expected a phoneme-space boundary for hyphen compound, got: {result}"
+        );
+    }
+
+    #[test]
+    fn test_g2p_underscore_compound_preserves_word_boundary() {
+        let g2p = G2P::new();
+        let result = g2p.convert("cat_dog").unwrap();
+        assert!(
+            result.contains(' '),
+            "Expected a phoneme-space boundary for underscore compound, got: {result}"
+        );
+    }
+
+    #[test]
+    fn test_g2p_hyphen_fallback_keeps_resolved_subtokens_without_espeak() {
+        let g2p = G2P::with_config(G2PConfig {
+            espeak_path: "/definitely/missing/espeak-ng".to_string(),
+        });
+        let result = g2p.convert("cat-unpronounceablexyz-dog").unwrap();
+        assert!(
+            result.contains(' '),
+            "Expected resolved neighboring words to remain separated, got: {result}"
+        );
+        assert!(
+            result.contains("d"),
+            "Expected resolved trailing word to remain present, got: {result}"
         );
     }
 

--- a/crates/voice-g2p/src/tokenizer.rs
+++ b/crates/voice-g2p/src/tokenizer.rs
@@ -356,6 +356,10 @@ pub fn subtokenize(word: &str) -> Vec<String> {
     }
 }
 
+fn is_subtoken_boundary_junk(text: &str) -> bool {
+    !text.is_empty() && text.chars().all(|c| matches!(c, '-' | '_' | '/'))
+}
+
 // ---------------------------------------------------------------------------
 // fold_left
 // ---------------------------------------------------------------------------
@@ -493,6 +497,9 @@ pub fn retokenize(tokens: Vec<MToken>) -> Vec<TokenOrGroup> {
             // starts uppercase (e.g. "use" | "Effect" from "useEffect").
             if i > 0 && !is_junk {
                 if let Some(prev) = subtokens.get(i - 1) {
+                    if is_subtoken_boundary_junk(prev) {
+                        sub_tok.underscore.prespace = true;
+                    }
                     if prev.chars().last().is_some_and(|c| c.is_lowercase())
                         && sub_text.chars().next().is_some_and(|c| c.is_uppercase())
                     {


### PR DESCRIPTION
## Summary
- mark hyphen, underscore, and slash subtokens as phoneme word boundaries for the following subtoken
- stop sending a whole hyphenated group through fallback when one subtoken fails resolution
- resolve fallback groups per subtoken so known pieces stay separate and espeak, when available, sees each word independently
- add regressions for hyphen/underscore compound spacing and no-espeak fallback preservation

Closes #78

## Verification
- `cargo test -p voice-g2p`
- `cargo clippy --workspace -- -D warnings`
- `cargo check --workspace`

## Notes
- On this Linux host, `espeak-ng` is not installed, so truly unknown pieces like `warmfem` can still disappear; that is the broader no-runtime-fallback issue tracked by #62.
- Known and mixed technical compounds now keep boundaries, e.g. `cat-dog` -> `kˌæt dˈɔɡ` and `StyleTTS2-LibriTTS` -> `stˈIl tˌitˌiˈɛs tˈu tˌitˌiˈɛs`.
