### PR TITLE
Add WebRTC sidecar spike example

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -95,6 +95,11 @@ Owns real-time media concerns:
 - accept local PCM frames from `voice` and send Opus RTP back to WhatsApp
 - terminate quickly and cleanly when the Graph lifecycle ends
 
+The repository includes a first Python spike in
+[`examples/webrtc-sidecar`](../examples/webrtc-sidecar/). It exposes the local
+SDP/PCM boundary described below, sends silence until outbound PCM is available,
+and lets `aiortc` handle Opus RTP, ICE, DTLS, and SRTP.
+
 ### `voice` Daemon
 
 Owns speech model concerns:
@@ -209,7 +214,8 @@ Risk: more time spent on WebRTC plumbing before validating Meta call behavior.
 
 Recommendation: spike in Python or Pipecat first, keep the local audio boundary
 as 48 kHz 20 ms PCM, then port the sidecar to Rust only after the signaling and
-timing behavior is proven.
+timing behavior is proven. The local `examples/webrtc-sidecar` spike follows
+that path.
 
 ## PR Sequence
 
@@ -217,6 +223,8 @@ timing behavior is proven.
 2. Add this architecture document and track open questions.
 3. Add a `voice` streaming STT input API that accepts fixed PCM frames.
 4. Prototype a sidecar that accepts a synthetic SDP offer and round-trips PCM.
+   The initial `examples/webrtc-sidecar` artifact covers the SDP answer,
+   outbound PCM-to-Opus/WebRTC track, and inbound decoded PCM sink.
 5. Wire Hermes WhatsApp Cloud `connect` webhooks to the sidecar.
 6. Build an inbound-call echo bot: WhatsApp audio in, same audio out.
 7. Replace echo with STT -> Hermes turn -> `stream_speak` TTS.

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -1,0 +1,85 @@
+# WebRTC Sidecar Spike
+
+This is a minimal Python `aiortc` sidecar for proving the live-call media
+boundary without pulling WebRTC into the Rust workspace yet.
+
+It accepts a remote SDP offer over local HTTP, creates a WebRTC answer, sends a
+48 kHz mono 20 ms PCM source as an outbound audio track, and writes decoded
+inbound audio to a raw PCM file. `aiortc` handles Opus RTP, ICE, DTLS, and SRTP.
+
+This is a spike. It does not call the WhatsApp Graph API, authenticate requests,
+run VAD, or manage Hermes sessions. Hermes should still own WhatsApp Cloud
+webhooks and Graph actions such as `pre_accept`, `accept`, and `terminate`.
+
+## Install
+
+```bash
+python3 -m venv /tmp/voice-webrtc-venv
+/tmp/voice-webrtc-venv/bin/pip install -r examples/webrtc-sidecar/requirements.txt
+```
+
+## Run
+
+Create a FIFO for outbound audio from `voice`:
+
+```bash
+mkfifo /tmp/voice-webrtc-out.s16le
+/tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/sidecar.py \
+  --tx-pcm /tmp/voice-webrtc-out.s16le \
+  --rx-pcm /tmp/voice-webrtc-in.s16le
+```
+
+Feed TTS frames into the FIFO:
+
+```bash
+voice stream --sample-rate 48000 --frame-ms 20 \
+  --raw-output /tmp/voice-webrtc-out.s16le \
+  "Hello from the WebRTC sidecar."
+```
+
+If `--tx-pcm` is omitted, the sidecar sends silence. That is useful for checking
+SDP, ICE, and call timing before TTS is wired in.
+
+## SDP API
+
+Post a remote offer:
+
+```bash
+curl -sS http://127.0.0.1:8787/offer \
+  -H 'content-type: application/json' \
+  -d '{"call_id":"local-test","type":"offer","sdp":"v=0..."}'
+```
+
+Response:
+
+```json
+{
+  "call_id": "local-test",
+  "type": "answer",
+  "sdp": "v=0...",
+  "audio": {
+    "sample_rate": 48000,
+    "channels": 1,
+    "frame_ms": 20,
+    "encoding": "pcm_s16le"
+  }
+}
+```
+
+Close a session:
+
+```bash
+curl -X POST http://127.0.0.1:8787/calls/local-test/close
+```
+
+## WhatsApp Calling Placement
+
+For WhatsApp Cloud Calling, Hermes should translate a `connect` webhook into a
+local `/offer` call, then pass the returned SDP answer to the Cloud API
+`pre_accept` and `accept` actions. The sidecar should already have an outbound
+audio track attached and ready before Hermes calls `accept`; the track sends
+silence until real TTS PCM arrives.
+
+Inbound decoded PCM is written as raw signed 16-bit little-endian mono samples.
+A later bridge layer can segment that stream with VAD and submit each segment
+to `voice stream-transcribe` or the daemon `stream_transcribe` RPC.

