### PR TITLE
Add Ogg Opus speech output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7072,11 +7072,19 @@ dependencies = [
  "rodio",
  "serde",
  "serde_json",
+ "voice-audio",
  "voice-g2p",
  "voice-protocol",
  "voice-stream",
  "voice-stt",
  "voice-tts",
+]
+
+[[package]]
+name = "voice-audio"
+version = "0.1.0"
+dependencies = [
+ "hound",
 ]
 
 [[package]]
@@ -7093,6 +7101,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "uuid",
+ "voice-audio",
  "voice-g2p",
  "voice-protocol",
  "voice-stream",

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ echo "The quick brown fox jumps over the lazy dog." | voice say
 
 # Save to file instead of playing
 voice say -o speech.wav "Good morning everyone."
+voice say --format ogg-opus -o speech.ogg "Good morning everyone."
 
 # Stream daemon TTS frames for bridge/WebRTC experiments
 voice stream --sample-rate 48000 --frame-ms 20 --raw-output speech.s16le "Good morning everyone."
@@ -102,7 +103,8 @@ Options:
   -f, --input-file <FILE>        Read text from a file (use - for stdin)
       --phonemes <IPA>           Raw phoneme string (IPA)
   -v, --voice <VOICE>            Voice name [default: af_heart]
-  -o, --output <PATH>            Write WAV to file instead of playing
+  -o, --output <PATH>            Write audio to file instead of playing
+      --format <FORMAT>          Output format: wav, ogg-opus
   -s, --speed <SPEED>            Speech speed factor [default: 1.0]
       --markdown                 Strip markdown/MDX formatting before speaking
       --sub <WORD=REPLACEMENT>   Word substitution (repeatable)
@@ -274,8 +276,10 @@ See [`examples/conversation.py`](examples/conversation.py) for a full speak/list
 
 Run `voiced --tts-only` to keep Kokoro warm without eagerly loading STT. When the
 daemon is running, `voice say -o output.wav ...` uses the daemon `synthesize`
-RPC and waits until the WAV exists. This is the compatibility path for Hermes'
-command TTS provider and WhatsApp voice-note delivery.
+RPC and waits until the WAV exists. For WhatsApp-ready voice notes, use
+`voice say --format ogg-opus -o output.ogg ...` or an `.ogg` / `.opus` output
+path; the CLI writes real `audio/ogg; codecs=opus` instead of a WAV with a
+misleading extension. OGG/Opus output requires `ffmpeg` on `PATH`.
 
 The macOS release archive includes both `voice` and `voiced`. Source installs
 should install both `crates/voice-cli` and `crates/voice-daemon` when the daemon
@@ -284,9 +288,10 @@ or `voice stream` surface is needed.
 See [docs/daemon.md](docs/daemon.md) for systemd user service and macOS
 LaunchAgent examples.
 
-For WhatsApp or Telegram voice-note delivery through Hermes, set
-`voice_compatible: true` on the command provider so Hermes converts Voice's WAV
-output to OGG/Opus when needed.
+For WhatsApp or Telegram voice-note delivery through Hermes, prefer
+`output_format: ogg` with `voice_compatible: true` so Hermes can send Voice's
+Opus output directly. `output_format: wav` remains a compatibility fallback,
+with Hermes converting to OGG/Opus when needed.
 
 For lower-level streaming, `stream_speak` emits `tts.started`, `tts.audio`, and
 terminal `tts.ended` / `tts.error` / `tts.cancelled` events over the same daemon
