### PR TITLE
Add structured STT evaluation harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 output.wav
 .context/
 .worktrees/
+eval/results/

--- a/README.md
+++ b/README.md
@@ -202,6 +202,22 @@ Performance is ~50× real-time on Apple Silicon (a 10-second recording transcrib
 STT_MODEL=distil-whisper/distil-medium.en voice listen
 ```
 
+## Evaluation
+
+The `eval/` scripts provide optional local STT/TTS evaluation. They may
+download model weights and are not part of normal CI.
+
+```bash
+cargo build --release -p voice
+./eval/compare.sh ./target/release/voice
+./eval/synth_eval.sh ./target/release/voice
+```
+
+`compare.sh` scores recordings from `eval/recordings/`. `synth_eval.sh`
+generates temporary TTS audio from `eval/phrases.txt` first. Both write JSON
+results with WER, CER, exact-match counts, elapsed time, audio duration, and
+real-time factor under `eval/results/`.
+
 ## JSON-RPC server
 
 `voice serve` runs a JSON-RPC 2.0 server on stdin/stdout, designed for integration with AI agents and tool-using LLMs.

--- a/eval/__init__.py
+++ b/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Evaluation helpers for voice."""

--- a/eval/compare.sh
+++ b/eval/compare.sh
@@ -3,12 +3,13 @@
 # Usage: ./eval/compare.sh [voice_binary]
 #
 # Transcribes each recording in eval/recordings/ and compares
-# against the expected text, computing word error rate.
+# against the expected text, computing WER/CER and latency metrics.
 
-set -e
+set -euo pipefail
 
 VOICE="${1:-./target/release/voice}"
 RECORDINGS="eval/recordings"
+RESULTS_DIR="eval/results"
 
 if [ ! -d "$RECORDINGS" ]; then
     echo "Error: $RECORDINGS not found. Run record.sh first."
@@ -25,80 +26,14 @@ echo "=== Voice STT Evaluation ==="
 echo "Using: $VOICE"
 echo ""
 
-normalize() {
-    # Lowercase, strip punctuation, collapse whitespace
-    echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9 ]//g' | tr -s ' ' | sed 's/^ //;s/ $//'
-}
-
-word_error_rate() {
-    local expected="$1"
-    local actual="$2"
-
-    # Simple WER: count words that differ
-    local exp_words=($expected)
-    local act_words=($actual)
-    local exp_len=${#exp_words[@]}
-    local act_len=${#act_words[@]}
-    local max_len=$((exp_len > act_len ? exp_len : act_len))
-
-    if [ "$max_len" -eq 0 ]; then
-        echo "0.0"
-        return
-    fi
-
-    local errors=0
-    for i in $(seq 0 $((max_len - 1))); do
-        local e="${exp_words[$i]:-}"
-        local a="${act_words[$i]:-}"
-        if [ "$e" != "$a" ]; then
-            errors=$((errors + 1))
-        fi
-    done
-
-    # WER as percentage
-    echo "scale=1; $errors * 100 / $exp_len" | bc
-}
+mkdir -p "$RESULTS_DIR"
 
 for model in "${MODELS[@]}"; do
-    echo "=== Model: $model ==="
-    total_wer=0
-    count=0
-
-    for txt_file in "$RECORDINGS"/*.txt; do
-        base=$(basename "$txt_file" .txt)
-        wav_file="$RECORDINGS/${base}.wav"
-
-        if [ ! -f "$wav_file" ]; then
-            continue
-        fi
-
-        expected=$(cat "$txt_file")
-        transcript=$(STT_MODEL="$model" "$VOICE" transcribe -q "$wav_file" 2>/dev/null || echo "ERROR")
-
-        exp_norm=$(normalize "$expected")
-        act_norm=$(normalize "$transcript")
-
-        wer=$(word_error_rate "$exp_norm" "$act_norm")
-        total_wer=$(echo "$total_wer + $wer" | bc)
-        count=$((count + 1))
-
-        if [ "$exp_norm" = "$act_norm" ]; then
-            status="PASS"
-        else
-            status="WER=${wer}%"
-        fi
-
-        printf "  %s [%s]\n" "$base" "$status"
-        if [ "$exp_norm" != "$act_norm" ]; then
-            printf "    expected: %s\n" "$exp_norm"
-            printf "    got:      %s\n" "$act_norm"
-        fi
-    done
-
-    if [ "$count" -gt 0 ]; then
-        avg_wer=$(echo "scale=1; $total_wer / $count" | bc)
-        echo ""
-        echo "  Average WER: ${avg_wer}% ($count phrases)"
-    fi
+    safe_model="${model//\//_}"
+    python3 eval/evaluate.py \
+        --recordings "$RECORDINGS" \
+        --voice "$VOICE" \
+        --model "$model" \
+        --json-out "$RESULTS_DIR/${safe_model}.json"
     echo ""
 done

--- a/eval/evaluate.py
+++ b/eval/evaluate.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Evaluate voice STT output with WER/CER, timing, and JSON output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import struct
+import subprocess
+import time
+import wave
+from pathlib import Path
+from typing import Sequence
+
+
+def normalize_text(text: str) -> str:
+    lowered = text.lower()
+    alnum_space = re.sub(r"[^a-z0-9\s]", "", lowered)
+    return " ".join(alnum_space.split())
+
+
+def edit_distance(expected: Sequence[str], actual: Sequence[str]) -> int:
+    if not expected:
+        return len(actual)
+    if not actual:
+        return len(expected)
+
+    previous = list(range(len(actual) + 1))
+    for i, expected_item in enumerate(expected, start=1):
+        current = [i]
+        for j, actual_item in enumerate(actual, start=1):
+            cost = 0 if expected_item == actual_item else 1
+            current.append(
+                min(
+                    previous[j] + 1,
+                    current[j - 1] + 1,
+                    previous[j - 1] + cost,
+                )
+            )
+        previous = current
+    return previous[-1]
+
+
+def _error_rate(errors: int, expected_count: int, actual_count: int) -> float:
+    if expected_count == 0:
+        return 0.0 if actual_count == 0 else float(errors)
+    return errors / expected_count
+
+
+def word_error_rate(expected: str, actual: str) -> float:
+    expected_words = normalize_text(expected).split()
+    actual_words = normalize_text(actual).split()
+    errors = edit_distance(expected_words, actual_words)
+    return _error_rate(errors, len(expected_words), len(actual_words))
+
+
+def char_error_rate(expected: str, actual: str) -> float:
+    expected_chars = list(normalize_text(expected).replace(" ", ""))
+    actual_chars = list(normalize_text(actual).replace(" ", ""))
+    errors = edit_distance(expected_chars, actual_chars)
+    return _error_rate(errors, len(expected_chars), len(actual_chars))
+
+
+def score_pair(expected: str, actual: str) -> dict[str, object]:
+    expected_normalized = normalize_text(expected)
+    actual_normalized = normalize_text(actual)
+    expected_words = expected_normalized.split()
+    actual_words = actual_normalized.split()
+    expected_chars = list(expected_normalized.replace(" ", ""))
+    actual_chars = list(actual_normalized.replace(" ", ""))
+    word_errors = edit_distance(expected_words, actual_words)
+    char_errors = edit_distance(expected_chars, actual_chars)
+
+    return {
+        "expected_normalized": expected_normalized,
+        "actual_normalized": actual_normalized,
+        "exact": expected_normalized == actual_normalized,
+        "word_errors": word_errors,
+        "word_count": len(expected_words),
+        "wer": _error_rate(word_errors, len(expected_words), len(actual_words)),
+        "char_errors": char_errors,
+        "char_count": len(expected_chars),
+        "cer": _error_rate(char_errors, len(expected_chars), len(actual_chars)),
+    }
+
+
+def wav_duration_seconds(path: Path) -> float | None:
+    try:
+        with wave.open(str(path), "rb") as reader:
+            frame_rate = reader.getframerate()
+            if frame_rate == 0:
+                return None
+            return reader.getnframes() / frame_rate
+    except (wave.Error, OSError, EOFError):
+        return riff_wav_duration_seconds(path)
+
+
+def riff_wav_duration_seconds(path: Path) -> float | None:
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return None
+
+    if len(data) < 12 or data[:4] != b"RIFF" or data[8:12] != b"WAVE":
+        return None
+
+    sample_rate = None
+    block_align = None
+    data_size = None
+    offset = 12
+    while offset + 8 <= len(data):
+        chunk_id = data[offset : offset + 4]
+        chunk_size = struct.unpack_from("<I", data, offset + 4)[0]
+        chunk_start = offset + 8
+        chunk_end = min(chunk_start + chunk_size, len(data))
+        chunk = data[chunk_start:chunk_end]
+
+        if chunk_id == b"fmt " and len(chunk) >= 16:
+            _format_tag, _channels, sample_rate, _byte_rate, block_align, _bits = (
+                struct.unpack_from("<HHIIHH", chunk, 0)
+            )
+        elif chunk_id == b"data":
+            data_size = chunk_size
+
+        offset = chunk_start + chunk_size + (chunk_size % 2)
+
+    if not sample_rate or not block_align or data_size is None:
+        return None
+    return (data_size / block_align) / sample_rate
+
+
+def recording_pairs(recordings: Path) -> list[tuple[str, Path, Path]]:
+    pairs = []
+    for text_path in sorted(recordings.glob("*.txt")):
+        wav_path = text_path.with_suffix(".wav")
+        if wav_path.exists():
+            pairs.append((text_path.stem, text_path, wav_path))
+    return pairs
+
+
+def transcribe(voice: str, model: str, wav_path: Path) -> tuple[str, float, str | None]:
+    env = os.environ.copy()
+    env["STT_MODEL"] = model
+    start = time.perf_counter()
+    try:
+        completed = subprocess.run(
+            [voice, "transcribe", "-q", str(wav_path)],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as err:
+        return "", time.perf_counter() - start, str(err)
+
+    elapsed = time.perf_counter() - start
+    transcript = completed.stdout.strip()
+    if completed.returncode != 0:
+        message = completed.stderr.strip() or f"exit status {completed.returncode}"
+        return transcript, elapsed, message
+    return transcript, elapsed, None
+
+
+def evaluate(recordings: Path, voice: str, model: str) -> dict[str, object]:
+    items = []
+    for item_id, text_path, wav_path in recording_pairs(recordings):
+        expected = text_path.read_text(encoding="utf-8").strip()
+        transcript, elapsed_seconds, error = transcribe(voice, model, wav_path)
+        duration_seconds = wav_duration_seconds(wav_path)
+        score = score_pair(expected, transcript)
+        item = {
+            "id": item_id,
+            "text_path": str(text_path),
+            "wav_path": str(wav_path),
+            "expected": expected,
+            "actual": transcript,
+            "elapsed_seconds": elapsed_seconds,
+            "duration_seconds": duration_seconds,
+            **score,
+        }
+        if error is not None:
+            item["error"] = error
+        items.append(item)
+
+    total = len(items)
+    exact = sum(1 for item in items if item["exact"])
+    total_audio_seconds = sum(
+        item["duration_seconds"] or 0.0 for item in items
+    )
+    total_elapsed_seconds = sum(float(item["elapsed_seconds"]) for item in items)
+    mean_wer = (
+        sum(float(item["wer"]) for item in items) / total if total else 0.0
+    )
+    mean_cer = (
+        sum(float(item["cer"]) for item in items) / total if total else 0.0
+    )
+
+    return {
+        "model": model,
+        "voice_binary": voice,
+        "recordings": str(recordings),
+        "total": total,
+        "exact": exact,
+        "mean_wer": mean_wer,
+        "mean_cer": mean_cer,
+        "total_audio_seconds": total_audio_seconds,
+        "total_elapsed_seconds": total_elapsed_seconds,
+        "rtf": (
+            total_elapsed_seconds / total_audio_seconds
+            if total_audio_seconds > 0.0
+            else None
+        ),
+        "items": items,
+    }
+
+
+def print_summary(summary: dict[str, object]) -> None:
+    total = int(summary["total"])
+    exact = int(summary["exact"])
+    mean_wer = float(summary["mean_wer"])
+    mean_cer = float(summary["mean_cer"])
+    rtf = summary["rtf"]
+
+    print(f"=== Model: {summary['model']} ===")
+    for item in summary["items"]:
+        status = "PASS" if item["exact"] else f"WER={float(item['wer']) * 100:.1f}%"
+        print(f"  {item['id']} [{status}]")
+        if not item["exact"]:
+            print(f"    expected: {item['expected_normalized']}")
+            print(f"    got:      {item['actual_normalized']}")
+        if "error" in item:
+            print(f"    error:    {item['error']}")
+
+    rtf_text = "n/a" if rtf is None else f"{float(rtf):.2f}x"
+    print()
+    print(
+        f"  Exact: {exact}/{total}; "
+        f"WER: {mean_wer * 100:.1f}%; "
+        f"CER: {mean_cer * 100:.1f}%; "
+        f"RTF: {rtf_text}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--recordings", required=True, type=Path)
+    parser.add_argument("--voice", default="./target/release/voice")
+    parser.add_argument("--model", default="distil-whisper/distil-medium.en")
+    parser.add_argument("--json-out", type=Path)
+    args = parser.parse_args()
+
+    if not args.recordings.is_dir():
+        parser.error(f"{args.recordings} is not a directory")
+
+    summary = evaluate(args.recordings, args.voice, args.model)
+    print_summary(summary)
+
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eval/phrases.txt
+++ b/eval/phrases.txt
@@ -8,3 +8,15 @@ The API endpoint returns a JSON response with the user's authentication token.
 Can you run the deployment pipeline and check the staging environment?
 Kubernetes pods are restarting because the liveness probe is failing.
 The neural network achieved ninety-seven percent accuracy on the test set.
+Please send this answer to WhatsApp through Hermes.
+The WebRTC stream should use twenty millisecond audio frames.
+The MCP server returned a JSON-RPC error for the missing parameter.
+CPU inference is slower than GPU inference but useful on Linux.
+The TTS daemon should keep running after a bad phoneme chunk.
+STT accuracy depends on clean microphone input and low background noise.
+nteract displayName and useEffect should be pronounced clearly.
+JupyterLab opens notebooks, terminals, and markdown previews.
+KV-cache reuse makes the decoder faster for long transcripts.
+The ASR model ignored two seconds of leading silence.
+Please compare WER and CER before merging the pull request.
+The agent read three files, wrote one patch, and opened a PR.

--- a/eval/synth_eval.sh
+++ b/eval/synth_eval.sh
@@ -5,21 +5,19 @@
 # Generates WAV files from phrases.txt using TTS, then transcribes
 # each with the current STT model and compares against expected text.
 
-set -e
+set -euo pipefail
 
 VOICE="${1:-./target/release/voice}"
 PHRASES="eval/phrases.txt"
 TMPDIR="/tmp/voice_synth_eval"
+RESULTS_DIR="eval/results"
 
 mkdir -p "$TMPDIR"
+mkdir -p "$RESULTS_DIR"
 
 echo "=== Synthetic STT Evaluation ==="
 echo "Using: $VOICE"
 echo ""
-
-normalize() {
-    echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9 ]//g' | tr -s ' ' | sed 's/^ //;s/ $//'
-}
 
 # Models to test
 MODELS=(
@@ -44,37 +42,11 @@ echo "Generated $n audio files."
 echo ""
 
 for model in "${MODELS[@]}"; do
-    echo "=== Model: $model ==="
-    pass=0
-    fail=0
-    start_time=$(date +%s)
-
-    for txt_file in "$TMPDIR"/*.txt; do
-        base=$(basename "$txt_file" .txt)
-        wav_file="$TMPDIR/${base}.wav"
-        [ ! -f "$wav_file" ] && continue
-
-        expected=$(cat "$txt_file")
-        transcript=$(STT_MODEL="$model" "$VOICE" transcribe -q "$wav_file" 2>/dev/null || echo "ERROR")
-
-        exp_norm=$(normalize "$expected")
-        act_norm=$(normalize "$transcript")
-
-        if [ "$exp_norm" = "$act_norm" ]; then
-            printf "  %s PASS\n" "$base"
-            pass=$((pass + 1))
-        else
-            printf "  %s FAIL\n" "$base"
-            printf "    expected: %s\n" "$exp_norm"
-            printf "    got:      %s\n" "$act_norm"
-            fail=$((fail + 1))
-        fi
-    done
-
-    end_time=$(date +%s)
-    elapsed=$((end_time - start_time))
-    total=$((pass + fail))
-    echo ""
-    echo "  Results: $pass/$total passed ($fail failed) in ${elapsed}s"
+    safe_model="${model//\//_}"
+    python3 eval/evaluate.py \
+        --recordings "$TMPDIR" \
+        --voice "$VOICE" \
+        --model "$model" \
+        --json-out "$RESULTS_DIR/synth_${safe_model}.json"
     echo ""
 done

--- a/eval/test_evaluate.py
+++ b/eval/test_evaluate.py
@@ -1,0 +1,77 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from eval.evaluate import (
+    char_error_rate,
+    edit_distance,
+    normalize_text,
+    score_pair,
+    wav_duration_seconds,
+    word_error_rate,
+)
+
+
+class EvaluationMetricTests(unittest.TestCase):
+    def test_normalize_text_lowercases_strips_punctuation_and_collapses_space(self):
+        self.assertEqual(
+            normalize_text("  Hello,   JSON-world!  "),
+            "hello jsonworld",
+        )
+
+    def test_edit_distance_handles_insert_delete_and_substitute(self):
+        self.assertEqual(edit_distance(["a", "b"], ["a", "b", "c"]), 1)
+        self.assertEqual(edit_distance(["a", "b", "c"], ["a", "c"]), 1)
+        self.assertEqual(edit_distance(["a", "b", "c"], ["a", "x", "c"]), 1)
+
+    def test_word_error_rate_uses_levenshtein_not_position_mismatch(self):
+        self.assertEqual(word_error_rate("alpha beta gamma", "alpha gamma"), 1 / 3)
+
+    def test_score_pair_exact_match_has_zero_error_rates(self):
+        score = score_pair("Hello, world!", "hello world")
+        self.assertTrue(score["exact"])
+        self.assertEqual(score["wer"], 0.0)
+        self.assertEqual(score["cer"], 0.0)
+
+    def test_empty_expected_and_actual_are_zero_error(self):
+        self.assertEqual(word_error_rate("", ""), 0.0)
+        self.assertEqual(char_error_rate("", ""), 0.0)
+
+    def test_empty_expected_with_actual_counts_insertions(self):
+        self.assertEqual(word_error_rate("", "extra words"), 2.0)
+        self.assertEqual(char_error_rate("", "abc"), 3.0)
+
+    def test_wav_duration_supports_extensible_float_fixture_shape(self):
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "extensible.wav"
+            sample_rate = 24_000
+            channels = 1
+            bytes_per_sample = 4
+            frames = 48_000
+            block_align = channels * bytes_per_sample
+            data_size = frames * block_align
+            byte_rate = sample_rate * block_align
+            fmt = (
+                b"fmt "
+                + (40).to_bytes(4, "little")
+                + (0xFFFE).to_bytes(2, "little")
+                + channels.to_bytes(2, "little")
+                + sample_rate.to_bytes(4, "little")
+                + byte_rate.to_bytes(4, "little")
+                + block_align.to_bytes(2, "little")
+                + (32).to_bytes(2, "little")
+                + (22).to_bytes(2, "little")
+                + (32).to_bytes(2, "little")
+                + (1).to_bytes(4, "little")
+                + (3).to_bytes(2, "little")
+                + b"\x00\x00\x00\x00\x10\x00\x80\x00\x00\xaa\x00\x38\x9b\x71"
+            )
+            data = b"data" + data_size.to_bytes(4, "little") + (b"\x00" * data_size)
+            riff_size = 4 + len(fmt) + len(data)
+            path.write_bytes(b"RIFF" + riff_size.to_bytes(4, "little") + b"WAVE" + fmt + data)
+
+            self.assertEqual(wav_duration_seconds(path), 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a stdlib Python evaluator that computes Levenshtein WER/CER, exact matches, elapsed time, audio duration, RTF, and JSON output
- route recorded and synthetic eval shell scripts through the same evaluator
- expand eval phrases and document optional local eval usage

## Tests
- `python3 -m unittest eval.test_evaluate`
- `python3 eval/evaluate.py --help`
- `bash -n eval/compare.sh eval/synth_eval.sh eval/record.sh`
- `./eval/compare.sh /bin/echo` plus JSON validation for generated ignored results
- `python3 -m py_compile eval/evaluate.py eval/test_evaluate.py`
- `cargo fmt --check`
- `cargo test -p voice-stt`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace --exclude voice-kokoro`

Note: full `cargo test --workspace` on this Linux host still reaches the pre-existing `voice-kokoro` Metal integration test that requires Candle Metal support.