### PR TITLE
Document WebRTC sidecar contract

### DIFF
--- a/docs/contracts/webrtc-sidecar-v1.json
+++ b/docs/contracts/webrtc-sidecar-v1.json
@@ -1,0 +1,81 @@
+{
+  "contract": "voice.webrtc_sidecar",
+  "version": 1,
+  "status": "experimental",
+  "summary": "Local HTTP/WebRTC bridge contract for WhatsApp Calling and voice streaming experiments.",
+  "audio": {
+    "sample_rate": 48000,
+    "channels": 1,
+    "frame_ms": 20,
+    "encoding": "pcm_s16le",
+    "bytes_per_sample": 2,
+    "samples_per_frame": 960,
+    "frame_bytes": 1920,
+    "default_drain_bytes": 96000,
+    "max_inbound_queue_bytes": 960000,
+    "max_drain_wait_ms": 5000
+  },
+  "endpoints": {
+    "contract": {
+      "method": "GET",
+      "path": "/contract",
+      "description": "Return this machine-readable contract."
+    },
+    "health": {
+      "method": "GET",
+      "path": "/health",
+      "description": "Return process health, active call IDs, and the fixed audio shape."
+    },
+    "offer": {
+      "method": "POST",
+      "path": "/offer",
+      "description": "Create or replace a call session from a remote SDP offer and return a local SDP answer."
+    },
+    "call_status": {
+      "method": "GET",
+      "path": "/calls/{call_id}",
+      "description": "Inspect a live call session and queue depths."
+    },
+    "receive_audio": {
+      "method": "GET",
+      "path": "/calls/{call_id}/audio",
+      "query": {
+        "max_bytes": "Positive byte count aligned to whole s16le samples. Defaults to audio.default_drain_bytes and is capped by audio.max_inbound_queue_bytes.",
+        "wait_ms": "Optional non-negative long-poll timeout. Capped by audio.max_drain_wait_ms."
+      },
+      "description": "Drain decoded inbound PCM from a live call session."
+    },
+    "send_audio": {
+      "method": "POST",
+      "path": "/calls/{call_id}/audio",
+      "description": "Queue outbound PCM for a live call session."
+    },
+    "close_call": {
+      "method": "POST",
+      "path": "/calls/{call_id}/close",
+      "description": "Close and remove a live call session."
+    }
+  },
+  "payloads": {
+    "send_audio_request": {
+      "sample_rate": "audio.sample_rate",
+      "channels": "audio.channels",
+      "frame_ms": "audio.frame_ms",
+      "encoding": "audio.encoding",
+      "pcm_s16le_base64": "Required base64 encoded signed 16-bit little-endian mono PCM."
+    },
+    "receive_audio_response": {
+      "call_id": "Call session identifier.",
+      "returned_bytes": "Number of decoded PCM bytes returned.",
+      "queued_rx_bytes": "Remaining inbound decoded PCM bytes queued after this drain.",
+      "pcm_s16le_base64": "Base64 encoded signed 16-bit little-endian mono PCM.",
+      "audio": "Fixed audio shape: sample_rate, channels, frame_ms, encoding."
+    },
+    "audio_shape": {
+      "sample_rate": "audio.sample_rate",
+      "channels": "audio.channels",
+      "frame_ms": "audio.frame_ms",
+      "encoding": "audio.encoding"
+    }
+  }
+}

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -149,6 +149,8 @@ It then emits `Event` frames until a terminal event:
 Audio frames are fixed-duration PCM packets. The last frame is padded with
 silence when needed so clients can feed frames directly into an Opus encoder.
 Use `sample_rate: 48000` and `frame_ms: 20` for a WebRTC-friendly stream.
+The WhatsApp/WebRTC sidecar v1 shape is also captured as machine-readable JSON
+in [`docs/contracts/webrtc-sidecar-v1.json`](contracts/webrtc-sidecar-v1.json).
 
 ### STT Input
 

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -136,7 +136,15 @@ common failure mode, and their API rejects mismatched SDP answers between
 ## Sidecar API Sketch
 
 The exact transport can be Unix socket, local HTTP, or WebSocket. The first
