### PR TITLE
Suppress Kokoro boundary token durations

### DIFF
--- a/crates/voice-kokoro/src/model.rs
+++ b/crates/voice-kokoro/src/model.rs
@@ -167,6 +167,7 @@ impl KModel {
             .iter()
             .map(|&v| v.max(1.0) as i64)
             .collect();
+        let pred_dur_vec = suppress_boundary_token_durations(pred_dur_vec);
 
         let total_frames: usize = pred_dur_vec.iter().sum::<i64>() as usize;
 
@@ -223,5 +224,36 @@ impl KModel {
 
         // audio: [1, 1, samples] -> [samples]
         audio.squeeze(0)?.squeeze(0)
+    }
+}
+
+fn suppress_boundary_token_durations(mut durations: Vec<i64>) -> Vec<i64> {
+    if let Some(first) = durations.first_mut() {
+        *first = 0;
+    }
+    if durations.len() > 1 {
+        let last_idx = durations.len() - 1;
+        durations[last_idx] = 0;
+    }
+    durations
+}
+
+#[cfg(test)]
+mod tests {
+    use super::suppress_boundary_token_durations;
+
+    #[test]
+    fn test_suppresses_bos_eos_duration_frames() {
+        let durations = suppress_boundary_token_durations(vec![4, 7, 9, 3]);
+        assert_eq!(durations, vec![0, 7, 9, 0]);
+    }
+
+    #[test]
+    fn test_suppresses_only_available_boundary_duration() {
+        assert_eq!(suppress_boundary_token_durations(vec![2]), vec![0]);
+        assert_eq!(
+            suppress_boundary_token_durations(Vec::new()),
+            Vec::<i64>::new()
+        );
     }
 }


### PR DESCRIPTION
## Summary
- keep BOS/EOS padding tokens in the encoder context but suppress their decoder alignment durations
- prevents boundary-token frames from being synthesized and stretched into audible leading/trailing artifacts at low speeds
- adds unit coverage for the duration normalization

Closes #80

## Local verification
- `cargo test -p voice-kokoro --lib`
- `cargo clippy --workspace -- -D warnings`
- `cargo check --workspace`

I also regenerated the issue examples through the local patched path with `--phonemes` to bypass the currently running daemon, which is still on the old build:

- `tˈɛst`, speed 0.5: daemon baseline `64200` samples / `2.675s` / first energy `452.2ms`; patched local `28200` samples / `1.175s` / first energy `187.2ms`
- `tˈɛst`, speed 1.0: daemon baseline `32400` samples / `1.350s` / first energy `403.6ms`; patched local `14400` samples / `0.600s` / first energy `103.7ms`
- `wəTˈɛvəɹ`, speed 0.5: daemon baseline `67800` samples / `2.825s` / first energy `430.8ms`; patched local `34800` samples / `1.450s` / first energy `324.8ms`
- `wəTˈɛvəɹ`, speed 1.0: daemon baseline `33600` samples / `1.400s` / first energy `387.4ms`; patched local `16800` samples / `0.700s` / first energy `137.1ms`

Note: `cargo test -p voice-kokoro` still hits the existing Linux/Metal-only integration test `stft_roundtrip` (`Device::new_metal`), so I used the library unit target for this PR.
