### PR TITLE
Add WebRTC sidecar audio ingress

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -171,8 +171,9 @@ Response:
 }
 ```
 
-Debug a live session with `GET /calls/{call_id}`. Terminate a local session
-with `POST /calls/{call_id}/close`.
+Debug a live session with `GET /calls/{call_id}`. Queue outbound audio for the
+WebRTC track with `POST /calls/{call_id}/audio`. Terminate a local session with
+`POST /calls/{call_id}/close`.
 
 Runtime events:
 
@@ -183,20 +184,41 @@ Runtime events:
 {"type": "ended", "reason": "remote_hangup"}
 ```
 
-Outbound audio command:
+Outbound audio:
 
-```json
+```http
+POST /calls/{call_id}/audio
 {
-  "type": "outbound_audio",
   "sequence": 17,
   "sample_rate": 48000,
+  "channels": 1,
   "frame_ms": 20,
+  "encoding": "pcm_s16le",
   "pcm_s16le_base64": "..."
 }
 ```
 
-This mirrors the current `voice` daemon stream shape closely enough that the
-bridge can be mostly mechanical.
+Response:
+
+```json
+{
+  "call_id": "wamid-call-id",
+  "accepted_bytes": 1920,
+  "queued_tx_bytes": 3840,
+  "audio": {
+    "sample_rate": 48000,
+    "channels": 1,
+    "frame_ms": 20,
+    "encoding": "pcm_s16le"
+  }
+}
+```
+
+Each 20 ms frame is 1920 bytes: 960 signed 16-bit little-endian mono samples at
+48 kHz. This mirrors the current `voice` daemon stream shape closely enough
+that the bridge can be mostly mechanical: Hermes can receive `stream_speak` raw
+frames, base64-encode each frame, and POST them to the sidecar while the WebRTC
+track sends queued audio or silence.
 
 ## Implementation Options
 

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -37,8 +37,25 @@ voice stream --sample-rate 48000 --frame-ms 20 \
   "Hello from the WebRTC sidecar."
 ```
 
-If `--tx-pcm` is omitted, the sidecar sends silence. That is useful for checking
-SDP, ICE, and call timing before TTS is wired in.
+You can also omit `--tx-pcm` and POST outbound frames over local HTTP once a
+call session exists. This is the shape Hermes can use when it receives
+`stream_speak` frames from the voice daemon:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8787/calls/local-test/audio \
+  -H 'content-type: application/json' \
+  -d '{
+    "sample_rate": 48000,
+    "channels": 1,
+    "frame_ms": 20,
+    "encoding": "pcm_s16le",
+    "pcm_s16le_base64": "AAAAAA=="
+  }'
+```
+
+Each 20 ms frame is 1920 bytes before base64 encoding. If both `--tx-pcm` and
+HTTP input are idle, the sidecar sends silence. That is useful for checking SDP,
+ICE, and call timing before TTS is wired in.
 
 ## SDP API
 
@@ -76,6 +93,14 @@ Inspect a live session:
 
 ```bash
 curl -sS http://127.0.0.1:8787/calls/local-test
+```
+
+Queue outbound PCM for a live session:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8787/calls/local-test/audio \
+  -H 'content-type: application/json' \
+  -d '{"sample_rate":48000,"channels":1,"frame_ms":20,"encoding":"pcm_s16le","pcm_s16le_base64":"AAAAAA=="}'
 ```
 
 Close a session:

--- a/examples/webrtc-sidecar/sidecar.py
+++ b/examples/webrtc-sidecar/sidecar.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import base64
+import binascii
 from fractions import Fraction
 import json
 import logging
@@ -64,6 +66,14 @@ class PcmSource:
         if self.fd is not None:
             os.close(self.fd)
             self.fd = None
+
+    @property
+    def queued_bytes(self) -> int:
+        return len(self.buffer)
+
+    def write_frame(self, pcm_s16le: bytes) -> int:
+        self.buffer.extend(pcm_s16le)
+        return len(pcm_s16le)
 
     def read_frame(self) -> bytes:
         if self.fd is not None:
@@ -186,6 +196,7 @@ class CallSession:
             "ice_gathering_state": self.pc.iceGatheringState,
             "signaling_state": self.pc.signalingState,
             "tasks": len(self.tasks),
+            "queued_tx_bytes": self.source.queued_bytes,
             "audio": audio_contract(),
         }
 
@@ -231,6 +242,43 @@ def audio_contract() -> dict[str, Any]:
         "frame_ms": FRAME_MS,
         "encoding": "pcm_s16le",
     }
+
+
+def required_int(body: dict[str, Any], key: str, default: int | None = None) -> int:
+    value = body.get(key, default)
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{key} must be an integer") from exc
+
+
+def decode_pcm_payload(body: dict[str, Any]) -> bytes:
+    sample_rate = required_int(body, "sample_rate")
+    channels = required_int(body, "channels", CHANNELS)
+    frame_ms = required_int(body, "frame_ms", FRAME_MS)
+    encoding = str(body.get("encoding") or "").strip().lower()
+    payload = str(body.get("pcm_s16le_base64") or "").strip()
+
+    if sample_rate != SAMPLE_RATE:
+        raise ValueError(f"sample_rate must be {SAMPLE_RATE}")
+    if channels != CHANNELS:
+        raise ValueError(f"channels must be {CHANNELS}")
+    if frame_ms != FRAME_MS:
+        raise ValueError(f"frame_ms must be {FRAME_MS}")
+    if encoding not in {"pcm_s16le", "pcm_s16_le"}:
+        raise ValueError("encoding must be pcm_s16le")
+    if not payload:
+        raise ValueError("pcm_s16le_base64 is required")
+
+    try:
+        pcm = base64.b64decode(payload, validate=True)
+    except binascii.Error as exc:
+        raise ValueError("pcm_s16le_base64 is not valid base64") from exc
+    if not pcm:
+        raise ValueError("decoded PCM payload is empty")
+    if len(pcm) % BYTES_PER_SAMPLE != 0:
+        raise ValueError("decoded PCM payload must contain whole s16le samples")
+    return pcm
 
 
 def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