-implementation should favor debuggability over abstraction.
+implementation should favor debuggability over abstraction. The canonical v1
+PCM and endpoint contract is machine-readable at
+[`docs/contracts/webrtc-sidecar-v1.json`](contracts/webrtc-sidecar-v1.json), and
+the Python sidecar exposes the same object at `GET /contract`.
+
+The sidecar HTTP API is a local control plane, not a public web API. It should
+bind to localhost or a private socket, with Hermes as the caller. Only the
+WebRTC media negotiation needs normal network access for ICE, DTLS, SRTP, and
+possibly TURN.
 
 ```http
 POST /offer

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -6,10 +6,16 @@ boundary without pulling WebRTC into the Rust workspace yet.
 It accepts a remote SDP offer over local HTTP, creates a WebRTC answer, sends a
 48 kHz mono 20 ms PCM source as an outbound audio track, and writes decoded
 inbound audio to a raw PCM file. `aiortc` handles Opus RTP, ICE, DTLS, and SRTP.
+The machine-readable v1 contract lives at
+[`docs/contracts/webrtc-sidecar-v1.json`](../../docs/contracts/webrtc-sidecar-v1.json)
+and is also exposed by the sidecar at `GET /contract`.
 
 This is a spike. It does not call the WhatsApp Graph API, authenticate requests,
 run VAD, or manage Hermes sessions. Hermes should still own WhatsApp Cloud
 webhooks and Graph actions such as `pre_accept`, `accept`, and `terminate`.
+Do not expose the HTTP control API publicly; bind it to localhost or a private
+socket and let only the local Hermes process call it. The WebRTC media path may
+still need normal outbound ICE/STUN/TURN network access.
 
 ## Install
 
@@ -63,6 +69,7 @@ call timing before TTS is wired in.
 Check process health and the fixed local audio contract:
 
 ```bash
