### PR TITLE
Anchor WebRTC stream contract constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7068,6 +7068,7 @@ dependencies = [
  "ctrlc",
  "dirs 5.0.1",
  "hound",
+ "libc",
  "pulldown-cmark",
  "rodio",
  "serde",
@@ -7154,6 +7155,7 @@ name = "voice-stream"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/voice-cli/README.md
+++ b/crates/voice-cli/README.md
@@ -47,6 +47,7 @@ echo "Hello" | voice say
 voice say --markdown -f post.mdx
 voice phonemes "ChatGPT uses RuntimeStateDoc"
 voice stream --sample-rate 48000 --frame-ms 20 --raw-output output.s16le "Hello"
+voice stream --sample-rate 48000 --frame-ms 20 --output streamed.ogg "Hello"
 
 # Speech-to-text from microphone
 voice listen
@@ -118,7 +119,9 @@ Options:
 ### `voice stream`
 
 Requires a running `voiced` daemon. Emits ordered signed 16-bit little-endian
-mono PCM frames as compact summaries or full JSON events.
+mono PCM frames as compact summaries or full JSON events. Use `--raw-output`
+for headerless PCM frames, or `--output` for streamed Ogg/Opus encoded from
+those frames without a WAV intermediate.
 
 ```
 Usage: voice stream [OPTIONS] [TEXT]...
@@ -130,6 +133,8 @@ Options:
       --sample-rate <SAMPLE_RATE>  Target stream sample rate [default: 24000]
       --frame-ms <FRAME_MS>        Target frame duration in milliseconds [default: 20]
   -o, --raw-output <PATH>          Write raw signed 16-bit little-endian mono PCM
+      --output <PATH>              Write streamed audio to an Ogg/Opus file
+      --format <FORMAT>            Output format: ogg-opus
       --json                       Print full JSON stream events
       --markdown                   Strip markdown/MDX formatting before speaking
       --sub <WORD=REPLACEMENT>     Word substitution (repeatable)

--- a/crates/voice-stream/Cargo.toml
+++ b/crates/voice-stream/Cargo.toml
@@ -9,3 +9,6 @@ repository = "https://github.com/rgbkrk/voice"
 
 [dependencies]
 serde = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/voice-stream/src/lib.rs
+++ b/crates/voice-stream/src/lib.rs
@@ -8,6 +8,24 @@
 use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_FRAME_MS: u32 = 20;
+pub const PCM_S16LE_BYTES_PER_SAMPLE: usize = 2;
+
+/// WebRTC-friendly local PCM contract used by Hermes/WhatsApp sidecar work.
+///
+/// WebRTC carries Opus over RTP on the wire, but the local `voice` boundary
+/// stays as signed 16-bit little-endian mono PCM so callers can choose whether
+/// to feed frames to a sidecar, an Opus encoder, or test fixtures.
+pub const WEBRTC_SAMPLE_RATE: u32 = 48_000;
+pub const WEBRTC_CHANNELS: u16 = 1;
+pub const WEBRTC_FRAME_MS: u32 = DEFAULT_FRAME_MS;
+pub const WEBRTC_SAMPLES_PER_FRAME: usize =
+    WEBRTC_SAMPLE_RATE as usize * WEBRTC_FRAME_MS as usize / 1_000;
+pub const WEBRTC_FRAME_BYTES: usize =
+    WEBRTC_SAMPLES_PER_FRAME * WEBRTC_CHANNELS as usize * PCM_S16LE_BYTES_PER_SAMPLE;
+pub const WEBRTC_DEFAULT_DRAIN_BYTES: usize = WEBRTC_FRAME_BYTES * 50;
+pub const WEBRTC_MAX_INBOUND_QUEUE_BYTES: usize =
+    WEBRTC_SAMPLE_RATE as usize * WEBRTC_CHANNELS as usize * PCM_S16LE_BYTES_PER_SAMPLE * 10;
+pub const WEBRTC_MAX_DRAIN_WAIT_MS: u32 = 5_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -348,6 +366,49 @@ mod tests {
     fn samples_per_frame_uses_minimum_one_sample() {
         assert_eq!(samples_per_frame(0, 0), 1);
         assert_eq!(samples_per_frame(1, 1), 1);
+    }
+
+    #[test]
+    fn webrtc_pcm_constants_describe_twenty_ms_mono_frames() {
+        assert_eq!(WEBRTC_SAMPLE_RATE, 48_000);
+        assert_eq!(WEBRTC_CHANNELS, 1);
+        assert_eq!(WEBRTC_FRAME_MS, 20);
+        assert_eq!(WEBRTC_SAMPLES_PER_FRAME, 960);
+        assert_eq!(WEBRTC_FRAME_BYTES, 1_920);
+        assert_eq!(
+            WEBRTC_SAMPLES_PER_FRAME,
+            samples_per_frame(WEBRTC_SAMPLE_RATE, WEBRTC_FRAME_MS)
+        );
+    }
+
+    #[test]
+    fn webrtc_sidecar_json_contract_matches_stream_constants() {
+        let contract_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../docs/contracts/webrtc-sidecar-v1.json");
+        let bytes = std::fs::read(&contract_path).unwrap_or_else(|err| {
+            panic!("read {}: {err}", contract_path.display());
+        });
+        let contract: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or_else(|err| {
+            panic!("parse {}: {err}", contract_path.display());
+        });
+
+        assert_eq!(contract["contract"], "voice.webrtc_sidecar");
+        assert_eq!(contract["version"], 1);
+
+        let audio = &contract["audio"];
+        assert_eq!(audio["sample_rate"], WEBRTC_SAMPLE_RATE);
+        assert_eq!(audio["channels"], WEBRTC_CHANNELS);
+        assert_eq!(audio["frame_ms"], WEBRTC_FRAME_MS);
+        assert_eq!(audio["encoding"], "pcm_s16le");
+        assert_eq!(audio["bytes_per_sample"], PCM_S16LE_BYTES_PER_SAMPLE);
+        assert_eq!(audio["samples_per_frame"], WEBRTC_SAMPLES_PER_FRAME);
+        assert_eq!(audio["frame_bytes"], WEBRTC_FRAME_BYTES);
+        assert_eq!(audio["default_drain_bytes"], WEBRTC_DEFAULT_DRAIN_BYTES);
+        assert_eq!(
+            audio["max_inbound_queue_bytes"],
+            WEBRTC_MAX_INBOUND_QUEUE_BYTES
+        );
+        assert_eq!(audio["max_drain_wait_ms"], WEBRTC_MAX_DRAIN_WAIT_MS);
     }
 
     #[test]

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -149,8 +149,9 @@ It then emits `Event` frames until a terminal event:
 Audio frames are fixed-duration PCM packets. The last frame is padded with
 silence when needed so clients can feed frames directly into an Opus encoder.
 Use `sample_rate: 48000` and `frame_ms: 20` for a WebRTC-friendly stream.
-The WhatsApp/WebRTC sidecar v1 shape is also captured as machine-readable JSON
-in [`docs/contracts/webrtc-sidecar-v1.json`](contracts/webrtc-sidecar-v1.json).
+The WebRTC-friendly constants live in the `voice-stream` crate and are checked
+against the machine-readable sidecar v1 shape in
+[`docs/contracts/webrtc-sidecar-v1.json`](contracts/webrtc-sidecar-v1.json).
 
 ### STT Input
 


### PR DESCRIPTION
## Summary
- add canonical WebRTC-friendly PCM constants to `voice-stream`
- test `docs/contracts/webrtc-sidecar-v1.json` against those Rust constants so the sidecar contract cannot drift silently
- clarify `voice stream --raw-output` vs streamed Ogg/Opus `--output` in CLI docs
- refresh `Cargo.lock` after the merged daemon install/uninstall PR added the macOS-only `libc` dependency to `voice`

## Notes
This intentionally does not tackle the reopened #119 follow-up to fold `voiced` into `voice`; it keeps this PR focused on the stream/sidecar contract.

## Verification
- `cargo test -p voice-stream`
- `cargo test -p voice`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py -k contract`
- `cargo test --workspace`