### PR TITLE
Add PCM stream transcription ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,8 +295,10 @@ with Hermes converting to OGG/Opus when needed.
 
 For lower-level streaming, `stream_speak` emits `tts.started`, `tts.audio`, and
 terminal `tts.ended` / `tts.error` / `tts.cancelled` events over the same daemon
-frame protocol. See [docs/streaming.md](docs/streaming.md) for the event schema
-and Hermes/WebRTC notes. See
+frame protocol. `stream_transcribe` accepts client-sent `stt.audio` frames and
+returns a terminal `stt.transcribed` event. See
+[docs/streaming.md](docs/streaming.md) for the event schema and Hermes/WebRTC
+notes. See
 [docs/whatsapp-calling-webrtc.md](docs/whatsapp-calling-webrtc.md) for the
 WhatsApp Calling architecture.
 

--- a/crates/voice-daemon/src/queue.rs
+++ b/crates/voice-daemon/src/queue.rs
@@ -23,6 +23,14 @@ pub struct StreamSpeakRequest {
     pub event_tx: mpsc::Sender<TtsStreamEvent>,
 }
 
+/// Parameters for a daemon STT stream after the socket layer has collected PCM.
+#[derive(Debug, Clone)]
+pub struct StreamTranscribeRequest {
+    pub stream_id: String,
+    pub samples: Vec<f32>,
+    pub sample_rate: u32,
+}
+
 /// What the worker will execute.
 #[derive(Debug, Clone)]
 pub enum VoiceRequest {
@@ -41,6 +49,8 @@ pub enum VoiceRequest {
     },
     /// Generate speech audio as ordered stream events.
     StreamSpeak(StreamSpeakRequest),
+    /// Transcribe caller-supplied PCM frames.
+    StreamTranscribe(StreamTranscribeRequest),
     Listen {
         max_duration_ms: Option<u64>,
     },
@@ -56,6 +66,7 @@ impl VoiceRequest {
             Self::Speak { .. } => "speak",
             Self::Synthesize { .. } => "synthesize",
             Self::StreamSpeak(_) => "stream_speak",
+            Self::StreamTranscribe(_) => "stream_transcribe",
             Self::Listen { .. } => "listen",
             Self::Converse { .. } => "converse",
         }
@@ -73,6 +84,11 @@ impl VoiceRequest {
                 let preview: String = request.text.chars().take(80).collect();
                 Some(preview)
             }
+            Self::StreamTranscribe(request) => Some(format!(
+                "{} samples @ {} Hz",
+                request.samples.len(),
+                request.sample_rate
+            )),
             Self::Listen { .. } => None,
         }
     }

--- a/crates/voice-daemon/src/socket.rs
+++ b/crates/voice-daemon/src/socket.rs
@@ -4,15 +4,19 @@
 //! instead of newline-delimited JSON.
 
 use crate::config::DaemonConfig;
-use crate::queue::{RequestQueue, StreamSpeakRequest};
+use crate::queue::{RequestQueue, StreamSpeakRequest, StreamTranscribeRequest, VoiceRequest};
 use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::UnixListener;
 use uuid::Uuid;
 use voice_audio::AudioOutputFormat;
 use voice_protocol::frames::{read_frame, write_frame, Frame, FrameType};
 use voice_protocol::rpc::{self, Response};
 use voice_stream::{TtsStreamEvent, DEFAULT_FRAME_MS};
+
+const DEFAULT_STREAM_TRANSCRIBE_MAX_MS: u64 = 60_000;
+const MAX_STREAM_TRANSCRIBE_MAX_MS: u64 = 5 * 60 * 1_000;
 
 pub fn socket_path() -> PathBuf {
     let path = voice_protocol::client::daemon_socket_path();
@@ -100,6 +104,21 @@ async fn handle_client(
                         break;
                     }
                 }
