### PR TITLE
Long-poll inbound WebRTC sidecar audio

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -188,7 +188,7 @@ Runtime events:
 Inbound audio:
 
 ```http
-GET /calls/{call_id}/audio?max_bytes=1920
+GET /calls/{call_id}/audio?max_bytes=1920&wait_ms=500
 ```
 
 Response:
@@ -207,6 +207,9 @@ Response:
   }
 }
 ```
+
+`wait_ms` is optional, capped by the sidecar, and lets Hermes long-poll for the
+next decoded PCM chunk instead of running a hot polling loop.
 
 Outbound audio:
 

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -99,7 +99,7 @@ curl -sS http://127.0.0.1:8787/calls/local-test
 Drain decoded inbound PCM for a live session:
 
 ```bash
-curl -sS 'http://127.0.0.1:8787/calls/local-test/audio?max_bytes=1920'
+curl -sS 'http://127.0.0.1:8787/calls/local-test/audio?max_bytes=1920&wait_ms=500'
 ```
 
 Queue outbound PCM for a live session:

--- a/examples/webrtc-sidecar/sidecar.py
+++ b/examples/webrtc-sidecar/sidecar.py
@@ -46,6 +46,7 @@ BYTES_PER_SAMPLE = 2
 FRAME_BYTES = SAMPLES_PER_FRAME * CHANNELS * BYTES_PER_SAMPLE
 DEFAULT_DRAIN_BYTES = FRAME_BYTES * 50
 MAX_INBOUND_QUEUE_BYTES = SAMPLE_RATE * CHANNELS * BYTES_PER_SAMPLE * 10
+MAX_DRAIN_WAIT_MS = 5_000
 
 
 class PcmSource:
@@ -139,6 +140,7 @@ class InboundPcmSink:
         self.max_queue_bytes = max_queue_bytes
         self.buffer = bytearray()
         self.file = None
+        self.ready = asyncio.Event()
 
     @property
     def queued_bytes(self) -> int:
@@ -155,13 +157,25 @@ class InboundPcmSink:
         self.buffer.extend(pcm_s16le)
         if len(self.buffer) > self.max_queue_bytes:
             del self.buffer[: len(self.buffer) - self.max_queue_bytes]
+        if self.buffer:
+            self.ready.set()
 
     def drain(self, max_bytes: int = DEFAULT_DRAIN_BYTES) -> bytes:
         if max_bytes <= 0 or not self.buffer:
             return b""
         chunk = bytes(self.buffer[:max_bytes])
         del self.buffer[:max_bytes]
+        if not self.buffer:
+            self.ready.clear()
         return chunk
+
+    async def wait_for_audio(self, wait_ms: int) -> None:
+        if self.buffer or wait_ms <= 0:
+            return
+        try:
+            await asyncio.wait_for(self.ready.wait(), timeout=wait_ms / 1_000)
+        except TimeoutError:
+            return
 
     def close(self) -> None:
         if self.file is not None:
@@ -358,6 +372,17 @@ def drain_size(request: web.Request) -> int:
     return min(parsed, MAX_INBOUND_QUEUE_BYTES)
 
 
+def drain_wait_ms(request: web.Request) -> int:
+    raw = str(request.query.get("wait_ms") or 0).strip()
+    try:
+        parsed = int(raw)
+    except ValueError as exc:
+        raise ValueError("wait_ms must be an integer") from exc
+    if parsed < 0:
+        raise ValueError("wait_ms must be non-negative")
+    return min(parsed, MAX_DRAIN_WAIT_MS)
+
+
 def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
     app = web.Application()
     sessions: dict[str, CallSession] = {}
@@ -449,9 +474,11 @@ def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
             return json_error("unknown call_id", status=404)
         try:
             max_bytes = drain_size(request)
+            wait_ms = drain_wait_ms(request)
         except ValueError as exc:
             return json_error(str(exc))
 
+        await session.inbound.wait_for_audio(wait_ms)
         pcm = session.inbound.drain(max_bytes)
         return web.json_response(
             {

--- a/examples/webrtc-sidecar/test_sidecar.py
+++ b/examples/webrtc-sidecar/test_sidecar.py
@@ -117,6 +117,21 @@ def test_inbound_pcm_sink_drains_queued_audio():
     assert sink.queued_bytes == 0
 
 
+def test_inbound_pcm_sink_waits_for_queued_audio():
+    sidecar = load_sidecar()
+
+    async def run():
+        sink = sidecar.InboundPcmSink(None)
+        waiter = asyncio.create_task(sink.wait_for_audio(500))
+        await asyncio.sleep(0)
+        assert not waiter.done()
+
+        sink.write(b"\x01\x00")
+        await asyncio.wait_for(waiter, timeout=1)
+
+    asyncio.run(run())
+
+
 def test_health_reports_audio_contract():
     sidecar = load_sidecar()
 
@@ -313,6 +328,49 @@ def test_audio_endpoint_drains_inbound_pcm_for_call():
                 "error": "max_bytes must contain whole s16le samples"
             }
 
+            wait_response = await client.get("/calls/call-1/audio?wait_ms=-1")
+            assert wait_response.status == 400
+            wait_body = await wait_response.json()
+            assert wait_body == {"error": "wait_ms must be non-negative"}
+
+    asyncio.run(run())
+
+
+def test_audio_endpoint_waits_for_inbound_pcm():
+    sidecar = load_sidecar()
+
+    class FakeSession:
+        def __init__(self) -> None:
+            self.inbound = sidecar.InboundPcmSink(None)
+
+        def snapshot(self):
+            return {"call_id": "call-1"}
+
+        async def close(self) -> None:
+            self.inbound.close()
+
+    async def run():
+        from aiohttp.test_utils import TestClient, TestServer
+
+        source = sidecar.PcmSource(None)
+        session = FakeSession()
+        app = sidecar.create_app(source, None)
+        app[sidecar.SESSIONS_KEY]["call-1"] = session
+
+        async with TestClient(TestServer(app)) as client:
+            pending = asyncio.create_task(
+                client.get("/calls/call-1/audio?max_bytes=2&wait_ms=500")
+            )
+            await asyncio.sleep(0.05)
+            assert not pending.done()
+
+            session.inbound.write(b"\x01\x00")
+            response = await asyncio.wait_for(pending, timeout=1)
+            assert response.status == 200
+            body = await response.json()
+            assert body["returned_bytes"] == 2
+            assert base64.b64decode(body["pcm_s16le_base64"]) == b"\x01\x00"
+
     asyncio.run(run())
 
 
@@ -452,7 +510,7 @@ def test_offer_loopback_drains_inbound_audio_over_http():
         deadline = asyncio.get_running_loop().time() + 5
         while asyncio.get_running_loop().time() < deadline:
             response = await client.get(
-                f"/calls/call-1/audio?max_bytes={sidecar.FRAME_BYTES}"
+                f"/calls/call-1/audio?max_bytes={sidecar.FRAME_BYTES}&wait_ms=500"
             )
             assert response.status == 200
             body = await response.json()


### PR DESCRIPTION
## Summary

- add optional `wait_ms` long-polling to `GET /calls/{call_id}/audio`
- wake inbound drain waiters as soon as decoded PCM reaches the sidecar queue
- document the low-latency drain query shape for Hermes

## Tests

- `/tmp/voice-webrtc-venv/bin/python -m py_compile examples/webrtc-sidecar/sidecar.py examples/webrtc-sidecar/test_sidecar.py`
- `git diff --check`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py -k 'wait or drain' -vv`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py`
