### PR TITLE
Add streamed Ogg/Opus output

### DIFF
--- a/crates/voice-audio/src/lib.rs
+++ b/crates/voice-audio/src/lib.rs
@@ -3,8 +3,8 @@
 use hound::{WavSpec, WavWriter};
 use std::fmt;
 use std::io::Write;
-use std::path::Path;
-use std::process::{Command, Stdio};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AudioOutputFormat {
@@ -199,6 +199,131 @@ pub fn save_ogg_opus(samples: &[f32], path: &Path, sample_rate: u32) -> Result<(
     Ok(())
 }
 
+pub struct OggOpusStreamWriter {
+    child: Option<Child>,
+    stdin: Option<ChildStdin>,
+    output_path: Option<PathBuf>,
+}
+
+impl OggOpusStreamWriter {
+    pub fn create(path: &Path, input_sample_rate: u32) -> Result<Self, String> {
+        let to_stdout = path.as_os_str() == "-";
+        if !to_stdout {
+            ensure_parent_dir(path)?;
+        }
+
+        let mut command = Command::new("ffmpeg");
+        command
+            .arg("-hide_banner")
+            .arg("-loglevel")
+            .arg("error")
+            .arg("-y")
+            .arg("-f")
+            .arg("s16le")
+            .arg("-ar")
+            .arg(input_sample_rate.to_string())
+            .arg("-ac")
+            .arg("1")
+            .arg("-i")
+            .arg("pipe:0")
+            .arg("-ac")
+            .arg("1")
+            .arg("-ar")
+            .arg("48000")
+            .arg("-c:a")
+            .arg("libopus")
+            .arg("-b:a")
+            .arg("32k")
+            .arg("-vbr")
+            .arg("on")
+            .arg("-application")
+            .arg("voip")
+            .arg("-f")
+            .arg("ogg");
+
+        if to_stdout {
+            command.arg("pipe:1").stdout(Stdio::inherit());
+        } else {
+            command.arg(path).stdout(Stdio::null());
+        }
+
+        let mut child = command
+            .stdin(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("spawn ffmpeg for streamed Ogg/Opus output: {e}"))?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "open ffmpeg stdin".to_string())?;
+
+        Ok(Self {
+            child: Some(child),
+            stdin: Some(stdin),
+            output_path: (!to_stdout).then(|| path.to_path_buf()),
+        })
+    }
+
+    pub fn write_pcm_s16le(&mut self, bytes: &[u8]) -> Result<(), String> {
+        let stdin = self
+            .stdin
+            .as_mut()
+            .ok_or_else(|| "ffmpeg stdin is closed".to_string())?;
+        stdin
+            .write_all(bytes)
+            .map_err(|e| format!("write PCM to ffmpeg: {e}"))
+    }
+
+    pub fn finish(mut self) -> Result<(), String> {
+        drop(self.stdin.take());
+        let Some(child) = self.child.take() else {
+            return Ok(());
+        };
+        let output = child
+            .wait_with_output()
+            .map_err(|e| format!("wait for ffmpeg: {e}"))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!(
+                "ffmpeg streamed Ogg/Opus encode failed with {}: {}",
+                output.status,
+                stderr.trim()
+            ));
+        }
+
+        if let Some(path) = &self.output_path {
+            if !is_ogg_opus_file(path) {
+                return Err(format!(
+                    "ffmpeg output is not an Ogg/Opus file: {}",
+                    path.display()
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for OggOpusStreamWriter {
+    fn drop(&mut self) {
+        drop(self.stdin.take());
+        if let Some(mut child) = self.child.take() {
+            match child.try_wait() {
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                }
+                Err(_) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                }
+            }
+        }
+    }
+}
+
 pub fn is_ogg_opus_file(path: &Path) -> bool {
     let Ok(bytes) = std::fs::read(path) else {
         return false;
@@ -298,6 +423,34 @@ mod tests {
         let path = temp_path("ogg");
         let samples = sine_wave(24_000);
         save_ogg_opus(&samples, &path, 24_000).expect("save ogg opus");
+        assert!(is_ogg_opus_file(&path));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn stream_ogg_opus_writer_writes_opus_head() {
+        if Command::new("ffmpeg").arg("-version").output().is_err() {
+            eprintln!("skipping streamed Ogg/Opus encode test because ffmpeg is not on PATH");
+            return;
+        }
+
+        let path = temp_path("stream.ogg");
+        let samples = sine_wave(24_000);
+        let mut writer = OggOpusStreamWriter::create(&path, 24_000).expect("create stream writer");
+        for chunk in samples.chunks(480) {
+            let mut bytes = Vec::with_capacity(chunk.len() * 2);
+            for sample in chunk {
+                let clamped = sample.clamp(-1.0, 1.0);
+                let pcm = if clamped >= 0.0 {
+                    (clamped * i16::MAX as f32).round() as i16
+                } else {
+                    (clamped * 32768.0).round() as i16
+                };
+                bytes.extend_from_slice(&pcm.to_le_bytes());
+            }
+            writer.write_pcm_s16le(&bytes).expect("write stream pcm");
+        }
+        writer.finish().expect("finish stream writer");
         assert!(is_ogg_opus_file(&path));
         let _ = std::fs::remove_file(path);
     }

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -42,6 +42,7 @@ macro_rules! info {
                   voice say --markdown -f post.mdx\n  \
                   voice phonemes \"ChatGPT uses RuntimeStateDoc\"\n  \
                   voice stream --json \"Hello world\"\n  \
+                  voice stream --output reply.ogg --format ogg-opus \"Hello world\"\n  \
                   voice stream-transcribe recording.wav\n  \
                   voice listen\n  \
                   voice listen --continuous\n  \
@@ -214,8 +215,16 @@ struct StreamArgs {
     frame_ms: u32,
 
     /// Write raw signed 16-bit little-endian mono PCM to this path (use - for stdout)
-    #[arg(short = 'o', long = "raw-output")]
+    #[arg(short = 'o', long = "raw-output", conflicts_with = "output")]
     raw_output: Option<PathBuf>,
+
+    /// Write streamed audio to an Ogg/Opus file (use - for stdout)
+    #[arg(long = "output", conflicts_with = "raw_output")]
+    output: Option<PathBuf>,
+
+    /// Output container/codec for --output. Defaults from extension: .ogg, .opus
+    #[arg(long = "format", value_enum, requires = "output")]
+    format: Option<SayOutputFormat>,
 
     /// Print full JSON stream events instead of compact summaries
     #[arg(long)]
@@ -474,6 +483,30 @@ fn resolve_stream_text(stream: &StreamArgs) -> Result<String, String> {
         return Err("No text provided on stdin".into());
     }
     Ok(text)
+}
+
+enum StreamOutputWriter {
+    Raw(Box<dyn Write>),
+    OggOpus(voice_audio::OggOpusStreamWriter),
+}
+
+impl StreamOutputWriter {
+    fn write_frame(&mut self, frame: &voice_stream::AudioFrame) -> Result<(), String> {
+        let bytes = frame.payload_le_bytes();
+        match self {
+            Self::Raw(writer) => writer
+                .write_all(&bytes)
+                .map_err(|e| format!("write raw PCM: {e}")),
+            Self::OggOpus(writer) => writer.write_pcm_s16le(&bytes),
+        }
+    }
+
+    fn finish(self) -> Result<(), String> {
+        match self {
+            Self::Raw(mut writer) => writer.flush().map_err(|e| format!("flush raw output: {e}")),
+            Self::OggOpus(writer) => writer.finish(),
+        }
+    }
 }
 
 fn resolve_phonemes_text(args: &PhonemesArgs) -> Result<String, String> {
@@ -1294,32 +1327,67 @@ fn run_stream(stream_args: StreamArgs) {
         stream_args.sub_file.clone(),
     );
 
+    validate_stream_frame_params(stream_args.sample_rate, stream_args.frame_ms).unwrap_or_else(
+        |e| {
+            eprintln!("voice stream: {e}");
+            std::process::exit(1);
+        },
+    );
+
     let raw_to_stdout = stream_args
         .raw_output
         .as_ref()
         .is_some_and(|path| path.as_os_str() == std::ffi::OsStr::new("-"));
-    if raw_to_stdout && stream_args.json {
-        eprintln!("Error: --json cannot be combined with --raw-output -");
+    let output_to_stdout = stream_args
+        .output
+        .as_ref()
+        .is_some_and(|path| path.as_os_str() == std::ffi::OsStr::new("-"));
+    let binary_to_stdout = raw_to_stdout || output_to_stdout;
+    if binary_to_stdout && stream_args.json {
+        eprintln!("Error: --json cannot be combined with binary stream output to stdout");
         std::process::exit(1);
     }
 
-    let mut raw_writer: Option<Box<dyn Write>> = stream_args.raw_output.as_ref().map(|path| {
-        if path.as_os_str() == std::ffi::OsStr::new("-") {
-            return Box::new(io::BufWriter::new(io::stdout())) as Box<dyn Write>;
-        }
-        if let Some(parent) = path.parent() {
-            if !parent.as_os_str().is_empty() {
-                std::fs::create_dir_all(parent).unwrap_or_else(|e| {
-                    eprintln!("Failed to create {}: {e}", parent.display());
+    let mut output_writer: Option<StreamOutputWriter> = if let Some(path) = &stream_args.raw_output
+    {
+        Some(StreamOutputWriter::Raw(
+            if path.as_os_str() == std::ffi::OsStr::new("-") {
+                Box::new(io::BufWriter::new(io::stdout())) as Box<dyn Write>
+            } else {
+                if let Some(parent) = path.parent() {
+                    if !parent.as_os_str().is_empty() {
+                        std::fs::create_dir_all(parent).unwrap_or_else(|e| {
+                            eprintln!("Failed to create {}: {e}", parent.display());
+                            std::process::exit(1);
+                        });
+                    }
+                }
+                Box::new(std::fs::File::create(path).unwrap_or_else(|e| {
+                    eprintln!("Failed to create {}: {e}", path.display());
                     std::process::exit(1);
-                });
-            }
-        }
-        Box::new(std::fs::File::create(path).unwrap_or_else(|e| {
-            eprintln!("Failed to create {}: {e}", path.display());
+                })) as Box<dyn Write>
+            },
+        ))
+    } else if let Some(path) = &stream_args.output {
+        let format = resolve_stream_output_format(path, stream_args.format).unwrap_or_else(|e| {
+            eprintln!("voice stream: {e}");
             std::process::exit(1);
-        })) as Box<dyn Write>
-    });
+        });
+        match format {
+            voice_audio::AudioOutputFormat::OggOpus => {
+                let writer =
+                    voice_audio::OggOpusStreamWriter::create(path, stream_args.sample_rate)
+                        .unwrap_or_else(|e| {
+                            eprintln!("voice stream: {e}");
+                            std::process::exit(1);
+                        });
+                Some(StreamOutputWriter::OggOpus(writer))
+            }
+            voice_audio::AudioOutputFormat::Wav => unreachable!(),
+        }
+    } else {
+        None
+    };
 
     let mut daemon = connect_daemon_or_exit();
     let mut terminal_error: Option<String> = None;
@@ -1346,7 +1414,7 @@ fn run_stream(stream_args: StreamArgs) {
                             metadata.frame_ms,
                             metadata.encoding
                         );
-                        if raw_to_stdout {
+                        if binary_to_stdout {
                             eprintln!("{line}");
                         } else {
                             println!("{line}");
@@ -1355,16 +1423,15 @@ fn run_stream(stream_args: StreamArgs) {
                 }
                 voice_stream::TtsStreamEvent::Audio { frame } => {
                     frame_count += 1;
-                    if let Some(file) = raw_writer.as_mut() {
-                        file.write_all(&frame.payload_le_bytes())
-                            .map_err(|e| format!("write raw PCM: {e}"))?;
+                    if let Some(writer) = output_writer.as_mut() {
+                        writer.write_frame(&frame)?;
                     }
                     if !stream_args.json {
                         let line = format!(
                             "audio seq={} samples={} padding={}",
                             frame.sequence, frame.sample_count, frame.padding_samples
                         );
-                        if raw_to_stdout {
+                        if binary_to_stdout {
                             eprintln!("{line}");
                         } else {
                             println!("{line}");
@@ -1377,7 +1444,7 @@ fn run_stream(stream_args: StreamArgs) {
                             "ended stream={} frames={} samples={} duration_ms={}",
                             end.stream_id, end.frames, end.samples, end.duration_ms
                         );
-                        if raw_to_stdout {
+                        if binary_to_stdout {
                             eprintln!("{line}");
                         } else {
                             println!("{line}");
@@ -1388,7 +1455,7 @@ fn run_stream(stream_args: StreamArgs) {
                     terminal_error = Some(err.message.clone());
                     if !stream_args.json {
                         let line = format!("error stream={}: {}", err.stream_id, err.message);
-                        if raw_to_stdout {
+                        if binary_to_stdout {
                             eprintln!("{line}");
                         } else {
                             println!("{line}");
@@ -1402,7 +1469,7 @@ fn run_stream(stream_args: StreamArgs) {
                             "cancelled stream={}: {}",
                             cancelled.stream_id, cancelled.reason
                         );
-                        if raw_to_stdout {
+                        if binary_to_stdout {
                             eprintln!("{line}");
                         } else {
                             println!("{line}");
@@ -1433,9 +1500,9 @@ fn run_stream(stream_args: StreamArgs) {
         std::process::exit(1);
     }
 
-    if let Some(mut file) = raw_writer {
-        file.flush().unwrap_or_else(|e| {
-            eprintln!("Failed to flush raw output: {e}");
+    if let Some(writer) = output_writer {
+        writer.finish().unwrap_or_else(|e| {
+            eprintln!("Failed to finish stream output: {e}");
             std::process::exit(1);
         });
     }
@@ -1550,6 +1617,30 @@ fn validate_stream_frame_params(sample_rate: u32, frame_ms: u32) -> Result<(), S
     }
 
     Ok(())
+}
+
+fn resolve_stream_output_format(
+    path: &Path,
+    explicit: Option<SayOutputFormat>,
+) -> Result<voice_audio::AudioOutputFormat, String> {
+    let explicit = explicit.map(voice_audio::AudioOutputFormat::from);
+    let format = if path.as_os_str() == std::ffi::OsStr::new("-") {
+        explicit.ok_or_else(|| {
+            "voice stream --output - requires --format ogg-opus so stdout is unambiguous"
+                .to_string()
+        })?
+    } else {
+        voice_audio::resolve_output_format(path, explicit)?
+    };
+
+    if format != voice_audio::AudioOutputFormat::OggOpus {
+        return Err(
+            "voice stream --output currently supports only Ogg/Opus; use .ogg/.opus or --format ogg-opus, or use --raw-output for PCM"
+                .to_string(),
+        );
+    }
+
+    Ok(format)
 }
 
 fn run_converse(args: ConverseArgs) {
@@ -1793,5 +1884,33 @@ mod tests {
         assert!(validate_stream_frame_params(0, 20).is_err());
         assert!(validate_stream_frame_params(48_000, 0).is_err());
         assert!(validate_stream_frame_params(48_000, 20).is_ok());
+    }
+
+    #[test]
+    fn resolve_stream_output_format_accepts_ogg_opus_paths() {
+        assert_eq!(
+            resolve_stream_output_format(Path::new("reply.ogg"), None).unwrap(),
+            voice_audio::AudioOutputFormat::OggOpus
+        );
+        assert_eq!(
+            resolve_stream_output_format(Path::new("reply.opus"), None).unwrap(),
+            voice_audio::AudioOutputFormat::OggOpus
+        );
+        assert_eq!(
+            resolve_stream_output_format(Path::new("reply"), Some(SayOutputFormat::OggOpus))
+                .unwrap(),
+            voice_audio::AudioOutputFormat::OggOpus
+        );
+    }
+
+    #[test]
+    fn resolve_stream_output_format_rejects_wav_and_stdout_without_format() {
+        assert!(resolve_stream_output_format(Path::new("reply.wav"), None).is_err());
+        assert!(resolve_stream_output_format(Path::new("reply"), None).is_err());
+        assert!(resolve_stream_output_format(Path::new("-"), None).is_err());
+        assert_eq!(
+            resolve_stream_output_format(Path::new("-"), Some(SayOutputFormat::OggOpus)).unwrap(),
+            voice_audio::AudioOutputFormat::OggOpus
+        );
     }
 }

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -10,7 +10,8 @@
   `.opus` output paths the same way as the CLI.
 - `stream_speak`: emit ordered audio events over the daemon socket. This is the
   transport-neutral path for WebRTC, voice bridges, or any client that wants
-  audio before a final file exists.
+  audio before a final file exists. `voice stream --output reply.ogg` can also
+  encode those frames to streamed Ogg/Opus without a WAV intermediate.
 - `stream_transcribe`: ingest ordered PCM events over the daemon socket and
   return a transcript after the client sends `stt.end`. This is the first
   inbound-audio contract for WebRTC sidecars. Partial transcripts are a later
@@ -75,9 +76,8 @@ Use `voice stream` to inspect the streaming event flow:
 voice stream "Hello from the stream"
 voice stream --json "Hello from the stream"
 voice say --format ogg-opus -o reply.ogg "Hello"
+voice stream --output streamed.ogg --format ogg-opus "Hello"
 voice stream --sample-rate 48000 --frame-ms 20 --raw-output reply.s16le "Hello"
-voice stream --sample-rate 48000 --frame-ms 20 --raw-output - "Hello" \
-  | ffmpeg -f s16le -ar 48000 -ac 1 -i - -c:a libopus reply.ogg
 voice stream-transcribe recording.wav
 voice stream-transcribe --json recording.wav
 ```
@@ -86,6 +86,12 @@ The raw output is signed 16-bit little-endian mono PCM with no container header.
 Use the event metadata for sample rate, frame duration, and stream ID.
 When `--raw-output -` is used, stdout is reserved for PCM bytes and compact
 progress lines move to stderr.
+
+`--output` is the encoded stream path. It currently accepts `.ogg` / `.opus` or
+`--format ogg-opus`, requires `ffmpeg`, and preserves the daemon's low-latency
+PCM frame contract while producing a valid `audio/ogg; codecs=opus` file.
+Use `--raw-output` when the consumer is a WebRTC sidecar or another process
+that wants raw PCM frames.
 
 `voice stream-transcribe` reads a WAV file, splits it into the same ordered PCM
 frames a WebRTC sidecar would send, and returns the terminal STT event from the


### PR DESCRIPTION
## Summary

- add a reusable `OggOpusStreamWriter` that encodes incremental `pcm_s16le` frames through ffmpeg
- add `voice stream --output <path> --format ogg-opus` for streamed Ogg/Opus output without a WAV intermediate
- keep `--raw-output` as the raw PCM/WebRTC path and reject misleading stream output formats
- document the direct streamed Ogg/Opus CLI path in `docs/streaming.md`

## Verification

- `cargo fmt --check`
- `cargo test -p voice-audio`
- `cargo test -p voice --no-default-features`
- `cargo clippy -p voice-audio -p voice --no-default-features -- -D warnings`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- live smoke: `target/debug/voice --quiet stream --output /tmp/voice-stream-opus.ogg --format ogg-opus --sample-rate 48000 --frame-ms 20 "Hello from streamed Opus output."`
- `ffprobe` on the smoke file reported `codec_name=opus`, `sample_rate=48000`, `channels=1`; file starts with `OggS` and contains `OpusHead`

## Notes

This keeps the daemon stream contract as ordered PCM frames, but gives integrations a first-class encoded stream/file mode for WhatsApp-style Opus output when they do not need raw PCM.