### PR TITLE
Support raw stream output on stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ voice say -o speech.wav "Good morning everyone."
 
 # Stream daemon TTS frames for bridge/WebRTC experiments
 voice stream --sample-rate 48000 --frame-ms 20 --raw-output speech.s16le "Good morning everyone."
+voice stream --sample-rate 48000 --frame-ms 20 --raw-output - "Good morning everyone." \
+  | ffmpeg -f s16le -ar 48000 -ac 1 -i - -c:a libopus speech.ogg
 
 # Read from a file, strip markdown
 voice say --markdown -f blog-post.mdx
@@ -159,6 +161,7 @@ Options:
       --sample-rate <SAMPLE_RATE>  Target stream sample rate [default: 24000]
       --frame-ms <FRAME_MS>        Target frame duration in milliseconds [default: 20]
   -o, --raw-output <PATH>          Write raw signed 16-bit little-endian mono PCM
+                                   (use - for stdout)
       --json                       Print full JSON stream events
       --markdown                   Strip markdown/MDX formatting before speaking
       --sub <WORD=REPLACEMENT>     Word substitution (repeatable)

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -189,7 +189,7 @@ struct StreamArgs {
     #[arg(long = "frame-ms", default_value = "20")]
     frame_ms: u32,
 
-    /// Write raw signed 16-bit little-endian mono PCM to this path
+    /// Write raw signed 16-bit little-endian mono PCM to this path (use - for stdout)
     #[arg(short = 'o', long = "raw-output")]
     raw_output: Option<PathBuf>,
 
@@ -1216,7 +1216,19 @@ fn run_stream(stream_args: StreamArgs) {
         stream_args.sub_file.clone(),
     );
 
-    let mut raw_writer = stream_args.raw_output.as_ref().map(|path| {
+    let raw_to_stdout = stream_args
+        .raw_output
+        .as_ref()
+        .is_some_and(|path| path.as_os_str() == std::ffi::OsStr::new("-"));
+    if raw_to_stdout && stream_args.json {
+        eprintln!("Error: --json cannot be combined with --raw-output -");
+        std::process::exit(1);
+    }
+
+    let mut raw_writer: Option<Box<dyn Write>> = stream_args.raw_output.as_ref().map(|path| {
+        if path.as_os_str() == std::ffi::OsStr::new("-") {
+            return Box::new(io::BufWriter::new(io::stdout())) as Box<dyn Write>;
+        }
         if let Some(parent) = path.parent() {
             if !parent.as_os_str().is_empty() {
                 std::fs::create_dir_all(parent).unwrap_or_else(|e| {
@@ -1225,10 +1237,10 @@ fn run_stream(stream_args: StreamArgs) {
                 });
             }
         }
-        std::fs::File::create(path).unwrap_or_else(|e| {
+        Box::new(std::fs::File::create(path).unwrap_or_else(|e| {
             eprintln!("Failed to create {}: {e}", path.display());
             std::process::exit(1);
-        })
+        })) as Box<dyn Write>
     });
 
     let mut daemon = connect_daemon_or_exit();
@@ -1249,13 +1261,18 @@ fn run_stream(stream_args: StreamArgs) {
             match event {
                 voice_stream::TtsStreamEvent::Started { metadata } => {
                     if !stream_args.json {
-                        println!(
+                        let line = format!(
                             "started stream={} rate={}Hz frame={}ms encoding={:?}",
                             metadata.stream_id,
                             metadata.sample_rate,
                             metadata.frame_ms,
                             metadata.encoding
                         );
+                        if raw_to_stdout {
+                            eprintln!("{line}");
+                        } else {
+                            println!("{line}");
+                        }
                     }
                 }
                 voice_stream::TtsStreamEvent::Audio { frame } => {
@@ -1265,33 +1282,53 @@ fn run_stream(stream_args: StreamArgs) {
                             .map_err(|e| format!("write raw PCM: {e}"))?;
                     }
                     if !stream_args.json {
-                        println!(
+                        let line = format!(
                             "audio seq={} samples={} padding={}",
                             frame.sequence, frame.sample_count, frame.padding_samples
                         );
+                        if raw_to_stdout {
+                            eprintln!("{line}");
+                        } else {
+                            println!("{line}");
+                        }
                     }
                 }
                 voice_stream::TtsStreamEvent::Ended(end) => {
                     if !stream_args.json {
-                        println!(
+                        let line = format!(
                             "ended stream={} frames={} samples={} duration_ms={}",
                             end.stream_id, end.frames, end.samples, end.duration_ms
                         );
+                        if raw_to_stdout {
+                            eprintln!("{line}");
+                        } else {
+                            println!("{line}");
+                        }
                     }
                 }
                 voice_stream::TtsStreamEvent::Error(err) => {
                     terminal_error = Some(err.message.clone());
                     if !stream_args.json {
-                        println!("error stream={}: {}", err.stream_id, err.message);
+                        let line = format!("error stream={}: {}", err.stream_id, err.message);
+                        if raw_to_stdout {
+                            eprintln!("{line}");
+                        } else {
+                            println!("{line}");
+                        }
                     }
                 }
                 voice_stream::TtsStreamEvent::Cancelled(cancelled) => {
                     terminal_error = Some(cancelled.reason.clone());
                     if !stream_args.json {
-                        println!(
+                        let line = format!(
                             "cancelled stream={}: {}",
                             cancelled.stream_id, cancelled.reason
                         );
+                        if raw_to_stdout {
+                            eprintln!("{line}");
+                        } else {
+                            println!("{line}");
+                        }
                     }
                 }
             }

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -64,10 +64,14 @@ Use `voice stream` to inspect the streaming event flow:
 voice stream "Hello from the stream"
 voice stream --json "Hello from the stream"
 voice stream --sample-rate 48000 --frame-ms 20 --raw-output reply.s16le "Hello"
+voice stream --sample-rate 48000 --frame-ms 20 --raw-output - "Hello" \
+  | ffmpeg -f s16le -ar 48000 -ac 1 -i - -c:a libopus reply.ogg
 ```
 
 The raw output is signed 16-bit little-endian mono PCM with no container header.
 Use the event metadata for sample rate, frame duration, and stream ID.
+When `--raw-output -` is used, stdout is reserved for PCM bytes and compact
+progress lines move to stderr.
 
 ## Daemon Protocol
 


### PR DESCRIPTION
## Summary
- allow `voice stream --raw-output -` to write raw PCM bytes to stdout
- move compact progress output to stderr when stdout is raw PCM
- reject `--json --raw-output -` because JSON events and PCM bytes cannot share stdout safely
- document piping the stream into ffmpeg/libopus for bridge and WebRTC experiments

## Verification
- `cargo fmt --check`
- `cargo check -p voice`
- `cargo build -p voice`
- `cargo test -p voice --no-run`
- `./target/debug/voice stream --sample-rate 48000 --frame-ms 20 --raw-output - "stdout stream smoke" > /tmp/voice-stdout-stream.s16le 2> /tmp/voice-stdout-stream.stderr` produced 115200 bytes and progress on stderr
- `./target/debug/voice stream --json --raw-output - "stdout json conflict"` exits nonzero with the expected conflict error
- `git diff --check`