### PR TITLE
Add deterministic TTS synthesis mode

### DIFF
--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -145,6 +145,10 @@ struct SayArgs {
     #[arg(short, long, default_value = "1.0")]
     speed: f32,
 
+    /// Use deterministic synthesis for reproducible evaluation output
+    #[arg(long)]
+    deterministic: bool,
+
     /// Strip markdown/MDX formatting before speaking
     #[arg(long)]
     markdown: bool,
@@ -756,6 +760,7 @@ fn main() {
                     voice: "af_heart".to_string(),
                     output: None,
                     speed: 1.0,
+                    deterministic: false,
                     markdown: false,
                     subs: Vec::new(),
                     sub_file: None,
@@ -1047,7 +1052,9 @@ fn run_say(say_args: SayArgs) {
     // If the daemon is running, delegate normal playback and file synthesis to it.
     // `--phonemes` stays local because the daemon RPC accepts text and runs its
     // own G2P pipeline.
-    if say_args.phonemes.is_none() {
+    // `--deterministic` stays local because the daemon protocol does not expose
+    // synthesis-mode selection yet.
+    if say_args.phonemes.is_none() && !say_args.deterministic {
         if let Some(mut daemon) = voice_protocol::client::DaemonClient::connect() {
             let text = match resolve_text(&say_args) {
                 Ok(t) => t,
@@ -1154,6 +1161,11 @@ fn run_say(say_args: SayArgs) {
 
     let mut model = load_tts_model(model_handle);
     let sample_rate = model.sample_rate;
+    let synthesis_mode = if say_args.deterministic {
+        voice_tts::SynthesisMode::Deterministic
+    } else {
+        voice_tts::SynthesisMode::Stochastic
+    };
 
     // Load voice (fast for builtins — embedded in binary, ~5ms).
     // Must happen after model is loaded so we can share its Metal device.
@@ -1174,6 +1186,7 @@ fn run_say(say_args: SayArgs) {
             &phoneme_chunks,
             say_args.speed,
             sample_rate,
+            synthesis_mode,
             output_path,
         );
     } else {
@@ -1183,6 +1196,7 @@ fn run_say(say_args: SayArgs) {
             &phoneme_chunks,
             say_args.speed,
             sample_rate,
+            synthesis_mode,
         );
     }
 }
@@ -1395,7 +1409,14 @@ fn run_converse(args: ConverseArgs) {
     // Start loading STT model in background while TTS plays
     let stt_handle = std::thread::spawn(listen::load_stt);
 
-    stream_playback(&mut model, &voice, &phoneme_chunks, args.speed, sample_rate);
+    stream_playback(
+        &mut model,
+        &voice,
+        &phoneme_chunks,
+        args.speed,
+        sample_rate,
+        voice_tts::SynthesisMode::Stochastic,
+    );
 
     if interrupted() {
         std::process::exit(130);
@@ -1445,6 +1466,7 @@ fn generate_to_file(
     chunks: &[String],
     speed: f32,
     sample_rate: u32,
+    synthesis_mode: voice_tts::SynthesisMode,
     output_path: &PathBuf,
 ) {
     info!("Generating audio...");
@@ -1460,7 +1482,7 @@ fn generate_to_file(
         if chunks.len() > 1 {
             info!("  generating chunk {}/{}...", i + 1, chunks.len());
         }
-        match voice_tts::generate(model, phonemes, voice, speed) {
+        match voice_tts::generate_with_mode(model, phonemes, voice, speed, synthesis_mode) {
             Ok(audio) => {
                 all_samples.extend_from_slice(&audio);
             }
@@ -1500,6 +1522,7 @@ fn stream_playback(
     chunks: &[String],
     speed: f32,
     sample_rate: u32,
+    synthesis_mode: voice_tts::SynthesisMode,
 ) {
     use rodio::{buffer::SamplesBuffer, DeviceSinkBuilder, Player};
     use std::num::NonZero;
@@ -1521,7 +1544,7 @@ fn stream_playback(
         if chunks.len() > 1 {
             info!("  generating chunk {}/{}...", i + 1, chunks.len());
         }
-        match voice_tts::generate(model, phonemes, voice, speed) {
+        match voice_tts::generate_with_mode(model, phonemes, voice, speed, synthesis_mode) {
             Ok(audio) => {
                 let source = SamplesBuffer::new(channels, rate, audio);
                 player.append(source);

--- a/crates/voice-kokoro/src/istftnet.rs
+++ b/crates/voice-kokoro/src/istftnet.rs
@@ -2,12 +2,50 @@
 //!
 //! Ported from kokoro/istftnet.py
 
-use candle_core::{DType, Device, Module, Result, Tensor};
+use candle_core::{DType, Device, Module, Result, Shape, Tensor};
 use candle_nn::{self as nn, VarBuilder};
 
 use crate::modules::{
     load_weight_norm_conv1d, load_weight_norm_conv_transpose1d, AdaIN1d, AdainResBlk1d,
 };
+
+/// Controls the small stochastic sources used by the iSTFT decoder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SynthesisMode {
+    /// Match the original Kokoro decoder with random harmonic phase and noise.
+    #[default]
+    Stochastic,
+    /// Replace decoder random phase and noise with zeros for reproducible output.
+    Deterministic,
+}
+
+fn rand_or_zero<S: Into<Shape>>(
+    mode: SynthesisMode,
+    lo: f32,
+    up: f32,
+    shape: S,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor> {
+    match mode {
+        SynthesisMode::Stochastic => Tensor::rand(lo, up, shape, device)?.to_dtype(dtype),
+        SynthesisMode::Deterministic => Tensor::zeros(shape, dtype, device),
+    }
+}
+
+fn randn_or_zero<S: Into<Shape>>(
+    mode: SynthesisMode,
+    mean: f32,
+    std: f32,
+    shape: S,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor> {
+    match mode {
+        SynthesisMode::Stochastic => Tensor::randn(mean, std, shape, device)?.to_dtype(dtype),
+        SynthesisMode::Deterministic => Tensor::zeros(shape, dtype, device),
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Snake activation: x + (1/alpha) * sin(alpha * x)^2
@@ -152,7 +190,12 @@ impl SineGen {
 
     /// f0: [B, T, 1]
     /// Returns: (sine_waves: [B, T, dim], uv: [B, T, 1])
-    fn forward(&self, f0: &Tensor, device: &Device) -> Result<(Tensor, Tensor)> {
+    fn forward_with_mode(
+        &self,
+        f0: &Tensor,
+        device: &Device,
+        mode: SynthesisMode,
+    ) -> Result<(Tensor, Tensor)> {
         let (b, t, _) = f0.dims3()?;
         let dim = self.harmonic_num + 1;
 
@@ -174,7 +217,7 @@ impl SineGen {
         // Fix 2: Add initial random phase for non-fundamental harmonics
         // Python: rand_ini = torch.rand(B, dim); rand_ini[:, 0] = 0
         //         rad_values[:, 0, :] += rand_ini
-        let rand_ini = Tensor::rand(0f32, 1f32, &[b, dim], device)?.to_dtype(f0.dtype())?;
+        let rand_ini = rand_or_zero(mode, 0f32, 1f32, &[b, dim], device, f0.dtype())?;
         // Zero out fundamental (column 0)
         let mask_data: Vec<f32> = (0..dim).map(|i| if i == 0 { 0.0 } else { 1.0 }).collect();
         let mask = Tensor::new(&mask_data[..], device)?
@@ -229,7 +272,7 @@ impl SineGen {
 
         // Noise for unvoiced regions
         let noise_amp = ((&uv * self.noise_std)? + ((1.0 - &uv)? * (self.sine_amp / 3.0))?)?;
-        let noise = Tensor::randn(0f32, 1f32, sines.shape(), device)?.to_dtype(sines.dtype())?;
+        let noise = randn_or_zero(mode, 0f32, 1f32, sines.shape(), device, sines.dtype())?;
         let noise = noise.broadcast_mul(&noise_amp)?;
 
         // Final: sine * uv + noise
@@ -276,15 +319,25 @@ impl SourceModuleHnNSF {
     /// x: [B, T, 1] (F0 values)
     /// Returns: (sine_merge: [B, T, 1], noise: [B, T, 1], uv: [B, T, 1])
     pub fn forward(&self, x: &Tensor) -> Result<(Tensor, Tensor, Tensor)> {
+        self.forward_with_mode(x, SynthesisMode::Stochastic)
+    }
+
+    /// x: [B, T, 1] (F0 values)
+    /// Returns: (sine_merge: [B, T, 1], noise: [B, T, 1], uv: [B, T, 1])
+    pub fn forward_with_mode(
+        &self,
+        x: &Tensor,
+        mode: SynthesisMode,
+    ) -> Result<(Tensor, Tensor, Tensor)> {
         let device = x.device();
-        let (sine_wavs, uv) = self.sine_gen.forward(x, device)?;
+        let (sine_wavs, uv) = self.sine_gen.forward_with_mode(x, device, mode)?;
 
         // Linear merge of harmonics -> single channel
         let sine_merge = self.l_linear.forward(&sine_wavs)?;
         let sine_merge = sine_merge.tanh()?;
 
         // Noise source
-        let noise = Tensor::randn(0f32, 1f32, uv.shape(), device)?.to_dtype(x.dtype())?;
+        let noise = randn_or_zero(mode, 0f32, 1f32, uv.shape(), device, x.dtype())?;
         let noise = (noise * (self.sine_amp / 3.0))?;
 
         Ok((sine_merge, noise, uv))
@@ -640,12 +693,23 @@ impl Generator {
 
     /// x: [B, C, T], s: [B, style_dim], f0: [B, T_f0]
     pub fn forward(&self, x: &Tensor, s: &Tensor, f0: &Tensor) -> Result<Tensor> {
+        self.forward_with_mode(x, s, f0, SynthesisMode::Stochastic)
+    }
+
+    /// x: [B, C, T], s: [B, style_dim], f0: [B, T_f0]
+    pub fn forward_with_mode(
+        &self,
+        x: &Tensor,
+        s: &Tensor,
+        f0: &Tensor,
+        mode: SynthesisMode,
+    ) -> Result<Tensor> {
         // Upsample F0 to full resolution
         let f0_up = upsample_nearest_1d_single(f0, self.upsample_scale)?; // [B, T_full]
         let f0_3d = f0_up.unsqueeze(2)?; // [B, T_full, 1]
 
         // Generate harmonic source
-        let (har_source, _noise_source, _uv) = self.m_source.forward(&f0_3d)?;
+        let (har_source, _noise_source, _uv) = self.m_source.forward_with_mode(&f0_3d, mode)?;
 
         // har_source: [B, T_full, 1] -> [B, 1, T_full] -> [B, T_full]
         let har_source = har_source.transpose(1, 2)?.contiguous()?;
@@ -823,6 +887,18 @@ impl Decoder {
         n: &Tensor,
         s: &Tensor,
     ) -> Result<Tensor> {
+        self.forward_with_mode(asr, f0_curve, n, s, SynthesisMode::Stochastic)
+    }
+
+    /// asr: [B, C, T], f0_curve: [B, T], n: [B, T], s: [B, style_dim]
+    pub fn forward_with_mode(
+        &self,
+        asr: &Tensor,
+        f0_curve: &Tensor,
+        n: &Tensor,
+        s: &Tensor,
+        mode: SynthesisMode,
+    ) -> Result<Tensor> {
         // F0 and N convolutions: [B, T] -> [B, 1, T] -> conv -> [B, 1, T/2]
         let f0 = self.f0_conv.forward(&f0_curve.unsqueeze(1)?)?;
         let n_out = self.n_conv.forward(&n.unsqueeze(1)?)?;
@@ -845,7 +921,7 @@ impl Decoder {
             }
         }
 
-        self.generator.forward(&x, s, f0_curve)
+        self.generator.forward_with_mode(&x, s, f0_curve, mode)
     }
 }
 
@@ -1015,4 +1091,66 @@ fn gpu_linear_upsample(
     let one_minus_frac = (1.0f64 - &frac_t)?;
     let result = (x_lo.broadcast_mul(&one_minus_frac)? + x_hi.broadcast_mul(&frac_t)?)?;
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{rand_or_zero, randn_or_zero, SynthesisMode};
+    use candle_core::{DType, Device, Result};
+
+    #[test]
+    fn deterministic_uniform_source_returns_zeros() -> Result<()> {
+        let tensor = rand_or_zero(
+            SynthesisMode::Deterministic,
+            0.0,
+            1.0,
+            (2, 3),
+            &Device::Cpu,
+            DType::F32,
+        )?;
+
+        assert_eq!(tensor.dims(), &[2, 3]);
+        assert_eq!(tensor.to_vec2::<f32>()?, vec![vec![0.0; 3], vec![0.0; 3]]);
+        Ok(())
+    }
+
+    #[test]
+    fn deterministic_normal_source_returns_zeros() -> Result<()> {
+        let tensor = randn_or_zero(
+            SynthesisMode::Deterministic,
+            0.0,
+            1.0,
+            (2, 3),
+            &Device::Cpu,
+            DType::F32,
+        )?;
+
+        assert_eq!(tensor.dims(), &[2, 3]);
+        assert_eq!(tensor.to_vec2::<f32>()?, vec![vec![0.0; 3], vec![0.0; 3]]);
+        Ok(())
+    }
+
+    #[test]
+    fn stochastic_sources_keep_requested_shape() -> Result<()> {
+        let uniform = rand_or_zero(
+            SynthesisMode::Stochastic,
+            0.0,
+            1.0,
+            (2, 3),
+            &Device::Cpu,
+            DType::F32,
+        )?;
+        let normal = randn_or_zero(
+            SynthesisMode::Stochastic,
+            0.0,
+            1.0,
+            (2, 3),
+            &Device::Cpu,
+            DType::F32,
+        )?;
+
+        assert_eq!(uniform.dims(), &[2, 3]);
+        assert_eq!(normal.dims(), &[2, 3]);
+        Ok(())
+    }
 }

--- a/crates/voice-kokoro/src/lib.rs
+++ b/crates/voice-kokoro/src/lib.rs
@@ -8,4 +8,5 @@ pub mod model;
 pub mod modules;
 
 pub use config::ModelConfig;
+pub use istftnet::SynthesisMode;
 pub use model::KModel;

--- a/crates/voice-kokoro/src/model.rs
+++ b/crates/voice-kokoro/src/model.rs
@@ -7,7 +7,7 @@ use candle_nn::{self as nn, VarBuilder};
 
 use crate::albert::CustomAlbert;
 use crate::config::ModelConfig;
-use crate::istftnet::Decoder;
+use crate::istftnet::{Decoder, SynthesisMode};
 use crate::modules::{ProsodyPredictor, TextEncoder};
 
 /// The top-level Kokoro-82M model.
@@ -85,6 +85,21 @@ impl KModel {
         ref_s: &Tensor,
         speed: f32,
         device: &Device,
+    ) -> Result<Tensor> {
+        self.forward_with_mode(input_ids, ref_s, speed, device, SynthesisMode::Stochastic)
+    }
+
+    /// Run inference with explicit synthesis-mode control.
+    ///
+    /// Deterministic mode removes the decoder's random harmonic phase and noise
+    /// sources, making output reproducible on CPU and GPU backends.
+    pub fn forward_with_mode(
+        &self,
+        input_ids: &[i64],
+        ref_s: &Tensor,
+        speed: f32,
+        device: &Device,
+        mode: SynthesisMode,
     ) -> Result<Tensor> {
         // Pad with BOS=0 and EOS=0
         let mut padded = Vec::with_capacity(input_ids.len() + 2);
@@ -220,7 +235,9 @@ impl KModel {
 
         // Decoder
         let s_acoustic = ref_s.narrow(1, 0, 128)?; // [1, 128]
-        let audio = self.decoder.forward(&asr, &f0_pred, &n_pred, &s_acoustic)?;
+        let audio = self
+            .decoder
+            .forward_with_mode(&asr, &f0_pred, &n_pred, &s_acoustic, mode)?;
 
         // audio: [1, 1, samples] -> [samples]
         audio.squeeze(0)?.squeeze(0)

--- a/crates/voice-tts/src/lib.rs
+++ b/crates/voice-tts/src/lib.rs
@@ -9,6 +9,7 @@ use candle_nn::VarBuilder;
 use hf_hub::api::sync::Api;
 
 pub use error::{Result, VoicersError};
+pub use voice_kokoro::SynthesisMode;
 
 const DEFAULT_REPO: &str = "prince-canuma/Kokoro-82M";
 
@@ -167,6 +168,20 @@ pub fn generate(
     voice: &Tensor,
     speed: f32,
 ) -> Result<Vec<f32>> {
+    generate_with_mode(model, phonemes, voice, speed, SynthesisMode::Stochastic)
+}
+
+/// Generate audio from phonemes with explicit synthesis-mode control.
+///
+/// Deterministic mode removes the Kokoro decoder's random phase and noise
+/// sources so repeated calls can produce byte-stable evaluation audio.
+pub fn generate_with_mode(
+    model: &mut KokoroModel,
+    phonemes: &str,
+    voice: &Tensor,
+    speed: f32,
+    mode: SynthesisMode,
+) -> Result<Vec<f32>> {
     let vocab = &model.config.vocab;
 
     // Convert phonemes to token IDs (character by character)
@@ -200,7 +215,7 @@ pub fn generate(
 
     let audio = model
         .model
-        .forward(&input_ids, &ref_s, speed, &model.device)
+        .forward_with_mode(&input_ids, &ref_s, speed, &model.device, mode)
         .map_err(|e| VoicersError::Model(e.to_string()))?;
 
     let samples = audio


### PR DESCRIPTION
## Summary
- add public Kokoro `SynthesisMode` and `forward_with_mode` paths through `voice-kokoro`
- expose `voice_tts::generate_with_mode` while keeping existing `generate` stochastic by default
- add `voice say --deterministic` for reproducible local WAV/playback synthesis, bypassing daemon delegation when selected
- cover deterministic iSTFT source helpers with unit tests

## Verification
- `cargo fmt --check`
- `cargo test -p voice-kokoro --lib`
- `cargo run -p voice --bin voice -- say --help`
- `cargo clippy --workspace -- -D warnings`
- `cargo test -p voice-tts`
- `cargo test --workspace --exclude voice-kokoro`
- `target/debug/voice say --deterministic -q -o /tmp/voice-deterministic-1.wav "Deterministic synthesis smoke test."`
- `target/debug/voice say --deterministic -q -o /tmp/voice-deterministic-2.wav "Deterministic synthesis smoke test."`
- `sha256sum /tmp/voice-deterministic-1.wav /tmp/voice-deterministic-2.wav` -> both `b5f842881e737d4f1d32c3cd76dd70bd47d01940f50ce9d4f58e97459993b94b`

## Known local caveat
- `cargo test --workspace` still fails on this Linux host in the pre-existing `voice-kokoro` `stft_roundtrip` integration test because it unconditionally creates a Metal device: `the candle crate has not been built with metal support`.