### PR TITLE
Package voice daemon in macOS releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,15 +19,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Build release
-        run: cargo build --release -p voice
+        run: cargo build --release -p voice -p voice-daemon
 
       - name: Package
         run: |
           mkdir -p dist
 
-          # Binary
+          # Binaries
           cp target/release/voice dist/
-          cd dist && tar czf voice-aarch64-apple-darwin.tar.gz voice && cd ..
+          cp target/release/voiced dist/
+          cd dist && tar czf voice-aarch64-apple-darwin.tar.gz voice voiced && cd ..
 
       - name: Sign release assets
         if: env.MINISIGN_KEY != ''

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ cargo install cargo-binstall
 cargo binstall voice
 ```
 
+The tagged macOS release archive also includes `voiced`, the optional daemon
+used by `voice stream` and daemon-backed file synthesis.
+
 ### Build from source
 
 Requires Git LFS for embedded voice/model data:
@@ -31,11 +34,12 @@ git lfs install
 git clone https://github.com/rgbkrk/voice.git
 cd voice
 cargo install --path crates/voice-cli
+cargo install --path crates/voice-daemon
 ```
 
 > **Why git-lfs?** Voice data (`.safetensors`) and tagger weights are stored with Git LFS. Without it, those files are tiny pointers instead of actual data — the build will catch this and tell you what to do.
 
-This puts the `voice` binary on your `$PATH`. Model weights are downloaded from HuggingFace Hub on first run and cached in `~/.cache/huggingface/hub/`. Seven popular voices and the model config are embedded in the binary — no network needed for common use.
+This puts the `voice` and `voiced` binaries on your `$PATH`. Model weights are downloaded from HuggingFace Hub on first run and cached in `~/.cache/huggingface/hub/`. Seven popular voices and the model config are embedded in the binary — no network needed for common use.
 
 ## Usage
 
@@ -269,6 +273,10 @@ Run `voiced --tts-only` to keep Kokoro warm without eagerly loading STT. When th
 daemon is running, `voice say -o output.wav ...` uses the daemon `synthesize`
 RPC and waits until the WAV exists. This is the compatibility path for Hermes'
 command TTS provider and WhatsApp voice-note delivery.
+
+The macOS release archive includes both `voice` and `voiced`. Source installs
+should install both `crates/voice-cli` and `crates/voice-daemon` when the daemon
+or `voice stream` surface is needed.
 
 For lower-level streaming, `stream_speak` emits `tts.started`, `tts.audio`, and
 terminal `tts.ended` / `tts.error` / `tts.cancelled` events over the same daemon

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -35,6 +35,9 @@ Run the daemon first so the Kokoro model stays resident:
 voiced --tts-only
 ```
 
+The macOS release archive includes `voiced` alongside `voice`. From source,
+install the daemon with `cargo install --path crates/voice-daemon`.
+
 `voice say -o ...` falls back to local synthesis if the daemon is unavailable,
 so the same command still works outside Hermes.
 


### PR DESCRIPTION
## Summary
- build the CLI and daemon in the macOS release workflow
- include both `voice` and `voiced` in the existing macOS release archive
- document daemon installation expectations for source and release-archive users

## Verification
- `cargo build --release -p voice -p voice-daemon`
- simulated release archive creation and verified contents: `voice`, `voiced`
- `git diff --check`