### PR TITLE
Document Hermes voice-compatible output

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,10 @@ The macOS release archive includes both `voice` and `voiced`. Source installs
 should install both `crates/voice-cli` and `crates/voice-daemon` when the daemon
 or `voice stream` surface is needed.
 
+For WhatsApp or Telegram voice-note delivery through Hermes, set
+`voice_compatible: true` on the command provider so Hermes converts Voice's WAV
+output to OGG/Opus when needed.
+
 For lower-level streaming, `stream_speak` emits `tts.started`, `tts.audio`, and
 terminal `tts.ended` / `tts.error` / `tts.cancelled` events over the same daemon
 frame protocol. See [docs/streaming.md](docs/streaming.md) for the event schema

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -23,6 +23,7 @@ tts:
       type: command
       command: /path/to/voice say --input-file {input_path} --output {output_path} --voice {voice} --speed {speed}
       output_format: wav
+      voice_compatible: true
       voice: af_heart
       speed: 1.0
       timeout: 180
@@ -40,6 +41,11 @@ install the daemon with `cargo install --path crates/voice-daemon`.
 
 `voice say -o ...` falls back to local synthesis if the daemon is unavailable,
 so the same command still works outside Hermes.
+
+Set `voice_compatible: true` so Hermes converts the WAV output to OGG/Opus
+when it needs native voice-note delivery. This requires `ffmpeg` in Hermes'
+environment and lets WhatsApp/Telegram paths receive an Opus voice note instead
+of a generic audio attachment.
 
 The repository also includes `examples/hermes-command-tts.sh`, which matches
 Hermes' command-provider argument order:


### PR DESCRIPTION
## Summary
- add `voice_compatible: true` to the Hermes command-provider example
- document that Hermes uses ffmpeg to convert Voice WAV output to OGG/Opus for native voice notes

## Verification
- `git diff --check`