+curl -sS http://127.0.0.1:8787/contract
 curl -sS http://127.0.0.1:8787/health
 ```
 

--- a/examples/webrtc-sidecar/sidecar.py
+++ b/examples/webrtc-sidecar/sidecar.py
@@ -16,6 +16,7 @@ import argparse
 import asyncio
 import base64
 import binascii
+import copy
 from fractions import Fraction
 import json
 import logging
@@ -38,15 +39,67 @@ except ImportError as exc:  # pragma: no cover - depends on optional extras
 
 
 LOGGER = logging.getLogger("voice-webrtc-sidecar")
-SAMPLE_RATE = 48_000
-FRAME_MS = 20
-CHANNELS = 1
-SAMPLES_PER_FRAME = SAMPLE_RATE * FRAME_MS // 1_000
-BYTES_PER_SAMPLE = 2
-FRAME_BYTES = SAMPLES_PER_FRAME * CHANNELS * BYTES_PER_SAMPLE
-DEFAULT_DRAIN_BYTES = FRAME_BYTES * 50
-MAX_INBOUND_QUEUE_BYTES = SAMPLE_RATE * CHANNELS * BYTES_PER_SAMPLE * 10
-MAX_DRAIN_WAIT_MS = 5_000
+CONTRACT_PATH = Path(__file__).resolve().parents[2] / "docs/contracts/webrtc-sidecar-v1.json"
+
+
+def load_contract() -> dict[str, Any]:
+    with CONTRACT_PATH.open(encoding="utf-8") as contract_file:
+        contract = json.load(contract_file)
+    validate_contract(contract)
+    return contract
+
+
+def validate_contract(contract: dict[str, Any]) -> None:
+    audio = contract.get("audio")
+    if not isinstance(audio, dict):
+        raise ValueError("contract audio section must be an object")
+
+    sample_rate = int(audio["sample_rate"])
+    channels = int(audio["channels"])
+    frame_ms = int(audio["frame_ms"])
+    bytes_per_sample = int(audio["bytes_per_sample"])
+    samples_per_frame = int(audio["samples_per_frame"])
+    frame_bytes = int(audio["frame_bytes"])
+    default_drain_bytes = int(audio["default_drain_bytes"])
+    max_inbound_queue_bytes = int(audio["max_inbound_queue_bytes"])
+    max_drain_wait_ms = int(audio["max_drain_wait_ms"])
+    encoding = str(audio["encoding"])
+
+    if encoding != "pcm_s16le":
+        raise ValueError("contract audio.encoding must be pcm_s16le")
+    if min(
+        sample_rate,
+        channels,
+        frame_ms,
+        bytes_per_sample,
+        samples_per_frame,
+        frame_bytes,
+        default_drain_bytes,
+        max_inbound_queue_bytes,
+        max_drain_wait_ms,
+    ) <= 0:
+        raise ValueError("contract audio integer fields must be positive")
+    if samples_per_frame != sample_rate * frame_ms // 1_000:
+        raise ValueError("contract samples_per_frame does not match sample_rate/frame_ms")
+    if frame_bytes != samples_per_frame * channels * bytes_per_sample:
+        raise ValueError("contract frame_bytes does not match audio shape")
+    if default_drain_bytes % frame_bytes != 0:
+        raise ValueError("contract default_drain_bytes must align to whole frames")
+    if max_inbound_queue_bytes < default_drain_bytes:
+        raise ValueError("contract max_inbound_queue_bytes is smaller than default drain size")
+
+
+CONTRACT = load_contract()
+AUDIO_CONTRACT = CONTRACT["audio"]
+SAMPLE_RATE = int(AUDIO_CONTRACT["sample_rate"])
+FRAME_MS = int(AUDIO_CONTRACT["frame_ms"])
+CHANNELS = int(AUDIO_CONTRACT["channels"])
+SAMPLES_PER_FRAME = int(AUDIO_CONTRACT["samples_per_frame"])
+BYTES_PER_SAMPLE = int(AUDIO_CONTRACT["bytes_per_sample"])
+FRAME_BYTES = int(AUDIO_CONTRACT["frame_bytes"])
+DEFAULT_DRAIN_BYTES = int(AUDIO_CONTRACT["default_drain_bytes"])
+MAX_INBOUND_QUEUE_BYTES = int(AUDIO_CONTRACT["max_inbound_queue_bytes"])
+MAX_DRAIN_WAIT_MS = int(AUDIO_CONTRACT["max_drain_wait_ms"])
 
 
 class PcmSource:
@@ -318,8 +371,12 @@ def audio_contract() -> dict[str, Any]:
         "sample_rate": SAMPLE_RATE,
         "channels": CHANNELS,
         "frame_ms": FRAME_MS,
-        "encoding": "pcm_s16le",
+        "encoding": str(AUDIO_CONTRACT["encoding"]),
     }
+
+
+def webrtc_contract() -> dict[str, Any]:
+    return copy.deepcopy(CONTRACT)
 
 
 def required_int(body: dict[str, Any], key: str, default: int | None = None) -> int:
@@ -397,6 +454,9 @@ def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
                 "audio": audio_contract(),
             }
         )
+
+    async def contract(_: web.Request) -> web.Response:
+        return web.json_response(webrtc_contract())
 
     async def offer(request: web.Request) -> web.Response:
         try:
@@ -503,6 +563,7 @@ def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
             await session.close()
         source.close()
 
+    app.router.add_get("/contract", contract)
     app.router.add_get("/health", health)
     app.router.add_post("/offer", offer)
     app.router.add_get("/calls/{call_id}", call_status)

--- a/examples/webrtc-sidecar/test_sidecar.py
+++ b/examples/webrtc-sidecar/test_sidecar.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
@@ -58,12 +59,41 @@ def synthetic_pcm_track(sidecar):
 def test_audio_contract_is_voice_pcm_shape():
     sidecar = load_sidecar()
 
+    contract = json.loads(sidecar.CONTRACT_PATH.read_text(encoding="utf-8"))
+    audio = contract["audio"]
+
     assert sidecar.audio_contract() == {
-        "sample_rate": 48000,
-        "channels": 1,
-        "frame_ms": 20,
-        "encoding": "pcm_s16le",
+        "sample_rate": audio["sample_rate"],
+        "channels": audio["channels"],
+        "frame_ms": audio["frame_ms"],
+        "encoding": audio["encoding"],
     }
+    assert sidecar.SAMPLES_PER_FRAME == audio["samples_per_frame"]
+    assert sidecar.FRAME_BYTES == audio["frame_bytes"]
+    assert sidecar.DEFAULT_DRAIN_BYTES == audio["default_drain_bytes"]
+    assert sidecar.MAX_INBOUND_QUEUE_BYTES == audio["max_inbound_queue_bytes"]
+    assert sidecar.MAX_DRAIN_WAIT_MS == audio["max_drain_wait_ms"]
+    assert sidecar.FRAME_BYTES == 1920
+
+
+def test_contract_endpoint_returns_machine_readable_contract():
+    sidecar = load_sidecar()
+
+    async def run():
+        from aiohttp.test_utils import TestClient, TestServer
+
+        source = sidecar.PcmSource(None)
+        app = sidecar.create_app(source, None)
+        async with TestClient(TestServer(app)) as client:
+            response = await client.get("/contract")
+            assert response.status == 200
+            body = await response.json()
+            assert body == sidecar.webrtc_contract()
+            assert body["contract"] == "voice.webrtc_sidecar"
+            assert body["version"] == 1
+            assert body["audio"]["frame_bytes"] == sidecar.FRAME_BYTES
+
+    asyncio.run(run())
 
 
 def test_pcm_source_pads_partial_frame(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add a versioned machine-readable WebRTC sidecar contract for the fixed PCM/audio HTTP API
- derive the Python sidecar PCM constants from that contract and expose it at GET /contract
- update streaming and WhatsApp Calling docs to point Hermes/client work at the contract artifact

## Verification
- /tmp/voice-webrtc-venv/bin/python -m py_compile examples/webrtc-sidecar/sidecar.py examples/webrtc-sidecar/test_sidecar.py
- git diff --check
- /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py -k contract
- /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py