### PR TITLE
Fix live microphone channel mixing

### DIFF
--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -29,6 +29,7 @@ use std::time::Instant;
 
 use rodio::microphone::MicrophoneBuilder;
 use rodio::{buffer::SamplesBuffer, DeviceSinkBuilder, Player};
+use voice_stream::InterleavedMonoMixer;
 
 use crate::{INTERRUPTED, QUIET};
 
@@ -499,7 +500,7 @@ fn start_mic_drain(
     channels: u16,
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
-        let ch = channels.max(1) as usize;
+        let mut mixer = InterleavedMonoMixer::new(channels as usize);
         let mut chunk_peak: f32 = 0.0;
         let mut sample_count = 0usize;
 
@@ -512,13 +513,8 @@ fn start_mic_drain(
             chunk_peak = chunk_peak.max(abs);
             sample_count += 1;
 
-            // For multi-channel, mix to mono by averaging
-            if ch == 1 {
-                buffer.lock().unwrap().push(sample);
-            } else if sample_count % ch == 0 {
-                // We get interleaved samples — just take every ch-th sample
-                // (rodio's SampleTypeConverter already converts to f32)
-                buffer.lock().unwrap().push(sample);
+            if let Some(mono) = mixer.push(sample) {
+                buffer.lock().unwrap().push(mono);
             }
 
             // Update peak every ~100 samples to avoid atomic contention

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -13,7 +13,8 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use voice_stream::{
-    resample_linear, AudioEncoding, Packetizer, StreamEnded, StreamMetadata, TtsStreamEvent,
+    resample_linear, AudioEncoding, InterleavedMonoMixer, Packetizer, StreamEnded, StreamMetadata,
+    TtsStreamEvent,
 };
 use voice_tts::KokoroModel;
 
@@ -754,7 +755,7 @@ fn listen(
     let peak_clone = recent_peak.clone();
     let stop_clone = stop.clone();
     let mic_thread = std::thread::spawn(move || {
-        let ch = channels.max(1) as usize;
+        let mut mixer = InterleavedMonoMixer::new(channels as usize);
         let mut chunk_peak: f32 = 0.0;
         let mut sample_count = 0usize;
 
@@ -767,9 +768,8 @@ fn listen(
             chunk_peak = chunk_peak.max(abs);
             sample_count += 1;
 
-            // Multi-channel: take every ch-th sample (mono mix)
-            if ch == 1 || sample_count % ch == 0 {
-                buf_clone.lock().unwrap().push(sample);
+            if let Some(mono) = mixer.push(sample) {
+                buf_clone.lock().unwrap().push(mono);
             }
 
             // Publish peak every ~100 samples, then reset

--- a/crates/voice-stream/src/lib.rs
+++ b/crates/voice-stream/src/lib.rs
@@ -211,6 +211,41 @@ impl Packetizer {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct InterleavedMonoMixer {
+    channels: usize,
+    pending_sum: f32,
+    pending_count: usize,
+}
+
+impl InterleavedMonoMixer {
+    pub fn new(channels: usize) -> Self {
+        Self {
+            channels: channels.max(1),
+            pending_sum: 0.0,
+            pending_count: 0,
+        }
+    }
+
+    pub fn push(&mut self, sample: f32) -> Option<f32> {
+        if self.channels == 1 {
+            return Some(sample);
+        }
+
+        self.pending_sum += sample;
+        self.pending_count += 1;
+
+        if self.pending_count == self.channels {
+            let mixed = self.pending_sum / self.channels as f32;
+            self.pending_sum = 0.0;
+            self.pending_count = 0;
+            Some(mixed)
+        } else {
+            None
+        }
+    }
+}
+
 pub fn f32_to_i16(sample: f32) -> i16 {
     let clamped = sample.clamp(-1.0, 1.0);
     if clamped >= 0.0 {
@@ -276,6 +311,37 @@ mod tests {
         assert_eq!(f32_to_i16(-1.0), -32768);
         assert_eq!(f32_to_i16(2.0), 32767);
         assert_eq!(f32_to_i16(-2.0), -32768);
+    }
+
+    #[test]
+    fn interleaved_mono_mixer_passes_mono_samples_through() {
+        let mut mixer = InterleavedMonoMixer::new(1);
+        assert_eq!(mixer.push(0.25), Some(0.25));
+        assert_eq!(mixer.push(-0.5), Some(-0.5));
+    }
+
+    #[test]
+    fn interleaved_mono_mixer_averages_stereo_frames() {
+        let mut mixer = InterleavedMonoMixer::new(2);
+        let input = [1.0, -1.0, 0.5, 0.25];
+        let output: Vec<f32> = input
+            .into_iter()
+            .filter_map(|sample| mixer.push(sample))
+            .collect();
+
+        assert_eq!(output, vec![0.0, 0.375]);
+    }
+
+    #[test]
+    fn interleaved_mono_mixer_treats_zero_channels_as_mono() {
+        let mut mixer = InterleavedMonoMixer::new(0);
+        assert_eq!(mixer.push(0.75), Some(0.75));
+    }
+
+    #[test]
+    fn interleaved_mono_mixer_holds_incomplete_frame() {
+        let mut mixer = InterleavedMonoMixer::new(2);
+        assert_eq!(mixer.push(1.0), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a shared `InterleavedMonoMixer` for interleaved live microphone samples
- use it in both CLI and daemon mic drains so multi-channel input is averaged instead of dropping channels
- add focused unit coverage for mono, stereo, zero-channel, and incomplete-frame behavior

## Tests
- `cargo fmt --check`
- `cargo test -p voice-stream interleaved`
- `cargo test -p voice-stream`
- `cargo test -p voice-daemon worker`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace --exclude voice-kokoro`
- `cargo test -p voice-kokoro --lib`

Note: `cargo test --workspace` on this Linux host reaches the pre-existing `voice-kokoro` Metal integration test `stft_roundtrip`, which fails with `the candle crate has not been built with metal support`.