+                Ok(req) if req.method == "stream_transcribe" => {
+                    if dispatch_stream_transcribe(
+                        req,
+                        &queue,
+                        &client_id,
+                        &automerge,
+                        &mut reader,
+                        &mut writer,
+                    )
+                    .await
+                    .is_err()
+                    {
+                        break;
+                    }
+                }
                 Ok(req) => {
                     let response = dispatch(req, &queue, &config, &client_id, &automerge).await;
                     if write_response(&mut writer, &response).await.is_err() {
@@ -129,16 +148,13 @@ async fn handle_client(
     eprintln!("voiced: client disconnected ({})", client_id);
 }
 
-async fn write_response(
-    writer: &mut tokio::net::unix::OwnedWriteHalf,
-    response: &Response,
-) -> std::io::Result<()> {
+async fn write_response(writer: &mut OwnedWriteHalf, response: &Response) -> std::io::Result<()> {
     let json = serde_json::to_vec(response).unwrap();
     write_frame(writer, &Frame::response(&json)).await
 }
 
 async fn write_stream_event(
-    writer: &mut tokio::net::unix::OwnedWriteHalf,
+    writer: &mut OwnedWriteHalf,
     event: &TtsStreamEvent,
 ) -> std::io::Result<()> {
     let envelope = rpc::Event::new(event.event_name(), serde_json::to_value(event).unwrap());
@@ -152,7 +168,7 @@ async fn dispatch_stream_speak(
     config: &Arc<DaemonConfig>,
     client_id: &str,
     automerge: &Arc<tokio::sync::Mutex<crate::automerge_state::AutomergeState>>,
-    writer: &mut tokio::net::unix::OwnedWriteHalf,
+    writer: &mut OwnedWriteHalf,
 ) -> std::io::Result<()> {
     if !(req.params.is_null() || req.params.is_object()) {
         let response = Response::error(req.id, rpc::INVALID_PARAMS, "params must be an object");
@@ -221,6 +237,200 @@ async fn dispatch_stream_speak(
     if !saw_terminal {
         let event = TtsStreamEvent::error(stream_id, "stream closed before terminal event");
         write_stream_event(writer, &event).await?;
+    }
+
+    Ok(())
+}
+
+async fn write_rpc_event(
+    writer: &mut OwnedWriteHalf,
+    event_name: &str,
+    data: serde_json::Value,
+) -> std::io::Result<()> {
+    let envelope = rpc::Event::new(event_name, data);
+    let json = serde_json::to_vec(&envelope).unwrap();
+    write_frame(writer, &Frame::event(&json)).await
+}
+
+async fn write_stt_error(
+    writer: &mut OwnedWriteHalf,
+    stream_id: &str,
+    message: impl Into<String>,
+) -> std::io::Result<()> {
+    write_rpc_event(
+        writer,
+        "stt.error",
+        serde_json::json!({
+            "stream_id": stream_id,
+            "message": message.into(),
+        }),
+    )
+    .await
+}
+
+async fn dispatch_stream_transcribe(
+    req: rpc::Request,
+    queue: &Arc<RequestQueue>,
+    client_id: &str,
+    automerge: &Arc<tokio::sync::Mutex<crate::automerge_state::AutomergeState>>,
+    reader: &mut OwnedReadHalf,
+    writer: &mut OwnedWriteHalf,
+) -> std::io::Result<()> {
+    if !(req.params.is_null() || req.params.is_object()) {
+        let response = Response::error(req.id, rpc::INVALID_PARAMS, "params must be an object");
+        return write_response(writer, &response).await;
+    }
+
+    let sample_rate = match optional_u32_param(&req, "sample_rate", 8_000, 96_000) {
+        Ok(rate) => rate.unwrap_or(48_000),
+        Err(resp) => return write_response(writer, &resp).await,
+    };
+    let frame_ms = match optional_u32_param(&req, "frame_ms", 5, 100) {
+        Ok(frame_ms) => frame_ms.unwrap_or(DEFAULT_FRAME_MS),
+        Err(resp) => return write_response(writer, &resp).await,
+    };
+    let channels = match optional_u32_param(&req, "channels", 1, 1) {
+        Ok(channels) => channels.unwrap_or(1),
+        Err(resp) => return write_response(writer, &resp).await,
+    };
+    if let Err(resp) = optional_audio_encoding_param(&req) {
+        return write_response(writer, &resp).await;
+    }
+    let max_duration_ms = match optional_duration_param(&req, "max_duration_ms") {
+        Ok(duration) => duration.unwrap_or(DEFAULT_STREAM_TRANSCRIBE_MAX_MS),
+        Err(resp) => return write_response(writer, &resp).await,
+    };
+    if max_duration_ms > MAX_STREAM_TRANSCRIBE_MAX_MS {
+        let response = Response::error(
+            req.id,
+            rpc::INVALID_PARAMS,
+            format!(
+                "param 'max_duration_ms' must be <= {}",
+                MAX_STREAM_TRANSCRIBE_MAX_MS
+            ),
+        );
+        return write_response(writer, &response).await;
+    }
+    let max_samples = ((sample_rate as u64).saturating_mul(max_duration_ms) / 1_000) as usize;
+    let stream_id = Uuid::new_v4().to_string();
+
+    let response = Response::success(
+        req.id,
+        serde_json::json!({
+            "stream_id": stream_id,
+            "status": "receiving",
+            "sample_rate": sample_rate,
+            "channels": channels,
+            "encoding": "pcm_s16le",
+            "frame_ms": frame_ms,
+            "max_duration_ms": max_duration_ms,
+        }),
+    );
+    write_response(writer, &response).await?;
+
+    let mut samples = Vec::<f32>::new();
+    let mut frames = 0u64;
+
+    loop {
+        let frame = match read_frame(reader).await {
+            Ok(Some(frame)) => frame,
+            Ok(None) => return Ok(()),
+            Err(e) => {
+                write_stt_error(writer, &stream_id, format!("read error: {e}")).await?;
+                return Ok(());
+            }
+        };
+
+        if frame.frame_type != FrameType::Event {
+            write_stt_error(
+                writer,
+                &stream_id,
+                format!("expected Event frame, got {:?}", frame.frame_type),
+            )
+            .await?;
+            return Ok(());
+        }
+
+        let event = match frame.json::<rpc::Event>() {
+            Ok(event) => event,
+            Err(e) => {
+                write_stt_error(writer, &stream_id, format!("invalid event JSON: {e}")).await?;
+                return Ok(());
+            }
+        };
+
+        match event.event.as_str() {
+            "stt.audio" => match parse_stt_audio_samples(&event.data, &stream_id, sample_rate) {
+                Ok(mut frame_samples) => {
+                    if samples.len().saturating_add(frame_samples.len()) > max_samples {
+                        write_stt_error(
+                            writer,
+                            &stream_id,
+                            format!("stream exceeded max_duration_ms ({max_duration_ms})"),
+                        )
+                        .await?;
+                        return Ok(());
+                    }
+                    frames += 1;
+                    samples.append(&mut frame_samples);
+                }
+                Err(message) => {
+                    write_stt_error(writer, &stream_id, message).await?;
+                    return Ok(());
+                }
+            },
+            "stt.end" => {
+                if let Err(message) = validate_stream_id(&event.data, &stream_id) {
+                    write_stt_error(writer, &stream_id, message).await?;
+                    return Ok(());
+                }
+                break;
+            }
+            other => {
+                write_stt_error(writer, &stream_id, format!("unexpected event: {other}")).await?;
+                return Ok(());
+            }
+        }
+    }
+
+    let (queue_id, completion_rx) = queue
+        .enqueue_and_wait(
+            client_id.to_string(),
+            VoiceRequest::StreamTranscribe(StreamTranscribeRequest {
+                stream_id: stream_id.clone(),
+                samples,
+                sample_rate,
+            }),
+        )
+        .await;
+    sync_automerge(queue, automerge).await;
+
+    match completion_rx.await {
+        Ok(completion) if completion.status == rpc::ItemStatus::Completed => {
+            let mut data = completion
+                .result
+                .as_deref()
+                .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+                .unwrap_or_else(|| serde_json::json!({ "text": completion.result }));
+            if let Some(obj) = data.as_object_mut() {
+                obj.insert("queue_id".to_string(), serde_json::json!(queue_id));
+                obj.insert("frames".to_string(), serde_json::json!(frames));
+            }
+            write_rpc_event(writer, "stt.transcribed", data).await?;
+        }
+        Ok(completion) => {
+            write_stt_error(
+                writer,
+                &stream_id,
+                completion
+                    .result
+                    .unwrap_or_else(|| "stream transcription failed".to_string()),
+            )
+            .await?;
+        }
+        Err(_) => {
+            write_stt_error(writer, &stream_id, "stream transcription worker dropped").await?;
+        }
     }
 
     Ok(())
@@ -488,6 +698,9 @@ async fn dispatch(
             VoiceRequest::StreamSpeak(_) => {
                 unreachable!("stream_speak is handled before dispatch")
             }
+            VoiceRequest::StreamTranscribe(_) => {
+                unreachable!("stream_transcribe is handled before dispatch")
+            }
             VoiceRequest::Listen { max_duration_ms } => {
                 queue
                     .enqueue_listen(client_id.to_string(), max_duration_ms)
@@ -693,6 +906,269 @@ fn optional_u32_param(
             )),
         },
         None => Ok(None),
+    }
+}
+
+fn optional_audio_encoding_param(req: &rpc::Request) -> Result<(), Response> {
+    let Some(value) = req.params.get("encoding") else {
+        return Ok(());
+    };
+    let Some(encoding) = value.as_str() else {
+        return Err(Response::error(
+            req.id.clone(),
+            rpc::INVALID_PARAMS,
+            "param 'encoding' must be a string",
+        ));
+    };
+    match encoding.trim().to_ascii_lowercase().as_str() {
+        "pcm_s16le" | "pcm_s16_le" => Ok(()),
+        _ => Err(Response::error(
+            req.id.clone(),
+            rpc::INVALID_PARAMS,
+            "param 'encoding' must be pcm_s16le",
+        )),
+    }
+}
+
+fn parse_stt_audio_samples(
+    data: &serde_json::Value,
+    stream_id: &str,
+    sample_rate: u32,
+) -> Result<Vec<f32>, String> {
+    let frame = data.get("frame").unwrap_or(data);
+    validate_stream_id(frame, stream_id)?;
+
+    if let Some(rate) = frame.get("sample_rate") {
+        let Some(rate) = rate.as_u64() else {
+            return Err("frame.sample_rate must be an unsigned integer".to_string());
+        };
+        if rate != sample_rate as u64 {
+            return Err(format!(
+                "frame.sample_rate {rate} does not match stream sample_rate {sample_rate}"
+            ));
+        }
+    }
+
+    if let Some(channels) = frame.get("channels") {
+        if channels.as_u64() != Some(1) {
+            return Err("frame.channels must be 1".to_string());
+        }
+    }
+
+    if let Some(encoding) = frame.get("encoding") {
+        let Some(encoding) = encoding.as_str() else {
+            return Err("frame.encoding must be a string".to_string());
+        };
+        match encoding.trim().to_ascii_lowercase().as_str() {
+            "pcm_s16le" | "pcm_s16_le" => {}
+            _ => return Err("frame.encoding must be pcm_s16le".to_string()),
+        }
+    }
+
+    let Some(samples) = frame.get("samples").and_then(|value| value.as_array()) else {
+        return Err("stt.audio frame must include samples array".to_string());
+    };
+    if samples.is_empty() {
+        return Err("stt.audio samples must not be empty".to_string());
+    }
+
+    samples
+        .iter()
+        .map(|value| {
+            let raw = value
+                .as_i64()
+                .ok_or_else(|| "stt.audio samples must be signed 16-bit integers".to_string())?;
+            let sample =
+                i16::try_from(raw).map_err(|_| "stt.audio sample out of i16 range".to_string())?;
+            Ok(i16_to_f32(sample))
+        })
+        .collect()
+}
+
+fn validate_stream_id(data: &serde_json::Value, stream_id: &str) -> Result<(), String> {
+    match data.get("stream_id") {
+        Some(value) if value.as_str() == Some(stream_id) => Ok(()),
+        Some(_) => Err("event stream_id does not match active stream".to_string()),
+        None => Ok(()),
+    }
+}
+
+fn i16_to_f32(sample: i16) -> f32 {
+    (sample as f32 / 32_768.0).clamp(-1.0, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::automerge_state::AutomergeState;
+    use crate::config::DaemonConfig;
+    use tokio::net::UnixStream;
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn parse_stt_audio_samples_accepts_nested_pcm_frame() {
+        let data = serde_json::json!({
+            "frame": {
+                "stream_id": "stream-1",
+                "sample_rate": 48_000,
+                "channels": 1,
+                "encoding": "pcm_s16le",
+                "samples": [0, 32767, -32768]
+            }
+        });
+
+        let samples = parse_stt_audio_samples(&data, "stream-1", 48_000).unwrap();
+        assert_eq!(samples.len(), 3);
+        assert_eq!(samples[0], 0.0);
+        assert!(samples[1] > 0.99);
+        assert_eq!(samples[2], -1.0);
+    }
+
+    #[test]
+    fn parse_stt_audio_samples_rejects_mismatched_stream_id() {
+        let data = serde_json::json!({
+            "stream_id": "other-stream",
+            "sample_rate": 48_000,
+            "samples": [0]
+        });
+
+        let err = parse_stt_audio_samples(&data, "stream-1", 48_000).unwrap_err();
+        assert!(err.contains("stream_id"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn stream_transcribe_socket_round_trips_to_queue() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let socket_path = std::env::temp_dir().join(format!(
+            "voice-daemon-stream-transcribe-{}-{}.sock",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let _ = std::fs::remove_file(&socket_path);
+        let old_socket = std::env::var(voice_protocol::client::daemon_socket_env_var()).ok();
+        std::env::set_var(
+            voice_protocol::client::daemon_socket_env_var(),
+            &socket_path,
+        );
+
+        let queue = Arc::new(RequestQueue::new());
+        let worker_queue = queue.clone();
+        let worker = tokio::spawn(async move {
+            worker_queue.notify.notified().await;
+            let Some(entry) = worker_queue.dequeue().await else {
+                return;
+            };
+            match entry.request {
+                VoiceRequest::StreamTranscribe(request) => {
+                    assert_eq!(request.sample_rate, 48_000);
+                    assert_eq!(request.samples.len(), 3);
+                    worker_queue
+                        .complete(
+                            Some(
+                                serde_json::json!({
+                                    "stream_id": request.stream_id,
+                                    "text": "hello",
+                                    "tokens": 1,
+                                    "sample_rate": request.sample_rate,
+                                    "audio_duration_ms": 0,
+                                    "elapsed_ms": 0,
+                                })
+                                .to_string(),
+                            ),
+                            None,
+                        )
+                        .await;
+                }
+                _ => worker_queue.fail("unexpected request".to_string()).await,
+            }
+        });
+
+        let automerge = Arc::new(tokio::sync::Mutex::new(AutomergeState::new()));
+        let server = tokio::spawn(serve(queue, Arc::new(DaemonConfig::new()), automerge));
+
+        for _ in 0..50 {
+            if socket_path.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        let mut stream = UnixStream::connect(&socket_path)
+            .await
+            .expect("socket server did not start");
+
+        let req = rpc::Request::new(
+            "stream_transcribe",
+            serde_json::json!({
+                "sample_rate": 48_000,
+                "channels": 1,
+                "encoding": "pcm_s16le",
+                "frame_ms": 20,
+            }),
+        )
+        .with_id(1);
+        let json = serde_json::to_vec(&req).unwrap();
+        write_frame(&mut stream, &Frame::request(&json))
+            .await
+            .unwrap();
+
+        let response_frame = read_frame(&mut stream)
+            .await
+            .unwrap()
+            .expect("missing stream_transcribe response");
+        let response = response_frame.json::<Response>().unwrap();
+        assert!(response.error.is_none());
+        let stream_id = response.result.unwrap()["stream_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let audio = rpc::Event::new(
+            "stt.audio",
+            serde_json::json!({
+                "frame": {
+                    "stream_id": &stream_id,
+                    "sample_rate": 48_000,
+                    "channels": 1,
+                    "encoding": "pcm_s16le",
+                    "samples": [0, 1, -1]
+                }
+            }),
+        );
+        write_frame(
+            &mut stream,
+            &Frame::event(&serde_json::to_vec(&audio).unwrap()),
+        )
+        .await
+        .unwrap();
+
+        let end = rpc::Event::new("stt.end", serde_json::json!({ "stream_id": &stream_id }));
+        write_frame(
+            &mut stream,
+            &Frame::event(&serde_json::to_vec(&end).unwrap()),
+        )
+        .await
+        .unwrap();
+
+        let event_frame = read_frame(&mut stream)
+            .await
+            .unwrap()
+            .expect("missing terminal STT event");
+        let event = event_frame.json::<rpc::Event>().unwrap();
+        assert_eq!(event.event, "stt.transcribed");
+        assert_eq!(event.data["text"], "hello");
+        assert_eq!(event.data["frames"], 1);
+
+        server.abort();
+        worker.abort();
+        let _ = std::fs::remove_file(&socket_path);
+        match old_socket {
+            Some(value) => {
+                std::env::set_var(voice_protocol::client::daemon_socket_env_var(), value)
+            }
+            None => std::env::remove_var(voice_protocol::client::daemon_socket_env_var()),
+        }
     }
 }
 

--- a/crates/voice-daemon/src/socket.rs
+++ b/crates/voice-daemon/src/socket.rs
@@ -1040,10 +1040,11 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn stream_transcribe_socket_round_trips_to_queue() {
         let _guard = ENV_LOCK.lock().unwrap();
-        let socket_path = std::env::temp_dir().join(format!(
-            "voice-daemon-stream-transcribe-{}-{}.sock",
+        let suffix = Uuid::new_v4().to_string();
+        let socket_path = PathBuf::from(format!(
+            "/tmp/vstt-{}-{}.sock",
             std::process::id(),
-            uuid::Uuid::new_v4()
+            &suffix[..8]
         ));
         let _ = std::fs::remove_file(&socket_path);
         let old_socket = std::env::var(voice_protocol::client::daemon_socket_env_var()).ok();

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -270,6 +270,34 @@ pub async fn run(
                         }
                     }
                 }
+                VoiceRequest::StreamTranscribe(request) => {
+                    let stream_id = request.stream_id.clone();
+                    let samples = request.samples.clone();
+                    let sample_rate = request.sample_rate;
+                    let stt = stt.clone();
+
+                    let result = tokio::task::spawn_blocking(move || {
+                        transcribe_stream(&stt, &stream_id, &samples, sample_rate)
+                    })
+                    .await;
+
+                    match result {
+                        Ok(Ok(msg)) => {
+                            queue.complete(Some(msg), None).await;
+                            sync_automerge(&queue, &automerge).await;
+                        }
+                        Ok(Err(e)) => {
+                            eprintln!("voiced: stream_transcribe error: {}", e);
+                            queue.fail(e).await;
+                            sync_automerge(&queue, &automerge).await;
+                        }
+                        Err(e) => {
+                            eprintln!("voiced: stream_transcribe panicked: {}", e);
+                            queue.fail(format!("panic: {}", e)).await;
+                            sync_automerge(&queue, &automerge).await;
+                        }
+                    }
+                }
                 VoiceRequest::Listen { max_duration_ms } => {
                     let max_ms = *max_duration_ms;
                     let stt = stt.clone();
@@ -877,6 +905,54 @@ fn listen(
     .to_string())
 }
 
+fn transcribe_stream(
+    stt: &Arc<Mutex<Option<voice_stt::WhisperModel>>>,
+    stream_id: &str,
+    samples: &[f32],
+    sample_rate: u32,
+) -> Result<String, String> {
+    let audio_duration_ms = samples.len().saturating_mul(1_000) as u64 / sample_rate.max(1) as u64;
+    if samples.is_empty() {
+        return Ok(serde_json::json!({
+            "stream_id": stream_id,
+            "text": "",
+            "tokens": 0,
+            "sample_rate": sample_rate,
+            "audio_duration_ms": 0,
+            "elapsed_ms": 0,
+        })
+        .to_string());
+    }
+
+    ensure_stt(stt)?;
+
+    let started = Instant::now();
+    eprintln!(
+        "voiced: transcribing stream {} ({:.1}s @ {} Hz)...",
+        stream_id,
+        audio_duration_ms as f32 / 1_000.0,
+        sample_rate
+    );
+
+    let mut guard = stt.lock().map_err(|e| format!("stt lock: {}", e))?;
+    let model = guard.as_mut().ok_or("STT model not loaded")?;
+    let result = voice_stt::transcribe_audio(model, samples, sample_rate)
+        .map_err(|e| format!("transcribe: {}", e))?;
+
+    let text = result.text.trim().to_string();
+    eprintln!("voiced: stream {} heard: {}", stream_id, text);
+
+    Ok(serde_json::json!({
+        "stream_id": stream_id,
+        "text": text,
+        "tokens": result.tokens.len(),
+        "sample_rate": sample_rate,
+        "audio_duration_ms": audio_duration_ms,
+        "elapsed_ms": started.elapsed().as_millis() as u64,
+    })
+    .to_string())
+}
+
 /// Play a simple sine tone (for ding/dong feedback).
 fn play_tone(freq: f32, duration_secs: f32) {
     let sample_rate = 24000u32;
@@ -1015,6 +1091,28 @@ async fn run_simulated(
                         .await;
                     sync_automerge(&queue, &automerge).await;
                 }
+                VoiceRequest::StreamTranscribe(request) => {
+                    let audio_duration_ms = request.samples.len().saturating_mul(1_000) as u64
+                        / request.sample_rate.max(1) as u64;
+                    queue
+                        .complete(
+                            Some(
+                                serde_json::json!({
+                                    "stream_id": &request.stream_id,
+                                    "text": "(simulated stream transcription)",
+                                    "tokens": 3,
+                                    "sample_rate": request.sample_rate,
+                                    "audio_duration_ms": audio_duration_ms,
+                                    "elapsed_ms": 0,
+                                    "simulated": true,
+                                })
+                                .to_string(),
+                            ),
+                            None,
+                        )
+                        .await;
+                    sync_automerge(&queue, &automerge).await;
+                }
                 VoiceRequest::Listen { .. } => {
                     tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
                     queue
@@ -1052,6 +1150,11 @@ fn short(req: &VoiceRequest) -> String {
             let preview: String = request.text.chars().take(50).collect();
             format!("stream_speak: {}", preview)
         }
+        VoiceRequest::StreamTranscribe(request) => format!(
+            "stream_transcribe: {} samples @ {} Hz",
+            request.samples.len(),
+            request.sample_rate
+        ),
         VoiceRequest::Listen { max_duration_ms } => {
             format!("listen ({}ms)", max_duration_ms.unwrap_or(30000))
         }
@@ -1224,6 +1327,34 @@ mod tests {
         let result = await_completion(completion_rx).await;
         assert_eq!(result.status, ItemStatus::Completed);
         assert_eq!(result.result.as_deref(), Some("simulated stream"));
+
+        worker.abort();
+    }
+
+    #[tokio::test]
+    async fn simulated_stream_transcribe_completes_with_metadata() {
+        let (queue, worker) = start_simulated_worker().await;
+        let stream_id = format!("stt-{}", unique_suffix());
+
+        let (_queue_id, completion_rx) = queue
+            .enqueue_and_wait(
+                "test-client".to_string(),
+                VoiceRequest::StreamTranscribe(crate::queue::StreamTranscribeRequest {
+                    stream_id: stream_id.clone(),
+                    samples: vec![0.0; 48_000],
+                    sample_rate: 48_000,
+                }),
+            )
+            .await;
+
+        let result = await_completion(completion_rx).await;
+        assert_eq!(result.status, ItemStatus::Completed);
+        let result_json: serde_json::Value =
+            serde_json::from_str(result.result.as_deref().unwrap()).unwrap();
+        assert_eq!(result_json["stream_id"], stream_id);
+        assert_eq!(result_json["sample_rate"], 48_000);
+        assert_eq!(result_json["audio_duration_ms"], 1_000);
+        assert_eq!(result_json["simulated"], true);
 
         worker.abort();
     }

--- a/crates/voice-protocol/src/client.rs
+++ b/crates/voice-protocol/src/client.rs
@@ -222,6 +222,109 @@ impl DaemonClient {
         Ok(response)
     }
 
+    /// Stream caller-supplied PCM frames into the daemon for transcription.
+    ///
+    /// This is an ingestion contract for WebRTC/bridge clients. The daemon
+    /// receives `stt.audio` event frames, then transcribes after `stt.end` and
+    /// emits either `stt.transcribed` or `stt.error`.
+    pub fn stream_transcribe<F>(
+        &mut self,
+        frames: &[Vec<i16>],
+        sample_rate: u32,
+        frame_ms: u32,
+        mut on_event: F,
+    ) -> Result<Response, String>
+    where
+        F: FnMut(rpc::Event) -> Result<(), String>,
+    {
+        let params = serde_json::json!({
+            "sample_rate": sample_rate,
+            "channels": 1,
+            "encoding": "pcm_s16le",
+            "frame_ms": frame_ms,
+        });
+        let req = rpc::Request::new("stream_transcribe", params).with_id(1);
+        let json = serde_json::to_vec(&req).map_err(|e| format!("serialize: {}", e))?;
+
+        write_frame_sync(&mut self.stream, &Frame::request(&json))
+            .map_err(|e| format!("write frame: {}", e))?;
+
+        let frame = read_frame_sync(&mut self.stream)
+            .map_err(|e| format!("read frame: {}", e))?
+            .ok_or_else(|| "connection closed before stream_transcribe response".to_string())?;
+        if frame.frame_type != FrameType::Response {
+            return Err(format!(
+                "unexpected frame type {:?}; expected stream_transcribe response",
+                frame.frame_type
+            ));
+        }
+
+        let response = frame
+            .json::<Response>()
+            .map_err(|e| format!("parse response: {}", e))?;
+        if response.error.is_some() {
+            return Ok(response);
+        }
+        let stream_id = response
+            .result
+            .as_ref()
+            .and_then(|result| result.get("stream_id"))
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| "stream_transcribe response missing stream_id".to_string())?
+            .to_string();
+
+        for (sequence, samples) in frames.iter().enumerate() {
+            let envelope = rpc::Event::new(
+                "stt.audio",
+                serde_json::json!({
+                    "frame": {
+                        "stream_id": &stream_id,
+                        "sequence": sequence as u64,
+                        "sample_rate": sample_rate,
+                        "channels": 1,
+                        "encoding": "pcm_s16le",
+                        "frame_ms": frame_ms,
+                        "sample_count": samples.len(),
+                        "samples": samples,
+                    }
+                }),
+            );
+            let json =
+                serde_json::to_vec(&envelope).map_err(|e| format!("serialize event: {e}"))?;
+            write_frame_sync(&mut self.stream, &Frame::event(&json))
+                .map_err(|e| format!("write stt.audio: {e}"))?;
+        }
+
+        let envelope = rpc::Event::new("stt.end", serde_json::json!({ "stream_id": &stream_id }));
+        let json = serde_json::to_vec(&envelope).map_err(|e| format!("serialize end: {e}"))?;
+        write_frame_sync(&mut self.stream, &Frame::event(&json))
+            .map_err(|e| format!("write stt.end: {e}"))?;
+
+        loop {
+            let frame = read_frame_sync(&mut self.stream)
+                .map_err(|e| format!("read stream_transcribe frame: {}", e))?
+                .ok_or_else(|| "connection closed before stream_transcribe finished".to_string())?;
+
+            if frame.frame_type != FrameType::Event {
+                return Err(format!(
+                    "unexpected frame type {:?}; expected stream_transcribe event",
+                    frame.frame_type
+                ));
+            }
+
+            let event = frame
+                .json::<rpc::Event>()
+                .map_err(|e| format!("parse event envelope: {}", e))?;
+            let terminal = matches!(event.event.as_str(), "stt.transcribed" | "stt.error");
+            on_event(event)?;
+            if terminal {
+                break;
+            }
+        }
+
+        Ok(response)
+    }
+
     /// Convenience: send a listen request. Blocks until transcription completes.
     pub fn listen(&mut self, max_duration_ms: Option<u64>) -> Result<Response, String> {
         let mut params = serde_json::json!({"wait": true});
@@ -448,6 +551,97 @@ mod tests {
 
         assert!(response.error.is_none());
         assert_eq!(events, vec!["tts.started", "tts.ended"]);
+
+        match old {
+            Some(value) => std::env::set_var(SOCKET_ENV, value),
+            None => std::env::remove_var(SOCKET_ENV),
+        }
+        let _ = std::fs::remove_file(path);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn stream_transcribe_writes_audio_events_and_reads_terminal_event() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "voice-protocol-stream-transcribe-test-{}.sock",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).unwrap();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request_frame = read_frame_sync(&mut stream).unwrap().unwrap();
+            let request = request_frame.json::<rpc::Request>().unwrap();
+            assert_eq!(request.method, "stream_transcribe");
+            assert_eq!(request.params["sample_rate"], 48_000);
+
+            let response = Response::success(
+                Some(serde_json::json!(1)),
+                serde_json::json!({
+                    "stream_id": "stt-stream",
+                    "status": "receiving",
+                    "sample_rate": 48_000,
+                    "channels": 1,
+                    "encoding": "pcm_s16le",
+                    "frame_ms": 20,
+                }),
+            );
+            write_frame_sync(
+                &mut stream,
+                &Frame::response(&serde_json::to_vec(&response).unwrap()),
+            )
+            .unwrap();
+
+            let audio_frame = read_frame_sync(&mut stream).unwrap().unwrap();
+            assert_eq!(audio_frame.frame_type, FrameType::Event);
+            let audio_event = audio_frame.json::<Event>().unwrap();
+            assert_eq!(audio_event.event, "stt.audio");
+            assert_eq!(audio_event.data["frame"]["stream_id"], "stt-stream");
+            assert_eq!(
+                audio_event.data["frame"]["samples"],
+                serde_json::json!([0, 1, -1])
+            );
+
+            let end_frame = read_frame_sync(&mut stream).unwrap().unwrap();
+            assert_eq!(end_frame.frame_type, FrameType::Event);
+            let end_event = end_frame.json::<Event>().unwrap();
+            assert_eq!(end_event.event, "stt.end");
+            assert_eq!(end_event.data["stream_id"], "stt-stream");
+
+            let terminal = Event::new(
+                "stt.transcribed",
+                serde_json::json!({
+                    "stream_id": "stt-stream",
+                    "text": "hello",
+                    "tokens": 1,
+                }),
+            );
+            write_frame_sync(
+                &mut stream,
+                &Frame::event(&serde_json::to_vec(&terminal).unwrap()),
+            )
+            .unwrap();
+        });
+
+        let old = std::env::var(SOCKET_ENV).ok();
+        std::env::set_var(SOCKET_ENV, &path);
+
+        let mut client = DaemonClient::connect().unwrap();
+        let mut events = Vec::new();
+        let response = client
+            .stream_transcribe(&[vec![0, 1, -1]], 48_000, 20, |event| {
+                events.push(event);
+                Ok(())
+            })
+            .unwrap();
+
+        assert!(response.error.is_none());
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event, "stt.transcribed");
+        assert_eq!(events[0].data["text"], "hello");
 
         match old {
             Some(value) => std::env::set_var(SOCKET_ENV, value),

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -1,6 +1,6 @@
 # Streaming TTS
 
-`voice` exposes three TTS surfaces relevant to integrations:
+`voice` exposes file and streaming surfaces relevant to integrations:
 
 - `say --output`: write a completed audio file. `.wav` writes float WAV, while
   `.ogg` / `.opus` or `--format ogg-opus` writes real
@@ -11,6 +11,10 @@
 - `stream_speak`: emit ordered audio events over the daemon socket. This is the
   transport-neutral path for WebRTC, voice bridges, or any client that wants
   audio before a final file exists.
+- `stream_transcribe`: ingest ordered PCM events over the daemon socket and
+  return a transcript after the client sends `stt.end`. This is the first
+  inbound-audio contract for WebRTC sidecars. Partial transcripts are a later
+  layer.
 
 ## Hermes / WhatsApp
 
@@ -83,6 +87,8 @@ progress lines move to stderr.
 
 ## Daemon Protocol
 
+### TTS Output
+
 Send a JSON-RPC request in a `Request` frame:
 
 ```json
@@ -128,3 +134,98 @@ It then emits `Event` frames until a terminal event:
 Audio frames are fixed-duration PCM packets. The last frame is padded with
 silence when needed so clients can feed frames directly into an Opus encoder.
 Use `sample_rate: 48000` and `frame_ms: 20` for a WebRTC-friendly stream.
+
+### STT Input
+
+Start a client-to-daemon transcription stream with a `Request` frame:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "stream_transcribe",
+  "params": {
+    "sample_rate": 48000,
+    "channels": 1,
+    "encoding": "pcm_s16le",
+    "frame_ms": 20,
+    "max_duration_ms": 300000
+  },
+  "id": 1
+}
+```
+
+The daemon replies with the stream metadata:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "stream_id": "...",
+    "status": "receiving",
+    "sample_rate": 48000,
+    "channels": 1,
+    "encoding": "pcm_s16le",
+    "frame_ms": 20,
+    "max_duration_ms": 300000
+  },
+  "id": 1
+}
+```
+
+The client then sends `Event` frames with `stt.audio` payloads. The frame shape
+matches `tts.audio` closely, but only `stream_id`, `sample_rate`, `channels`,
+`encoding`, and `samples` are required today:
+
+```json
+{
+  "event": "stt.audio",
+  "data": {
+    "frame": {
+      "stream_id": "...",
+      "sequence": 0,
+      "sample_rate": 48000,
+      "channels": 1,
+      "encoding": "pcm_s16le",
+      "frame_ms": 20,
+      "sample_count": 960,
+      "samples": [0, 12, -8]
+    }
+  }
+}
+```
+
+End the stream with:
+
+```json
+{
+  "event": "stt.end",
+  "data": {
+    "stream_id": "..."
+  }
+}
+```
+
+The daemon enqueues one STT job and emits one terminal event:
+
+```json
+{
+  "event": "stt.transcribed",
+  "data": {
+    "stream_id": "...",
+    "queue_id": "...",
+    "frames": 42,
+    "text": "hello",
+    "tokens": 8,
+    "sample_rate": 48000,
+    "audio_duration_ms": 840,
+    "elapsed_ms": 120
+  }
+}
+```
+
+If validation or transcription fails, the terminal event is `stt.error` with a
+`message` field.
+
+`max_duration_ms` defaults to 60 seconds and is capped at 300 seconds. Treat
+each `stream_transcribe` session as one utterance or segment from the WebRTC
+sidecar rather than a whole call.

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -100,7 +100,7 @@ Owns real-time media concerns:
 Owns speech model concerns:
 
 - TTS: emit 48 kHz 20 ms PCM frames from `stream_speak`
-- STT: consume 16 kHz or 48 kHz PCM frames through a future streaming STT API
+- STT: consume 16 kHz or 48 kHz PCM frames through `stream_transcribe`
 - cancellation: stop current TTS on barge-in or call termination
 - backpressure: avoid unbounded audio buffering
 
@@ -229,9 +229,8 @@ timing behavior is proven.
   calling target.
 - Which sidecar runtime should own the first spike: `aiortc`, Pipecat, Node, or
   Rust `webrtc-rs`?
-- Should streaming STT live in `voice-daemon` as a first-class RPC, or should
-  Hermes feed buffered call audio into the existing file transcribe path until
-  latency forces the daemon API?
+- Should `stream_transcribe` grow partial transcript events, or should the first
+  sidecar keep one transcript per completed utterance?
 - How much silence should the sidecar send before the agent's first TTS frame
   is ready? WebRTC calls should have media flowing immediately after accept.
 - What barge-in policy should Hermes use: immediate cancel on VAD, cancel after


### PR DESCRIPTION
## Summary
- add `stream_transcribe` daemon RPC for client-sent `stt.audio` PCM frames
- enqueue collected PCM as a `StreamTranscribe` STT job and emit terminal `stt.transcribed` / `stt.error` events
- add a sync `voice-protocol` client helper for sending PCM frame streams
- document the inbound STT event contract for WebRTC sidecars

## Notes
- This is a transport contract for inbound WebRTC audio, not partial Whisper streaming yet. The daemon transcribes after `stt.end`.
- Streams default to 60s and are capped at 300s; treat each stream as one utterance/segment.

## Verification
- `cargo test -p voice-daemon -p voice-protocol`
- `cargo clippy --workspace -- -D warnings`
- `git diff --check`
- temporary daemon smoke: `stream_transcribe` request -> `stt.end` -> terminal `stt.transcribed` event
