### PR TITLE
Add WebRTC sidecar inbound audio drain

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -171,8 +171,9 @@ Response:
 }
 ```
 
-Debug a live session with `GET /calls/{call_id}`. Queue outbound audio for the
-WebRTC track with `POST /calls/{call_id}/audio`. Terminate a local session with
+Debug a live session with `GET /calls/{call_id}`. Drain decoded inbound audio
+with `GET /calls/{call_id}/audio`. Queue outbound audio for the WebRTC track
+with `POST /calls/{call_id}/audio`. Terminate a local session with
 `POST /calls/{call_id}/close`.
 
 Runtime events:
@@ -182,6 +183,29 @@ Runtime events:
 {"type": "inbound_audio", "sequence": 42, "pcm_s16le_base64": "..."}
 {"type": "dtmf", "digit": "1"}
 {"type": "ended", "reason": "remote_hangup"}
+```
+
+Inbound audio:
+
+```http
+GET /calls/{call_id}/audio?max_bytes=1920
+```
+
+Response:
+
+```json
+{
+  "call_id": "wamid-call-id",
+  "returned_bytes": 1920,
+  "queued_rx_bytes": 3840,
+  "pcm_s16le_base64": "...",
+  "audio": {
+    "sample_rate": 48000,
+    "channels": 1,
+    "frame_ms": 20,
+    "encoding": "pcm_s16le"
+  }
+}
 ```
 
 Outbound audio:

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -96,6 +96,12 @@ Inspect a live session:
 curl -sS http://127.0.0.1:8787/calls/local-test
 ```
 
+Drain decoded inbound PCM for a live session:
+
+```bash
+curl -sS 'http://127.0.0.1:8787/calls/local-test/audio?max_bytes=1920'
+```
+
 Queue outbound PCM for a live session:
 
 ```bash
@@ -118,8 +124,9 @@ local `/offer` call, then pass the returned SDP answer to the Cloud API
 audio track attached and ready before Hermes calls `accept`; the track sends
 silence until real TTS PCM arrives.
 
