### PR TITLE
Add nteract identifier pronunciation coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ voice stream --sample-rate 48000 --frame-ms 20 --raw-output speech.s16le "Good m
 # Read from a file, strip markdown
 voice say --markdown -f blog-post.mdx
 
+# Inspect G2P output without synthesis
+voice phonemes "ChatGPT uses RuntimeStateDoc"
+
 # Adjust speed
 voice say -s 0.8 "Take it slow."
 
@@ -98,6 +101,26 @@ Options:
       --markdown                 Strip markdown/MDX formatting before speaking
       --sub <WORD=REPLACEMENT>   Word substitution (repeatable)
       --sub-file <PATH>          Load substitutions from a file
+  -q, --quiet                    Suppress progress output
+  -h, --help                     Print help
+```
+
+### `voice phonemes`
+
+```
+Convert text to phoneme chunks without synthesis
+
+Usage: voice phonemes [OPTIONS] [TEXT]...
+
+Arguments:
+  [TEXT]...                       Text to convert
+
+Options:
+  -f, --input-file <FILE>        Read text from a file (use - for stdin)
+      --markdown                 Strip markdown/MDX formatting before conversion
+      --sub <WORD=REPLACEMENT>   Word substitution (repeatable)
+      --sub-file <PATH>          Load substitutions from a file
+      --json                     Print a JSON object with preprocessed text and phoneme chunks
   -q, --quiet                    Suppress progress output
   -h, --help                     Print help
 ```
@@ -229,7 +252,8 @@ and Hermes/WebRTC notes.
 
 `voice` is built to work well with AI agents and coding assistants:
 
-- **Phoneme output**: The CLI emits phoneme chunks to stderr, so agents can see the IPA representation of what's being spoken
+- **Phoneme inspection**: `voice phonemes` emits the exact G2P chunks without loading the TTS model or playing audio
+- **Phoneme output**: `voice say` emits phoneme chunks to stderr, so agents can see the IPA representation of what's being spoken
 - **Phoneme input**: `--phonemes` accepts raw IPA strings, giving agents precise control over pronunciation without going through G2P
 - **Stdin pipe**: `echo "text" | voice say` lets agents speak from any script or tool
 - **Markdown stripping**: `--markdown` cleans up LLM-generated markdown before speaking

--- a/crates/voice-cli/README.md
+++ b/crates/voice-cli/README.md
@@ -44,6 +44,7 @@ voice say -v am_michael "How are you today?"
 voice say -f script.txt -o output.wav
 echo "Hello" | voice say
 voice say --markdown -f post.mdx
+voice phonemes "ChatGPT uses RuntimeStateDoc"
 voice stream --sample-rate 48000 --frame-ms 20 --raw-output output.s16le "Hello"
 
 # Speech-to-text from microphone
@@ -66,10 +67,14 @@ Usage: voice [OPTIONS] [COMMAND] [TEXT]...
 
 Commands:
   say         Speak text aloud (default when no subcommand given)
+  phonemes    Convert text to phoneme chunks without synthesis
   stream      Stream TTS audio chunks from the voice daemon
+  converse    Speak text aloud, then listen for a response
   listen      Record from microphone and transcribe (speech-to-text)
   transcribe  Transcribe a WAV audio file
   serve       Run as a JSON-RPC 2.0 server on stdin/stdout
+  mcp         Run as an MCP server on stdin/stdout
+  daemon      Inspect and control a running voice daemon
 
 Arguments:
   [TEXT]...  Text to speak (shorthand for `voice say <text>`)
@@ -93,6 +98,19 @@ Options:
       --markdown                 Strip markdown/MDX formatting before speaking
       --sub <WORD=REPLACEMENT>   Word substitution (repeatable)
       --sub-file <PATH>          Load substitutions from a file
+```
+
+### `voice phonemes`
+
+```
+Usage: voice phonemes [OPTIONS] [TEXT]...
+
+Options:
+  -f, --input-file <FILE>        Read text from a file (use - for stdin)
+      --markdown                 Strip markdown/MDX formatting before conversion
+      --sub <WORD=REPLACEMENT>   Word substitution (repeatable)
+      --sub-file <PATH>          Load substitutions from a file
+      --json                     Print a JSON object with preprocessed text and phoneme chunks
 ```
 
 ### `voice stream`

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -39,6 +39,7 @@ macro_rules! info {
                   voice say -f speech.txt -o output.wav\n  \
                   voice say --phonemes \"hɛloʊ wɜːld\"\n  \
                   voice say --markdown -f post.mdx\n  \
+                  voice phonemes \"ChatGPT uses RuntimeStateDoc\"\n  \
                   voice stream --json \"Hello world\"\n  \
                   voice listen\n  \
                   voice listen --continuous\n  \
@@ -65,6 +66,9 @@ enum Command {
     /// Speak text aloud (default when no subcommand given)
     Say(SayArgs),
 
+    /// Convert text to phoneme chunks without synthesis
+    Phonemes(PhonemesArgs),
+
     /// Stream TTS audio chunks from the voice daemon
     Stream(StreamArgs),
 
@@ -85,6 +89,34 @@ enum Command {
 
     /// Inspect and control a running voice daemon
     Daemon(DaemonArgs),
+}
+
+#[derive(clap::Args, Debug)]
+struct PhonemesArgs {
+    /// Text to convert
+    #[arg(trailing_var_arg = true)]
+    text: Vec<String>,
+
+    /// Read text from a file (use - for stdin)
+    #[arg(short = 'f', long = "input-file")]
+    input_file: Option<PathBuf>,
+
+    /// Strip markdown/MDX formatting before conversion
+    #[arg(long)]
+    markdown: bool,
+
+    /// Word substitutions (pre-processing), e.g. --sub nteract=enteract
+    #[arg(long = "sub", value_name = "WORD=REPLACEMENT")]
+    subs: Vec<String>,
+
+    /// Load substitutions from a file (one WORD=REPLACEMENT per line, # comments).
+    /// If not set, .voice-subs is auto-discovered from the working directory upward.
+    #[arg(long = "sub-file", value_name = "PATH")]
+    sub_file: Option<PathBuf>,
+
+    /// Print a JSON object with preprocessed text and phoneme chunks
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(clap::Args, Debug)]
@@ -402,6 +434,44 @@ fn resolve_stream_text(stream: &StreamArgs) -> Result<String, String> {
     Ok(text)
 }
 
+fn resolve_phonemes_text(args: &PhonemesArgs) -> Result<String, String> {
+    if let Some(path) = &args.input_file {
+        let text = if path.to_str() == Some("-") {
+            let mut buf = String::new();
+            io::stdin()
+                .read_to_string(&mut buf)
+                .map_err(|e| format!("Failed to read stdin: {e}"))?;
+            buf
+        } else {
+            std::fs::read_to_string(path)
+                .map_err(|e| format!("Failed to read {}: {e}", path.display()))?
+        };
+        let text = text.trim().to_string();
+        if text.is_empty() {
+            return Err("Input file is empty".into());
+        }
+        return Ok(text);
+    }
+
+    if !args.text.is_empty() {
+        return Ok(args.text.join(" "));
+    }
+
+    if io::stdin().is_terminal() {
+        return Err("No text provided. Pass text as arguments, use -f, or pipe to stdin.".into());
+    }
+
+    let mut buf = String::new();
+    io::stdin()
+        .read_to_string(&mut buf)
+        .map_err(|e| format!("Failed to read stdin: {e}"))?;
+    let text = buf.trim().to_string();
+    if text.is_empty() {
+        return Err("No text provided on stdin".into());
+    }
+    Ok(text)
+}
+
 /// Strip markdown/MDX to clean prose for TTS using pulldown-cmark.
 ///
 /// Keeps text content from paragraphs, headings, list items, and block quotes.
@@ -666,6 +736,9 @@ fn main() {
         Some(Command::Say(say_args)) => {
             run_say(say_args);
         }
+        Some(Command::Phonemes(phonemes_args)) => {
+            run_phonemes(phonemes_args);
+        }
         Some(Command::Stream(stream_args)) => {
             run_stream(stream_args);
         }
@@ -916,6 +989,58 @@ fn run_mcp(serve_args: ServeArgs) {
         sub_file_path: sub_file,
         mem_stats: serve_args.mem,
     });
+}
+
+fn run_phonemes(args: PhonemesArgs) {
+    let text = match resolve_phonemes_text(&args) {
+        Ok(text) => text,
+        Err(msg) => {
+            eprintln!("Error: {msg}");
+            std::process::exit(1);
+        }
+    };
+
+    let text = if args.markdown {
+        strip_markdown(&text)
+    } else {
+        text
+    };
+    let sub_file = args.sub_file.clone().or_else(find_sub_file);
+    if let Some(ref path) = sub_file {
+        info!("Using substitutions from {}", path.display());
+    }
+    let (subs, phoneme_overrides) = collect_subs(&args.subs, sub_file.as_deref());
+    let text = apply_tech_subs(&text);
+    let text = if subs.is_empty() {
+        text
+    } else {
+        apply_substitutions(&text, &subs)
+    };
+
+    let chunks = if phoneme_overrides.is_empty() {
+        voice_g2p::text_to_phoneme_chunks(&text)
+    } else {
+        voice_g2p::text_to_phoneme_chunks_with_overrides(&text, &phoneme_overrides)
+    };
+    let chunks = match chunks {
+        Ok(chunks) => chunks,
+        Err(e) => {
+            eprintln!("G2P error: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    if args.json {
+        let output = serde_json::json!({
+            "text": text,
+            "chunks": chunks,
+        });
+        println!("{}", serde_json::to_string_pretty(&output).unwrap());
+    } else {
+        for chunk in chunks {
+            println!("{chunk}");
+        }
+    }
 }
 
 fn run_say(say_args: SayArgs) {

--- a/crates/voice-g2p/src/lib.rs
+++ b/crates/voice-g2p/src/lib.rs
@@ -74,12 +74,15 @@ impl G2P {
     /// Words whose default lexicon/espeak phonemes are wrong or misleading.
     fn builtin_overrides() -> HashMap<String, String> {
         const ENTRIES: &[(&str, &str)] = &[
+            ("acl", "ˈA sˈi ˈɛl"),
             ("api", "ˈA pˈi ˌI"),
             ("apis", "ˈA pˈi ˈIz"),
             ("automerge", "ˈɔTO mˈɜɹʤ"),
+            ("automunge", "ˈɔTO mˈʌnʤ"),
             ("aws", "ˈA dˈʌbᵊlju ˈɛs"),
             ("anywidget", "ˈɛni wˌɪʤət"),
             ("bilstm", "bˈI ˈɛl ˈɛs tˈi ˈɛm"),
+            ("byoc", "bˈi wˈI ˈO sˈi"),
             ("chatgpt", "ʧˈæt ʤˈi pˈi tˈi"),
             ("cli", "sˈi ˈɛl ˌI"),
             ("clis", "sˈi ˈɛl ˈIz"),
@@ -92,6 +95,7 @@ impl G2P {
             ("csr", "sˈi ˈɛs ˈɑɹ"),
             ("css", "sˈi ˈɛs ˈɛs"),
             ("cuda", "kˈudə"),
+            ("d1", "dˈi wˈʌn"),
             ("deno", "dˈinO"),
             ("demo", "dˈɛmO"),
             ("demos", "dˈɛmOz"),
@@ -113,10 +117,14 @@ impl G2P {
             ("http", "ˈAʧ tˈi tˈi pˈi"),
             ("https", "ˈAʧ tˈi tˈi pˈi ˈɛs"),
             ("html", "ˈAʧ tˈi ˈɛm ˈɛl"),
+            ("htmliframeelement", "ˈAʧ tˈi ˈɛm ˈɛl ˌI fɹˌAm ˈɛləmənt"),
+            ("id", "ˈI dˈi"),
+            ("ids", "ˈI dˈiz"),
             ("idb", "ˌI dˈi bˈi"),
             ("iframe", "ˌI fɹˌAm"),
             ("ios", "ˈI ˈO ˈɛs"),
             ("indexeddb", "ˈɪndɛkst dˈi bˈi"),
+            ("ipc", "ˌI pˈi sˈi"),
             ("ipykernel", "ˈI pˈI kˌɜɹnᵊl"),
             ("ipython", "ˌI pˈIθˌɑn"),
             ("ipywidgets", "ˌI pˈI wˌɪʤəts"),
@@ -160,6 +168,7 @@ impl G2P {
             ("node.js", "nˈOd ʤˈA ˈɛs"),
             ("nodejs", "nˈOd ʤˈA ˈɛs"),
             ("nteract", "ˈɛntəɹˌækt"),
+            ("nteract-dev", "ˈɛntəɹˌækt dˈɛv"),
             ("numpy", "nˈʌm pˌI"),
             ("oauth", "ˌO ˈɔθ"),
             ("ogg", "ˈɑɡ"),
@@ -168,18 +177,24 @@ impl G2P {
             ("openai-codex", "ˌOpᵊn ˈAˌI kˈOdˌɛks"),
             ("openapi", "ˈOpᵊn ˈA pˈi ˌI"),
             ("opfs", "ˈO pˈi ˈɛf ˈɛs"),
+            ("outerbounds", "ˈWTəɹ bˈWndz"),
+            ("outputidchanges", "ˈWtpˌʊt ˌI dˌi ʧˈAnʤᵻz"),
             ("pnpm", "pˈi ˈɛn pˈi ˈɛm"),
             ("postgres", "pˈOstɡɹɛs"),
             ("postgresql", "pˈOst ɡɹˈɛs kjˈu ˈɛl"),
             ("pcm", "pˈi sˈi ˈɛm"),
             ("protobuf", "pɹˈOTO bˌʌf"),
             ("pwa", "pˈi dˈʌbᵊlju ˈA"),
+            ("put_blob", "pˌʊt blˈɑb"),
+            ("putblob", "pˌʊt blˈɑb"),
             ("pyodide", "pˈI ə dˌId"),
             ("pyarrow", "pˈI ˈɛɹO"),
             ("pypi", "pˈI pˈi ˌI"),
             ("pyo3", "pˈI ˈO θɹˈi"),
             ("pytest", "pˈI tˌɛst"),
             ("qqbot", "kjˈu kjˈu bˌɑt"),
+            ("r2", "ˈɑɹ tˈu"),
+            ("js", "ʤˈA ˈɛs"),
             ("todo", "tˈudu"),
             // Developer acronyms and initialisms
             ("ipynb", "nˈOtbˌʊk fˈIl"),
@@ -192,7 +207,12 @@ impl G2P {
             ("rtcp", "ˈɑɹ tˈi sˈi pˈi"),
             ("rtp", "ˈɑɹ tˈi pˈi"),
             ("rxjs", "ˈɑɹ ˈɛks ʤˈA ˈɛs"),
+            ("repr-llm", "ɹˈɛpəɹ ˈɛl ˈɛl ˈɛm"),
+            ("runt-nightly", "ɹˈʌnt nˈItli"),
             ("runtimed", "ɹˈʌntIm dˈi"),
+            ("runtimed-wasm", "ɹˈʌntIm dˈi wˈæzəm"),
+            ("runtime_peer", "ɹˈʌntIm pˈɪɹ"),
+            ("runtime-peer", "ɹˈʌntIm pˈɪɹ"),
             ("s3", "ˈɛs θɹˈi"),
             ("safetensors", "sˈAf tˌɛnsəɹz"),
             ("scikit-learn", "sˈɪkɪt lˌɜɹn"),
@@ -220,11 +240,14 @@ impl G2P {
             ("tsx", "tˈi ˈɛs ˈɛks"),
             ("tts", "tˈi tˈi ˈɛs"),
             ("typescript", "tˈIp skɹˌɪpt"),
+            ("ui", "jˈu ˈI"),
             ("ulid", "jˈu lˌɪd"),
             ("url", "jˈu ˈɑɹ ˈɛl"),
             ("urls", "jˈu ˈɑɹ ˈɛlz"),
             ("uri", "jˈu ˈɑɹ ˌI"),
             ("uris", "jˈu ˈɑɹ ˈIz"),
+            ("utf8view", "jˈu tˈi ˈɛf ˈAt vjˈu"),
+            ("ux", "jˈu ˈɛks"),
             ("uuid", "jˈu jˈu ˌI dˈi"),
             ("uuids", "jˈu jˈu ˌI dˈiz"),
             ("vad", "vˈi ˈA dˈi"),
@@ -382,16 +405,20 @@ impl G2P {
                 (None, None)
             } else {
                 let merged = merge_tokens(&group[left..right], None);
-                self.lexicon.call(
-                    &merged.text,
-                    merged.underscore.alias.as_deref(),
-                    &merged.tag,
-                    merged.underscore.stress,
-                    merged.underscore.currency,
-                    merged.underscore.is_head,
-                    &merged.underscore.num_flags,
-                    ctx,
-                )
+                if let Some(ps) = self.overrides.get(&merged.text.to_lowercase()) {
+                    (Some(ps.clone()), Some(5))
+                } else {
+                    self.lexicon.call(
+                        &merged.text,
+                        merged.underscore.alias.as_deref(),
+                        &merged.tag,
+                        merged.underscore.stress,
+                        merged.underscore.currency,
+                        merged.underscore.is_head,
+                        &merged.underscore.num_flags,
+                        ctx,
+                    )
+                }
             };
 
             if let Some(ps) = ps {
@@ -980,12 +1007,15 @@ mod tests {
     fn test_builtin_overrides() {
         let g2p = G2P::new();
         let pronounces = |text: &str| g2p.convert(text).unwrap().trim().to_string();
+        assert_eq!(pronounces("ACL"), "ˈA sˈi ˈɛl");
         assert_eq!(pronounces("API"), "ˈA pˈi ˌI");
         assert_eq!(pronounces("APIs"), "ˈA pˈi ˈIz");
         assert_eq!(pronounces("anywidget"), "ˈɛni wˌɪʤət");
         assert_eq!(pronounces("Automerge"), "ˈɔTO mˈɜɹʤ");
+        assert_eq!(pronounces("automunge"), "ˈɔTO mˈʌnʤ");
         assert_eq!(pronounces("AWS"), "ˈA dˈʌbᵊlju ˈɛs");
         assert_eq!(pronounces("BiLSTM"), "bˈI ˈɛl ˈɛs tˈi ˈɛm");
+        assert_eq!(pronounces("BYOC"), "bˈi wˈI ˈO sˈi");
         assert_eq!(pronounces("CLI"), "sˈi ˈɛl ˌI");
         assert_eq!(pronounces("CLIs"), "sˈi ˈɛl ˈIz");
         assert_eq!(pronounces("Cloudflare"), "klˈWd flˈɛɹ");
@@ -997,6 +1027,7 @@ mod tests {
         assert_eq!(pronounces("CSR"), "sˈi ˈɛs ˈɑɹ");
         assert_eq!(pronounces("CSS"), "sˈi ˈɛs ˈɛs");
         assert_eq!(pronounces("CUDA"), "kˈudə");
+        assert_eq!(pronounces("D1"), "dˈi wˈʌn");
         assert_eq!(pronounces("Deno"), "dˈinO");
         assert_eq!(pronounces("demos"), "dˈɛmOz");
         assert_eq!(pronounces("demo"), "dˈɛmO");
@@ -1020,10 +1051,17 @@ mod tests {
         assert_eq!(pronounces("HTTP"), "ˈAʧ tˈi tˈi pˈi");
         assert_eq!(pronounces("HTTPS"), "ˈAʧ tˈi tˈi pˈi ˈɛs");
         assert_eq!(pronounces("HTML"), "ˈAʧ tˈi ˈɛm ˈɛl");
+        assert_eq!(
+            pronounces("HTMLIFrameElement"),
+            "ˈAʧ tˈi ˈɛm ˈɛl ˌI fɹˌAm ˈɛləmənt"
+        );
+        assert_eq!(pronounces("ID"), "ˈI dˈi");
+        assert_eq!(pronounces("IDs"), "ˈI dˈiz");
         assert_eq!(pronounces("IDB"), "ˌI dˈi bˈi");
         assert_eq!(pronounces("iframe"), "ˌI fɹˌAm");
         assert_eq!(pronounces("iOS"), "ˈI ˈO ˈɛs");
         assert_eq!(pronounces("IndexedDB"), "ˈɪndɛkst dˈi bˈi");
+        assert_eq!(pronounces("IPC"), "ˌI pˈi sˈi");
         assert_eq!(pronounces("ipykernel"), "ˈI pˈI kˌɜɹnᵊl");
         assert_eq!(pronounces("IPython"), "ˌI pˈIθˌɑn");
         assert_eq!(pronounces("ipywidgets"), "ˌI pˈI wˌɪʤəts");
@@ -1032,6 +1070,7 @@ mod tests {
         assert_eq!(pronounces("JAX"), "ʤˈæks");
         assert_eq!(pronounces("JSON"), "ʤˌA sˈæhn");
         assert_eq!(pronounces("JSONRPC"), "ʤˌA sˈæhn ˈɑɹ pˈi sˈi");
+        assert_eq!(pronounces("JS"), "ʤˈA ˈɛs");
         assert_eq!(pronounces("JSX"), "ʤˈA ˈɛs ˈɛks");
         assert_eq!(pronounces("Jupyter"), "ʤˈupɪTəɹ");
         assert_eq!(pronounces("JWT"), "ʤˈA dˈʌbᵊlju tˈi");
@@ -1067,6 +1106,7 @@ mod tests {
         assert_eq!(pronounces("Node.js"), "nˈOd ʤˈA ˈɛs");
         assert_eq!(pronounces("NodeJS"), "nˈOd ʤˈA ˈɛs");
         assert_eq!(pronounces("nteract"), "ˈɛntəɹˌækt");
+        assert_eq!(pronounces("nteract-dev"), "ˈɛntəɹˌækt dˈɛv");
         assert_eq!(pronounces("NumPy"), "nˈʌm pˌI");
         assert_eq!(pronounces("OAuth"), "ˌO ˈɔθ");
         assert_eq!(pronounces("OGG"), "ˈɑɡ");
@@ -1075,18 +1115,23 @@ mod tests {
         assert_eq!(pronounces("openai-codex"), "ˌOpᵊn ˈAˌI kˈOdˌɛks");
         assert_eq!(pronounces("OpenAPI"), "ˈOpᵊn ˈA pˈi ˌI");
         assert_eq!(pronounces("OPFS"), "ˈO pˈi ˈɛf ˈɛs");
+        assert_eq!(pronounces("Outerbounds"), "ˈWTəɹ bˈWndz");
+        assert_eq!(pronounces("outputIdChanges"), "ˈWtpˌʊt ˌI dˌi ʧˈAnʤᵻz");
         assert_eq!(pronounces("pnpm"), "pˈi ˈɛn pˈi ˈɛm");
         assert_eq!(pronounces("Postgres"), "pˈOstɡɹɛs");
         assert_eq!(pronounces("PostgreSQL"), "pˈOst ɡɹˈɛs kjˈu ˈɛl");
         assert_eq!(pronounces("PCM"), "pˈi sˈi ˈɛm");
         assert_eq!(pronounces("Protobuf"), "pɹˈOTO bˌʌf");
         assert_eq!(pronounces("PWA"), "pˈi dˈʌbᵊlju ˈA");
+        assert_eq!(pronounces("PUT_BLOB"), "pˌʊt blˈɑb");
+        assert_eq!(pronounces("PutBlob"), "pˌʊt blˈɑb");
         assert_eq!(pronounces("PyArrow"), "pˈI ˈɛɹO");
         assert_eq!(pronounces("Pyodide"), "pˈI ə dˌId");
         assert_eq!(pronounces("PyPI"), "pˈI pˈi ˌI");
         assert_eq!(pronounces("PyO3"), "pˈI ˈO θɹˈi");
         assert_eq!(pronounces("pytest"), "pˈI tˌɛst");
         assert_eq!(pronounces("QQBot"), "kjˈu kjˈu bˌɑt");
+        assert_eq!(pronounces("R2"), "ˈɑɹ tˈu");
         assert_eq!(pronounces("PyTorch"), "pˈI tˌɔɹʧ");
         assert_eq!(pronounces("vitest"), "vˈi tˌɛst");
         assert_eq!(pronounces("tsconfig"), "tˈi ˈɛs kˌɑnfˈɪɡ");
@@ -1098,7 +1143,12 @@ mod tests {
         assert_eq!(pronounces("Rodio"), "ɹˈOdiˌO");
         assert_eq!(pronounces("RTCP"), "ˈɑɹ tˈi sˈi pˈi");
         assert_eq!(pronounces("RTP"), "ˈɑɹ tˈi pˈi");
+        assert_eq!(pronounces("repr-llm"), "ɹˈɛpəɹ ˈɛl ˈɛl ˈɛm");
+        assert_eq!(pronounces("runt-nightly"), "ɹˈʌnt nˈItli");
         assert_eq!(pronounces("runtimed"), "ɹˈʌntIm dˈi");
+        assert_eq!(pronounces("runtimed-wasm"), "ɹˈʌntIm dˈi wˈæzəm");
+        assert_eq!(pronounces("runtime-peer"), "ɹˈʌntIm pˈɪɹ");
+        assert_eq!(pronounces("runtime_peer"), "ɹˈʌntIm pˈɪɹ");
         assert_eq!(pronounces("S3"), "ˈɛs θɹˈi");
         assert_eq!(pronounces("safetensors"), "sˈAf tˌɛnsəɹz");
         assert_eq!(pronounces("scikit-learn"), "sˈɪkɪt lˌɜɹn");
@@ -1124,11 +1174,14 @@ mod tests {
         assert_eq!(pronounces("TTS"), "tˈi tˈi ˈɛs");
         assert_eq!(pronounces("TSX"), "tˈi ˈɛs ˈɛks");
         assert_eq!(pronounces("TypeScript"), "tˈIp skɹˌɪpt");
+        assert_eq!(pronounces("UI"), "jˈu ˈI");
         assert_eq!(pronounces("ULID"), "jˈu lˌɪd");
         assert_eq!(pronounces("URL"), "jˈu ˈɑɹ ˈɛl");
         assert_eq!(pronounces("URLs"), "jˈu ˈɑɹ ˈɛlz");
         assert_eq!(pronounces("URI"), "jˈu ˈɑɹ ˌI");
         assert_eq!(pronounces("URIs"), "jˈu ˈɑɹ ˈIz");
+        assert_eq!(pronounces("Utf8View"), "jˈu tˈi ˈɛf ˈAt vjˈu");
+        assert_eq!(pronounces("UX"), "jˈu ˈɛks");
         assert_eq!(pronounces("UUID"), "jˈu jˈu ˌI dˈi");
         assert_eq!(pronounces("UUIDs"), "jˈu jˈu ˌI dˈiz");
         assert_eq!(pronounces("VAD"), "vˈi ˈA dˈi");
@@ -1149,6 +1202,60 @@ mod tests {
         assert_eq!(pronounces("Yjs"), "wˈI ʤˈA ˈɛs");
         assert_eq!(pronounces("ZeroMQ"), "zˈɪɹO ˈɛm kjˈu");
         assert_eq!(pronounces("ZMQ"), "zˈi ˈɛm kjˈu");
+    }
+
+    #[test]
+    fn test_nteract_identifier_phrases() {
+        let g2p = G2P::new();
+        let assert_contains = |text: &str, expected: &[&str]| {
+            let result = g2p.convert(text).unwrap();
+            for part in expected {
+                assert!(
+                    result.contains(part),
+                    "expected {text:?} to contain {part:?}, got {result:?}"
+                );
+            }
+        };
+
+        assert_contains(
+            "runtime_peer writes RuntimeStateDoc and CommsDoc",
+            &["ɹˈʌntIm pˈɪɹ", "ɹˈʌntIm stˈAt dˌɑk", "kˈɑmz dˌɑk"],
+        );
+        assert_contains(
+            "ACL checks gate PUT_BLOB in Cloudflare D1 and R2",
+            &[
+                "ˈA sˈi ˈɛl",
+                "pˌʊt blˈɑb",
+                "klˈWd flˈɛɹ",
+                "dˈi wˈʌn",
+                "ˈɑɹ tˈu",
+            ],
+        );
+        assert_contains(
+            "nteract.dx.blob uses SyncEngine and CommBridgeManager",
+            &[
+                "ˈɛntəɹˌækt dˈi ˈɛks blˌɑb",
+                "sˌɪŋk ˈɛnʤən",
+                "kˌɑm bɹˈɪʤ mˈænɪʤəɹ",
+            ],
+        );
+        assert_contains(
+            "runt-nightly starts runtimed-wasm for nteract-dev",
+            &["ɹˈʌnt nˈItli", "ɹˈʌntIm dˈi wˈæzəm", "ˈɛntəɹˌækt dˈɛv"],
+        );
+        assert_contains(
+            "Arrow IPC uses Utf8View in Sift",
+            &["ˈɛɹO", "ˌI pˈi sˈi", "jˈu tˈi ˈɛf ˈAt vjˈu", "sˈɪft"],
+        );
+        assert_contains(
+            "HTMLElement reads URLSearchParams and cell_id in NotebookUI",
+            &[
+                "ˈAʧ tˈi ˈɛm ˈɛl ˌɛləmənt",
+                "jˈu ˈɑɹ ˈɛl sˌɜɹʧ pˈɑɹæms",
+                "sˌɛl ˈI dˈi",
+                "nˈOtbˌʊk jˌu ˌI",
+            ],
+        );
     }
 
     // -- camelCase tests ------------------------------------------------------

--- a/crates/voice-g2p/src/tokenizer.rs
+++ b/crates/voice-g2p/src/tokenizer.rs
@@ -314,7 +314,7 @@ fn subtokenize_regex() -> &'static Regex {
         Regex::new(
             r"(?x)
             ^[''']+ |
-            \p{Lu}(?=\p{Lu}\p{Ll}) |
+            \p{Lu}+(?=\p{Lu}\p{Ll}) |
             (?:^-)?(?:\d?[,.]?\d)+ |
             [-_]+ |
             [''']{2,} |
@@ -357,7 +357,7 @@ pub fn subtokenize(word: &str) -> Vec<String> {
 }
 
 fn is_subtoken_boundary_junk(text: &str) -> bool {
-    !text.is_empty() && text.chars().all(|c| matches!(c, '-' | '_' | '/'))
+    !text.is_empty() && text.chars().all(|c| matches!(c, '-' | '_' | '/' | '.'))
 }
 
 // ---------------------------------------------------------------------------
@@ -501,6 +501,11 @@ pub fn retokenize(tokens: Vec<MToken>) -> Vec<TokenOrGroup> {
                         sub_tok.underscore.prespace = true;
                     }
                     if prev.chars().last().is_some_and(|c| c.is_lowercase())
+                        && sub_text.chars().next().is_some_and(|c| c.is_uppercase())
+                    {
+                        sub_tok.underscore.prespace = true;
+                    }
+                    if prev.chars().all(|c| c.is_uppercase())
                         && sub_text.chars().next().is_some_and(|c| c.is_uppercase())
                     {
                         sub_tok.underscore.prespace = true;
@@ -836,6 +841,15 @@ mod tests {
             result.len() >= 2,
             "Expected split for camelCase: {:?}",
             result
+        );
+    }
+
+    #[test]
+    fn subtokenize_acronym_prefix_before_word() {
+        assert_eq!(subtokenize("HTMLElement"), vec!["HTML", "Element"]);
+        assert_eq!(
+            subtokenize("URLSearchParams"),
+            vec!["URL", "Search", "Params"]
         );
     }
 


### PR DESCRIPTION
## Summary

- adds a `voice phonemes` CLI command for inspecting G2P chunks without loading TTS or playing audio
- adds high-confidence nteract identifier/acronym overrides found in #90 follow-up audit: `ACL`, `IPC`, `BYOC`, `automunge`, `Outerbounds`, `Utf8View`, `outputIdChanges`, `PUT_BLOB`, `runtime_peer`, `runtime-peer`, `runt-nightly`, `runtimed-wasm`, `nteract-dev`, `repr-llm`, `D1`, and `R2`
- adds common technical initialism overrides for `ID`, `IDs`, `UI`, `UX`, and `JS`, and fixes the `outputIdChanges` direct phonemes to spell `ID`
- adds a direct DOM-class override for `HTMLIFrameElement`, where generic acronym splitting otherwise treats `HTMLI` as one prefix
- teaches grouped identifier resolution to consider builtin overrides for subspans before falling back to the lexicon
- splits acronym prefixes before capitalized identifier words, so names like `HTMLElement` and `URLSearchParams` preserve `HTML` and `URL`
- treats `.` as an identifier boundary like `_`, `-`, and `/`, so dotted namespaces such as `nteract.dx.blob` no longer concatenate adjacent phonemes
- adds phrase-level regression coverage using representative nteract wording around `RuntimeStateDoc`, `CommsDoc`, `SyncEngine`, `CommBridgeManager`, `Cloudflare`, `Arrow IPC`, `Sift`, `HTMLElement`, `URLSearchParams`, `cell_id`, and `NotebookUI`
- documents `voice phonemes` in the root and CLI READMEs

## Dependency

This is stacked on #91. Until #91 lands, GitHub will show this PR as including the earlier pronunciation commits plus this follow-on commit:

- #91: `c32697f` `Add nteract pronunciation overrides`
- #91: `2c7b396` `Add voice audio pronunciation overrides`
- #91: `5699c0a` `Add Hermes provider pronunciation overrides`
- #91: `05b4cdf` `Add notebook data science pronunciation overrides`
- #91: `44562a6` `Add frontend tooling pronunciation overrides`
- #91: `7366af4` `Add streaming audio pronunciation overrides`
- #91: `3418117` `Add model and tool pronunciation overrides`
- this PR: `fd8b018` `Add nteract identifier pronunciation coverage`

After #91 merges, this branch should be rebased onto `main` so the review diff collapses to the identifier/CLI changes.

## Verification

- `cargo fmt --check`
- `cargo test -p voice-g2p test_builtin_overrides -- --nocapture`
- `cargo test -p voice-g2p test_nteract_identifier_phrases -- --nocapture`
- `cargo test -p voice-g2p subtokenize_acronym_prefix_before_word -- --nocapture`
- `cargo test -p voice-g2p`
- `cargo run -q -p voice -- phonemes "ChatGPT uses RuntimeStateDoc and nteract.dx.blob"`
- `cargo run -q -p voice -- phonemes --json "Arrow IPC uses Utf8View"`
- `cargo run -q -p voice -- phonemes HTMLElement URLSearchParams NotebookUI runtimeStateDocId cell_id outputId outputIdChanges peerId display_id ID IDs UI UX JS runtime-peer`
- `cargo run -q -p voice -- phonemes HTMLIFrameElement HTMLElement URLSearchParams ID UI JS`
- `cargo run -q -p voice -- phonemes SDP DTLS SRTP CPAL Rodio HTMLElement URLSearchParams HTMLIFrameElement ID UI JS runtime-peer`
- `cargo run -q -p voice -- phonemes Kokoro-82M DFT LFS openai-codex HTMLElement URLSearchParams HTMLIFrameElement ID UI JS runtime-peer`
- `printf 'ACL checks nteract.dx.blob\n' | cargo run -q -p voice -- phonemes`
- `cargo run -q -p voice -- phonemes --help`
- `cargo check --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace --exclude voice-kokoro`
- `git diff --check`

`cargo test --workspace` still fails on this Linux machine in `voice-kokoro --test stft_roundtrip` because Candle was built without Metal support. The changed crates and the non-`voice-kokoro` workspace tests passed.

Refs #90.