--- a/examples/webrtc-sidecar/requirements.txt
+++ b/examples/webrtc-sidecar/requirements.txt
@@ -1,0 +1,3 @@
+aiohttp>=3.9
+aiortc>=1.10
+av>=12

--- a/examples/webrtc-sidecar/sidecar.py
+++ b/examples/webrtc-sidecar/sidecar.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Minimal local WebRTC sidecar for the voice PCM stream contract.
+
+This example is intentionally small:
+
+- local HTTP accepts a remote SDP offer and returns an SDP answer
+- outbound audio is raw pcm_s16le, mono, 48 kHz, 20 ms frames
+- inbound WebRTC audio is decoded to raw pcm_s16le, mono, 48 kHz
+
+The WhatsApp Graph API and Hermes session loop stay outside this process.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from fractions import Fraction
+import json
+import logging
+import os
+from pathlib import Path
+import signal
+import sys
+from typing import Any
+
+try:
+    import av
+    from aiohttp import web
+    from aiortc import MediaStreamTrack, RTCPeerConnection, RTCSessionDescription
+    from aiortc.mediastreams import MediaStreamError
+except ImportError as exc:  # pragma: no cover - depends on optional extras
+    raise SystemExit(
+        "Missing WebRTC sidecar dependencies. Install with:\n"
+        "  python -m pip install -r examples/webrtc-sidecar/requirements.txt"
+    ) from exc
+
+
+LOGGER = logging.getLogger("voice-webrtc-sidecar")
+SAMPLE_RATE = 48_000
+FRAME_MS = 20
+CHANNELS = 1
+SAMPLES_PER_FRAME = SAMPLE_RATE * FRAME_MS // 1_000
+BYTES_PER_SAMPLE = 2
+FRAME_BYTES = SAMPLES_PER_FRAME * CHANNELS * BYTES_PER_SAMPLE
+
+
+class PcmSource:
+    """Non-blocking raw PCM source with silence fallback."""
+
+    def __init__(self, path: str | None) -> None:
+        self.path = path
+        self.fd: int | None = None
+        self.buffer = bytearray()
+        if not path:
+            return
+
+        if path == "-":
+            self.fd = os.dup(sys.stdin.fileno())
+        else:
+            self.fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+        os.set_blocking(self.fd, False)
+
+    def close(self) -> None:
+        if self.fd is not None:
+            os.close(self.fd)
+            self.fd = None
+
+    def read_frame(self) -> bytes:
+        if self.fd is not None:
+            while len(self.buffer) < FRAME_BYTES:
+                try:
+                    chunk = os.read(self.fd, FRAME_BYTES - len(self.buffer))
+                except BlockingIOError:
+                    break
+                if not chunk:
+                    break
+                self.buffer.extend(chunk)
+
+        if len(self.buffer) >= FRAME_BYTES:
+            frame = bytes(self.buffer[:FRAME_BYTES])
+            del self.buffer[:FRAME_BYTES]
+            return frame
+
+        frame = bytes(self.buffer)
+        self.buffer.clear()
+        return frame + (b"\x00" * (FRAME_BYTES - len(frame)))
+
+
+class VoicePcmAudioTrack(MediaStreamTrack):
+    """Outbound WebRTC audio track backed by local pcm_s16le frames."""
+
+    kind = "audio"
+
+    def __init__(self, source: PcmSource) -> None:
+        super().__init__()
+        self.source = source
+        self.pts = 0
+        self.started_at: float | None = None
+        self.next_frame_at: float | None = None
+
+    async def recv(self) -> av.AudioFrame:
+        loop = asyncio.get_running_loop()
+        now = loop.time()
+        if self.started_at is None:
+            self.started_at = now
+            self.next_frame_at = now
+        elif self.next_frame_at is not None and now < self.next_frame_at:
+            await asyncio.sleep(self.next_frame_at - now)
+
+        assert self.next_frame_at is not None
+        self.next_frame_at += FRAME_MS / 1_000
+
+        frame = av.AudioFrame(format="s16", layout="mono", samples=SAMPLES_PER_FRAME)
+        frame.planes[0].update(self.source.read_frame())
+        frame.sample_rate = SAMPLE_RATE
+        frame.time_base = Fraction(1, SAMPLE_RATE)
+        frame.pts = self.pts
+        self.pts += SAMPLES_PER_FRAME
+        return frame
+
+
+async def write_inbound_pcm(track: MediaStreamTrack, path: str | None) -> None:
+    if not path:
+        while True:
+            try:
+                await track.recv()
+            except MediaStreamError:
+                return
+
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    resampler = av.AudioResampler(format="s16", layout="mono", rate=SAMPLE_RATE)
+
+    with target.open("ab") as sink:
+        while True:
+            try:
+                frame = await track.recv()
+            except MediaStreamError:
+                return
+            for out in resampler.resample(frame):
+                sink.write(bytes(out.planes[0]))
+                sink.flush()
+
+
+class CallSession:
+    def __init__(self, call_id: str, source: PcmSource, rx_pcm: str | None) -> None:
+        self.call_id = call_id
+        self.source = source
+        self.rx_pcm = rx_pcm
+        self.pc = RTCPeerConnection()
+        self.tasks: set[asyncio.Task[Any]] = set()
+        self.closed = False
+        self.pc.addTrack(VoicePcmAudioTrack(source))
+
+        @self.pc.on("track")
+        def on_track(track: MediaStreamTrack) -> None:
+            LOGGER.info("call %s received %s track", self.call_id, track.kind)
+            if track.kind == "audio":
+                task = asyncio.create_task(write_inbound_pcm(track, self.rx_pcm))
+                self.tasks.add(task)
+                task.add_done_callback(self.tasks.discard)
+
+        @self.pc.on("connectionstatechange")
+        async def on_connectionstatechange() -> None:
+            LOGGER.info("call %s connection state: %s", self.call_id, self.pc.connectionState)
+            if self.pc.connectionState == "failed":
+                await self.close()
+
+    async def answer(self, remote_sdp: str, remote_type: str) -> RTCSessionDescription:
+        await self.pc.setRemoteDescription(
+            RTCSessionDescription(sdp=remote_sdp, type=remote_type)
+        )
+        answer = await self.pc.createAnswer()
+        await self.pc.setLocalDescription(answer)
+        await wait_for_ice_complete(self.pc)
+        assert self.pc.localDescription is not None
+        return self.pc.localDescription
+
+    async def close(self) -> None:
+        if self.closed:
+            return
+        self.closed = True
+        for task in list(self.tasks):
+            task.cancel()
+        if self.tasks:
+            await asyncio.gather(*self.tasks, return_exceptions=True)
+        await self.pc.close()
+
+
+async def wait_for_ice_complete(pc: RTCPeerConnection, timeout: float = 5.0) -> None:
+    if pc.iceGatheringState == "complete":
+        return
+
+    done = asyncio.Event()
+
+    @pc.on("icegatheringstatechange")
+    def on_icegatheringstatechange() -> None:
+        if pc.iceGatheringState == "complete":
+            done.set()
+
+    try:
+        await asyncio.wait_for(done.wait(), timeout=timeout)
+    except TimeoutError:
+        LOGGER.warning("ICE gathering did not complete within %.1fs", timeout)
+
+
+def json_error(message: str, status: int = 400) -> web.Response:
+    return web.json_response({"error": message}, status=status)
+
+
+def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
+    app = web.Application()
+    sessions: dict[str, CallSession] = {}
+
+    async def health(_: web.Request) -> web.Response:
+        return web.json_response({"ok": True, "sessions": len(sessions)})
+
+    async def offer(request: web.Request) -> web.Response:
+        try:
+            body = await request.json()
+        except json.JSONDecodeError:
+            return json_error("request body must be JSON")
+
+        call_id = str(body.get("call_id") or "").strip()
+        remote_sdp = str(body.get("sdp") or body.get("remote_sdp") or "").strip()
+        remote_type = str(body.get("type") or "offer").strip()
+
+        if not call_id:
+            return json_error("call_id is required")
+        if not remote_sdp:
+            return json_error("sdp is required")
+        if remote_type != "offer":
+            return json_error("only SDP offers are supported")
+        if call_id in sessions:
+            await sessions.pop(call_id).close()
+
+        session = CallSession(call_id, source, rx_pcm)
+        sessions[call_id] = session
+        try:
+            answer = await session.answer(remote_sdp, remote_type)
+        except Exception:
+            await sessions.pop(call_id, session).close()
+            LOGGER.exception("call %s failed to create answer", call_id)
+            return json_error("failed to create SDP answer", status=500)
+
+        return web.json_response(
+            {
+                "call_id": call_id,
+                "type": answer.type,
+                "sdp": answer.sdp,
+                "audio": {
+                    "sample_rate": SAMPLE_RATE,
+                    "channels": CHANNELS,
+                    "frame_ms": FRAME_MS,
+                    "encoding": "pcm_s16le",
+                },
+            }
+        )
+
+    async def close_call(request: web.Request) -> web.Response:
+        call_id = request.match_info["call_id"]
+        session = sessions.pop(call_id, None)
+        if session is None:
+            return json_error("unknown call_id", status=404)
+        await session.close()
+        return web.json_response({"call_id": call_id, "closed": True})
+
+    async def cleanup(_: web.Application) -> None:
+        for session in list(sessions.values()):
+            await session.close()
+        source.close()
+
+    app.router.add_get("/health", health)
+    app.router.add_post("/offer", offer)
+    app.router.add_post("/calls/{call_id}/close", close_call)
+    app.on_cleanup.append(cleanup)
+    return app
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8787)
+    parser.add_argument(
+        "--tx-pcm",
+        help="raw pcm_s16le mono 48 kHz source path, FIFO, or '-' for stdin",
+    )
+    parser.add_argument(
+        "--rx-pcm",
+        help="raw pcm_s16le mono 48 kHz sink for decoded inbound WebRTC audio",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    source = PcmSource(args.tx_pcm)
+    app = create_app(source, args.rx_pcm)
+    runner = web.AppRunner(app)
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    stop = asyncio.Event()
+    for signame in ("SIGINT", "SIGTERM"):
+        signum = getattr(signal, signame, None)
+        if signum is not None:
+            loop.add_signal_handler(signum, stop.set)
+
+    async def run() -> None:
+        await runner.setup()
+        site = web.TCPSite(runner, args.host, args.port)
+        await site.start()
+        LOGGER.info("listening on http://%s:%d", args.host, args.port)
+        await stop.wait()
+        await runner.cleanup()
+
+    try:
+        loop.run_until_complete(run())
+    finally:
+        loop.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `examples/webrtc-sidecar`, a minimal Python `aiortc` sidecar for the WhatsApp Calling/WebRTC spike path
- accept remote SDP offers over local HTTP and return SDP answers with Opus audio
- send outbound 48 kHz mono 20 ms `pcm_s16le` frames as a WebRTC audio track, with silence fallback
- write inbound decoded WebRTC audio as raw `pcm_s16le` for later VAD/`stream_transcribe` integration
- update the WhatsApp Calling architecture doc to point at the spike artifact

## Verification
- `python3 -m py_compile examples/webrtc-sidecar/sidecar.py`
- optional dependency smoke in `/tmp/voice-webrtc-venv`: installed `examples/webrtc-sidecar/requirements.txt`, started sidecar, `GET /health` returned `{"ok": true, "sessions": 0}`
- optional SDP smoke in `/tmp/voice-webrtc-venv`: generated an `aiortc` audio offer, posted it to `/offer`, received an SDP answer containing `opus/48000`
- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `git diff --check`