### PR TITLE
Roll up voice daemon, eval, and deterministic TTS fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,22 +17,11 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      # Homebrew's llvm@15 clang lacks __bf16 support, which breaks
-      # mlx-sys bindgen. Point bindgen to Xcode's clang instead.
-      - name: Fix clang for bindgen
-        run: |
-          brew unlink llvm@15 2>/dev/null || true
-          TOOLCHAIN=$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain
-          echo "LIBCLANG_PATH=${TOOLCHAIN}/usr/lib" >> "$GITHUB_ENV"
-          SDK_PATH=$(xcrun --show-sdk-path)
-          echo "BINDGEN_EXTRA_CLANG_ARGS=-isysroot ${SDK_PATH}" >> "$GITHUB_ENV"
-
       - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            ~/.mlx
             target
           key: ${{ runner.os }}-${{ github.repository }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      # Homebrew's llvm@15 clang lacks __bf16 support, which breaks
-      # mlx-sys bindgen. Point bindgen to Xcode's clang instead.
-      - name: Fix clang for bindgen
-        run: |
-          brew unlink llvm@15 2>/dev/null || true
-          TOOLCHAIN=$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain
-          echo "LIBCLANG_PATH=${TOOLCHAIN}/usr/lib" >> "$GITHUB_ENV"
-          SDK_PATH=$(xcrun --show-sdk-path)
-          echo "BINDGEN_EXTRA_CLANG_ARGS=-isysroot ${SDK_PATH}" >> "$GITHUB_ENV"
-
       - name: Build release
         run: cargo build --release -p voice
 
@@ -39,15 +29,6 @@ jobs:
           cp target/release/voice dist/
           cd dist && tar czf voice-aarch64-apple-darwin.tar.gz voice && cd ..
 
-          # Metallib — needed at runtime for MLX Metal kernels
-          METALLIB=$(find target/release/build -name "mlx.metallib" -print -quit)
-          if [ -n "$METALLIB" ]; then
-            cp "$METALLIB" dist/mlx.metallib
-          else
-            echo "::error::mlx.metallib not found in build output"
-            exit 1
-          fi
-
       - name: Sign release assets
         if: env.MINISIGN_KEY != ''
         env:
@@ -56,7 +37,6 @@ jobs:
           brew install minisign
           echo "$MINISIGN_KEY" > /tmp/signing.key
           minisign -S -W -s /tmp/signing.key -x dist/voice-aarch64-apple-darwin.tar.gz.sig -m dist/voice-aarch64-apple-darwin.tar.gz
-          minisign -S -W -s /tmp/signing.key -x dist/mlx.metallib.sig -m dist/mlx.metallib
           rm -f /tmp/signing.key
 
       - name: Create release
@@ -65,8 +45,6 @@ jobs:
           files: |
             dist/voice-aarch64-apple-darwin.tar.gz
             dist/voice-aarch64-apple-darwin.tar.gz.sig
-            dist/mlx.metallib
-            dist/mlx.metallib.sig
           generate_release_notes: true
           prerelease: ${{ contains(github.ref, '-rc.') || contains(github.ref, '-alpha.') || contains(github.ref, '-beta.') }}
           fail_on_unmatched_files: false
@@ -82,7 +60,7 @@ jobs:
 
       # Publish workspace crates in dependency order.
       # `--no-verify` skips the build step — we already verified in the build job,
-      # and these crates require macOS + Metal to compile.
+      # and the publish job should only package the already-checked sources.
       # Each publish is allowed to fail with "already exists" so we don't break
       # when only a subset of crates have version bumps.
       - name: Publish to crates.io
@@ -110,16 +88,16 @@ jobs:
             sleep 15
           }
 
-          # Leaf crates (no workspace deps)
-          publish voice-dsp
+          # Leaf crates and shared foundations
+          publish voice-stream
+          publish voice-protocol
           publish voice-g2p
+          publish voice-kokoro
+          publish voice-whisper
+
+          # Model-facing libraries
+          publish voice-tts
           publish voice-stt
 
-          # voice-nn depends on voice-dsp
-          publish voice-nn
-
-          # voice-tts depends on voice-dsp, voice-nn
-          publish voice-tts
-
-          # voice (CLI) depends on voice-tts, voice-g2p, voice-stt
+          # voice (CLI) depends on the libraries above
           publish voice

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 output.wav
 .context/
 .worktrees/
+eval/results/

--- a/README.md
+++ b/README.md
@@ -214,9 +214,9 @@ cargo build --release -p voice
 ```
 
 `compare.sh` scores recordings from `eval/recordings/`. `synth_eval.sh`
-generates temporary TTS audio from `eval/phrases.txt` first. Both write JSON
-results with WER, CER, exact-match counts, elapsed time, audio duration, and
-real-time factor under `eval/results/`.
+generates deterministic temporary TTS audio from `eval/phrases.txt` first. Both
+write JSON results with WER, CER, exact-match counts, elapsed time, audio
+duration, and real-time factor under `eval/results/`.
 
 ## JSON-RPC server
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,22 @@ Performance is ~50× real-time on Apple Silicon (a 10-second recording transcrib
 STT_MODEL=distil-whisper/distil-medium.en voice listen
 ```
 
+## Evaluation
+
+The `eval/` scripts provide optional local STT/TTS evaluation. They may
+download model weights and are not part of normal CI.
+
+```bash
+cargo build --release -p voice
+./eval/compare.sh ./target/release/voice
+./eval/synth_eval.sh ./target/release/voice
+```
+
+`compare.sh` scores recordings from `eval/recordings/`. `synth_eval.sh`
+generates temporary TTS audio from `eval/phrases.txt` first. Both write JSON
+results with WER, CER, exact-match counts, elapsed time, audio duration, and
+real-time factor under `eval/results/`.
+
 ## JSON-RPC server
 
 `voice serve` runs a JSON-RPC 2.0 server on stdin/stdout, designed for integration with AI agents and tool-using LLMs.

--- a/crates/voice-cli/README.md
+++ b/crates/voice-cli/README.md
@@ -1,6 +1,6 @@
 # voice
 