-Inbound decoded PCM is written as raw signed 16-bit little-endian mono samples.
-A later bridge layer can segment that stream with VAD and submit each segment
+Inbound decoded PCM is kept in a bounded per-call queue and can also be mirrored
+to a raw signed 16-bit little-endian mono sink with `--rx-pcm`. A later bridge
+layer can drain or read that stream, segment it with VAD, and submit each segment
 directly to the daemon STT stream contract:
 
 ```bash

--- a/examples/webrtc-sidecar/sidecar.py
+++ b/examples/webrtc-sidecar/sidecar.py
@@ -44,6 +44,8 @@ CHANNELS = 1
 SAMPLES_PER_FRAME = SAMPLE_RATE * FRAME_MS // 1_000
 BYTES_PER_SAMPLE = 2
 FRAME_BYTES = SAMPLES_PER_FRAME * CHANNELS * BYTES_PER_SAMPLE
+DEFAULT_DRAIN_BYTES = FRAME_BYTES * 50
+MAX_INBOUND_QUEUE_BYTES = SAMPLE_RATE * CHANNELS * BYTES_PER_SAMPLE * 10
 
 
 class PcmSource:
@@ -125,6 +127,48 @@ class CallPcmSource:
         return self.fallback.read_frame()
 
 
+class InboundPcmSink:
+    """Decoded inbound PCM sink with optional file mirroring and HTTP draining."""
+
+    def __init__(
+        self,
+        path: str | None,
+        max_queue_bytes: int = MAX_INBOUND_QUEUE_BYTES,
+    ) -> None:
+        self.path = Path(path) if path else None
+        self.max_queue_bytes = max_queue_bytes
+        self.buffer = bytearray()
+        self.file = None
+
+    @property
+    def queued_bytes(self) -> int:
+        return len(self.buffer)
+
+    def write(self, pcm_s16le: bytes) -> None:
+        if self.path is not None:
+            if self.file is None:
+                self.path.parent.mkdir(parents=True, exist_ok=True)
+                self.file = self.path.open("ab")
+            self.file.write(pcm_s16le)
+            self.file.flush()
+
+        self.buffer.extend(pcm_s16le)
+        if len(self.buffer) > self.max_queue_bytes:
+            del self.buffer[: len(self.buffer) - self.max_queue_bytes]
+
+    def drain(self, max_bytes: int = DEFAULT_DRAIN_BYTES) -> bytes:
+        if max_bytes <= 0 or not self.buffer:
+            return b""
+        chunk = bytes(self.buffer[:max_bytes])
+        del self.buffer[:max_bytes]
+        return chunk
+
+    def close(self) -> None:
+        if self.file is not None:
+            self.file.close()
+            self.file = None
+
+
 class VoicePcmAudioTrack(MediaStreamTrack):
     """Outbound WebRTC audio track backed by local pcm_s16le frames."""
 
@@ -158,34 +202,23 @@ class VoicePcmAudioTrack(MediaStreamTrack):
         return frame
 
 
-async def write_inbound_pcm(track: MediaStreamTrack, path: str | None) -> None:
-    if not path:
-        while True:
-            try:
-                await track.recv()
-            except MediaStreamError:
-                return
-
-    target = Path(path)
-    target.parent.mkdir(parents=True, exist_ok=True)
+async def write_inbound_pcm(track: MediaStreamTrack, sink: InboundPcmSink) -> None:
     resampler = av.AudioResampler(format="s16", layout="mono", rate=SAMPLE_RATE)
 
-    with target.open("ab") as sink:
-        while True:
-            try:
-                frame = await track.recv()
-            except MediaStreamError:
-                return
-            for out in resampler.resample(frame):
-                sink.write(bytes(out.planes[0]))
-                sink.flush()
+    while True:
+        try:
+            frame = await track.recv()
+        except MediaStreamError:
+            return
+        for out in resampler.resample(frame):
+            sink.write(bytes(out.planes[0]))
 
 
 class CallSession:
     def __init__(self, call_id: str, source: PcmSource, rx_pcm: str | None) -> None:
         self.call_id = call_id
         self.source = CallPcmSource(source)
-        self.rx_pcm = rx_pcm
+        self.inbound = InboundPcmSink(rx_pcm)
         self.pc = RTCPeerConnection()
         self.tasks: set[asyncio.Task[Any]] = set()
         self.closed = False
@@ -195,7 +228,7 @@ class CallSession:
         def on_track(track: MediaStreamTrack) -> None:
             LOGGER.info("call %s received %s track", self.call_id, track.kind)
             if track.kind == "audio":
-                task = asyncio.create_task(write_inbound_pcm(track, self.rx_pcm))
+                task = asyncio.create_task(write_inbound_pcm(track, self.inbound))
                 self.tasks.add(task)
                 task.add_done_callback(self.tasks.discard)
 
@@ -226,6 +259,7 @@ class CallSession:
             "signaling_state": self.pc.signalingState,
             "tasks": len(self.tasks),
             "queued_tx_bytes": self.source.queued_bytes,
+            "queued_rx_bytes": self.inbound.queued_bytes,
             "audio": audio_contract(),
         }
 
@@ -237,6 +271,7 @@ class CallSession:
             task.cancel()
         if self.tasks:
             await asyncio.gather(*self.tasks, return_exceptions=True)
+        self.inbound.close()
         await self.pc.close()
 
 
@@ -308,6 +343,19 @@ def decode_pcm_payload(body: dict[str, Any]) -> bytes:
     if len(pcm) % BYTES_PER_SAMPLE != 0:
         raise ValueError("decoded PCM payload must contain whole s16le samples")
     return pcm
+
+
+def drain_size(request: web.Request) -> int:
+    raw = str(request.query.get("max_bytes") or DEFAULT_DRAIN_BYTES).strip()
+    try:
+        parsed = int(raw)
+    except ValueError as exc:
+        raise ValueError("max_bytes must be an integer") from exc
+    if parsed <= 0:
+        raise ValueError("max_bytes must be positive")
+    if parsed % BYTES_PER_SAMPLE != 0:
+        raise ValueError("max_bytes must contain whole s16le samples")
+    return min(parsed, MAX_INBOUND_QUEUE_BYTES)
 
 
 def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
@@ -394,6 +442,27 @@ def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
             }
         )
 
+    async def receive_audio(request: web.Request) -> web.Response:
+        call_id = request.match_info["call_id"]
+        session = sessions.get(call_id)
+        if session is None:
+            return json_error("unknown call_id", status=404)
+        try:
+            max_bytes = drain_size(request)
+        except ValueError as exc:
+            return json_error(str(exc))
+
+        pcm = session.inbound.drain(max_bytes)
+        return web.json_response(
+            {
+                "call_id": call_id,
+                "returned_bytes": len(pcm),
+                "queued_rx_bytes": session.inbound.queued_bytes,
+                "pcm_s16le_base64": base64.b64encode(pcm).decode("ascii"),
+                "audio": audio_contract(),
+            }
+        )
+
     async def close_call(request: web.Request) -> web.Response:
         call_id = request.match_info["call_id"]
         session = sessions.pop(call_id, None)
@@ -410,6 +479,7 @@ def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
     app.router.add_get("/health", health)
     app.router.add_post("/offer", offer)
     app.router.add_get("/calls/{call_id}", call_status)
+    app.router.add_get("/calls/{call_id}/audio", receive_audio)
     app.router.add_post("/calls/{call_id}/audio", send_audio)
     app.router.add_post("/calls/{call_id}/close", close_call)
     app.on_cleanup.append(cleanup)

--- a/examples/webrtc-sidecar/test_sidecar.py
+++ b/examples/webrtc-sidecar/test_sidecar.py
@@ -21,6 +21,40 @@ def load_sidecar():
     return module
 
 
+def synthetic_pcm_track(sidecar):
+    class SyntheticPcmTrack(sidecar.MediaStreamTrack):
+        kind = "audio"
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.pts = 0
+            samples = [
+                (12_000 if index % 2 == 0 else -12_000).to_bytes(
+                    2,
+                    byteorder="little",
+                    signed=True,
+                )
+                for index in range(sidecar.SAMPLES_PER_FRAME)
+            ]
+            self.frame_bytes = b"".join(samples)
+
+        async def recv(self):
+            await asyncio.sleep(sidecar.FRAME_MS / 1_000)
+            frame = sidecar.av.AudioFrame(
+                format="s16",
+                layout="mono",
+                samples=sidecar.SAMPLES_PER_FRAME,
+            )
+            frame.planes[0].update(self.frame_bytes)
+            frame.sample_rate = sidecar.SAMPLE_RATE
+            frame.time_base = sidecar.Fraction(1, sidecar.SAMPLE_RATE)
+            frame.pts = self.pts
+            self.pts += sidecar.SAMPLES_PER_FRAME
+            return frame
+
+    return SyntheticPcmTrack()
+
+
 def test_audio_contract_is_voice_pcm_shape():
     sidecar = load_sidecar()
 
@@ -67,6 +101,20 @@ def test_call_pcm_source_isolates_per_call_queue():
     frame_a = call_a.read_frame()
     assert frame_a.startswith(b"\x01\x00\xff\xff")
     assert frame_a[4:] == b"\x00" * (sidecar.FRAME_BYTES - 4)
+
+
+def test_inbound_pcm_sink_drains_queued_audio():
+    sidecar = load_sidecar()
+    sink = sidecar.InboundPcmSink(None, max_queue_bytes=6)
+
+    sink.write(b"\x01\x00\x02\x00")
+    sink.write(b"\x03\x00\x04\x00")
+
+    assert sink.queued_bytes == 6
+    assert sink.drain(2) == b"\x02\x00"
+    assert sink.queued_bytes == 4
+    assert sink.drain(99) == b"\x03\x00\x04\x00"
+    assert sink.queued_bytes == 0
 
 
 def test_health_reports_audio_contract():
@@ -221,6 +269,53 @@ def test_audio_endpoint_rejects_mismatched_contract():
     asyncio.run(run())
 
 
+def test_audio_endpoint_drains_inbound_pcm_for_call():
+    sidecar = load_sidecar()
+
+    class FakeSession:
+        def __init__(self) -> None:
+            self.inbound = sidecar.InboundPcmSink(None)
+
+        def snapshot(self):
+            return {"call_id": "call-1"}
+
+        async def close(self) -> None:
+            self.inbound.close()
+
+    async def run():
+        from aiohttp.test_utils import TestClient, TestServer
+
+        source = sidecar.PcmSource(None)
+        session = FakeSession()
+        session.inbound.write(b"\x01\x00\xff\xff")
+        app = sidecar.create_app(source, None)
+        app[sidecar.SESSIONS_KEY]["call-1"] = session
+
+        async with TestClient(TestServer(app)) as client:
+            response = await client.get("/calls/call-1/audio?max_bytes=2")
+            assert response.status == 200
+            body = await response.json()
+            assert body["call_id"] == "call-1"
+            assert body["returned_bytes"] == 2
+            assert body["queued_rx_bytes"] == 2
+            assert base64.b64decode(body["pcm_s16le_base64"]) == b"\x01\x00"
+            assert body["audio"] == sidecar.audio_contract()
+
+            invalid_response = await client.get("/calls/call-1/audio?max_bytes=0")
+            assert invalid_response.status == 400
+            invalid_body = await invalid_response.json()
+            assert invalid_body == {"error": "max_bytes must be positive"}
+
+            partial_response = await client.get("/calls/call-1/audio?max_bytes=1")
+            assert partial_response.status == 400
+            partial_body = await partial_response.json()
+            assert partial_body == {
+                "error": "max_bytes must contain whole s16le samples"
+            }
+
+    asyncio.run(run())
+
+
 def test_offer_loopback_receives_http_queued_audio():
     sidecar = load_sidecar()
 
@@ -300,36 +395,6 @@ def test_offer_loopback_writes_inbound_audio_to_pcm_sink(tmp_path: Path):
     sidecar = load_sidecar()
     rx_path = tmp_path / "inbound.s16le"
 
-    class SyntheticPcmTrack(sidecar.MediaStreamTrack):
-        kind = "audio"
-
-        def __init__(self) -> None:
-            super().__init__()
-            self.pts = 0
-            samples = [
-                (12_000 if index % 2 == 0 else -12_000).to_bytes(
-                    2,
-                    byteorder="little",
-                    signed=True,
-                )
-                for index in range(sidecar.SAMPLES_PER_FRAME)
-            ]
-            self.frame_bytes = b"".join(samples)
-
-        async def recv(self):
-            await asyncio.sleep(sidecar.FRAME_MS / 1_000)
-            frame = sidecar.av.AudioFrame(
-                format="s16",
-                layout="mono",
-                samples=sidecar.SAMPLES_PER_FRAME,
-            )
-            frame.planes[0].update(self.frame_bytes)
-            frame.sample_rate = sidecar.SAMPLE_RATE
-            frame.time_base = sidecar.Fraction(1, sidecar.SAMPLE_RATE)
-            frame.pts = self.pts
-            self.pts += sidecar.SAMPLES_PER_FRAME
-            return frame
-
     async def wait_for_non_silent_pcm() -> None:
         deadline = asyncio.get_running_loop().time() + 5
         while asyncio.get_running_loop().time() < deadline:
@@ -347,7 +412,7 @@ def test_offer_loopback_writes_inbound_audio_to_pcm_sink(tmp_path: Path):
         source = sidecar.PcmSource(None)
         app = sidecar.create_app(source, str(rx_path))
         pc = sidecar.RTCPeerConnection()
-        pc.addTrack(SyntheticPcmTrack())
+        pc.addTrack(synthetic_pcm_track(sidecar))
 
         async with TestClient(TestServer(app)) as client:
             try:
@@ -374,6 +439,64 @@ def test_offer_loopback_writes_inbound_audio_to_pcm_sink(tmp_path: Path):
                 )
 
                 await wait_for_non_silent_pcm()
+            finally:
+                await pc.close()
+
+    asyncio.run(run())
+
+
+def test_offer_loopback_drains_inbound_audio_over_http():
+    sidecar = load_sidecar()
+
+    async def wait_for_non_silent_drain(client) -> None:
+        deadline = asyncio.get_running_loop().time() + 5
+        while asyncio.get_running_loop().time() < deadline:
+            response = await client.get(
+                f"/calls/call-1/audio?max_bytes={sidecar.FRAME_BYTES}"
+            )
+            assert response.status == 200
+            body = await response.json()
+            pcm = base64.b64decode(body["pcm_s16le_base64"])
+            assert body["returned_bytes"] == len(pcm)
+            assert body["audio"] == sidecar.audio_contract()
+            if len(pcm) >= sidecar.FRAME_BYTES and any(pcm):
+                return
+            await asyncio.sleep(0.05)
+        pytest.fail("inbound HTTP audio drain stayed silent or empty")
+
+    async def run():
+        from aiohttp.test_utils import TestClient, TestServer
+
+        source = sidecar.PcmSource(None)
+        app = sidecar.create_app(source, None)
+        pc = sidecar.RTCPeerConnection()
+        pc.addTrack(synthetic_pcm_track(sidecar))
+
+        async with TestClient(TestServer(app)) as client:
+            try:
+                offer = await pc.createOffer()
+                await pc.setLocalDescription(offer)
+                await sidecar.wait_for_ice_complete(pc)
+                assert pc.localDescription is not None
+
+                offer_response = await client.post(
+                    "/offer",
+                    json={
+                        "call_id": "call-1",
+                        "type": pc.localDescription.type,
+                        "sdp": pc.localDescription.sdp,
+                    },
+                )
+                assert offer_response.status == 200
+                answer = await offer_response.json()
+                await pc.setRemoteDescription(
+                    sidecar.RTCSessionDescription(
+                        sdp=answer["sdp"],
+                        type=answer["type"],
+                    )
+                )
+
+                await wait_for_non_silent_drain(client)
             finally:
                 await pc.close()
 


### PR DESCRIPTION
## Summary

- keep decoded inbound WebRTC audio in a bounded per-call PCM queue
- add `GET /calls/{call_id}/audio` to drain inbound `pcm_s16le` frames over local HTTP
- continue mirroring inbound audio to `--rx-pcm` when configured
- document the inbound drain endpoint for Hermes/voice STT integration

## Tests

- `/tmp/voice-webrtc-venv/bin/python -m py_compile examples/webrtc-sidecar/sidecar.py examples/webrtc-sidecar/test_sidecar.py`
- `git diff --check`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py -k 'drain or inbound' -vv`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py`
