### PR TITLE
Add stream transcribe CLI probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ voice stream --sample-rate 48000 --frame-ms 20 --raw-output speech.s16le "Good m
 voice stream --sample-rate 48000 --frame-ms 20 --raw-output - "Good morning everyone." \
   | ffmpeg -f s16le -ar 48000 -ac 1 -i - -c:a libopus speech.ogg
 
+# Replay a WAV through daemon streaming STT
+voice stream-transcribe recording.wav
+
 # Read from a file, strip markdown
 voice say --markdown -f blog-post.mdx
 
@@ -168,6 +171,25 @@ Options:
       --markdown                   Strip markdown/MDX formatting before speaking
       --sub <WORD=REPLACEMENT>     Word substitution (repeatable)
       --sub-file <PATH>            Load substitutions from a file
+```
+
+### `voice stream-transcribe`
+
+Replays a WAV file as ordered PCM frames into a running `voiced` daemon. Use
+this to smoke-test the inbound STT stream contract that WebRTC and bridge
+clients use.
+
+```
+Usage: voice stream-transcribe [OPTIONS] <FILE>
+
+Arguments:
+  <FILE>                 Path to WAV audio file
+
+Options:
+      --frame-ms <MS>    Target stream frame duration in milliseconds [default: 20]
+      --json             Print full JSON STT events
+  -q, --quiet            Suppress progress output
+  -h, --help             Print help
 ```
 
 ### `voice transcribe`
@@ -296,7 +318,8 @@ with Hermes converting to OGG/Opus when needed.
 For lower-level streaming, `stream_speak` emits `tts.started`, `tts.audio`, and
 terminal `tts.ended` / `tts.error` / `tts.cancelled` events over the same daemon
 frame protocol. `stream_transcribe` accepts client-sent `stt.audio` frames and
-returns a terminal `stt.transcribed` event. See
+returns a terminal `stt.transcribed` event. Use `voice stream-transcribe` to
+replay a WAV through that inbound stream path. See
 [docs/streaming.md](docs/streaming.md) for the event schema and Hermes/WebRTC
 notes. See
 [docs/whatsapp-calling-webrtc.md](docs/whatsapp-calling-webrtc.md) for the

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -53,6 +53,11 @@ pub struct CachedSound {
     pub channels: u16,
 }
 
+pub struct TranscriptionAudio {
+    pub samples: Vec<f32>,
+    pub sample_rate: u32,
+}
+
 impl SoundConfig {
     pub fn new() -> Self {
         Self {
@@ -124,6 +129,59 @@ pub fn load_wav_sound(path: &std::path::Path) -> Result<CachedSound, String> {
         samples,
         sample_rate,
         channels,
+    })
+}
+
+pub fn load_transcription_wav(path: &Path) -> Result<TranscriptionAudio, String> {
+    let reader = hound::WavReader::open(path)
+        .map_err(|e| format!("Failed to open {}: {e}", path.display()))?;
+
+    let spec = reader.spec();
+    let channels = spec.channels as usize;
+    let sample_rate = spec.sample_rate;
+
+    if sample_rate == 0 {
+        return Err("Invalid WAV: sample rate is 0".to_string());
+    }
+    if channels == 0 {
+        return Err("Invalid WAV: channel count is 0".to_string());
+    }
+
+    let samples: Vec<f32> = match spec.sample_format {
+        hound::SampleFormat::Int => {
+            let bits = spec.bits_per_sample;
+            if bits == 0 || bits > 32 {
+                return Err(format!(
+                    "Unsupported bits_per_sample {bits}; expected 1..=32"
+                ));
+            }
+            let max_val = (1u32 << (bits - 1)) as f32;
+            reader
+                .into_samples::<i32>()
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| format!("Failed to read WAV samples: {e}"))?
+                .into_iter()
+                .map(|s| s as f32 / max_val)
+                .collect()
+        }
+        hound::SampleFormat::Float => reader
+            .into_samples::<f32>()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("Failed to read WAV samples: {e}"))?,
+    };
+
+    let mono = if channels > 1 {
+        samples
+            .chunks(channels)
+            .map(|frame| frame.iter().sum::<f32>() / channels as f32)
+            .collect()
+    } else {
+        samples
+    };
+
+    Ok(TranscriptionAudio {
+        samples: mono,
+        sample_rate,
     })
 }
 
@@ -1422,54 +1480,25 @@ pub fn transcribe_file(path: &Path) {
         eprintln!("Transcribing: {}", path.display());
     }
 
-    // Load WAV
-    let reader = match hound::WavReader::open(path) {
-        Ok(r) => r,
+    let audio = match load_transcription_wav(path) {
+        Ok(audio) => audio,
         Err(e) => {
-            eprintln!("Failed to open {}: {e}", path.display());
+            eprintln!("{e}");
             std::process::exit(1);
         }
     };
 
-    let spec = reader.spec();
-    let channels = spec.channels as usize;
-    let sample_rate = spec.sample_rate;
-
-    let samples: Vec<f32> = match spec.sample_format {
-        hound::SampleFormat::Int => {
-            let max_val = (1u32 << (spec.bits_per_sample - 1)) as f32;
-            reader
-                .into_samples::<i32>()
-                .map(|s| s.unwrap_or(0) as f32 / max_val)
-                .collect()
-        }
-        hound::SampleFormat::Float => reader
-            .into_samples::<f32>()
-            .map(|s| s.unwrap_or(0.0))
-            .collect(),
-    };
-
-    // Mix to mono
-    let mono: Vec<f32> = if channels > 1 {
-        samples
-            .chunks(channels)
-            .map(|frame| frame.iter().sum::<f32>() / channels as f32)
-            .collect()
-    } else {
-        samples
-    };
-
-    let duration = mono.len() as f32 / sample_rate as f32;
+    let duration = audio.samples.len() as f32 / audio.sample_rate as f32;
     if !QUIET.load(Ordering::Relaxed) {
         eprintln!(
             "Audio: {:.1}s ({} samples at {}Hz)",
             duration,
-            mono.len(),
-            sample_rate
+            audio.samples.len(),
+            audio.sample_rate
         );
     }
 
-    let result = match voice_stt::transcribe_audio(&mut model, &mono, sample_rate) {
+    let result = match voice_stt::transcribe_audio(&mut model, &audio.samples, audio.sample_rate) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("Transcription failed: {e}");

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -42,6 +42,7 @@ macro_rules! info {
                   voice say --markdown -f post.mdx\n  \
                   voice phonemes \"ChatGPT uses RuntimeStateDoc\"\n  \
                   voice stream --json \"Hello world\"\n  \
+                  voice stream-transcribe recording.wav\n  \
                   voice listen\n  \
                   voice listen --continuous\n  \
                   voice transcribe recording.wav\n  \
@@ -72,6 +73,9 @@ enum Command {
 
     /// Stream TTS audio chunks from the voice daemon
     Stream(StreamArgs),
+
+    /// Replay a WAV file through daemon streaming STT
+    StreamTranscribe(StreamTranscribeArgs),
 
     /// Speak text aloud, then listen for a response (speak + listen in one shot)
     Converse(ConverseArgs),
@@ -229,6 +233,20 @@ struct StreamArgs {
     /// If not set, .voice-subs is auto-discovered from the working directory upward.
     #[arg(long = "sub-file", value_name = "PATH")]
     sub_file: Option<PathBuf>,
+}
+
+#[derive(clap::Args, Debug)]
+struct StreamTranscribeArgs {
+    /// Path to WAV audio file
+    file: PathBuf,
+
+    /// Target stream frame duration in milliseconds
+    #[arg(long = "frame-ms", default_value = "20")]
+    frame_ms: u32,
+
+    /// Print full JSON STT events instead of only the transcript
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(clap::Args, Debug)]
@@ -765,6 +783,9 @@ fn main() {
         }
         Some(Command::Stream(stream_args)) => {
             run_stream(stream_args);
+        }
+        Some(Command::StreamTranscribe(stream_args)) => {
+            run_stream_transcribe(stream_args);
         }
         None => {
             // Backward compatibility: `voice Hello world` = `voice say Hello world`
@@ -1425,6 +1446,137 @@ fn run_stream(stream_args: StreamArgs) {
     }
 }
 
+fn run_stream_transcribe(stream_args: StreamTranscribeArgs) {
+    let audio = match listen::load_transcription_wav(&stream_args.file) {
+        Ok(audio) => audio,
+        Err(e) => {
+            eprintln!("{e}");
+            std::process::exit(1);
+        }
+    };
+
+    let frames = match pcm_i16_frames(&audio.samples, audio.sample_rate, stream_args.frame_ms) {
+        Ok(frames) => frames,
+        Err(e) => {
+            eprintln!("voice stream-transcribe: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    if !QUIET.load(Ordering::Relaxed) {
+        let duration = audio.samples.len() as f64 / audio.sample_rate as f64;
+        eprintln!(
+            "Streaming: {} ({:.1}s, {}Hz, {} frames)",
+            stream_args.file.display(),
+            duration,
+            audio.sample_rate,
+            frames.len()
+        );
+    }
+
+    let mut daemon = connect_daemon_or_exit();
+    let mut transcript: Option<String> = None;
+    let mut terminal_error: Option<String> = None;
+    let mut received_terminal = false;
+
+    let result =
+        daemon.stream_transcribe(&frames, audio.sample_rate, stream_args.frame_ms, |event| {
+            if stream_args.json {
+                println!("{}", serde_json::to_string(&event).unwrap());
+            }
+
+            match event.event.as_str() {
+                "stt.transcribed" => {
+                    received_terminal = true;
+                    transcript = Some(
+                        event
+                            .data
+                            .get("text")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                    );
+                }
+                "stt.error" => {
+                    received_terminal = true;
+                    terminal_error = Some(
+                        event
+                            .data
+                            .get("message")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or("stream transcription failed")
+                            .to_string(),
+                    );
+                }
+                _ => {}
+            }
+
+            Ok(())
+        });
+
+    match result {
+        Ok(resp) => {
+            if let Some(err) = resp.error {
+                eprintln!("voice daemon: {}", err.message);
+                std::process::exit(1);
+            }
+        }
+        Err(e) => {
+            eprintln!("voice daemon stream-transcribe: {e}");
+            std::process::exit(1);
+        }
+    }
+
+    if let Some(err) = terminal_error {
+        eprintln!("voice stream-transcribe failed: {err}");
+        std::process::exit(1);
+    }
+
+    if !received_terminal {
+        eprintln!("voice stream-transcribe produced no terminal event");
+        std::process::exit(1);
+    }
+
+    if !stream_args.json {
+        println!("{}", transcript.unwrap_or_default());
+    }
+}
+
+fn pcm_i16_frames(
+    samples: &[f32],
+    sample_rate: u32,
+    frame_ms: u32,
+) -> Result<Vec<Vec<i16>>, String> {
+    if sample_rate == 0 {
+        return Err("sample rate must be greater than 0".to_string());
+    }
+    if frame_ms == 0 {
+        return Err("frame-ms must be greater than 0".to_string());
+    }
+
+    let frame_samples = (u64::from(sample_rate) * u64::from(frame_ms) / 1_000) as usize;
+    if frame_samples == 0 {
+        return Err(format!(
+            "frame-ms {frame_ms} is too small for sample rate {sample_rate}"
+        ));
+    }
+
+    Ok(samples
+        .chunks(frame_samples)
+        .map(|chunk| chunk.iter().copied().map(f32_to_i16_pcm).collect())
+        .collect())
+}
+
+fn f32_to_i16_pcm(sample: f32) -> i16 {
+    if sample <= -1.0 {
+        i16::MIN
+    } else if sample >= 1.0 {
+        i16::MAX
+    } else {
+        (sample.clamp(-1.0, 1.0) * f32::from(i16::MAX)).round() as i16
+    }
+}
+
 fn run_converse(args: ConverseArgs) {
     if args.text.is_empty() {
         eprintln!("Error: No text provided. Usage: voice converse <text>");
@@ -1654,5 +1806,38 @@ fn stream_playback(
             break;
         }
         std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn f32_to_i16_pcm_clamps_to_signed_pcm_range() {
+        assert_eq!(f32_to_i16_pcm(-2.0), i16::MIN);
+        assert_eq!(f32_to_i16_pcm(-1.0), i16::MIN);
+        assert_eq!(f32_to_i16_pcm(0.0), 0);
+        assert_eq!(f32_to_i16_pcm(1.0), i16::MAX);
+        assert_eq!(f32_to_i16_pcm(2.0), i16::MAX);
+    }
+
+    #[test]
+    fn pcm_i16_frames_splits_by_frame_duration() {
+        let samples = vec![0.0; 1_000];
+        let frames = pcm_i16_frames(&samples, 1_000, 20).unwrap();
+
+        assert_eq!(frames.len(), 50);
+        assert!(frames.iter().all(|frame| frame.len() == 20));
+    }
+
+    #[test]
+    fn pcm_i16_frames_keeps_short_final_frame() {
+        let samples = vec![0.0; 25];
+        let frames = pcm_i16_frames(&samples, 1_000, 20).unwrap();
+
+        assert_eq!(frames.len(), 2);
+        assert_eq!(frames[0].len(), 20);
+        assert_eq!(frames[1].len(), 5);
     }
 }

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -78,12 +78,19 @@ voice say --format ogg-opus -o reply.ogg "Hello"
 voice stream --sample-rate 48000 --frame-ms 20 --raw-output reply.s16le "Hello"
 voice stream --sample-rate 48000 --frame-ms 20 --raw-output - "Hello" \
   | ffmpeg -f s16le -ar 48000 -ac 1 -i - -c:a libopus reply.ogg
+voice stream-transcribe recording.wav
+voice stream-transcribe --json recording.wav
 ```
 
 The raw output is signed 16-bit little-endian mono PCM with no container header.
 Use the event metadata for sample rate, frame duration, and stream ID.
 When `--raw-output -` is used, stdout is reserved for PCM bytes and compact
 progress lines move to stderr.
+
+`voice stream-transcribe` reads a WAV file, splits it into the same ordered PCM
+frames a WebRTC sidecar would send, and returns the terminal STT event from the
+daemon. It is a transport smoke test; `voice transcribe` remains the direct
+file transcription command.
 
 ## Daemon Protocol
 


### PR DESCRIPTION
## Summary
- add `voice stream-transcribe <file.wav>` to replay WAV audio through the daemon `stream_transcribe` STT ingress
- share WAV loading/mixing between direct file transcription and the streaming probe
- document the inbound streaming smoke command and add focused PCM frame conversion tests

## Verification
- `cargo test -p voice -p voice-daemon -p voice-protocol`
- `cargo clippy --workspace -- -D warnings`
- `cargo run --quiet -p voice -- --quiet stream-transcribe --json /tmp/voice-empty-stream-transcribe.wav`
- `cargo run --quiet -p voice -- stream-transcribe --help`
- `cargo test --workspace`
- `git diff --check`