### PR TITLE
Remove runtime espeak-ng G2P fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ All other voices are fetched from HuggingFace Hub on first use:
 | [`voice-stt`](https://crates.io/crates/voice-stt) | Speech-to-text library — Whisper transcription, resampling |
 | [`voice-kokoro`](https://crates.io/crates/voice-kokoro) | Kokoro TTS backend — ALBERT encoder, prosody predictor, iSTFT decoder |
 | [`voice-whisper`](https://crates.io/crates/voice-whisper) | Whisper STT backend — greedy decoding, GPU mel spectrogram |
-| [`voice-g2p`](https://crates.io/crates/voice-g2p) | Grapheme-to-phoneme — misaki dictionary + espeak-ng fallback |
+| [`voice-g2p`](https://crates.io/crates/voice-g2p) | Grapheme-to-phoneme — misaki dictionary + embedded OOV fallback |
 
 ## Library usage
 
@@ -369,7 +369,7 @@ fn main() -> voice_stt::Result<()> {
 
 ### TTS: Kokoro (82M)
 
-- **G2P pipeline**: Ports [misaki](https://github.com/hexgrad/misaki)'s English G2P — POS tagging (embedded averaged perceptron), 90k gold + 93k silver dictionary entries, morphological decomposition, number/currency handling, espeak-ng fallback
+- **G2P pipeline**: Ports [misaki](https://github.com/hexgrad/misaki)'s English G2P — POS tagging (embedded averaged perceptron), 90k gold + 93k silver dictionary entries, morphological decomposition, number/currency handling, embedded OOV fallback
 - **Inference**: StyleTTS2-based model with ISTFT vocoder head. Audio chunks stream to speakers as they're generated — the first chunk plays while subsequent chunks are still synthesizing
 - **Startup**: Model loads in a background thread while text resolution, G2P, and voice loading happen on the main thread
 
@@ -386,7 +386,6 @@ fn main() -> voice_stt::Result<()> {
 - Rust 1.85+
 - Git LFS (`brew install git-lfs && git lfs install`)
 - Xcode command line tools
-- espeak-ng (optional, for G2P fallback on unknown words): `brew install espeak-ng`
 
 ## License
 

--- a/crates/voice-g2p/Cargo.toml
+++ b/crates/voice-g2p/Cargo.toml
@@ -3,7 +3,7 @@ name = "voice-g2p"
 version = "0.2.2"
 edition = "2021"
 rust-version = "1.85.0"
-description = "Grapheme-to-phoneme conversion: misaki dictionary + espeak-ng fallback"
+description = "Grapheme-to-phoneme conversion: misaki dictionary + embedded OOV fallback"
 license = "MIT"
 repository = "https://github.com/rgbkrk/voice"
 

--- a/crates/voice-g2p/README.md
+++ b/crates/voice-g2p/README.md
@@ -24,33 +24,18 @@ for chunk in &chunks {
 }
 ```
 
-### Custom configuration
-
-If `uv` or `espeak-ng` aren't on your `$PATH`:
-
-```rust
-let config = voice_g2p::G2PConfig {
-    uv_path: "/opt/homebrew/bin/uv".into(),
-    espeak_path: "/opt/homebrew/bin/espeak-ng".into(),
-};
-let g2p = voice_g2p::G2P::with_config(config);
-let phonemes = g2p.convert("Hello world")?;
-```
-
 ## What's inside
 
 - **Dictionary lookup** — 90k gold + 93k silver pronunciation entries embedded at compile time
 - **Morphological decomposition** — `-s`, `-ed`, `-ing` suffix rules with voicing logic
 - **Number handling** — cardinals, ordinals, years, currency, phone numbers
-- **POS tagging** — optional spaCy subprocess (via `uv run`) for context-dependent pronunciation
-- **Fallback** — espeak-ng per-word for unknown words
+- **POS tagging** — embedded averaged perceptron model for context-dependent pronunciation
+- **Fallback** — embedded OOV phonemizer for unknown words, acronyms, and mixed alphanumeric tokens
 
-## Optional dependencies
+## Offline tooling
 
-- **espeak-ng** — fallback pronunciation for words not in the dictionary (`brew install espeak-ng`)
-- **uv** — runs spaCy for POS-based disambiguation (e.g. "read" as past vs. present tense)
-
-Both are optional. Without them, the pipeline still works using dictionary lookup alone.
+The runtime G2P pipeline is self-contained. The `generate-bronze` helper binary
+still uses `espeak-ng` to regenerate the embedded bronze dictionary data.
 
 ## License
 

--- a/crates/voice-g2p/src/espeak.rs
+++ b/crates/voice-g2p/src/espeak.rs
@@ -1,9 +1,8 @@
-//! Per-word espeak-ng fallback phonemizer, ported from misaki's `espeak.py`.
+//! OOV fallback phonemizer plus espeak-ng conversion helpers.
 //!
-//! This differs from the sentence-level `english_to_phonemes` in `lib.rs`:
-//! 1. Phonemizes one word at a time (not full sentences)
-//! 2. Uses `--tie=^` so multi-character IPA sequences are explicitly tied
-//! 3. Applies misaki's exact E2M (espeak-to-misaki) mapping table
+//! Runtime G2P uses the embedded fallback in this module so `voice` does not
+//! require an `espeak-ng` binary on fresh machines. The espeak conversion
+//! helpers are still used by the offline bronze-dictionary generator.
 
 use std::process::Command;
 
@@ -37,9 +36,8 @@ pub(crate) const E2M: &[(&str, &str)] = &[
     ("\u{02B2}", ""),                 // bare ʲ → remove
 ];
 
-/// Per-word espeak-ng fallback, ported from misaki's `EspeakFallback`.
+/// Per-word fallback for OOV pronunciations.
 pub struct EspeakFallback {
-    british: bool,
     espeak_path: String,
 }
 
@@ -47,20 +45,19 @@ impl EspeakFallback {
     /// Create a new fallback with US English and default PATH lookup.
     pub fn new() -> Self {
         Self {
-            british: false,
             espeak_path: "espeak-ng".to_string(),
         }
     }
 
     /// Create a new fallback with a custom espeak-ng binary path.
     pub fn with_path(espeak_path: String) -> Self {
-        Self {
-            british: false,
-            espeak_path,
-        }
+        Self { espeak_path }
     }
 
     /// Check if espeak-ng is available on the system.
+    ///
+    /// Runtime fallback no longer depends on this; it is retained for tests and
+    /// offline dictionary-generation tooling.
     pub fn is_available(&self) -> bool {
         Command::new(&self.espeak_path)
             .arg("--version")
@@ -69,51 +66,287 @@ impl EspeakFallback {
             .unwrap_or(false)
     }
 
-    /// Convert a single word to Kokoro-compatible phonemes via espeak-ng.
+    /// Convert a single OOV word to Kokoro-compatible phonemes.
     ///
-    /// Returns `Some((phonemes, 2))` on success, or `None` if espeak-ng
-    /// is unavailable or produces no output. Rating 2 indicates espeak fallback.
+    /// Returns `Some((phonemes, 2))` on success. Rating 2 matches the former
+    /// legacy espeak fallback priority.
     pub fn convert_word(&self, word: &str) -> Option<(String, u8)> {
-        let lang = if self.british { "en-gb" } else { "en-us" };
-
-        let output = Command::new(&self.espeak_path)
-            .args(["--ipa", "-q", "-v", lang, "--tie=^", word])
-            .output()
-            .ok()?;
-
-        if !output.status.success() {
-            return None;
-        }
-
-        let raw = String::from_utf8_lossy(&output.stdout);
-        let ps = raw.trim();
-        if ps.is_empty() {
-            return None;
-        }
-
-        if self.british {
-            // British path kept inline (not extracted since bronze is US-only)
-            let mut ps = ps.to_string();
-            for &(old, new) in E2M {
-                ps = ps.replace(old, new);
-            }
-            ps = replace_syllabic_mark(&ps);
-            ps = ps.replace("e^ə", "\u{025B}\u{02D0}"); // e^ə → ɛː
-            ps = ps.replace("i\u{0259}", "\u{026A}\u{0259}"); // iə → ɪə
-            ps = ps.replace("\u{0259}^\u{028A}", "Q"); // ə^ʊ → Q
-            ps = ps.replace('^', "");
-            ps = ps.replace('\u{027E}', "T");
-            ps = ps.replace('\u{0294}', "t");
-            Some((ps, 2))
-        } else {
-            Some((apply_e2m_us(ps), 2))
-        }
+        embedded_oov_word(word).map(|phonemes| (phonemes, 2))
     }
 }
 
 impl Default for EspeakFallback {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+fn embedded_oov_word(word: &str) -> Option<String> {
+    let trimmed = word.trim_matches(|c: char| !c.is_alphanumeric());
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut current_kind: Option<CharKind> = None;
+
+    for ch in trimmed.chars() {
+        let Some(kind) = CharKind::of(ch) else {
+            flush_oov_part(&mut parts, &mut current, current_kind.take());
+            continue;
+        };
+
+        if current_kind.is_some_and(|k| k != kind) {
+            flush_oov_part(&mut parts, &mut current, current_kind.take());
+        }
+        current_kind = Some(kind);
+        current.push(ch);
+    }
+    flush_oov_part(&mut parts, &mut current, current_kind);
+
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(" "))
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CharKind {
+    Letter,
+    Digit,
+}
+
+impl CharKind {
+    fn of(ch: char) -> Option<Self> {
+        if ch.is_ascii_alphabetic() {
+            Some(Self::Letter)
+        } else if ch.is_ascii_digit() {
+            Some(Self::Digit)
+        } else {
+            None
+        }
+    }
+}
+
+fn flush_oov_part(parts: &mut Vec<String>, current: &mut String, kind: Option<CharKind>) {
+    if current.is_empty() {
+        return;
+    }
+    match kind {
+        Some(CharKind::Letter) => parts.push(letters_to_phonemes(current)),
+        Some(CharKind::Digit) => {
+            parts.extend(
+                current
+                    .chars()
+                    .filter_map(digit_name_phonemes)
+                    .map(str::to_string),
+            );
+        }
+        None => {}
+    }
+    current.clear();
+}
+
+fn letters_to_phonemes(word: &str) -> String {
+    if should_spell_letters(word) {
+        return spell_letters(word);
+    }
+
+    rough_word_phonemes(&word.to_lowercase())
+}
+
+fn should_spell_letters(word: &str) -> bool {
+    let letters = word.chars().filter(|c| c.is_ascii_alphabetic()).count();
+    letters <= 3 || (letters <= 8 && word.chars().all(|c| c.is_ascii_uppercase()))
+}
+
+fn spell_letters(word: &str) -> String {
+    word.chars()
+        .filter_map(letter_name_phonemes)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn rough_word_phonemes(word: &str) -> String {
+    let chars: Vec<char> = word.chars().collect();
+    let mut out = String::new();
+    let mut i = 0;
+    let mut stressed = false;
+
+    while i < chars.len() {
+        let remaining = &word[i..];
+        if let Some((grapheme, phoneme)) = DIGRAPHS
+            .iter()
+            .find(|(grapheme, _)| remaining.starts_with(*grapheme))
+        {
+            push_phoneme(&mut out, phoneme, is_vowel_phoneme(phoneme), &mut stressed);
+            i += grapheme.len();
+            continue;
+        }
+
+        let ch = chars[i];
+        if ch == 'e' && i == chars.len() - 1 && stressed {
+            i += 1;
+            continue;
+        }
+
+        if let Some(phoneme) = single_letter_phoneme(ch, chars.get(i + 1).copied()) {
+            push_phoneme(&mut out, phoneme, is_vowel_phoneme(phoneme), &mut stressed);
+        }
+        i += ch.len_utf8();
+    }
+
+    if out.is_empty() {
+        spell_letters(word)
+    } else {
+        out
+    }
+}
+
+fn push_phoneme(out: &mut String, phoneme: &str, is_vowel: bool, stressed: &mut bool) {
+    if is_vowel && !*stressed {
+        out.push('\u{02C8}');
+        *stressed = true;
+    }
+    out.push_str(phoneme);
+}
+
+fn is_vowel_phoneme(phoneme: &str) -> bool {
+    phoneme.chars().any(|c| {
+        matches!(
+            c,
+            'A' | 'I'
+                | 'O'
+                | 'W'
+                | 'Y'
+                | 'Q'
+                | 'i'
+                | 'u'
+                | '\u{00E6}'
+                | '\u{0251}'
+                | '\u{0254}'
+                | '\u{0259}'
+                | '\u{025B}'
+                | '\u{026A}'
+                | '\u{028A}'
+                | '\u{028C}'
+                | '\u{025C}'
+        )
+    })
+}
+
+const DIGRAPHS: &[(&str, &str)] = &[
+    ("tion", "\u{0283}\u{1D4A}n"),
+    ("ough", "O"),
+    ("augh", "\u{0254}"),
+    ("eigh", "A"),
+    ("igh", "I"),
+    ("air", "\u{025B}\u{0279}"),
+    ("ear", "i\u{0259}\u{0279}"),
+    ("er", "\u{025C}\u{0279}"),
+    ("ir", "\u{025C}\u{0279}"),
+    ("ur", "\u{025C}\u{0279}"),
+    ("ar", "\u{0251}\u{0279}"),
+    ("or", "\u{0254}\u{0279}"),
+    ("ch", "\u{02A7}"),
+    ("sh", "\u{0283}"),
+    ("th", "\u{03B8}"),
+    ("ph", "f"),
+    ("wh", "w"),
+    ("ck", "k"),
+    ("ng", "\u{014B}"),
+    ("qu", "kw"),
+    ("ee", "i"),
+    ("ea", "i"),
+    ("oo", "u"),
+    ("ai", "A"),
+    ("ay", "A"),
+    ("oa", "O"),
+    ("ow", "O"),
+    ("ou", "W"),
+];
+
+fn single_letter_phoneme(ch: char, next: Option<char>) -> Option<&'static str> {
+    match ch {
+        'a' => Some("\u{00E6}"),
+        'b' => Some("b"),
+        'c' if next.is_some_and(|n| matches!(n, 'e' | 'i' | 'y')) => Some("s"),
+        'c' => Some("k"),
+        'd' => Some("d"),
+        'e' => Some("\u{025B}"),
+        'f' => Some("f"),
+        'g' if next.is_some_and(|n| matches!(n, 'e' | 'i' | 'y')) => Some("\u{02A4}"),
+        'g' => Some("\u{0261}"),
+        'h' => Some("h"),
+        'i' => Some("\u{026A}"),
+        'j' => Some("\u{02A4}"),
+        'k' => Some("k"),
+        'l' => Some("l"),
+        'm' => Some("m"),
+        'n' => Some("n"),
+        'o' => Some("\u{0251}"),
+        'p' => Some("p"),
+        'q' => Some("k"),
+        'r' => Some("\u{0279}"),
+        's' => Some("s"),
+        't' => Some("t"),
+        'u' => Some("\u{028C}"),
+        'v' => Some("v"),
+        'w' => Some("w"),
+        'x' => Some("ks"),
+        'y' => Some("i"),
+        'z' => Some("z"),
+        _ => None,
+    }
+}
+
+fn letter_name_phonemes(ch: char) -> Option<&'static str> {
+    match ch.to_ascii_lowercase() {
+        'a' => Some("\u{02C8}A"),
+        'b' => Some("b\u{02C8}i"),
+        'c' => Some("s\u{02C8}i"),
+        'd' => Some("d\u{02C8}i"),
+        'e' => Some("\u{02C8}i"),
+        'f' => Some("\u{02C8}\u{025B}f"),
+        'g' => Some("\u{02A4}\u{02C8}i"),
+        'h' => Some("\u{02C8}A\u{02A7}"),
+        'i' => Some("\u{02C8}I"),
+        'j' => Some("\u{02A4}\u{02C8}A"),
+        'k' => Some("k\u{02C8}A"),
+        'l' => Some("\u{02C8}\u{025B}l"),
+        'm' => Some("\u{02C8}\u{025B}m"),
+        'n' => Some("\u{02C8}\u{025B}n"),
+        'o' => Some("\u{02C8}O"),
+        'p' => Some("p\u{02C8}i"),
+        'q' => Some("kj\u{02C8}u"),
+        'r' => Some("\u{02C8}\u{0251}\u{0279}"),
+        's' => Some("\u{02C8}\u{025B}s"),
+        't' => Some("t\u{02C8}i"),
+        'u' => Some("j\u{02C8}u"),
+        'v' => Some("v\u{02C8}i"),
+        'w' => Some("d\u{02C8}\u{028C}b\u{1D4A}l j\u{02CC}u"),
+        'x' => Some("\u{02C8}\u{025B}ks"),
+        'y' => Some("w\u{02C8}I"),
+        'z' => Some("z\u{02C8}i"),
+        _ => None,
+    }
+}
+
+fn digit_name_phonemes(ch: char) -> Option<&'static str> {
+    match ch {
+        '0' => Some("z\u{02C8}i\u{0279}O"),
+        '1' => Some("w\u{02C8}\u{028C}n"),
+        '2' => Some("t\u{02C8}u"),
+        '3' => Some("\u{03B8}\u{0279}\u{02C8}i"),
+        '4' => Some("f\u{02C8}\u{0254}\u{0279}"),
+        '5' => Some("f\u{02C8}Iv"),
+        '6' => Some("s\u{02C8}\u{026A}ks"),
+        '7' => Some("s\u{02C8}\u{025B}v\u{1D4A}n"),
+        '8' => Some("\u{02C8}A\u{02A7}"),
+        '9' => Some("n\u{02C8}In"),
+        _ => None,
     }
 }
 
@@ -177,8 +410,8 @@ pub fn apply_e2m_us(raw_ipa: &str) -> String {
 
 /// Sentence-level espeak-ng phonemization (no tie marker).
 ///
-/// This wraps the same espeak-ng subprocess call used by `english_to_phonemes`
-/// in `lib.rs`, but returns `Option<String>` for convenience in fallback chains.
+/// Runtime G2P does not use this. It remains available for offline tooling and
+/// compatibility with callers that still want to post-process espeak output.
 pub fn espeak_sentence(text: &str, espeak_path: &str) -> Option<String> {
     let output = Command::new(espeak_path)
         .args(["--ipa", "-q", "-v", "en-us", text])
@@ -270,26 +503,27 @@ mod tests {
     }
 
     #[test]
-    fn test_convert_word_available() {
-        let fb = EspeakFallback::new();
-        if !fb.is_available() {
-            eprintln!("Skipping test: espeak-ng not installed");
-            return;
-        }
-        let result = fb.convert_word("hello");
-        assert!(
-            result.is_some(),
-            "espeak-ng should produce output for 'hello'"
-        );
+    fn test_convert_word_embedded_without_espeak() {
+        let fb = EspeakFallback::with_path("/definitely/missing/espeak-ng".into());
+        let result = fb.convert_word("neologismxyz");
+        assert!(result.is_some(), "embedded fallback should cover OOV words");
         let (ps, rating) = result.unwrap();
         assert_eq!(rating, 2);
         assert!(!ps.is_empty());
-        // Should contain the O diphthong
         assert!(
-            ps.contains('O'),
-            "Expected O diphthong in phonemes for 'hello': {}",
+            ps.contains('\u{02C8}'),
+            "Expected embedded fallback to assign primary stress: {}",
             ps
         );
+    }
+
+    #[test]
+    fn test_convert_word_embedded_handles_digits() {
+        let fb = EspeakFallback::with_path("/definitely/missing/espeak-ng".into());
+        let (ps, rating) = fb.convert_word("TTS2").unwrap();
+        assert_eq!(rating, 2);
+        assert!(ps.contains("t\u{02C8}i"), "Expected T spelling in: {ps}");
+        assert!(ps.contains("t\u{02C8}u"), "Expected 2 spelling in: {ps}");
     }
 
     #[test]

--- a/crates/voice-g2p/src/lib.rs
+++ b/crates/voice-g2p/src/lib.rs
@@ -17,9 +17,9 @@ use tokenizer::TokenOrGroup;
 
 #[derive(Debug, thiserror::Error)]
 pub enum G2pError {
-    #[error("espeak-ng not found. Install with: brew install espeak-ng")]
+    #[error("legacy espeak-ng helper not found")]
     EspeakNotFound,
-    #[error("espeak-ng failed: {0}")]
+    #[error("legacy espeak-ng helper failed: {0}")]
     EspeakFailed(String),
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
@@ -28,8 +28,11 @@ pub enum G2pError {
 /// Configuration for external tool paths used by the G2P pipeline.
 #[derive(Debug, Clone)]
 pub struct G2PConfig {
-    /// Path to the `espeak-ng` binary for fallback pronunciation.
-    /// Defaults to `"espeak-ng"` (PATH lookup).
+    /// Legacy path to the `espeak-ng` binary.
+    ///
+    /// Runtime OOV fallback is embedded and does not require this binary; the
+    /// field is retained so existing callers can keep constructing
+    /// `G2PConfig` without source changes.
     pub espeak_path: String,
 }
 
@@ -97,7 +100,7 @@ impl G2P {
     /// Set custom word-to-phoneme overrides (builder pattern).
     ///
     /// Overrides map lowercase words to phoneme strings, checked before
-    /// the lexicon and espeak fallback.
+    /// the lexicon and embedded fallback.
     pub fn with_overrides(mut self, overrides: HashMap<String, String>) -> Self {
         self.overrides.extend(overrides);
         self
@@ -164,7 +167,7 @@ impl G2P {
             return;
         }
 
-        // Check custom overrides before lexicon/espeak fallback
+        // Check custom overrides before lexicon/embedded fallback.
         let lookup_key = w.text.to_lowercase();
         if let Some(ps) = self.overrides.get(&lookup_key) {
             w.phonemes = Some(ps.clone());
@@ -418,7 +421,7 @@ impl Default for G2P {
 
 /// Convert English text to a Kokoro-compatible phoneme string.
 ///
-/// Uses misaki-style dictionary lookup with espeak-ng fallback for unknown words.
+/// Uses misaki-style dictionary lookup with embedded fallback for unknown words.
 pub fn english_to_phonemes(text: &str) -> Result<String, G2pError> {
     global_g2p().convert(text)
 }
@@ -426,7 +429,7 @@ pub fn english_to_phonemes(text: &str) -> Result<String, G2pError> {
 /// Convert English text to phonemes with custom word overrides.
 ///
 /// Overrides map lowercase words to phoneme strings, checked before
-/// the lexicon and espeak fallback.
+/// the lexicon and embedded fallback.
 pub fn english_to_phonemes_with_overrides(
     text: &str,
     overrides: &HashMap<String, String>,
@@ -512,7 +515,7 @@ pub fn text_to_phoneme_chunks(text: &str) -> Result<Vec<String>, G2pError> {
 /// 510-character context limit, with custom word-to-phoneme overrides.
 ///
 /// Overrides map lowercase words to phoneme strings, checked before
-/// the lexicon and espeak fallback.
+/// the lexicon and embedded fallback.
 pub fn text_to_phoneme_chunks_with_overrides(
     text: &str,
     overrides: &HashMap<String, String>,
@@ -721,6 +724,22 @@ mod tests {
         assert!(result.is_ok());
         let phonemes = result.unwrap();
         assert!(!phonemes.is_empty());
+    }
+
+    #[test]
+    fn test_oov_fallback_does_not_require_espeak() {
+        let g2p = G2P::with_config(G2PConfig {
+            espeak_path: "/definitely/missing/espeak-ng".into(),
+        });
+        let result = g2p.convert("neologismxyz").unwrap();
+        assert!(
+            !result.trim().is_empty(),
+            "OOV fallback should produce phonemes without espeak-ng"
+        );
+        assert!(
+            result.contains('\u{02C8}'),
+            "OOV fallback should assign primary stress: {result}"
+        );
     }
 
     // -- Punctuation preservation tests --------------------------------------

--- a/crates/voice-g2p/src/tokenizer.rs
+++ b/crates/voice-g2p/src/tokenizer.rs
@@ -2,8 +2,8 @@
 //!
 //! Splits text into [`MToken`]s using whitespace-based word boundaries, then
 //! assigns POS tags via an embedded averaged perceptron tagger (no external
-//! processes required). espeak-ng subprocess is still used downstream as an
-//! OOV pronunciation fallback, but tokenization itself is fully self-contained.
+//! processes required). OOV fallback is also embedded, so tokenization and
+//! pronunciation are fully self-contained at runtime.
 
 use std::sync::OnceLock;
 


### PR DESCRIPTION
## Summary
- replace the per-word `espeak-ng` subprocess fallback with an embedded OOV phonemizer for unknown words, acronyms, and mixed alphanumeric tokens
- keep espeak conversion helpers only for offline bronze dictionary generation / compatibility
- update docs and crate metadata so fresh-machine runtime requirements no longer mention `espeak-ng`

This intentionally chooses a deterministic embedded fallback instead of the proposed neural fallback in #62. It removes the runtime dependency and avoids silent OOV drops now; a future quality-improvement issue can still replace the heuristic fallback with a trained model if needed.

Closes #62

## Tests
- `cargo test -p voice-g2p`
- `cargo clippy --workspace -- -D warnings`
- `cargo check --workspace`
- `cargo run --quiet --manifest-path /tmp/voice-g2p-probe/Cargo.toml -- "neologismxyz" "warmfem-aligned character" "StyleTTS2-LibriTTS" "abc123"`