-Like `say`, but with [Kokoro](https://huggingface.co/prince-canuma/Kokoro-82M) TTS and [Moonshine](https://huggingface.co/UsefulSensors/moonshine-tiny) STT. A command-line speech tool for macOS, powered by MLX on Apple Silicon.
+Like `say`, but with [Kokoro](https://huggingface.co/prince-canuma/Kokoro-82M) TTS and [Whisper](https://huggingface.co/distil-whisper/distil-large-v3) STT. A command-line speech tool powered by Candle, with Metal acceleration on Apple Silicon and CPU fallback on Linux.
 
 ## Install
 
@@ -31,7 +31,7 @@ cd voice
 cargo install --path crates/voice-cli
 ```
 
-> **Note:** `cargo install voice` compiles from source on crates.io, but the Metal shader library path can break — see the [main README](../../README.md) for details. Use `cargo binstall voice` or build from a local clone instead.
+> **Note:** `cargo install voice` compiles from source on crates.io. Use `cargo binstall voice` for the pre-built binary, or build from a local clone when working on the repo.
 
 ## Usage
 

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -29,6 +29,7 @@ use std::time::Instant;
 
 use rodio::microphone::MicrophoneBuilder;
 use rodio::{buffer::SamplesBuffer, DeviceSinkBuilder, Player};
+use voice_stream::InterleavedMonoMixer;
 
 use crate::{INTERRUPTED, QUIET};
 
@@ -499,7 +500,7 @@ fn start_mic_drain(
     channels: u16,
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
-        let ch = channels.max(1) as usize;
+        let mut mixer = InterleavedMonoMixer::new(channels as usize);
         let mut chunk_peak: f32 = 0.0;
         let mut sample_count = 0usize;
 
@@ -512,13 +513,8 @@ fn start_mic_drain(
             chunk_peak = chunk_peak.max(abs);
             sample_count += 1;
 
-            // For multi-channel, mix to mono by averaging
-            if ch == 1 {
-                buffer.lock().unwrap().push(sample);
-            } else if sample_count % ch == 0 {
-                // We get interleaved samples — just take every ch-th sample
-                // (rodio's SampleTypeConverter already converts to f32)
-                buffer.lock().unwrap().push(sample);
+            if let Some(mono) = mixer.push(sample) {
+                buffer.lock().unwrap().push(mono);
             }
 
             // Update peak every ~100 samples to avoid atomic contention

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -1010,10 +1010,10 @@ pub fn record_continuous(
 /// Consume segments from the recording queue and transcribe each one.
 ///
 /// Spawns a thread that pulls segments, trims silence, resamples, and
-/// runs Moonshine inference. Results are sent to the returned receiver.
+/// runs Whisper inference. Results are sent to the returned receiver.
 ///
-/// The model and tokenizer are moved into this thread — they're not
-/// thread-safe, so single-threaded access is correct.
+/// The model is moved into this thread because single-threaded access is
+/// required by the decoder state.
 pub fn transcribe_segments(
     mut model: voice_stt::WhisperModel,
     segments: mpsc::Receiver<Segment>,
@@ -1142,7 +1142,7 @@ pub fn listen_continuous_for_rpc(
 /// Trim leading and trailing silence from audio samples.
 ///
 /// Bluetooth microphones (e.g. AirPods) can take ~0.5-1s before audio
-/// actually flows, producing a block of zeros at the start. Moonshine
+/// actually flows, producing a block of zeros at the start. Whisper
 /// is sensitive to the silence-to-speech ratio, especially on short
 /// recordings — trimming silence dramatically improves accuracy.
 fn trim_silence(samples: &[f32], sample_rate: u32) -> Vec<f32> {

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -145,6 +145,10 @@ struct SayArgs {
     #[arg(short, long, default_value = "1.0")]
     speed: f32,
 
+    /// Use deterministic synthesis for reproducible evaluation output
+    #[arg(long)]
+    deterministic: bool,
+
     /// Strip markdown/MDX formatting before speaking
     #[arg(long)]
     markdown: bool,
@@ -756,6 +760,7 @@ fn main() {
                     voice: "af_heart".to_string(),
                     output: None,
                     speed: 1.0,
+                    deterministic: false,
                     markdown: false,
                     subs: Vec::new(),
                     sub_file: None,
@@ -1047,7 +1052,9 @@ fn run_say(say_args: SayArgs) {
     // If the daemon is running, delegate normal playback and file synthesis to it.
     // `--phonemes` stays local because the daemon RPC accepts text and runs its
     // own G2P pipeline.
-    if say_args.phonemes.is_none() {
+    // `--deterministic` stays local because the daemon protocol does not expose
+    // synthesis-mode selection yet.
+    if say_args.phonemes.is_none() && !say_args.deterministic {
         if let Some(mut daemon) = voice_protocol::client::DaemonClient::connect() {
             let text = match resolve_text(&say_args) {
                 Ok(t) => t,
@@ -1154,6 +1161,11 @@ fn run_say(say_args: SayArgs) {
 
     let mut model = load_tts_model(model_handle);
     let sample_rate = model.sample_rate;
+    let synthesis_mode = if say_args.deterministic {
+        voice_tts::SynthesisMode::Deterministic
+    } else {
+        voice_tts::SynthesisMode::Stochastic
+    };
 
     // Load voice (fast for builtins — embedded in binary, ~5ms).
     // Must happen after model is loaded so we can share its Metal device.
@@ -1174,6 +1186,7 @@ fn run_say(say_args: SayArgs) {
             &phoneme_chunks,
             say_args.speed,
             sample_rate,
+            synthesis_mode,
             output_path,
         );
     } else {
@@ -1183,6 +1196,7 @@ fn run_say(say_args: SayArgs) {
             &phoneme_chunks,
             say_args.speed,
             sample_rate,
+            synthesis_mode,
         );
     }
 }
@@ -1395,7 +1409,14 @@ fn run_converse(args: ConverseArgs) {
     // Start loading STT model in background while TTS plays
     let stt_handle = std::thread::spawn(listen::load_stt);
 
-    stream_playback(&mut model, &voice, &phoneme_chunks, args.speed, sample_rate);
+    stream_playback(
+        &mut model,
+        &voice,
+        &phoneme_chunks,
+        args.speed,
+        sample_rate,
+        voice_tts::SynthesisMode::Stochastic,
+    );
 
     if interrupted() {
         std::process::exit(130);
@@ -1445,6 +1466,7 @@ fn generate_to_file(
     chunks: &[String],
     speed: f32,
     sample_rate: u32,
+    synthesis_mode: voice_tts::SynthesisMode,
     output_path: &PathBuf,
 ) {
     info!("Generating audio...");
@@ -1460,7 +1482,7 @@ fn generate_to_file(
         if chunks.len() > 1 {
             info!("  generating chunk {}/{}...", i + 1, chunks.len());
         }
-        match voice_tts::generate(model, phonemes, voice, speed) {
+        match voice_tts::generate_with_mode(model, phonemes, voice, speed, synthesis_mode) {
             Ok(audio) => {
                 all_samples.extend_from_slice(&audio);
             }
@@ -1500,6 +1522,7 @@ fn stream_playback(
     chunks: &[String],
     speed: f32,
     sample_rate: u32,
+    synthesis_mode: voice_tts::SynthesisMode,
 ) {
     use rodio::{buffer::SamplesBuffer, DeviceSinkBuilder, Player};
     use std::num::NonZero;
@@ -1521,7 +1544,7 @@ fn stream_playback(
         if chunks.len() > 1 {
             info!("  generating chunk {}/{}...", i + 1, chunks.len());
         }
-        match voice_tts::generate(model, phonemes, voice, speed) {
+        match voice_tts::generate_with_mode(model, phonemes, voice, speed, synthesis_mode) {
             Ok(audio) => {
                 let source = SamplesBuffer::new(channels, rate, audio);
                 player.append(source);

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -13,7 +13,8 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use voice_stream::{
-    resample_linear, AudioEncoding, Packetizer, StreamEnded, StreamMetadata, TtsStreamEvent,
+    resample_linear, AudioEncoding, InterleavedMonoMixer, Packetizer, StreamEnded, StreamMetadata,
+    TtsStreamEvent,
 };
 use voice_tts::KokoroModel;
 
@@ -754,7 +755,7 @@ fn listen(
     let peak_clone = recent_peak.clone();
     let stop_clone = stop.clone();
     let mic_thread = std::thread::spawn(move || {
-        let ch = channels.max(1) as usize;
+        let mut mixer = InterleavedMonoMixer::new(channels as usize);
         let mut chunk_peak: f32 = 0.0;
         let mut sample_count = 0usize;
 
@@ -767,9 +768,8 @@ fn listen(
             chunk_peak = chunk_peak.max(abs);
             sample_count += 1;
 
-            // Multi-channel: take every ch-th sample (mono mix)
-            if ch == 1 || sample_count % ch == 0 {
-                buf_clone.lock().unwrap().push(sample);
+            if let Some(mono) = mixer.push(sample) {
+                buf_clone.lock().unwrap().push(mono);
             }
 
             // Publish peak every ~100 samples, then reset

--- a/crates/voice-kokoro/src/istftnet.rs
+++ b/crates/voice-kokoro/src/istftnet.rs
@@ -2,12 +2,50 @@
 //!
 //! Ported from kokoro/istftnet.py
 
-use candle_core::{DType, Device, Module, Result, Tensor};
+use candle_core::{DType, Device, Module, Result, Shape, Tensor};
 use candle_nn::{self as nn, VarBuilder};
 
 use crate::modules::{
     load_weight_norm_conv1d, load_weight_norm_conv_transpose1d, AdaIN1d, AdainResBlk1d,
 };
+
+/// Controls the small stochastic sources used by the iSTFT decoder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SynthesisMode {
+    /// Match the original Kokoro decoder with random harmonic phase and noise.
+    #[default]
+    Stochastic,
+    /// Replace decoder random phase and noise with zeros for reproducible output.
+    Deterministic,
+}
+
+fn rand_or_zero<S: Into<Shape>>(
+    mode: SynthesisMode,
+    lo: f32,
+    up: f32,
+    shape: S,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor> {
+    match mode {
+        SynthesisMode::Stochastic => Tensor::rand(lo, up, shape, device)?.to_dtype(dtype),
+        SynthesisMode::Deterministic => Tensor::zeros(shape, dtype, device),
+    }
+}
+
+fn randn_or_zero<S: Into<Shape>>(
+    mode: SynthesisMode,
+    mean: f32,
+    std: f32,
+    shape: S,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor> {
+    match mode {
+        SynthesisMode::Stochastic => Tensor::randn(mean, std, shape, device)?.to_dtype(dtype),
+        SynthesisMode::Deterministic => Tensor::zeros(shape, dtype, device),
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Snake activation: x + (1/alpha) * sin(alpha * x)^2
@@ -152,7 +190,12 @@ impl SineGen {
 
     /// f0: [B, T, 1]
     /// Returns: (sine_waves: [B, T, dim], uv: [B, T, 1])
-    fn forward(&self, f0: &Tensor, device: &Device) -> Result<(Tensor, Tensor)> {
+    fn forward_with_mode(
+        &self,
+        f0: &Tensor,
+        device: &Device,
+        mode: SynthesisMode,
+    ) -> Result<(Tensor, Tensor)> {
         let (b, t, _) = f0.dims3()?;
         let dim = self.harmonic_num + 1;
 
@@ -174,7 +217,7 @@ impl SineGen {
         // Fix 2: Add initial random phase for non-fundamental harmonics
         // Python: rand_ini = torch.rand(B, dim); rand_ini[:, 0] = 0
         //         rad_values[:, 0, :] += rand_ini
-        let rand_ini = Tensor::rand(0f32, 1f32, &[b, dim], device)?.to_dtype(f0.dtype())?;
+        let rand_ini = rand_or_zero(mode, 0f32, 1f32, &[b, dim], device, f0.dtype())?;
         // Zero out fundamental (column 0)
         let mask_data: Vec<f32> = (0..dim).map(|i| if i == 0 { 0.0 } else { 1.0 }).collect();
         let mask = Tensor::new(&mask_data[..], device)?
@@ -229,7 +272,7 @@ impl SineGen {
 
         // Noise for unvoiced regions
         let noise_amp = ((&uv * self.noise_std)? + ((1.0 - &uv)? * (self.sine_amp / 3.0))?)?;
-        let noise = Tensor::randn(0f32, 1f32, sines.shape(), device)?.to_dtype(sines.dtype())?;
+        let noise = randn_or_zero(mode, 0f32, 1f32, sines.shape(), device, sines.dtype())?;
         let noise = noise.broadcast_mul(&noise_amp)?;
 
         // Final: sine * uv + noise
@@ -276,15 +319,25 @@ impl SourceModuleHnNSF {
     /// x: [B, T, 1] (F0 values)
     /// Returns: (sine_merge: [B, T, 1], noise: [B, T, 1], uv: [B, T, 1])
     pub fn forward(&self, x: &Tensor) -> Result<(Tensor, Tensor, Tensor)> {
+        self.forward_with_mode(x, SynthesisMode::Stochastic)
+    }
+
+    /// x: [B, T, 1] (F0 values)
+    /// Returns: (sine_merge: [B, T, 1], noise: [B, T, 1], uv: [B, T, 1])
+    pub fn forward_with_mode(
+        &self,
+        x: &Tensor,
+        mode: SynthesisMode,
+    ) -> Result<(Tensor, Tensor, Tensor)> {
         let device = x.device();
-        let (sine_wavs, uv) = self.sine_gen.forward(x, device)?;
+        let (sine_wavs, uv) = self.sine_gen.forward_with_mode(x, device, mode)?;
 
         // Linear merge of harmonics -> single channel
         let sine_merge = self.l_linear.forward(&sine_wavs)?;
         let sine_merge = sine_merge.tanh()?;
 
         // Noise source
-        let noise = Tensor::randn(0f32, 1f32, uv.shape(), device)?.to_dtype(x.dtype())?;
+        let noise = randn_or_zero(mode, 0f32, 1f32, uv.shape(), device, x.dtype())?;
         let noise = (noise * (self.sine_amp / 3.0))?;
 
         Ok((sine_merge, noise, uv))
@@ -640,12 +693,23 @@ impl Generator {
 
     /// x: [B, C, T], s: [B, style_dim], f0: [B, T_f0]
     pub fn forward(&self, x: &Tensor, s: &Tensor, f0: &Tensor) -> Result<Tensor> {
+        self.forward_with_mode(x, s, f0, SynthesisMode::Stochastic)
+    }
+
+    /// x: [B, C, T], s: [B, style_dim], f0: [B, T_f0]
+    pub fn forward_with_mode(
+        &self,
+        x: &Tensor,
+        s: &Tensor,
+        f0: &Tensor,
+        mode: SynthesisMode,
+    ) -> Result<Tensor> {
         // Upsample F0 to full resolution
         let f0_up = upsample_nearest_1d_single(f0, self.upsample_scale)?; // [B, T_full]
         let f0_3d = f0_up.unsqueeze(2)?; // [B, T_full, 1]
 
         // Generate harmonic source
-        let (har_source, _noise_source, _uv) = self.m_source.forward(&f0_3d)?;
+        let (har_source, _noise_source, _uv) = self.m_source.forward_with_mode(&f0_3d, mode)?;
 
         // har_source: [B, T_full, 1] -> [B, 1, T_full] -> [B, T_full]
         let har_source = har_source.transpose(1, 2)?.contiguous()?;
@@ -823,6 +887,18 @@ impl Decoder {
         n: &Tensor,
         s: &Tensor,
     ) -> Result<Tensor> {
+        self.forward_with_mode(asr, f0_curve, n, s, SynthesisMode::Stochastic)
+    }
+
+    /// asr: [B, C, T], f0_curve: [B, T], n: [B, T], s: [B, style_dim]
+    pub fn forward_with_mode(
+        &self,
+        asr: &Tensor,
+        f0_curve: &Tensor,
+        n: &Tensor,
+        s: &Tensor,
+        mode: SynthesisMode,
+    ) -> Result<Tensor> {
         // F0 and N convolutions: [B, T] -> [B, 1, T] -> conv -> [B, 1, T/2]
         let f0 = self.f0_conv.forward(&f0_curve.unsqueeze(1)?)?;
         let n_out = self.n_conv.forward(&n.unsqueeze(1)?)?;
@@ -845,7 +921,7 @@ impl Decoder {
             }
         }
 
-        self.generator.forward(&x, s, f0_curve)
+        self.generator.forward_with_mode(&x, s, f0_curve, mode)
     }
 }
 
@@ -1015,4 +1091,66 @@ fn gpu_linear_upsample(
     let one_minus_frac = (1.0f64 - &frac_t)?;
     let result = (x_lo.broadcast_mul(&one_minus_frac)? + x_hi.broadcast_mul(&frac_t)?)?;
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{rand_or_zero, randn_or_zero, SynthesisMode};
+    use candle_core::{DType, Device, Result};
+
+    #[test]
+    fn deterministic_uniform_source_returns_zeros() -> Result<()> {
+        let tensor = rand_or_zero(
+            SynthesisMode::Deterministic,
+            0.0,
+            1.0,
+            (2, 3),
+            &Device::Cpu,
+            DType::F32,
+        )?;
+
+        assert_eq!(tensor.dims(), &[2, 3]);
+        assert_eq!(tensor.to_vec2::<f32>()?, vec![vec![0.0; 3], vec![0.0; 3]]);
+        Ok(())
+    }
+
+    #[test]
+    fn deterministic_normal_source_returns_zeros() -> Result<()> {
+        let tensor = randn_or_zero(
+            SynthesisMode::Deterministic,
+            0.0,
+            1.0,
+            (2, 3),
+            &Device::Cpu,
+            DType::F32,
+        )?;
+
+        assert_eq!(tensor.dims(), &[2, 3]);
+        assert_eq!(tensor.to_vec2::<f32>()?, vec![vec![0.0; 3], vec![0.0; 3]]);
+        Ok(())
+    }
+
+    #[test]
+    fn stochastic_sources_keep_requested_shape() -> Result<()> {
+        let uniform = rand_or_zero(
+            SynthesisMode::Stochastic,
+            0.0,
+            1.0,
+            (2, 3),
+            &Device::Cpu,
+            DType::F32,
+        )?;
+        let normal = randn_or_zero(
+            SynthesisMode::Stochastic,
+            0.0,
+            1.0,
+            (2, 3),
+            &Device::Cpu,
+            DType::F32,
+        )?;
+
+        assert_eq!(uniform.dims(), &[2, 3]);
+        assert_eq!(normal.dims(), &[2, 3]);
+        Ok(())
+    }
 }

--- a/crates/voice-kokoro/src/lib.rs
+++ b/crates/voice-kokoro/src/lib.rs
@@ -8,4 +8,5 @@ pub mod model;
 pub mod modules;
 
 pub use config::ModelConfig;
+pub use istftnet::SynthesisMode;
 pub use model::KModel;

--- a/crates/voice-kokoro/src/model.rs
+++ b/crates/voice-kokoro/src/model.rs
@@ -7,7 +7,7 @@ use candle_nn::{self as nn, VarBuilder};
 
 use crate::albert::CustomAlbert;
 use crate::config::ModelConfig;
-use crate::istftnet::Decoder;
+use crate::istftnet::{Decoder, SynthesisMode};
 use crate::modules::{ProsodyPredictor, TextEncoder};
 
 /// The top-level Kokoro-82M model.
@@ -85,6 +85,21 @@ impl KModel {
         ref_s: &Tensor,
         speed: f32,
         device: &Device,
+    ) -> Result<Tensor> {
+        self.forward_with_mode(input_ids, ref_s, speed, device, SynthesisMode::Stochastic)
+    }
+
+    /// Run inference with explicit synthesis-mode control.
+    ///
+    /// Deterministic mode removes the decoder's random harmonic phase and noise
+    /// sources, making output reproducible on CPU and GPU backends.
+    pub fn forward_with_mode(
+        &self,
+        input_ids: &[i64],
+        ref_s: &Tensor,
+        speed: f32,
+        device: &Device,
+        mode: SynthesisMode,
     ) -> Result<Tensor> {
         // Pad with BOS=0 and EOS=0
         let mut padded = Vec::with_capacity(input_ids.len() + 2);
@@ -215,7 +230,9 @@ impl KModel {
 
         // Decoder
         let s_acoustic = ref_s.narrow(1, 0, 128)?; // [1, 128]
-        let audio = self.decoder.forward(&asr, &f0_pred, &n_pred, &s_acoustic)?;
+        let audio = self
+            .decoder
+            .forward_with_mode(&asr, &f0_pred, &n_pred, &s_acoustic, mode)?;
 
         // audio: [1, 1, samples] -> [samples]
         audio.squeeze(0)?.squeeze(0)

--- a/crates/voice-kokoro/src/model.rs
+++ b/crates/voice-kokoro/src/model.rs
@@ -2,7 +2,7 @@
 //!
 //! Ported from kokoro/model.py
 
-use candle_core::{DType, Device, Module, Result, Tensor};
+use candle_core::{DType, Device, Error, Module, Result, Tensor};
 use candle_nn::{self as nn, VarBuilder};
 
 use crate::albert::CustomAlbert;
@@ -93,12 +93,7 @@ impl KModel {
         padded.push(0i64);
 
         let seq_len = padded.len();
-        assert!(
-            seq_len <= self.context_length,
-            "Input too long: {} > {}",
-            seq_len,
-            self.context_length
-        );
+        validate_context_length(seq_len, self.context_length)?;
 
         let input_ids_t = Tensor::new(&padded[..], device)?.unsqueeze(0)?; // [1, T]
         let input_lengths = Tensor::new(&[seq_len as i64][..], device)?; // [1]
@@ -227,6 +222,15 @@ impl KModel {
     }
 }
 
+fn validate_context_length(seq_len: usize, context_length: usize) -> Result<()> {
+    if seq_len > context_length {
+        return Err(Error::Msg(format!(
+            "Input too long: {seq_len} > {context_length}"
+        )));
+    }
+    Ok(())
+}
+
 fn suppress_boundary_token_durations(mut durations: Vec<i64>) -> Vec<i64> {
     if let Some(first) = durations.first_mut() {
         *first = 0;
@@ -240,7 +244,18 @@ fn suppress_boundary_token_durations(mut durations: Vec<i64>) -> Vec<i64> {
 
 #[cfg(test)]
 mod tests {
-    use super::suppress_boundary_token_durations;
+    use super::{suppress_boundary_token_durations, validate_context_length};
+
+    #[test]
+    fn context_length_allows_equal_length() {
+        assert!(validate_context_length(510, 510).is_ok());
+    }
+
+    #[test]
+    fn context_length_rejects_overlong_input() {
+        let err = validate_context_length(511, 510).unwrap_err();
+        assert!(err.to_string().contains("Input too long: 511 > 510"));
+    }
 
     #[test]
     fn test_suppresses_bos_eos_duration_frames() {

--- a/crates/voice-kokoro/tests/stft_roundtrip.rs
+++ b/crates/voice-kokoro/tests/stft_roundtrip.rs
@@ -3,7 +3,7 @@ use voice_kokoro::istftnet::TorchSTFT;
 
 #[test]
 fn stft_roundtrip() {
-    let device = Device::new_metal(0).unwrap();
+    let device = stft_test_device();
 
     // Simple 440Hz sine wave, 0.1 seconds at 24kHz
     let n = 2400;
@@ -33,4 +33,16 @@ fn stft_roundtrip() {
         / len as f32;
 
     assert!(mse < 0.01, "STFT roundtrip MSE too high: {}", mse);
+}
+
+fn stft_test_device() -> Device {
+    #[cfg(target_os = "macos")]
+    {
+        Device::new_metal(0).unwrap_or(Device::Cpu)
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        Device::Cpu
+    }
 }

--- a/crates/voice-stream/src/lib.rs
+++ b/crates/voice-stream/src/lib.rs
@@ -211,6 +211,41 @@ impl Packetizer {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct InterleavedMonoMixer {
+    channels: usize,
+    pending_sum: f32,
+    pending_count: usize,
+}
+
+impl InterleavedMonoMixer {
+    pub fn new(channels: usize) -> Self {
+        Self {
+            channels: channels.max(1),
+            pending_sum: 0.0,
+            pending_count: 0,
+        }
+    }
+
+    pub fn push(&mut self, sample: f32) -> Option<f32> {
+        if self.channels == 1 {
+            return Some(sample);
+        }
+
+        self.pending_sum += sample;
+        self.pending_count += 1;
+
+        if self.pending_count == self.channels {
+            let mixed = self.pending_sum / self.channels as f32;
+            self.pending_sum = 0.0;
+            self.pending_count = 0;
+            Some(mixed)
+        } else {
+            None
+        }
+    }
+}
+
 pub fn f32_to_i16(sample: f32) -> i16 {
     let clamped = sample.clamp(-1.0, 1.0);
     if clamped >= 0.0 {
@@ -276,6 +311,37 @@ mod tests {
         assert_eq!(f32_to_i16(-1.0), -32768);
         assert_eq!(f32_to_i16(2.0), 32767);
         assert_eq!(f32_to_i16(-2.0), -32768);
+    }
+
+    #[test]
+    fn interleaved_mono_mixer_passes_mono_samples_through() {
+        let mut mixer = InterleavedMonoMixer::new(1);
+        assert_eq!(mixer.push(0.25), Some(0.25));
+        assert_eq!(mixer.push(-0.5), Some(-0.5));
+    }
+
+    #[test]
+    fn interleaved_mono_mixer_averages_stereo_frames() {
+        let mut mixer = InterleavedMonoMixer::new(2);
+        let input = [1.0, -1.0, 0.5, 0.25];
+        let output: Vec<f32> = input
+            .into_iter()
+            .filter_map(|sample| mixer.push(sample))
+            .collect();
+
+        assert_eq!(output, vec![0.0, 0.375]);
+    }
+
+    #[test]
+    fn interleaved_mono_mixer_treats_zero_channels_as_mono() {
+        let mut mixer = InterleavedMonoMixer::new(0);
+        assert_eq!(mixer.push(0.75), Some(0.75));
+    }
+
+    #[test]
+    fn interleaved_mono_mixer_holds_incomplete_frame() {
+        let mut mixer = InterleavedMonoMixer::new(2);
+        assert_eq!(mixer.push(1.0), None);
     }
 
     #[test]

--- a/crates/voice-stt/examples/transcribe.rs
+++ b/crates/voice-stt/examples/transcribe.rs
@@ -1,4 +1,4 @@
-//! Example: transcribe a WAV file using Moonshine.
+//! Example: transcribe a WAV file using Whisper.
 //!
 //! Usage:
 //!     cargo run -p voice-stt --example transcribe -- /path/to/audio.wav
@@ -25,15 +25,12 @@ fn main() {
     let audio_path = &args[1];
 
     let repo =
-        env::var("MOONSHINE_MODEL").unwrap_or_else(|_| "UsefulSensors/moonshine-tiny".to_string());
+        env::var("STT_MODEL").unwrap_or_else(|_| "distil-whisper/distil-medium.en".to_string());
 
     eprintln!("Loading model: {repo}");
     let t0 = Instant::now();
     let mut model = voice_stt::load_model(&repo).expect("Failed to load model");
     eprintln!("Model loaded in {:.2}s", t0.elapsed().as_secs_f64());
-
-    eprintln!("Loading tokenizer...");
-    let tokenizer = voice_stt::load_tokenizer(&repo).expect("Failed to load tokenizer");
 
     eprintln!("Transcribing: {audio_path}");
     let t1 = Instant::now();
@@ -48,8 +45,7 @@ fn main() {
     );
 
     let result =
-        voice_stt::transcribe_audio_with_tokenizer(&mut model, &samples, 16000, &tokenizer)
-            .expect("Transcription failed");
+        voice_stt::transcribe_audio(&mut model, &samples, 16000).expect("Transcription failed");
 
     let elapsed = t1.elapsed().as_secs_f64();
     let rtf = elapsed / duration_secs;

--- a/crates/voice-tts/README.md
+++ b/crates/voice-tts/README.md
@@ -1,6 +1,6 @@
 # voice-tts
 
-Core TTS library for [Kokoro](https://huggingface.co/prince-canuma/Kokoro-82M) model inference on Apple Silicon via [mlx-rs](https://github.com/oxiglade/mlx-rs).
+Core TTS library for [Kokoro](https://huggingface.co/prince-canuma/Kokoro-82M) model inference on Candle, with Metal acceleration on Apple Silicon and CPU fallback elsewhere.
 
 ## Install
 
@@ -50,8 +50,8 @@ for phonemes in &chunks {
 
 ## Requirements
 
-- macOS with Apple Silicon (MLX requirement)
-- Xcode command line tools (for Metal compilation)
+- Rust 1.85+
+- macOS with Apple Silicon for fast Metal inference, or a CPU-only host for slower portable inference
 
 ## License
 

--- a/crates/voice-tts/src/lib.rs
+++ b/crates/voice-tts/src/lib.rs
@@ -9,6 +9,7 @@ use candle_nn::VarBuilder;
 use hf_hub::api::sync::Api;
 
 pub use error::{Result, VoicersError};
+pub use voice_kokoro::SynthesisMode;
 
 const DEFAULT_REPO: &str = "prince-canuma/Kokoro-82M";
 
@@ -167,6 +168,20 @@ pub fn generate(
     voice: &Tensor,
     speed: f32,
 ) -> Result<Vec<f32>> {
+    generate_with_mode(model, phonemes, voice, speed, SynthesisMode::Stochastic)
+}
+
+/// Generate audio from phonemes with explicit synthesis-mode control.
+///
+/// Deterministic mode removes the Kokoro decoder's random phase and noise
+/// sources so repeated calls can produce byte-stable evaluation audio.
+pub fn generate_with_mode(
+    model: &mut KokoroModel,
+    phonemes: &str,
+    voice: &Tensor,
+    speed: f32,
+    mode: SynthesisMode,
+) -> Result<Vec<f32>> {
     let vocab = &model.config.vocab;
 
     // Convert phonemes to token IDs (character by character)
@@ -200,7 +215,7 @@ pub fn generate(
 
     let audio = model
         .model
-        .forward(&input_ids, &ref_s, speed, &model.device)
+        .forward_with_mode(&input_ids, &ref_s, speed, &model.device, mode)
         .map_err(|e| VoicersError::Model(e.to_string()))?;
 
     let samples = audio

--- a/eval/__init__.py
+++ b/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Evaluation helpers for voice."""

--- a/eval/compare.sh
+++ b/eval/compare.sh
@@ -3,12 +3,13 @@
 # Usage: ./eval/compare.sh [voice_binary]
 #
 # Transcribes each recording in eval/recordings/ and compares
-# against the expected text, computing word error rate.
+# against the expected text, computing WER/CER and latency metrics.
 
-set -e
+set -euo pipefail
 
 VOICE="${1:-./target/release/voice}"
 RECORDINGS="eval/recordings"
+RESULTS_DIR="eval/results"
 
 if [ ! -d "$RECORDINGS" ]; then
     echo "Error: $RECORDINGS not found. Run record.sh first."
@@ -25,80 +26,14 @@ echo "=== Voice STT Evaluation ==="
 echo "Using: $VOICE"
 echo ""
 
-normalize() {
-    # Lowercase, strip punctuation, collapse whitespace
-    echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9 ]//g' | tr -s ' ' | sed 's/^ //;s/ $//'
-}
-
-word_error_rate() {
-    local expected="$1"
-    local actual="$2"
-
-    # Simple WER: count words that differ
-    local exp_words=($expected)
-    local act_words=($actual)
-    local exp_len=${#exp_words[@]}
-    local act_len=${#act_words[@]}
-    local max_len=$((exp_len > act_len ? exp_len : act_len))
-
-    if [ "$max_len" -eq 0 ]; then
-        echo "0.0"
-        return
-    fi
-
-    local errors=0
-    for i in $(seq 0 $((max_len - 1))); do
-        local e="${exp_words[$i]:-}"
-        local a="${act_words[$i]:-}"
-        if [ "$e" != "$a" ]; then
-            errors=$((errors + 1))
-        fi
-    done
-
-    # WER as percentage
-    echo "scale=1; $errors * 100 / $exp_len" | bc
-}
+mkdir -p "$RESULTS_DIR"
 
 for model in "${MODELS[@]}"; do
-    echo "=== Model: $model ==="
-    total_wer=0
-    count=0
-
-    for txt_file in "$RECORDINGS"/*.txt; do
-        base=$(basename "$txt_file" .txt)
-        wav_file="$RECORDINGS/${base}.wav"
-
-        if [ ! -f "$wav_file" ]; then
-            continue
-        fi
-
-        expected=$(cat "$txt_file")
-        transcript=$(STT_MODEL="$model" "$VOICE" transcribe -q "$wav_file" 2>/dev/null || echo "ERROR")
-
-        exp_norm=$(normalize "$expected")
-        act_norm=$(normalize "$transcript")
-
-        wer=$(word_error_rate "$exp_norm" "$act_norm")
-        total_wer=$(echo "$total_wer + $wer" | bc)
-        count=$((count + 1))
-
-        if [ "$exp_norm" = "$act_norm" ]; then
-            status="PASS"
-        else
-            status="WER=${wer}%"
-        fi
-
-        printf "  %s [%s]\n" "$base" "$status"
-        if [ "$exp_norm" != "$act_norm" ]; then
-            printf "    expected: %s\n" "$exp_norm"
-            printf "    got:      %s\n" "$act_norm"
-        fi
-    done
-
-    if [ "$count" -gt 0 ]; then
-        avg_wer=$(echo "scale=1; $total_wer / $count" | bc)
-        echo ""
-        echo "  Average WER: ${avg_wer}% ($count phrases)"
-    fi
+    safe_model="${model//\//_}"
+    python3 eval/evaluate.py \
+        --recordings "$RECORDINGS" \
+        --voice "$VOICE" \
+        --model "$model" \
+        --json-out "$RESULTS_DIR/${safe_model}.json"
     echo ""
 done

--- a/eval/evaluate.py
+++ b/eval/evaluate.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Evaluate voice STT output with WER/CER, timing, and JSON output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import struct
+import subprocess
+import time
+import wave
+from pathlib import Path
+from typing import Sequence
+
+
+def normalize_text(text: str) -> str:
+    lowered = text.lower()
+    alnum_space = re.sub(r"[^a-z0-9\s]", "", lowered)
+    return " ".join(alnum_space.split())
+
+
+def edit_distance(expected: Sequence[str], actual: Sequence[str]) -> int:
+    if not expected:
+        return len(actual)
+    if not actual:
+        return len(expected)
+
+    previous = list(range(len(actual) + 1))
+    for i, expected_item in enumerate(expected, start=1):
+        current = [i]
+        for j, actual_item in enumerate(actual, start=1):
+            cost = 0 if expected_item == actual_item else 1
+            current.append(
+                min(
+                    previous[j] + 1,
+                    current[j - 1] + 1,
+                    previous[j - 1] + cost,
+                )
+            )
+        previous = current
+    return previous[-1]
+
+
+def _error_rate(errors: int, expected_count: int, actual_count: int) -> float:
+    if expected_count == 0:
+        return 0.0 if actual_count == 0 else float(errors)
+    return errors / expected_count
+
+
+def word_error_rate(expected: str, actual: str) -> float:
+    expected_words = normalize_text(expected).split()
+    actual_words = normalize_text(actual).split()
+    errors = edit_distance(expected_words, actual_words)
+    return _error_rate(errors, len(expected_words), len(actual_words))
+
+
+def char_error_rate(expected: str, actual: str) -> float:
+    expected_chars = list(normalize_text(expected).replace(" ", ""))
+    actual_chars = list(normalize_text(actual).replace(" ", ""))
+    errors = edit_distance(expected_chars, actual_chars)
+    return _error_rate(errors, len(expected_chars), len(actual_chars))
+
+
+def score_pair(expected: str, actual: str) -> dict[str, object]:
+    expected_normalized = normalize_text(expected)
+    actual_normalized = normalize_text(actual)
+    expected_words = expected_normalized.split()
+    actual_words = actual_normalized.split()
+    expected_chars = list(expected_normalized.replace(" ", ""))
+    actual_chars = list(actual_normalized.replace(" ", ""))
+    word_errors = edit_distance(expected_words, actual_words)
+    char_errors = edit_distance(expected_chars, actual_chars)
+
+    return {
+        "expected_normalized": expected_normalized,
+        "actual_normalized": actual_normalized,
+        "exact": expected_normalized == actual_normalized,
+        "word_errors": word_errors,
+        "word_count": len(expected_words),
+        "wer": _error_rate(word_errors, len(expected_words), len(actual_words)),
+        "char_errors": char_errors,
+        "char_count": len(expected_chars),
+        "cer": _error_rate(char_errors, len(expected_chars), len(actual_chars)),
+    }
+
+
+def wav_duration_seconds(path: Path) -> float | None:
+    try:
+        with wave.open(str(path), "rb") as reader:
+            frame_rate = reader.getframerate()
+            if frame_rate == 0:
+                return None
+            return reader.getnframes() / frame_rate
+    except (wave.Error, OSError, EOFError):
+        return riff_wav_duration_seconds(path)
+
+
+def riff_wav_duration_seconds(path: Path) -> float | None:
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return None
+
+    if len(data) < 12 or data[:4] != b"RIFF" or data[8:12] != b"WAVE":
+        return None
+
+    sample_rate = None
+    block_align = None
+    data_size = None
+    offset = 12
+    while offset + 8 <= len(data):
+        chunk_id = data[offset : offset + 4]
+        chunk_size = struct.unpack_from("<I", data, offset + 4)[0]
+        chunk_start = offset + 8
+        chunk_end = min(chunk_start + chunk_size, len(data))
+        chunk = data[chunk_start:chunk_end]
+
+        if chunk_id == b"fmt " and len(chunk) >= 16:
+            _format_tag, _channels, sample_rate, _byte_rate, block_align, _bits = (
+                struct.unpack_from("<HHIIHH", chunk, 0)
+            )
+        elif chunk_id == b"data":
+            data_size = chunk_size
+
+        offset = chunk_start + chunk_size + (chunk_size % 2)
+
+    if not sample_rate or not block_align or data_size is None:
+        return None
+    return (data_size / block_align) / sample_rate
+
+
+def recording_pairs(recordings: Path) -> list[tuple[str, Path, Path]]:
+    pairs = []
+    for text_path in sorted(recordings.glob("*.txt")):
+        wav_path = text_path.with_suffix(".wav")
+        if wav_path.exists():
+            pairs.append((text_path.stem, text_path, wav_path))
+    return pairs
+
+
+def transcribe(voice: str, model: str, wav_path: Path) -> tuple[str, float, str | None]:
+    env = os.environ.copy()
+    env["STT_MODEL"] = model
+    start = time.perf_counter()
+    try:
+        completed = subprocess.run(
+            [voice, "transcribe", "-q", str(wav_path)],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as err:
+        return "", time.perf_counter() - start, str(err)
+
+    elapsed = time.perf_counter() - start
+    transcript = completed.stdout.strip()
+    if completed.returncode != 0:
+        message = completed.stderr.strip() or f"exit status {completed.returncode}"
+        return transcript, elapsed, message
+    return transcript, elapsed, None
+
+
+def evaluate(recordings: Path, voice: str, model: str) -> dict[str, object]:
+    items = []
+    for item_id, text_path, wav_path in recording_pairs(recordings):
+        expected = text_path.read_text(encoding="utf-8").strip()
+        transcript, elapsed_seconds, error = transcribe(voice, model, wav_path)
+        duration_seconds = wav_duration_seconds(wav_path)
+        score = score_pair(expected, transcript)
+        item = {
+            "id": item_id,
+            "text_path": str(text_path),
+            "wav_path": str(wav_path),
+            "expected": expected,
+            "actual": transcript,
+            "elapsed_seconds": elapsed_seconds,
+            "duration_seconds": duration_seconds,
+            **score,
+        }
+        if error is not None:
+            item["error"] = error
+        items.append(item)
+
+    total = len(items)
+    exact = sum(1 for item in items if item["exact"])
+    total_audio_seconds = sum(
+        item["duration_seconds"] or 0.0 for item in items
+    )
+    total_elapsed_seconds = sum(float(item["elapsed_seconds"]) for item in items)
+    mean_wer = (
+        sum(float(item["wer"]) for item in items) / total if total else 0.0
+    )
+    mean_cer = (
+        sum(float(item["cer"]) for item in items) / total if total else 0.0
+    )
+
+    return {
+        "model": model,
+        "voice_binary": voice,
+        "recordings": str(recordings),
+        "total": total,
+        "exact": exact,
+        "mean_wer": mean_wer,
+        "mean_cer": mean_cer,
+        "total_audio_seconds": total_audio_seconds,
+        "total_elapsed_seconds": total_elapsed_seconds,
+        "rtf": (
+            total_elapsed_seconds / total_audio_seconds
+            if total_audio_seconds > 0.0
+            else None
+        ),
+        "items": items,
+    }
+
+
+def print_summary(summary: dict[str, object]) -> None:
+    total = int(summary["total"])
+    exact = int(summary["exact"])
+    mean_wer = float(summary["mean_wer"])
+    mean_cer = float(summary["mean_cer"])
+    rtf = summary["rtf"]
+
+    print(f"=== Model: {summary['model']} ===")
+    for item in summary["items"]:
+        status = "PASS" if item["exact"] else f"WER={float(item['wer']) * 100:.1f}%"
+        print(f"  {item['id']} [{status}]")
+        if not item["exact"]:
+            print(f"    expected: {item['expected_normalized']}")
+            print(f"    got:      {item['actual_normalized']}")
+        if "error" in item:
+            print(f"    error:    {item['error']}")
+
+    rtf_text = "n/a" if rtf is None else f"{float(rtf):.2f}x"
+    print()
+    print(
+        f"  Exact: {exact}/{total}; "
+        f"WER: {mean_wer * 100:.1f}%; "
+        f"CER: {mean_cer * 100:.1f}%; "
+        f"RTF: {rtf_text}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--recordings", required=True, type=Path)
+    parser.add_argument("--voice", default="./target/release/voice")
+    parser.add_argument("--model", default="distil-whisper/distil-medium.en")
+    parser.add_argument("--json-out", type=Path)
+    args = parser.parse_args()
+
+    if not args.recordings.is_dir():
+        parser.error(f"{args.recordings} is not a directory")
+
+    summary = evaluate(args.recordings, args.voice, args.model)
+    print_summary(summary)
+
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eval/phrases.txt
+++ b/eval/phrases.txt
@@ -8,3 +8,15 @@ The API endpoint returns a JSON response with the user's authentication token.
 Can you run the deployment pipeline and check the staging environment?
 Kubernetes pods are restarting because the liveness probe is failing.
 The neural network achieved ninety-seven percent accuracy on the test set.
+Please send this answer to WhatsApp through Hermes.
+The WebRTC stream should use twenty millisecond audio frames.
+The MCP server returned a JSON-RPC error for the missing parameter.
+CPU inference is slower than GPU inference but useful on Linux.
+The TTS daemon should keep running after a bad phoneme chunk.
+STT accuracy depends on clean microphone input and low background noise.
+nteract displayName and useEffect should be pronounced clearly.
+JupyterLab opens notebooks, terminals, and markdown previews.
+KV-cache reuse makes the decoder faster for long transcripts.
+The ASR model ignored two seconds of leading silence.
+Please compare WER and CER before merging the pull request.
+The agent read three files, wrote one patch, and opened a PR.

--- a/eval/synth_eval.sh
+++ b/eval/synth_eval.sh
@@ -2,14 +2,14 @@
 # Automated eval using TTS-generated audio (no human recording needed).
 # Usage: ./eval/synth_eval.sh [voice_binary]
 #
-# Generates WAV files from phrases.txt using TTS, then transcribes
-# each with the current STT model and compares against expected text.
+# Generates deterministic WAV files from phrases.txt using TTS, then
+# transcribes each with the current STT model and compares against expected text.
 
 set -euo pipefail
 
 VOICE="${1:-./target/release/voice}"
 PHRASES="eval/phrases.txt"
-TMPDIR="/tmp/voice_synth_eval"
+TMPDIR="/tmp/voice_synth_eval_deterministic"
 RESULTS_DIR="eval/results"
 
 mkdir -p "$TMPDIR"
@@ -34,7 +34,7 @@ while IFS= read -r phrase; do
     padded=$(printf "%03d" "$n")
     wav="$TMPDIR/${padded}.wav"
     if [ ! -f "$wav" ]; then
-        "$VOICE" say -q -o "$wav" "$phrase"
+        "$VOICE" say --deterministic -q -o "$wav" "$phrase"
     fi
     echo "$phrase" > "$TMPDIR/${padded}.txt"
 done < "$PHRASES"

--- a/eval/synth_eval.sh
+++ b/eval/synth_eval.sh
@@ -5,21 +5,19 @@
 # Generates WAV files from phrases.txt using TTS, then transcribes
 # each with the current STT model and compares against expected text.
 
-set -e
+set -euo pipefail
 
 VOICE="${1:-./target/release/voice}"
 PHRASES="eval/phrases.txt"
 TMPDIR="/tmp/voice_synth_eval"
+RESULTS_DIR="eval/results"
 
 mkdir -p "$TMPDIR"
+mkdir -p "$RESULTS_DIR"
 
 echo "=== Synthetic STT Evaluation ==="
 echo "Using: $VOICE"
 echo ""
-
-normalize() {
-    echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9 ]//g' | tr -s ' ' | sed 's/^ //;s/ $//'
-}
 
 # Models to test
 MODELS=(
@@ -44,37 +42,11 @@ echo "Generated $n audio files."
 echo ""
 
 for model in "${MODELS[@]}"; do
-    echo "=== Model: $model ==="
-    pass=0
-    fail=0
-    start_time=$(date +%s)
-
-    for txt_file in "$TMPDIR"/*.txt; do
-        base=$(basename "$txt_file" .txt)
-        wav_file="$TMPDIR/${base}.wav"
-        [ ! -f "$wav_file" ] && continue
-
-        expected=$(cat "$txt_file")
-        transcript=$(STT_MODEL="$model" "$VOICE" transcribe -q "$wav_file" 2>/dev/null || echo "ERROR")
-
-        exp_norm=$(normalize "$expected")
-        act_norm=$(normalize "$transcript")
-
-        if [ "$exp_norm" = "$act_norm" ]; then
-            printf "  %s PASS\n" "$base"
-            pass=$((pass + 1))
-        else
-            printf "  %s FAIL\n" "$base"
-            printf "    expected: %s\n" "$exp_norm"
-            printf "    got:      %s\n" "$act_norm"
-            fail=$((fail + 1))
-        fi
-    done
-
-    end_time=$(date +%s)
-    elapsed=$((end_time - start_time))
-    total=$((pass + fail))
-    echo ""
-    echo "  Results: $pass/$total passed ($fail failed) in ${elapsed}s"
+    safe_model="${model//\//_}"
+    python3 eval/evaluate.py \
+        --recordings "$TMPDIR" \
+        --voice "$VOICE" \
+        --model "$model" \
+        --json-out "$RESULTS_DIR/synth_${safe_model}.json"
     echo ""
 done

--- a/eval/test_evaluate.py
+++ b/eval/test_evaluate.py
@@ -1,0 +1,77 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from eval.evaluate import (
+    char_error_rate,
+    edit_distance,
+    normalize_text,
+    score_pair,
+    wav_duration_seconds,
+    word_error_rate,
+)
+
+
+class EvaluationMetricTests(unittest.TestCase):
+    def test_normalize_text_lowercases_strips_punctuation_and_collapses_space(self):
+        self.assertEqual(
+            normalize_text("  Hello,   JSON-world!  "),
+            "hello jsonworld",
+        )
+
+    def test_edit_distance_handles_insert_delete_and_substitute(self):
+        self.assertEqual(edit_distance(["a", "b"], ["a", "b", "c"]), 1)
+        self.assertEqual(edit_distance(["a", "b", "c"], ["a", "c"]), 1)
+        self.assertEqual(edit_distance(["a", "b", "c"], ["a", "x", "c"]), 1)
+
+    def test_word_error_rate_uses_levenshtein_not_position_mismatch(self):
+        self.assertEqual(word_error_rate("alpha beta gamma", "alpha gamma"), 1 / 3)
+
+    def test_score_pair_exact_match_has_zero_error_rates(self):
+        score = score_pair("Hello, world!", "hello world")
+        self.assertTrue(score["exact"])
+        self.assertEqual(score["wer"], 0.0)
+        self.assertEqual(score["cer"], 0.0)
+
+    def test_empty_expected_and_actual_are_zero_error(self):
+        self.assertEqual(word_error_rate("", ""), 0.0)
+        self.assertEqual(char_error_rate("", ""), 0.0)
+
+    def test_empty_expected_with_actual_counts_insertions(self):
+        self.assertEqual(word_error_rate("", "extra words"), 2.0)
+        self.assertEqual(char_error_rate("", "abc"), 3.0)
+
+    def test_wav_duration_supports_extensible_float_fixture_shape(self):
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "extensible.wav"
+            sample_rate = 24_000
+            channels = 1
+            bytes_per_sample = 4
+            frames = 48_000
+            block_align = channels * bytes_per_sample
+            data_size = frames * block_align
+            byte_rate = sample_rate * block_align
+            fmt = (
+                b"fmt "
+                + (40).to_bytes(4, "little")
+                + (0xFFFE).to_bytes(2, "little")
+                + channels.to_bytes(2, "little")
+                + sample_rate.to_bytes(4, "little")
+                + byte_rate.to_bytes(4, "little")
+                + block_align.to_bytes(2, "little")
+                + (32).to_bytes(2, "little")
+                + (22).to_bytes(2, "little")
+                + (32).to_bytes(2, "little")
+                + (1).to_bytes(4, "little")
+                + (3).to_bytes(2, "little")
+                + b"\x00\x00\x00\x00\x10\x00\x80\x00\x00\xaa\x00\x38\x9b\x71"
+            )
+            data = b"data" + data_size.to_bytes(4, "little") + (b"\x00" * data_size)
+            riff_size = 4 + len(fmt) + len(data)
+            path.write_bytes(b"RIFF" + riff_size.to_bytes(4, "little") + b"WAVE" + fmt + data)
+
+            self.assertEqual(wav_duration_seconds(path), 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- roll up the green voice quality PR queue: #93, #94, #95, #96, #97, and #98
- fix live mic channel mixing for CLI and daemon capture with a tested shared helper
- return a typed Kokoro context-length error instead of panicking on overlong input
- remove stale Moonshine/MLX release and docs paths
- add structured STT/TTS evaluation with WER, CER, JSON output, duration, latency, and RTF
- add deterministic Kokoro synthesis mode and wire synthetic eval generation through `voice say --deterministic`
- make the Kokoro STFT roundtrip test portable so `cargo test --workspace` passes on Linux CPU

## Verification
- `bash -n eval/compare.sh eval/synth_eval.sh eval/record.sh`
- `python3 -m unittest eval.test_evaluate`
- `python3 -m py_compile eval/evaluate.py eval/test_evaluate.py`
- `python3 eval/evaluate.py --help`
- `./eval/compare.sh /bin/echo`
- `cargo fmt --check`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`

## Notes
This PR is intended as the mergeable rollup for the currently green individual PRs. The individual PRs can be closed after this lands.