@@ -293,6 +341,30 @@ def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
             return json_error("unknown call_id", status=404)
         return web.json_response(session.snapshot())
 
+    async def send_audio(request: web.Request) -> web.Response:
+        call_id = request.match_info["call_id"]
+        session = sessions.get(call_id)
+        if session is None:
+            return json_error("unknown call_id", status=404)
+        try:
+            body = await request.json()
+        except json.JSONDecodeError:
+            return json_error("request body must be JSON")
+        try:
+            pcm = decode_pcm_payload(body)
+        except ValueError as exc:
+            return json_error(str(exc))
+
+        accepted_bytes = session.source.write_frame(pcm)
+        return web.json_response(
+            {
+                "call_id": call_id,
+                "accepted_bytes": accepted_bytes,
+                "queued_tx_bytes": session.source.queued_bytes,
+                "audio": audio_contract(),
+            }
+        )
+
     async def close_call(request: web.Request) -> web.Response:
         call_id = request.match_info["call_id"]
         session = sessions.pop(call_id, None)
@@ -309,6 +381,7 @@ def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
     app.router.add_get("/health", health)
     app.router.add_post("/offer", offer)
     app.router.add_get("/calls/{call_id}", call_status)
+    app.router.add_post("/calls/{call_id}/audio", send_audio)
     app.router.add_post("/calls/{call_id}/close", close_call)
     app.on_cleanup.append(cleanup)
     return app

--- a/examples/webrtc-sidecar/test_sidecar.py
+++ b/examples/webrtc-sidecar/test_sidecar.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import importlib.util
 from pathlib import Path
 
@@ -109,5 +110,89 @@ def test_call_status_and_close_use_session_snapshot():
             assert missing_response.status == 404
             missing_body = await missing_response.json()
             assert missing_body == {"error": "unknown call_id"}
+
+    asyncio.run(run())
+
+
+def test_audio_endpoint_queues_pcm_for_call():
+    sidecar = load_sidecar()
+
+    class FakeSession:
+        def __init__(self, source) -> None:
+            self.source = source
+
+        def snapshot(self):
+            return {
+                "call_id": "call-1",
+                "queued_tx_bytes": self.source.queued_bytes,
+                "audio": sidecar.audio_contract(),
+            }
+
+        async def close(self) -> None:
+            pass
+
+    async def run():
+        from aiohttp.test_utils import TestClient, TestServer
+
+        source = sidecar.PcmSource(None)
+        app = sidecar.create_app(source, None)
+        app[sidecar.SESSIONS_KEY]["call-1"] = FakeSession(source)
+
+        payload = {
+            "sample_rate": 48000,
+            "channels": 1,
+            "frame_ms": 20,
+            "encoding": "pcm_s16le",
+            "pcm_s16le_base64": base64.b64encode(b"\x01\x00\xff\xff").decode("ascii"),
+        }
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post("/calls/call-1/audio", json=payload)
+            assert response.status == 200
+            body = await response.json()
+            assert body["accepted_bytes"] == 4
+            assert body["queued_tx_bytes"] == 4
+
+            frame = source.read_frame()
+            assert frame.startswith(b"\x01\x00\xff\xff")
+            assert frame[4:] == b"\x00" * (sidecar.FRAME_BYTES - 4)
+
+    asyncio.run(run())
+
+
+def test_audio_endpoint_rejects_mismatched_contract():
+    sidecar = load_sidecar()
+
+    class FakeSession:
+        def __init__(self, source) -> None:
+            self.source = source
+
+        def snapshot(self):
+            return {"call_id": "call-1"}
+
+        async def close(self) -> None:
+            pass
+
+    async def run():
+        from aiohttp.test_utils import TestClient, TestServer
+
+        source = sidecar.PcmSource(None)
+        app = sidecar.create_app(source, None)
+        app[sidecar.SESSIONS_KEY]["call-1"] = FakeSession(source)
+
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post(
+                "/calls/call-1/audio",
+                json={
+                    "sample_rate": 16000,
+                    "channels": 1,
+                    "frame_ms": 20,
+                    "encoding": "pcm_s16le",
+                    "pcm_s16le_base64": base64.b64encode(b"\x00\x00").decode("ascii"),
+                },
+            )
+            assert response.status == 400
+            body = await response.json()
+            assert body == {"error": "sample_rate must be 48000"}
+            assert source.queued_bytes == 0
 
     asyncio.run(run())


### PR DESCRIPTION
## Summary

- add `POST /calls/{call_id}/audio` to queue outbound pcm_s16le frames for the WebRTC sidecar
- expose queued outbound byte counts in call snapshots and audio enqueue responses
- document the HTTP PCM ingress path for Hermes/voice stream_speak integration

## Tests

- `/tmp/voice-webrtc-venv/bin/python -m py_compile examples/webrtc-sidecar/sidecar.py examples/webrtc-sidecar/test_sidecar.py`
- `git diff --check`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py`
