### PR TITLE
Add WebRTC sidecar status checks

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -132,10 +132,11 @@ The exact transport can be Unix socket, local HTTP, or WebSocket. The first
 implementation should favor debuggability over abstraction.
 
 ```http
-POST /calls
+POST /offer
 {
   "call_id": "wamid-call-id",
-  "remote_sdp": "v=0..."
+  "type": "offer",
+  "sdp": "v=0..."
 }
 ```
 
@@ -144,15 +145,27 @@ Response:
 ```json
 {
   "call_id": "wamid-call-id",
-  "local_sdp": "v=0...",
+  "type": "answer",
+  "sdp": "v=0...",
   "audio": {
     "sample_rate": 48000,
     "channels": 1,
     "frame_ms": 20,
     "encoding": "pcm_s16le"
+  },
+  "state": {
+    "call_id": "wamid-call-id",
+    "closed": false,
+    "connection_state": "new",
+    "ice_connection_state": "new",
+    "ice_gathering_state": "complete",
+    "signaling_state": "stable"
   }
 }
 ```
+
+Debug a live session with `GET /calls/{call_id}`. Terminate a local session
+with `POST /calls/{call_id}/close`.
 
 Runtime events:
 

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -42,6 +42,12 @@ SDP, ICE, and call timing before TTS is wired in.
 
 ## SDP API
 
+Check process health and the fixed local audio contract:
+
+```bash
+curl -sS http://127.0.0.1:8787/health
+```
+
 Post a remote offer:
 
 ```bash
@@ -66,6 +72,12 @@ Response:
 }
 ```
 
