### PR TITLE
Isolate WebRTC sidecar call audio queues

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -218,7 +218,7 @@ Each 20 ms frame is 1920 bytes: 960 signed 16-bit little-endian mono samples at
 48 kHz. This mirrors the current `voice` daemon stream shape closely enough
 that the bridge can be mostly mechanical: Hermes can receive `stream_speak` raw
 frames, base64-encode each frame, and POST them to the sidecar while the WebRTC
-track sends queued audio or silence.
+track sends per-call queued audio or silence.
 
 ## Implementation Options
 

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -53,9 +53,10 @@ curl -sS -X POST http://127.0.0.1:8787/calls/local-test/audio \
   }'
 ```
 
-Each 20 ms frame is 1920 bytes before base64 encoding. If both `--tx-pcm` and
-HTTP input are idle, the sidecar sends silence. That is useful for checking SDP,
-ICE, and call timing before TTS is wired in.
+Each 20 ms frame is 1920 bytes before base64 encoding. HTTP input is queued per
+`call_id`; `--tx-pcm` remains a process-level fallback source. If both sources
+are idle, the sidecar sends silence. That is useful for checking SDP, ICE, and
+call timing before TTS is wired in.
 
 ## SDP API
 

--- a/examples/webrtc-sidecar/sidecar.py
+++ b/examples/webrtc-sidecar/sidecar.py
@@ -96,12 +96,41 @@ class PcmSource:
         return frame + (b"\x00" * (FRAME_BYTES - len(frame)))
 
 
+class CallPcmSource:
+    """Per-call PCM queue with a process-level source as fallback."""
+
+    def __init__(self, fallback: PcmSource) -> None:
+        self.fallback = fallback
+        self.buffer = bytearray()
+
+    @property
+    def queued_bytes(self) -> int:
+        return len(self.buffer)
+
+    def write_frame(self, pcm_s16le: bytes) -> int:
+        self.buffer.extend(pcm_s16le)
+        return len(pcm_s16le)
+
+    def read_frame(self) -> bytes:
+        if len(self.buffer) >= FRAME_BYTES:
+            frame = bytes(self.buffer[:FRAME_BYTES])
+            del self.buffer[:FRAME_BYTES]
+            return frame
+
+        if self.buffer:
+            frame = bytes(self.buffer)
+            self.buffer.clear()
+            return frame + (b"\x00" * (FRAME_BYTES - len(frame)))
+
+        return self.fallback.read_frame()
+
+
 class VoicePcmAudioTrack(MediaStreamTrack):
     """Outbound WebRTC audio track backed by local pcm_s16le frames."""
 
     kind = "audio"
 
-    def __init__(self, source: PcmSource) -> None:
+    def __init__(self, source: PcmSource | CallPcmSource) -> None:
         super().__init__()
         self.source = source
         self.pts = 0
@@ -155,12 +184,12 @@ async def write_inbound_pcm(track: MediaStreamTrack, path: str | None) -> None:
 class CallSession:
     def __init__(self, call_id: str, source: PcmSource, rx_pcm: str | None) -> None:
         self.call_id = call_id
-        self.source = source
+        self.source = CallPcmSource(source)
         self.rx_pcm = rx_pcm
         self.pc = RTCPeerConnection()
         self.tasks: set[asyncio.Task[Any]] = set()
         self.closed = False
-        self.pc.addTrack(VoicePcmAudioTrack(source))
+        self.pc.addTrack(VoicePcmAudioTrack(self.source))
 
         @self.pc.on("track")
         def on_track(track: MediaStreamTrack) -> None:

--- a/examples/webrtc-sidecar/test_sidecar.py
+++ b/examples/webrtc-sidecar/test_sidecar.py
@@ -48,6 +48,27 @@ def test_pcm_source_pads_partial_frame(tmp_path: Path):
     assert frame[4:] == b"\x00" * (sidecar.FRAME_BYTES - 4)
 
 
+def test_call_pcm_source_isolates_per_call_queue():
+    sidecar = load_sidecar()
+
+    fallback = sidecar.PcmSource(None)
+    call_a = sidecar.CallPcmSource(fallback)
+    call_b = sidecar.CallPcmSource(fallback)
+
+    accepted = call_a.write_frame(b"\x01\x00\xff\xff")
+
+    assert accepted == 4
+    assert call_a.queued_bytes == 4
+    assert call_b.queued_bytes == 0
+
+    frame_b = call_b.read_frame()
+    assert frame_b == b"\x00" * sidecar.FRAME_BYTES
+
+    frame_a = call_a.read_frame()
+    assert frame_a.startswith(b"\x01\x00\xff\xff")
+    assert frame_a[4:] == b"\x00" * (sidecar.FRAME_BYTES - 4)
+
+
 def test_health_reports_audio_contract():
     sidecar = load_sidecar()
 
@@ -134,8 +155,9 @@ def test_audio_endpoint_queues_pcm_for_call():
     async def run():
         from aiohttp.test_utils import TestClient, TestServer
 
-        source = sidecar.PcmSource(None)
-        app = sidecar.create_app(source, None)
+        fallback = sidecar.PcmSource(None)
+        source = sidecar.CallPcmSource(fallback)
+        app = sidecar.create_app(fallback, None)
         app[sidecar.SESSIONS_KEY]["call-1"] = FakeSession(source)
 
         payload = {
@@ -175,8 +197,9 @@ def test_audio_endpoint_rejects_mismatched_contract():
     async def run():
         from aiohttp.test_utils import TestClient, TestServer
 
-        source = sidecar.PcmSource(None)
-        app = sidecar.create_app(source, None)
+        fallback = sidecar.PcmSource(None)
+        source = sidecar.CallPcmSource(fallback)
+        app = sidecar.create_app(fallback, None)
         app[sidecar.SESSIONS_KEY]["call-1"] = FakeSession(source)
 
         async with TestClient(TestServer(app)) as client:


### PR DESCRIPTION
## Summary

- queue HTTP outbound PCM per call session instead of on the shared sidecar source
- keep `--tx-pcm` as a process-level fallback when a call has no queued HTTP audio
- document the per-call queue behavior

## Tests

- `/tmp/voice-webrtc-venv/bin/python -m py_compile examples/webrtc-sidecar/sidecar.py examples/webrtc-sidecar/test_sidecar.py`
- `git diff --check`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py`
