### PR TITLE
Handle legacy daemon systemd service

### DIFF
--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -2162,6 +2162,7 @@ fn run_daemon_install(no_start: bool) {
     });
 
     let unit_path = systemd_dir.join("voiced.service");
+    let legacy_unit_path = systemd_dir.join("voice-daemon.service");
     let voice_str = voice_path.display().to_string();
 
     let unit = format!(
@@ -2178,6 +2179,24 @@ fn run_daemon_install(no_start: bool) {
     println!("Installing voice daemon as a systemd user service...");
     println!("  voice:   {voice_str}");
     println!("  unit:    {}", unit_path.display());
+
+    if legacy_unit_path.exists() {
+        println!("  legacy: disabling voice-daemon.service");
+        let legacy_disable = std::process::Command::new("systemctl")
+            .args(["--user", "disable", "--now", "voice-daemon.service"])
+            .output();
+        match legacy_disable {
+            Ok(out) if out.status.success() => {}
+            Ok(out) => eprintln!(
+                "warning: systemctl disable legacy voice-daemon.service exited {}: {}",
+                out.status,
+                String::from_utf8_lossy(&out.stderr).trim()
+            ),
+            Err(e) => {
+                eprintln!("warning: systemctl disable legacy voice-daemon.service failed: {e}")
+            }
+        }
+    }
 
     let reload = std::process::Command::new("systemctl")
         .args(["--user", "daemon-reload"])
@@ -2268,28 +2287,45 @@ fn run_daemon_uninstall() {
             .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
             .join(".config")
     });
-    let unit_path = config_dir.join("systemd/user/voiced.service");
+    let systemd_dir = config_dir.join("systemd/user");
+    let unit_path = systemd_dir.join("voiced.service");
+    let legacy_unit_path = systemd_dir.join("voice-daemon.service");
 
-    if !unit_path.exists() {
+    if !unit_path.exists() && !legacy_unit_path.exists() {
         eprintln!("voice daemon service not installed (unit file not found)");
         std::process::exit(1);
     }
 
-    let _ = std::process::Command::new("systemctl")
-        .args(["--user", "disable", "--now", "voiced.service"])
-        .output();
+    if unit_path.exists() {
+        let _ = std::process::Command::new("systemctl")
+            .args(["--user", "disable", "--now", "voiced.service"])
+            .output();
+    }
+    if legacy_unit_path.exists() {
+        let _ = std::process::Command::new("systemctl")
+            .args(["--user", "disable", "--now", "voice-daemon.service"])
+            .output();
+    }
 
     let _ = std::process::Command::new("systemctl")
         .args(["--user", "daemon-reload"])
         .output();
 
-    std::fs::remove_file(&unit_path).unwrap_or_else(|e| {
-        eprintln!("error: could not remove {}: {e}", unit_path.display());
-        std::process::exit(1);
-    });
+    let mut removed = Vec::new();
+    for path in [&unit_path, &legacy_unit_path] {
+        if path.exists() {
+            std::fs::remove_file(path).unwrap_or_else(|e| {
+                eprintln!("error: could not remove {}: {e}", path.display());
+                std::process::exit(1);
+            });
+            removed.push(path.display().to_string());
+        }
+    }
 
     println!("Uninstalled voice daemon systemd user service.");
-    println!("  removed: {}", unit_path.display());
+    for path in removed {
+        println!("  removed: {path}");
+    }
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -17,6 +17,8 @@ voice daemon install
 `voice daemon install` auto-detects the platform and writes the appropriate
 service file (macOS LaunchAgent or Linux systemd user unit), loads it, and
 starts the daemon. It also prints `voice daemon status` output on success.
+On Linux, it disables the older `voice-daemon.service` unit if one exists so
+only the current `voiced.service` registration owns the daemon socket.
 
 To install the service file without starting immediately:
 


### PR DESCRIPTION
## Summary
- disable an older `voice-daemon.service` unit during `voice daemon install` before enabling the current `voiced.service`
- let `voice daemon uninstall` remove both current and legacy Linux user units when present
- document the Linux migration behavior

## Context
Local deployment after #125 still had an enabled `voice-daemon.service` running `/home/ubuntu/.local/bin/voiced --tts-only`. This patch prevents that older unit from competing with the new one-binary `voice daemon start --tts-only` service.

## Verification
- `cargo fmt -p voice`
- `git diff --check`
- `cargo check -p voice`
- `cargo test -p voice`

Local deployment smoke after #125:
- installed `/home/ubuntu/.local/bin/voice` from current main
- switched local daemon to `/home/ubuntu/.local/bin/voice daemon start --tts-only`
- verified direct `voice say --format ogg-opus --input-file ... --output ...` produces Ogg/Opus mono 48 kHz
- restarted `hermes-gateway.service` after updating `~/.hermes/config.yaml` to call direct `voice say --format ogg-opus`