### PR TITLE
Remove stale Moonshine and MLX release paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,22 +17,11 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      # Homebrew's llvm@15 clang lacks __bf16 support, which breaks
-      # mlx-sys bindgen. Point bindgen to Xcode's clang instead.
-      - name: Fix clang for bindgen
-        run: |
-          brew unlink llvm@15 2>/dev/null || true
-          TOOLCHAIN=$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain
-          echo "LIBCLANG_PATH=${TOOLCHAIN}/usr/lib" >> "$GITHUB_ENV"
-          SDK_PATH=$(xcrun --show-sdk-path)
-          echo "BINDGEN_EXTRA_CLANG_ARGS=-isysroot ${SDK_PATH}" >> "$GITHUB_ENV"
-
       - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            ~/.mlx
             target
           key: ${{ runner.os }}-${{ github.repository }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      # Homebrew's llvm@15 clang lacks __bf16 support, which breaks
-      # mlx-sys bindgen. Point bindgen to Xcode's clang instead.
-      - name: Fix clang for bindgen
-        run: |
-          brew unlink llvm@15 2>/dev/null || true
-          TOOLCHAIN=$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain
-          echo "LIBCLANG_PATH=${TOOLCHAIN}/usr/lib" >> "$GITHUB_ENV"
-          SDK_PATH=$(xcrun --show-sdk-path)
-          echo "BINDGEN_EXTRA_CLANG_ARGS=-isysroot ${SDK_PATH}" >> "$GITHUB_ENV"
-
       - name: Build release
         run: cargo build --release -p voice
 
@@ -39,15 +29,6 @@ jobs:
           cp target/release/voice dist/
           cd dist && tar czf voice-aarch64-apple-darwin.tar.gz voice && cd ..
 
-          # Metallib — needed at runtime for MLX Metal kernels
-          METALLIB=$(find target/release/build -name "mlx.metallib" -print -quit)
-          if [ -n "$METALLIB" ]; then
-            cp "$METALLIB" dist/mlx.metallib
-          else
-            echo "::error::mlx.metallib not found in build output"
-            exit 1
-          fi
-
       - name: Sign release assets
         if: env.MINISIGN_KEY != ''
         env:
@@ -56,7 +37,6 @@ jobs:
           brew install minisign
           echo "$MINISIGN_KEY" > /tmp/signing.key
           minisign -S -W -s /tmp/signing.key -x dist/voice-aarch64-apple-darwin.tar.gz.sig -m dist/voice-aarch64-apple-darwin.tar.gz
-          minisign -S -W -s /tmp/signing.key -x dist/mlx.metallib.sig -m dist/mlx.metallib
           rm -f /tmp/signing.key
 
       - name: Create release
@@ -65,8 +45,6 @@ jobs:
           files: |
             dist/voice-aarch64-apple-darwin.tar.gz
             dist/voice-aarch64-apple-darwin.tar.gz.sig
-            dist/mlx.metallib
-            dist/mlx.metallib.sig
           generate_release_notes: true
           prerelease: ${{ contains(github.ref, '-rc.') || contains(github.ref, '-alpha.') || contains(github.ref, '-beta.') }}
           fail_on_unmatched_files: false
@@ -82,7 +60,7 @@ jobs:
 
       # Publish workspace crates in dependency order.
       # `--no-verify` skips the build step — we already verified in the build job,
-      # and these crates require macOS + Metal to compile.
+      # and the publish job should only package the already-checked sources.
       # Each publish is allowed to fail with "already exists" so we don't break
       # when only a subset of crates have version bumps.
       - name: Publish to crates.io
@@ -110,16 +88,16 @@ jobs:
             sleep 15
           }
 
-          # Leaf crates (no workspace deps)
-          publish voice-dsp
+          # Leaf crates and shared foundations
+          publish voice-stream
+          publish voice-protocol
           publish voice-g2p
+          publish voice-kokoro
+          publish voice-whisper
+
+          # Model-facing libraries
+          publish voice-tts
           publish voice-stt
 
-          # voice-nn depends on voice-dsp
-          publish voice-nn
-
-          # voice-tts depends on voice-dsp, voice-nn
-          publish voice-tts
-
-          # voice (CLI) depends on voice-tts, voice-g2p, voice-stt
+          # voice (CLI) depends on the libraries above
           publish voice

--- a/crates/voice-cli/README.md
+++ b/crates/voice-cli/README.md
@@ -1,6 +1,6 @@
 # voice
 