@@ -369,7 +374,8 @@ All other voices are fetched from HuggingFace Hub on first use:
 | Crate | Description |
 |-------|-------------|
 | [`voice`](https://crates.io/crates/voice) | CLI binary — installs as `voice` |
-| [`voice-tts`](https://crates.io/crates/voice-tts) | Core TTS library — model loading, inference, WAV output |
+| [`voice-audio`](https://crates.io/crates/voice-audio) | Audio container helpers — WAV and OGG/Opus output |
+| [`voice-tts`](https://crates.io/crates/voice-tts) | Core TTS library — model loading and inference |
 | [`voice-stt`](https://crates.io/crates/voice-stt) | Speech-to-text library — Whisper transcription, resampling |
 | [`voice-kokoro`](https://crates.io/crates/voice-kokoro) | Kokoro TTS backend — ALBERT encoder, prosody predictor, iSTFT decoder |
 | [`voice-whisper`](https://crates.io/crates/voice-whisper) | Whisper STT backend — greedy decoding, GPU mel spectrogram |

--- a/crates/voice-audio/Cargo.toml
+++ b/crates/voice-audio/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "voice-audio"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.85.0"
+description = "Audio container and codec helpers for voice"
+license = "MIT"
+repository = "https://github.com/rgbkrk/voice"
+
+[dependencies]
+hound = { workspace = true }

--- a/crates/voice-audio/src/lib.rs
+++ b/crates/voice-audio/src/lib.rs
@@ -1,0 +1,304 @@
+//! Audio container and codec helpers shared by the CLI and daemon.
+
+use hound::{WavSpec, WavWriter};
+use std::fmt;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudioOutputFormat {
+    Wav,
+    OggOpus,
+}
+
+impl AudioOutputFormat {
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "wav" | "wave" => Some(Self::Wav),
+            "ogg" | "opus" | "ogg-opus" | "ogg_opus" => Some(Self::OggOpus),
+            _ => None,
+        }
+    }
+
+    pub fn from_path(path: &Path) -> Option<Self> {
+        let extension = path.extension()?.to_str()?;
+        Self::from_name(extension)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Wav => "wav",
+            Self::OggOpus => "ogg-opus",
+        }
+    }
+
+    pub fn mime_type(self) -> &'static str {
+        match self {
+            Self::Wav => "audio/wav",
+            Self::OggOpus => "audio/ogg; codecs=opus",
+        }
+    }
+}
+
+impl fmt::Display for AudioOutputFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+pub fn save_audio(
+    samples: &[f32],
+    path: &Path,
+    sample_rate: u32,
+    format: AudioOutputFormat,
+) -> Result<(), String> {
+    match format {
+        AudioOutputFormat::Wav => save_wav(samples, path, sample_rate),
+        AudioOutputFormat::OggOpus => save_ogg_opus(samples, path, sample_rate),
+    }
+}
+
+pub fn resolve_output_format(
+    path: &Path,
+    explicit: Option<AudioOutputFormat>,
+) -> Result<AudioOutputFormat, String> {
+    let inferred = AudioOutputFormat::from_path(path);
+    let extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase());
+
+    if let Some(explicit) = explicit {
+        if let Some(inferred) = inferred {
+            if inferred != explicit {
+                return Err(format!(
+                    "output extension .{} implies {}, but requested format is {}",
+                    extension.as_deref().unwrap_or(""),
+                    inferred,
+                    explicit
+                ));
+            }
+        } else if let Some(extension) = extension {
+            return Err(format!(
+                "unsupported output extension .{} for format {}; use .wav, .ogg, .opus, or omit the extension",
+                extension, explicit
+            ));
+        }
+        return Ok(explicit);
+    }
+
+    if let Some(inferred) = inferred {
+        return Ok(inferred);
+    }
+
+    if let Some(extension) = extension {
+        return Err(format!(
+            "unsupported output extension .{}; use format wav or ogg-opus with .wav, .ogg, or .opus",
+            extension
+        ));
+    }
+
+    Ok(AudioOutputFormat::Wav)
+}
+
+pub fn save_wav(samples: &[f32], path: &Path, sample_rate: u32) -> Result<(), String> {
+    ensure_parent_dir(path)?;
+
+    let spec = WavSpec {
+        channels: 1,
+        sample_rate,
+        bits_per_sample: 32,
+        sample_format: hound::SampleFormat::Float,
+    };
+
+    let mut writer =
+        WavWriter::create(path, spec).map_err(|e| format!("create WAV {}: {e}", path.display()))?;
+
+    for &sample in samples {
+        writer
+            .write_sample(sample)
+            .map_err(|e| format!("write WAV sample: {e}"))?;
+    }
+
+    writer
+        .finalize()
+        .map_err(|e| format!("finalize WAV {}: {e}", path.display()))?;
+
+    Ok(())
+}
+
+pub fn save_ogg_opus(samples: &[f32], path: &Path, sample_rate: u32) -> Result<(), String> {
+    ensure_parent_dir(path)?;
+
+    let mut child = Command::new("ffmpeg")
+        .arg("-hide_banner")
+        .arg("-loglevel")
+        .arg("error")
+        .arg("-y")
+        .arg("-f")
+        .arg("f32le")
+        .arg("-ar")
+        .arg(sample_rate.to_string())
+        .arg("-ac")
+        .arg("1")
+        .arg("-i")
+        .arg("pipe:0")
+        .arg("-ac")
+        .arg("1")
+        .arg("-ar")
+        .arg("48000")
+        .arg("-c:a")
+        .arg("libopus")
+        .arg("-b:a")
+        .arg("32k")
+        .arg("-vbr")
+        .arg("on")
+        .arg("-application")
+        .arg("voip")
+        .arg("-f")
+        .arg("ogg")
+        .arg(path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("spawn ffmpeg for Ogg/Opus output: {e}"))?;
+
+    {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "open ffmpeg stdin".to_string())?;
+        for sample in samples {
+            stdin
+                .write_all(&sample.clamp(-1.0, 1.0).to_le_bytes())
+                .map_err(|e| format!("write PCM to ffmpeg: {e}"))?;
+        }
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| format!("wait for ffmpeg: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "ffmpeg Ogg/Opus encode failed with {}: {}",
+            output.status,
+            stderr.trim()
+        ));
+    }
+
+    if !is_ogg_opus_file(path) {
+        return Err(format!(
+            "ffmpeg output is not an Ogg/Opus file: {}",
+            path.display()
+        ));
+    }
+
+    Ok(())
+}
+
+pub fn is_ogg_opus_file(path: &Path) -> bool {
+    let Ok(bytes) = std::fs::read(path) else {
+        return false;
+    };
+    bytes.starts_with(b"OggS") && bytes.windows(b"OpusHead".len()).any(|w| w == b"OpusHead")
+}
+
+fn ensure_parent_dir(path: &Path) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("create output dir {}: {e}", parent.display()))?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_path(extension: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "voice_audio_test_{}_{}.{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("unnamed"),
+            extension
+        ))
+    }
+
+    fn sine_wave(sample_rate: u32) -> Vec<f32> {
+        let len = (sample_rate as f32 * 0.1) as usize;
+        (0..len)
+            .map(|i| {
+                let t = i as f32 / sample_rate as f32;
+                (2.0 * std::f32::consts::PI * 440.0 * t).sin() * 0.25
+            })
+            .collect()
+    }
+
+    #[test]
+    fn output_format_parses_names_and_extensions() {
+        assert_eq!(
+            AudioOutputFormat::from_name("ogg-opus"),
+            Some(AudioOutputFormat::OggOpus)
+        );
+        assert_eq!(
+            AudioOutputFormat::from_name("ogg"),
+            Some(AudioOutputFormat::OggOpus)
+        );
+        assert_eq!(
+            AudioOutputFormat::from_path(Path::new("reply.opus")),
+            Some(AudioOutputFormat::OggOpus)
+        );
+        assert_eq!(
+            AudioOutputFormat::from_path(Path::new("reply.wav")),
+            Some(AudioOutputFormat::Wav)
+        );
+        assert_eq!(AudioOutputFormat::from_name("mp3"), None);
+    }
+
+    #[test]
+    fn resolve_output_format_rejects_misleading_extensions() {
+        assert_eq!(
+            resolve_output_format(Path::new("reply.ogg"), None).unwrap(),
+            AudioOutputFormat::OggOpus
+        );
+        assert_eq!(
+            resolve_output_format(Path::new("reply"), None).unwrap(),
+            AudioOutputFormat::Wav
+        );
+        assert!(
+            resolve_output_format(Path::new("reply.wav"), Some(AudioOutputFormat::OggOpus))
+                .is_err()
+        );
+        assert!(resolve_output_format(Path::new("reply.mp3"), None).is_err());
+    }
+
+    #[test]
+    fn save_wav_writes_riff_file() {
+        let path = temp_path("wav");
+        let samples = sine_wave(24_000);
+        save_wav(&samples, &path, 24_000).expect("save wav");
+        let bytes = std::fs::read(&path).expect("read wav");
+        assert!(bytes.starts_with(b"RIFF"));
+        assert_eq!(&bytes[8..12], b"WAVE");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn save_ogg_opus_writes_opus_head() {
+        if Command::new("ffmpeg").arg("-version").output().is_err() {
+            eprintln!("skipping Ogg/Opus encode test because ffmpeg is not on PATH");
+            return;
+        }
+
+        let path = temp_path("ogg");
+        let samples = sine_wave(24_000);
+        save_ogg_opus(&samples, &path, 24_000).expect("save ogg opus");
+        assert!(is_ogg_opus_file(&path));
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/crates/voice-cli/Cargo.toml
+++ b/crates/voice-cli/Cargo.toml
@@ -36,4 +36,5 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 voice-protocol = { path = "../voice-protocol" }
 voice-stream = { path = "../voice-stream" }
+voice-audio = { path = "../voice-audio" }
 dirs = "5"

--- a/crates/voice-cli/README.md
+++ b/crates/voice-cli/README.md
@@ -42,6 +42,7 @@ voice Hello world
 # Text-to-speech with the say subcommand
 voice say -v am_michael "How are you today?"
 voice say -f script.txt -o output.wav
+voice say --format ogg-opus -o output.ogg "Hello WhatsApp"
 echo "Hello" | voice say
 voice say --markdown -f post.mdx
 voice phonemes "ChatGPT uses RuntimeStateDoc"
@@ -93,7 +94,8 @@ Options:
   -f, --input-file <FILE>        Read text from a file (use - for stdin)
       --phonemes <IPA>           Raw phoneme string (IPA)
   -v, --voice <VOICE>            Voice name [default: af_heart]
-  -o, --output <PATH>            Write WAV to file instead of playing
+  -o, --output <PATH>            Write audio to file instead of playing
+      --format <FORMAT>          Output format: wav, ogg-opus
   -s, --speed <SPEED>            Speech speed factor [default: 1.0]
       --markdown                 Strip markdown/MDX formatting before speaking
       --sub <WORD=REPLACEMENT>   Word substitution (repeatable)

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -6,7 +6,7 @@ use clap::{Parser, ValueEnum};
 use pulldown_cmark::{Event, Options, Parser as MdParser, Tag, TagEnd};
 use std::collections::HashMap;
 use std::io::{self, IsTerminal, Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 const MODEL_REPO: &str = "prince-canuma/Kokoro-82M";
@@ -1231,8 +1231,10 @@ fn run_say(say_args: SayArgs) {
             say_args.speed,
             sample_rate,
             synthesis_mode,
-            output_path,
-            output_format.expect("output format resolved when output path is set"),
+            FileOutput {
+                path: output_path.as_path(),
+                format: output_format.expect("output format resolved when output path is set"),
+            },
         ) {
             eprintln!("Failed to write audio: {e}");
             std::process::exit(1);
@@ -1551,7 +1553,12 @@ fn load_tts_model(
     }
 }
 
-/// Batch-generate all chunks and write a single WAV file.
+struct FileOutput<'a> {
+    path: &'a Path,
+    format: voice_audio::AudioOutputFormat,
+}
+
+/// Batch-generate all chunks and write a single audio file.
 fn generate_to_file(
     model: &mut voice_tts::KokoroModel,
     voice: &candle_core::Tensor,
@@ -1559,8 +1566,7 @@ fn generate_to_file(
     speed: f32,
     sample_rate: u32,
     synthesis_mode: voice_tts::SynthesisMode,
-    output_path: &PathBuf,
-    output_format: voice_audio::AudioOutputFormat,
+    output: FileOutput<'_>,
 ) -> Result<(), String> {
     info!("Generating audio...");
     let mut all_samples: Vec<f32> = Vec::new();
@@ -1590,8 +1596,8 @@ fn generate_to_file(
         std::process::exit(130);
     }
 
-    voice_audio::save_audio(&all_samples, output_path, sample_rate, output_format)?;
-    info!("Saved {} to {}", output_format, output_path.display());
+    voice_audio::save_audio(&all_samples, output.path, sample_rate, output.format)?;
+    info!("Saved {} to {}", output.format, output.path.display());
     Ok(())
 }
 

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -2,7 +2,7 @@ mod jsonrpc;
 mod listen;
 mod mcp;
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use pulldown_cmark::{Event, Options, Parser as MdParser, Tag, TagEnd};
 use std::collections::HashMap;
 use std::io::{self, IsTerminal, Read, Write};
@@ -37,6 +37,7 @@ macro_rules! info {
                   voice say -v am_adam \"How are you today?\"\n  \
                   echo \"Hello\" | voice say\n  \
                   voice say -f speech.txt -o output.wav\n  \
+                  voice say --format ogg-opus -o reply.ogg \"Hello\"\n  \
                   voice say --phonemes \"hɛloʊ wɜːld\"\n  \
                   voice say --markdown -f post.mdx\n  \
                   voice phonemes \"ChatGPT uses RuntimeStateDoc\"\n  \
@@ -137,9 +138,13 @@ struct SayArgs {
     #[arg(short, long, default_value = "af_heart")]
     voice: String,
 
-    /// Write WAV to file instead of playing
+    /// Write audio to file instead of playing
     #[arg(short, long)]
     output: Option<PathBuf>,
+
+    /// Output container/codec for --output. Defaults from extension: .wav, .ogg, .opus
+    #[arg(long = "format", value_enum, requires = "output")]
+    format: Option<SayOutputFormat>,
 
     /// Speech speed factor (1.0 = normal)
     #[arg(short, long, default_value = "1.0")]
@@ -161,6 +166,21 @@ struct SayArgs {
     /// If not set, .voice-subs is auto-discovered from the working directory upward.
     #[arg(long = "sub-file", value_name = "PATH")]
     sub_file: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum SayOutputFormat {
+    Wav,
+    OggOpus,
+}
+
+impl From<SayOutputFormat> for voice_audio::AudioOutputFormat {
+    fn from(format: SayOutputFormat) -> Self {
+        match format {
+            SayOutputFormat::Wav => Self::Wav,
+            SayOutputFormat::OggOpus => Self::OggOpus,
+        }
+    }
 }
 
 #[derive(clap::Args, Debug)]
@@ -759,6 +779,7 @@ fn main() {
                     phonemes: None,
                     voice: "af_heart".to_string(),
                     output: None,
+                    format: None,
                     speed: 1.0,
                     deterministic: false,
                     markdown: false,
@@ -1049,6 +1070,17 @@ fn run_phonemes(args: PhonemesArgs) {
 }
 
 fn run_say(say_args: SayArgs) {
+    let output_format = match say_args.output.as_ref() {
+        Some(output_path) => match resolve_say_output_format(output_path, say_args.format) {
+            Ok(format) => Some(format),
+            Err(msg) => {
+                eprintln!("Error: {msg}");
+                std::process::exit(1);
+            }
+        },
+        None => None,
+    };
+
     // If the daemon is running, delegate normal playback and file synthesis to it.
     // `--phonemes` stays local because the daemon RPC accepts text and runs its
     // own G2P pipeline.
@@ -1071,9 +1103,10 @@ fn run_say(say_args: SayArgs) {
             );
 
             let daemon_result = if let Some(output_path) = &say_args.output {
-                daemon.synthesize(
+                daemon.synthesize_with_format(
                     &text,
                     &output_path.to_string_lossy(),
+                    output_format.map(|format| format.as_str()),
                     Some(&say_args.voice),
                     Some(say_args.speed as f64),
                 )
@@ -1089,10 +1122,21 @@ fn run_say(say_args: SayArgs) {
                         .and_then(|r| r.get("status"))
                         .and_then(|s| s.as_str())
                         == Some("failed");
-                    if !failed {
-                        return;
+                    if failed {
+                        eprintln!("Daemon synthesis failed, falling back to local");
+                    } else {
+                        if output_format == Some(voice_audio::AudioOutputFormat::OggOpus) {
+                            if let Some(output_path) = &say_args.output {
+                                if voice_audio::is_ogg_opus_file(output_path) {
+                                    return;
+                                }
+                                let _ = std::fs::remove_file(output_path);
+                                eprintln!("Daemon output was not Ogg/Opus, falling back to local");
+                            }
+                        } else {
+                            return;
+                        }
                     }
-                    eprintln!("Daemon synthesis failed, falling back to local");
                 }
                 Ok(resp) => {
                     if let Some(err) = resp.error {
@@ -1180,7 +1224,7 @@ fn run_say(say_args: SayArgs) {
     };
 
     if let Some(output_path) = &say_args.output {
-        generate_to_file(
+        if let Err(e) = generate_to_file(
             &mut model,
             &voice,
             &phoneme_chunks,
@@ -1188,7 +1232,11 @@ fn run_say(say_args: SayArgs) {
             sample_rate,
             synthesis_mode,
             output_path,
-        );
+            output_format.expect("output format resolved when output path is set"),
+        ) {
+            eprintln!("Failed to write audio: {e}");
+            std::process::exit(1);
+        }
     } else {
         stream_playback(
             &mut model,
@@ -1199,6 +1247,13 @@ fn run_say(say_args: SayArgs) {
             synthesis_mode,
         );
     }
+}
+
+fn resolve_say_output_format(
+    output_path: &std::path::Path,
+    explicit: Option<SayOutputFormat>,
+) -> Result<voice_audio::AudioOutputFormat, String> {
+    voice_audio::resolve_output_format(output_path, explicit.map(Into::into))
 }
 
 fn run_stream(stream_args: StreamArgs) {
@@ -1505,7 +1560,8 @@ fn generate_to_file(
     sample_rate: u32,
     synthesis_mode: voice_tts::SynthesisMode,
     output_path: &PathBuf,
-) {
+    output_format: voice_audio::AudioOutputFormat,
+) -> Result<(), String> {
     info!("Generating audio...");
     let mut all_samples: Vec<f32> = Vec::new();
 
@@ -1534,18 +1590,9 @@ fn generate_to_file(
         std::process::exit(130);
     }
 
-    let spec = hound::WavSpec {
-        channels: 1,
-        sample_rate,
-        bits_per_sample: 32,
-        sample_format: hound::SampleFormat::Float,
-    };
-    let mut writer = hound::WavWriter::create(output_path, spec).expect("Failed to create WAV");
-    for s in &all_samples {
-        writer.write_sample(*s).expect("Failed to write sample");
-    }
-    writer.finalize().expect("Failed to finalize WAV");
-    info!("Saved to {}", output_path.display());
+    voice_audio::save_audio(&all_samples, output_path, sample_rate, output_format)?;
+    info!("Saved {} to {}", output_format, output_path.display());
+    Ok(())
 }
 
 /// Generate audio chunks and stream them to the speakers via rodio.

--- a/crates/voice-daemon/Cargo.toml
+++ b/crates/voice-daemon/Cargo.toml
@@ -22,6 +22,7 @@ voice-tts = { path = "../voice-tts" }
 voice-stt = { path = "../voice-stt" }
 voice-g2p = { path = "../voice-g2p" }
 voice-stream = { path = "../voice-stream" }
+voice-audio = { path = "../voice-audio" }
 candle-core = { workspace = true }
 rodio = { version = "0.22", features = ["experimental"] }
 hound = { workspace = true }

--- a/crates/voice-daemon/src/queue.rs
+++ b/crates/voice-daemon/src/queue.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, Mutex, Notify};
 use uuid::Uuid;
+use voice_audio::AudioOutputFormat;
 use voice_protocol::rpc::{DaemonState, ItemStatus, QueueItem};
 use voice_stream::TtsStreamEvent;
 
@@ -34,6 +35,7 @@ pub enum VoiceRequest {
     Synthesize {
         text: String,
         output_path: String,
+        output_format: Option<AudioOutputFormat>,
         voice: Option<String>,
         speed: Option<f64>,
     },
@@ -160,6 +162,7 @@ impl RequestQueue {
         client_id: String,
         text: String,
         output_path: String,
+        output_format: Option<AudioOutputFormat>,
         voice: Option<String>,
         speed: Option<f64>,
     ) -> String {
@@ -168,6 +171,7 @@ impl RequestQueue {
             VoiceRequest::Synthesize {
                 text,
                 output_path,
+                output_format,
                 voice,
                 speed,
             },

--- a/crates/voice-daemon/src/socket.rs
+++ b/crates/voice-daemon/src/socket.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::net::UnixListener;
 use uuid::Uuid;
+use voice_audio::AudioOutputFormat;
 use voice_protocol::frames::{read_frame, write_frame, Frame, FrameType};
 use voice_protocol::rpc::{self, Response};
 use voice_stream::{TtsStreamEvent, DEFAULT_FRAME_MS};
@@ -289,9 +290,14 @@ async fn dispatch(
                 Ok(speed) => speed,
                 Err(resp) => return resp,
             };
+            let output_format = match optional_audio_output_format_param(&req) {
+                Ok(output_format) => output_format,
+                Err(resp) => return resp,
+            };
             VoiceRequest::Synthesize {
                 text,
                 output_path,
+                output_format,
                 voice,
                 speed,
             }
@@ -464,11 +470,19 @@ async fn dispatch(
             VoiceRequest::Synthesize {
                 text,
                 output_path,
+                output_format,
                 voice,
                 speed,
             } => {
                 queue
-                    .enqueue_synthesize(client_id.to_string(), text, output_path, voice, speed)
+                    .enqueue_synthesize(
+                        client_id.to_string(),
+                        text,
+                        output_path,
+                        output_format,
+                        voice,
+                        speed,
+                    )
                     .await
             }
             VoiceRequest::StreamSpeak(_) => {
@@ -597,6 +611,34 @@ fn optional_speed_param(req: &rpc::Request) -> Result<Option<f64>, Response> {
         return Ok(None);
     }
     required_speed_param(req).map(Some)
+}
+
+fn optional_audio_output_format_param(
+    req: &rpc::Request,
+) -> Result<Option<AudioOutputFormat>, Response> {
+    let raw = req
+        .params
+        .get("format")
+        .or_else(|| req.params.get("output_format"));
+    let Some(value) = raw else {
+        return Ok(None);
+    };
+    let Some(format) = value.as_str() else {
+        return Err(Response::error(
+            req.id.clone(),
+            rpc::INVALID_PARAMS,
+            "param 'format' must be a string",
+        ));
+    };
+    AudioOutputFormat::from_name(format)
+        .map(Some)
+        .ok_or_else(|| {
+            Response::error(
+                req.id.clone(),
+                rpc::INVALID_PARAMS,
+                "param 'format' must be one of: wav, ogg, opus, ogg-opus",
+            )
+        })
 }
 
 fn validate_speed(req: &rpc::Request, speed: f64) -> Result<f64, Response> {

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -12,6 +12,7 @@ use std::num::NonZero;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
+use voice_audio::AudioOutputFormat;
 use voice_stream::{
     resample_linear, AudioEncoding, InterleavedMonoMixer, Packetizer, StreamEnded, StreamMetadata,
     TtsStreamEvent,
@@ -192,11 +193,13 @@ pub async fn run(
                 VoiceRequest::Synthesize {
                     text,
                     output_path,
+                    output_format,
                     voice,
                     speed,
                 } => {
                     let text = text.clone();
                     let output_path = output_path.clone();
+                    let output_format = *output_format;
                     let voice = voice.clone().or_else(|| Some(config.get_voice_name()));
                     let speed = speed.or_else(|| Some(config.get_speed() as f64));
                     let tts = tts.clone();
@@ -207,6 +210,7 @@ pub async fn run(
                             &tts,
                             &text,
                             &output_path,
+                            output_format,
                             voice.as_deref(),
                             speed,
                             &cancelled,
@@ -460,6 +464,7 @@ fn synthesize_to_file(
     tts: &Arc<Mutex<TtsState>>,
     text: &str,
     output_path: &str,
+    output_format: Option<AudioOutputFormat>,
     voice_name: Option<&str>,
     speed: Option<f64>,
     cancelled: &Arc<AtomicBool>,
@@ -508,17 +513,13 @@ fn synthesize_to_file(
     }
 
     let path = std::path::Path::new(output_path);
-    if let Some(parent) = path.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| format!("create output dir {}: {}", parent.display(), e))?;
-        }
-    }
-
-    audio_recorder::save_wav(path, &all_samples, sample_rate)?;
+    let output_format = voice_audio::resolve_output_format(path, output_format)?;
+    voice_audio::save_audio(&all_samples, path, sample_rate, output_format)?;
 
     Ok(serde_json::json!({
         "output_path": output_path,
+        "format": output_format.as_str(),
+        "mime_type": output_format.mime_type(),
         "duration_ms": started.elapsed().as_millis() as u64,
         "chunks": chunks.len(),
         "samples": all_samples.len(),
@@ -932,7 +933,10 @@ async fn run_simulated(
                     sync_automerge(&queue, &automerge).await;
                 }
                 VoiceRequest::Synthesize {
-                    text, output_path, ..
+                    text,
+                    output_path,
+                    output_format,
+                    ..
                 } => {
                     let words = text.split_whitespace().count();
                     let ms = (words as u64 * 50).max(100);
@@ -941,12 +945,21 @@ async fn run_simulated(
                     if let Some(parent) = path.parent() {
                         let _ = std::fs::create_dir_all(parent);
                     }
-                    let _ = audio_recorder::save_wav(path, &[], 24_000);
+                    let format = voice_audio::resolve_output_format(path, *output_format)
+                        .unwrap_or(AudioOutputFormat::Wav);
+                    let samples = if matches!(format, AudioOutputFormat::OggOpus) {
+                        vec![0.0; 2_400]
+                    } else {
+                        Vec::new()
+                    };
+                    let _ = voice_audio::save_audio(&samples, path, 24_000, format);
                     queue
                         .complete(
                             Some(
                                 serde_json::json!({
                                     "output_path": output_path,
+                                    "format": format.as_str(),
+                                    "mime_type": format.mime_type(),
                                     "duration_ms": ms,
                                     "chunks": 0,
                                     "samples": 0,
@@ -1088,6 +1101,7 @@ mod tests {
                 VoiceRequest::Synthesize {
                     text: "hello from simulated synthesis".to_string(),
                     output_path: output_path.to_string_lossy().to_string(),
+                    output_format: None,
                     voice: None,
                     speed: None,
                 },
@@ -1106,6 +1120,58 @@ mod tests {
 
         let (_samples, sample_rate) = audio_recorder::read_wav(&output_path).unwrap();
         assert_eq!(sample_rate, 24_000);
+
+        let _ = std::fs::remove_file(output_path);
+        worker.abort();
+    }
+
+    #[tokio::test]
+    async fn simulated_synthesize_writes_ogg_opus_and_completes() {
+        if std::process::Command::new("ffmpeg")
+            .arg("-version")
+            .output()
+            .is_err()
+        {
+            eprintln!("skipping daemon Ogg/Opus test because ffmpeg is not on PATH");
+            return;
+        }
+
+        let (queue, worker) = start_simulated_worker().await;
+        let output_path = std::env::temp_dir().join(format!(
+            "voice-daemon-simulated-synth-{}-{}.ogg",
+            std::process::id(),
+            unique_suffix()
+        ));
+
+        let (_queue_id, rx) = queue
+            .enqueue_and_wait(
+                "test-client".to_string(),
+                VoiceRequest::Synthesize {
+                    text: "hello from simulated opus synthesis".to_string(),
+                    output_path: output_path.to_string_lossy().to_string(),
+                    output_format: Some(AudioOutputFormat::OggOpus),
+                    voice: None,
+                    speed: None,
+                },
+            )
+            .await;
+
+        let result = await_completion(rx).await;
+        assert_eq!(result.status, ItemStatus::Completed);
+        let result_json: serde_json::Value =
+            serde_json::from_str(result.result.as_deref().unwrap()).unwrap();
+        assert_eq!(
+            result_json.get("format").and_then(|v| v.as_str()),
+            Some("ogg-opus")
+        );
+        assert_eq!(
+            result_json.get("mime_type").and_then(|v| v.as_str()),
+            Some("audio/ogg; codecs=opus")
+        );
+        assert!(
+            voice_audio::is_ogg_opus_file(&output_path),
+            "simulated synth should create Ogg/Opus"
+        );
 
         let _ = std::fs::remove_file(output_path);
         worker.abort();

--- a/crates/voice-protocol/src/client.rs
+++ b/crates/voice-protocol/src/client.rs
@@ -101,11 +101,26 @@ impl DaemonClient {
         self.call("speak", params)
     }
 
-    /// Convenience: synthesize text to a WAV file via the daemon and wait for completion.
+    /// Convenience: synthesize text to an audio file via the daemon and wait for completion.
+    ///
+    /// The daemon infers the output format from `output_path` (`.wav`, `.ogg`, `.opus`).
     pub fn synthesize(
         &mut self,
         text: &str,
         output_path: &str,
+        voice: Option<&str>,
+        speed: Option<f64>,
+    ) -> Result<Response, String> {
+        self.synthesize_with_format(text, output_path, None, voice, speed)
+    }
+
+    /// Convenience: synthesize text to an audio file via the daemon with an
+    /// explicit output format.
+    pub fn synthesize_with_format(
+        &mut self,
+        text: &str,
+        output_path: &str,
+        output_format: Option<&str>,
         voice: Option<&str>,
         speed: Option<f64>,
     ) -> Result<Response, String> {
@@ -114,6 +129,9 @@ impl DaemonClient {
             "output_path": output_path,
             "wait": true,
         });
+        if let Some(format) = output_format {
+            params["format"] = Value::String(format.to_string());
+        }
         if let Some(v) = voice {
             params["voice"] = Value::String(v.to_string());
         }

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -1,10 +1,13 @@
 # Streaming TTS
 
-`voice` exposes two daemon-backed TTS surfaces:
+`voice` exposes three TTS surfaces relevant to integrations:
 
-- `synthesize`: write a completed WAV file. This is the compatibility path for
-  tools that expect `{input_path} -> {output_path}`, including Hermes command
-  TTS providers.
+- `say --output`: write a completed audio file. `.wav` writes float WAV, while
+  `.ogg` / `.opus` or `--format ogg-opus` writes real
+  `audio/ogg; codecs=opus` for WhatsApp-style voice notes. OGG/Opus output
+  requires `ffmpeg` on `PATH`.
+- `synthesize`: daemon RPC for completed files. It infers `.wav`, `.ogg`, and
+  `.opus` output paths the same way as the CLI.
 - `stream_speak`: emit ordered audio events over the daemon socket. This is the
   transport-neutral path for WebRTC, voice bridges, or any client that wants
   audio before a final file exists.
@@ -12,8 +15,8 @@
 ## Hermes / WhatsApp
 
 Hermes' current WhatsApp path sends local media files to the WhatsApp bridge.
-The bridge reads the completed file and converts non-Opus audio to OGG/Opus for
-native `ptt` voice-note delivery. Use daemon synthesis for that path:
+Use OGG/Opus output for native `ptt` voice-note delivery without an extra
+Hermes-side conversion:
 
 ```yaml
 tts:
@@ -21,8 +24,8 @@ tts:
   providers:
     kokoro:
       type: command
-      command: /path/to/voice say --input-file {input_path} --output {output_path} --voice {voice} --speed {speed}
-      output_format: wav
+      command: /path/to/voice say --format ogg-opus --input-file {input_path} --output {output_path} --voice {voice} --speed {speed}
+      output_format: ogg
       voice_compatible: true
       voice: af_heart
       speed: 1.0
@@ -42,10 +45,10 @@ install the daemon with `cargo install --path crates/voice-daemon`.
 `voice say -o ...` falls back to local synthesis if the daemon is unavailable,
 so the same command still works outside Hermes.
 
-Set `voice_compatible: true` so Hermes converts the WAV output to OGG/Opus
-when it needs native voice-note delivery. This requires `ffmpeg` in Hermes'
-environment and lets WhatsApp/Telegram paths receive an Opus voice note instead
-of a generic audio attachment.
+Set `voice_compatible: true` so Hermes routes the returned `.ogg` file as a
+native voice note. `output_format: wav` remains valid as a compatibility
+fallback; Hermes and the WhatsApp bridge can still convert non-Opus audio when
+needed.
 
 The repository also includes `examples/hermes-command-tts.sh`, which matches
 Hermes' command-provider argument order:
@@ -63,6 +66,7 @@ Use `voice stream` to inspect the streaming event flow:
 ```bash
 voice stream "Hello from the stream"
 voice stream --json "Hello from the stream"
+voice say --format ogg-opus -o reply.ogg "Hello"
 voice stream --sample-rate 48000 --frame-ms 20 --raw-output reply.s16le "Hello"
 voice stream --sample-rate 48000 --frame-ms 20 --raw-output - "Hello" \
   | ffmpeg -f s16le -ar 48000 -ac 1 -i - -c:a libopus reply.ogg


### PR DESCRIPTION
## Summary
- add a shared voice-audio crate for output format resolution, WAV writing, and Ogg/Opus encoding
- add `voice say --format ogg-opus -o reply.ogg` plus .ogg/.opus extension inference and misleading-extension errors
- teach daemon synthesize to write WAV or Ogg/Opus and return format/MIME metadata
- document Hermes/WhatsApp Ogg output and keep PCM streaming docs clear

## Verification
- `cargo fmt --check`
- `cargo check -p voice-audio -p voice-protocol -p voice -p voice-daemon`
- `cargo test -p voice-audio -p voice-protocol -p voice-daemon`
- `cargo test -p voice --no-run`
- `git diff --check`
- `./target/debug/voice say --format ogg-opus -o /tmp/voice-ogg-opus-smoke.ogg "Direct Opus output smoke test."`
- `ffprobe` verified codec=opus, sample_rate=48000, channels=1
- isolated debug daemon smoke verified daemon-backed .ogg output is Ogg/Opus