+Inspect a live session:
+
+```bash
+curl -sS http://127.0.0.1:8787/calls/local-test
+```
+
 Close a session:
 
 ```bash
@@ -83,3 +95,14 @@ silence until real TTS PCM arrives.
 Inbound decoded PCM is written as raw signed 16-bit little-endian mono samples.
 A later bridge layer can segment that stream with VAD and submit each segment
 to `voice stream-transcribe` or the daemon `stream_transcribe` RPC.
+
+## Tests
+
+The sidecar tests are optional because they need the Python WebRTC dependency
+set:
+
+```bash
+python3 -m venv /tmp/voice-webrtc-venv
+/tmp/voice-webrtc-venv/bin/pip install -r examples/webrtc-sidecar/requirements.txt pytest
+/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py
+```

--- a/examples/webrtc-sidecar/sidecar.py
+++ b/examples/webrtc-sidecar/sidecar.py
@@ -176,6 +176,19 @@ class CallSession:
         assert self.pc.localDescription is not None
         return self.pc.localDescription
 
+    def snapshot(self) -> dict[str, Any]:
+        """Return call state useful for local health checks and Hermes debugging."""
+        return {
+            "call_id": self.call_id,
+            "closed": self.closed,
+            "connection_state": self.pc.connectionState,
+            "ice_connection_state": self.pc.iceConnectionState,
+            "ice_gathering_state": self.pc.iceGatheringState,
+            "signaling_state": self.pc.signalingState,
+            "tasks": len(self.tasks),
+            "audio": audio_contract(),
+        }
+
     async def close(self) -> None:
         if self.closed:
             return
@@ -185,6 +198,9 @@ class CallSession:
         if self.tasks:
             await asyncio.gather(*self.tasks, return_exceptions=True)
         await self.pc.close()
+
+
+SESSIONS_KEY = web.AppKey("sessions", dict[str, CallSession])
 
 
 async def wait_for_ice_complete(pc: RTCPeerConnection, timeout: float = 5.0) -> None:
@@ -208,12 +224,29 @@ def json_error(message: str, status: int = 400) -> web.Response:
     return web.json_response({"error": message}, status=status)
 
 
+def audio_contract() -> dict[str, Any]:
+    return {
+        "sample_rate": SAMPLE_RATE,
+        "channels": CHANNELS,
+        "frame_ms": FRAME_MS,
+        "encoding": "pcm_s16le",
+    }
+
+
 def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
     app = web.Application()
     sessions: dict[str, CallSession] = {}
+    app[SESSIONS_KEY] = sessions
 
     async def health(_: web.Request) -> web.Response:
-        return web.json_response({"ok": True, "sessions": len(sessions)})
+        return web.json_response(
+            {
+                "ok": True,
+                "sessions": len(sessions),
+                "call_ids": sorted(sessions.keys()),
+                "audio": audio_contract(),
+            }
+        )
 
     async def offer(request: web.Request) -> web.Response:
         try:
@@ -248,14 +281,17 @@ def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
                 "call_id": call_id,
                 "type": answer.type,
                 "sdp": answer.sdp,
-                "audio": {
-                    "sample_rate": SAMPLE_RATE,
-                    "channels": CHANNELS,
-                    "frame_ms": FRAME_MS,
-                    "encoding": "pcm_s16le",
-                },
+                "audio": audio_contract(),
+                "state": session.snapshot(),
             }
         )
+
+    async def call_status(request: web.Request) -> web.Response:
+        call_id = request.match_info["call_id"]
+        session = sessions.get(call_id)
+        if session is None:
+            return json_error("unknown call_id", status=404)
+        return web.json_response(session.snapshot())
 
     async def close_call(request: web.Request) -> web.Response:
         call_id = request.match_info["call_id"]
@@ -272,6 +308,7 @@ def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
 
     app.router.add_get("/health", health)
     app.router.add_post("/offer", offer)
+    app.router.add_get("/calls/{call_id}", call_status)
     app.router.add_post("/calls/{call_id}/close", close_call)
     app.on_cleanup.append(cleanup)
     return app

--- a/examples/webrtc-sidecar/test_sidecar.py
+++ b/examples/webrtc-sidecar/test_sidecar.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def load_sidecar():
+    path = Path(__file__).with_name("sidecar.py")
+    spec = importlib.util.spec_from_file_location("voice_webrtc_sidecar", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except SystemExit as exc:
+        pytest.skip(str(exc))
+    return module
+
+
+def test_audio_contract_is_voice_pcm_shape():
+    sidecar = load_sidecar()
+
+    assert sidecar.audio_contract() == {
+        "sample_rate": 48000,
+        "channels": 1,
+        "frame_ms": 20,
+        "encoding": "pcm_s16le",
+    }
+
+
+def test_pcm_source_pads_partial_frame(tmp_path: Path):
+    sidecar = load_sidecar()
+    source_path = tmp_path / "short.s16le"
+    source_path.write_bytes(b"\x01\x02\x03\x04")
+
+    source = sidecar.PcmSource(str(source_path))
+    try:
+        frame = source.read_frame()
+    finally:
+        source.close()
+
+    assert len(frame) == sidecar.FRAME_BYTES
+    assert frame.startswith(b"\x01\x02\x03\x04")
+    assert frame[4:] == b"\x00" * (sidecar.FRAME_BYTES - 4)
+
+
+def test_health_reports_audio_contract():
+    sidecar = load_sidecar()
+
+    async def run():
+        from aiohttp.test_utils import TestClient, TestServer
+
+        source = sidecar.PcmSource(None)
+        app = sidecar.create_app(source, None)
+        async with TestClient(TestServer(app)) as client:
+            response = await client.get("/health")
+            assert response.status == 200
+            body = await response.json()
+            assert body["ok"] is True
+            assert body["sessions"] == 0
+            assert body["call_ids"] == []
+            assert body["audio"] == sidecar.audio_contract()
+
+    asyncio.run(run())
+
+
+def test_call_status_and_close_use_session_snapshot():
+    sidecar = load_sidecar()
+
+    class FakeSession:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def snapshot(self):
+            return {
+                "call_id": "call-1",
+                "closed": self.closed,
+                "audio": sidecar.audio_contract(),
+            }
+
+        async def close(self) -> None:
+            self.closed = True
+
+    async def run():
+        from aiohttp.test_utils import TestClient, TestServer
+
+        source = sidecar.PcmSource(None)
+        app = sidecar.create_app(source, None)
+        app[sidecar.SESSIONS_KEY]["call-1"] = FakeSession()
+
+        async with TestClient(TestServer(app)) as client:
+            status_response = await client.get("/calls/call-1")
+            assert status_response.status == 200
+            status_body = await status_response.json()
+            assert status_body["call_id"] == "call-1"
+            assert status_body["closed"] is False
+            assert status_body["audio"] == sidecar.audio_contract()
+
+            close_response = await client.post("/calls/call-1/close")
+            assert close_response.status == 200
+            close_body = await close_response.json()
+            assert close_body == {"call_id": "call-1", "closed": True}
+            assert app[sidecar.SESSIONS_KEY] == {}
+
+            missing_response = await client.get("/calls/call-1")
+            assert missing_response.status == 404
+            missing_body = await missing_response.json()
+            assert missing_body == {"error": "unknown call_id"}
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary\n\n- add a stable audio contract helper and expose it from sidecar health/offer responses\n- add `GET /calls/{call_id}` for per-call state snapshots so Hermes can debug active WebRTC sessions\n- document the health/status endpoints and add optional pytest coverage for the sidecar contract and PCM padding\n\n## Verification\n\n- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py`\n- `/tmp/voice-webrtc-venv/bin/python -m py_compile examples/webrtc-sidecar/sidecar.py examples/webrtc-sidecar/test_sidecar.py`\n- `cargo test -p voice-stream`\n- `git diff --check --cached`