-Like `say`, but with [Kokoro](https://huggingface.co/prince-canuma/Kokoro-82M) TTS and [Moonshine](https://huggingface.co/UsefulSensors/moonshine-tiny) STT. A command-line speech tool for macOS, powered by MLX on Apple Silicon.
+Like `say`, but with [Kokoro](https://huggingface.co/prince-canuma/Kokoro-82M) TTS and [Whisper](https://huggingface.co/distil-whisper/distil-large-v3) STT. A command-line speech tool powered by Candle, with Metal acceleration on Apple Silicon and CPU fallback on Linux.
 
 ## Install
 
@@ -31,7 +31,7 @@ cd voice
 cargo install --path crates/voice-cli
 ```
 
-> **Note:** `cargo install voice` compiles from source on crates.io, but the Metal shader library path can break — see the [main README](../../README.md) for details. Use `cargo binstall voice` or build from a local clone instead.
+> **Note:** `cargo install voice` compiles from source on crates.io. Use `cargo binstall voice` for the pre-built binary, or build from a local clone when working on the repo.
 
 ## Usage
 

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -1014,10 +1014,10 @@ pub fn record_continuous(
 /// Consume segments from the recording queue and transcribe each one.
 ///
 /// Spawns a thread that pulls segments, trims silence, resamples, and
-/// runs Moonshine inference. Results are sent to the returned receiver.
+/// runs Whisper inference. Results are sent to the returned receiver.
 ///
-/// The model and tokenizer are moved into this thread — they're not
-/// thread-safe, so single-threaded access is correct.
+/// The model is moved into this thread because single-threaded access is
+/// required by the decoder state.
 pub fn transcribe_segments(
     mut model: voice_stt::WhisperModel,
     segments: mpsc::Receiver<Segment>,
@@ -1146,7 +1146,7 @@ pub fn listen_continuous_for_rpc(
 /// Trim leading and trailing silence from audio samples.
 ///
 /// Bluetooth microphones (e.g. AirPods) can take ~0.5-1s before audio
-/// actually flows, producing a block of zeros at the start. Moonshine
+/// actually flows, producing a block of zeros at the start. Whisper
 /// is sensitive to the silence-to-speech ratio, especially on short
 /// recordings — trimming silence dramatically improves accuracy.
 fn trim_silence(samples: &[f32], sample_rate: u32) -> Vec<f32> {

--- a/crates/voice-stt/examples/transcribe.rs
+++ b/crates/voice-stt/examples/transcribe.rs
@@ -1,4 +1,4 @@
-//! Example: transcribe a WAV file using Moonshine.
+//! Example: transcribe a WAV file using Whisper.
 //!
 //! Usage:
 //!     cargo run -p voice-stt --example transcribe -- /path/to/audio.wav
@@ -25,15 +25,12 @@ fn main() {
     let audio_path = &args[1];
 
     let repo =
-        env::var("MOONSHINE_MODEL").unwrap_or_else(|_| "UsefulSensors/moonshine-tiny".to_string());
+        env::var("STT_MODEL").unwrap_or_else(|_| "distil-whisper/distil-medium.en".to_string());
 
     eprintln!("Loading model: {repo}");
     let t0 = Instant::now();
     let mut model = voice_stt::load_model(&repo).expect("Failed to load model");
     eprintln!("Model loaded in {:.2}s", t0.elapsed().as_secs_f64());
-
-    eprintln!("Loading tokenizer...");
-    let tokenizer = voice_stt::load_tokenizer(&repo).expect("Failed to load tokenizer");
 
     eprintln!("Transcribing: {audio_path}");
     let t1 = Instant::now();
@@ -48,8 +45,7 @@ fn main() {
     );
 
     let result =
-        voice_stt::transcribe_audio_with_tokenizer(&mut model, &samples, 16000, &tokenizer)
-            .expect("Transcription failed");
+        voice_stt::transcribe_audio(&mut model, &samples, 16000).expect("Transcription failed");
 
     let elapsed = t1.elapsed().as_secs_f64();
     let rtf = elapsed / duration_secs;

--- a/crates/voice-tts/README.md
+++ b/crates/voice-tts/README.md
@@ -1,6 +1,6 @@
 # voice-tts
 
-Core TTS library for [Kokoro](https://huggingface.co/prince-canuma/Kokoro-82M) model inference on Apple Silicon via [mlx-rs](https://github.com/oxiglade/mlx-rs).
+Core TTS library for [Kokoro](https://huggingface.co/prince-canuma/Kokoro-82M) model inference on Candle, with Metal acceleration on Apple Silicon and CPU fallback elsewhere.
 
 ## Install
 
@@ -50,8 +50,8 @@ for phonemes in &chunks {
 
 ## Requirements
 
-- macOS with Apple Silicon (MLX requirement)
-- Xcode command line tools (for Metal compilation)
+- Rust 1.85+
+- macOS with Apple Silicon for fast Metal inference, or a CPU-only host for slower portable inference
 
 ## License
 


### PR DESCRIPTION
## Summary
- remove MLX-era bindgen/cache setup and `mlx.metallib` release packaging
- update release publish order to current workspace crates needed by the CLI
- update stale Moonshine/MLX docs and the STT example to current Whisper/Candle APIs

## Tests
- `cargo fmt --check`
- `cargo check -p voice-stt --example transcribe`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace --exclude voice-kokoro`
- `rg -n "Moonshine|UsefulSensors|mlx-sys|mlx\.metallib|voice-dsp|voice-nn|MLX requirement|powered by MLX|mlx-rs|Metallib|~/.mlx" .github README.md crates/voice-cli crates/voice-stt crates/voice-tts crates/voice-kokoro crates/voice-whisper` (no matches)

Note: full `cargo test --workspace` on this Linux host still reaches the pre-existing `voice-kokoro` Metal integration test that requires Candle Metal support.