### PR TITLE
Add WebRTC sidecar voice stream poster

### DIFF
--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -26,26 +26,29 @@ python3 -m venv /tmp/voice-webrtc-venv
 
 ## Run
 
-Create a FIFO for outbound audio from `voice`:
+Start the sidecar:
 
 ```bash
-mkfifo /tmp/voice-webrtc-out.s16le
 /tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/sidecar.py \
-  --tx-pcm /tmp/voice-webrtc-out.s16le \
   --rx-pcm /tmp/voice-webrtc-in.s16le
 ```
 
-Feed TTS frames into the FIFO:
+Once Hermes or a local test has created a call session, stream TTS frames into
+the sidecar's per-call outbound queue:
 
 ```bash
-voice stream --sample-rate 48000 --frame-ms 20 \
-  --raw-output /tmp/voice-webrtc-out.s16le \
+python examples/webrtc-sidecar/post_voice_stream.py local-test \
   "Hello from the WebRTC sidecar."
 ```
 
-You can also omit `--tx-pcm` and POST outbound frames over local HTTP once a
-call session exists. This is the shape Hermes can use when it receives
-`stream_speak` frames from the voice daemon:
+The helper runs `voice stream --raw-output - --sample-rate 48000 --frame-ms 20`
+and POSTs each 1920-byte PCM frame to `POST /calls/{call_id}/audio`. Use
+`--sidecar-url` when the sidecar is not listening on `http://127.0.0.1:8787`,
+and pass normal voice options such as `--voice`, `--speed`, `--markdown`,
+`--input-file`, `--sub`, and `--sub-file`.
+
+You can also POST outbound frames yourself. This is the shape Hermes can use
+when it receives `stream_speak` frames from the voice daemon:
 
 ```bash
 curl -sS -X POST http://127.0.0.1:8787/calls/local-test/audio \
@@ -63,6 +66,18 @@ Each 20 ms frame is 1920 bytes before base64 encoding. HTTP input is queued per
 `call_id`; `--tx-pcm` remains a process-level fallback source. If both sources
 are idle, the sidecar sends silence. That is useful for checking SDP, ICE, and
 call timing before TTS is wired in.
+
+For FIFO-based smoke tests, start the sidecar with `--tx-pcm`:
+
+```bash
+mkfifo /tmp/voice-webrtc-out.s16le
+/tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/sidecar.py \
+  --tx-pcm /tmp/voice-webrtc-out.s16le \
+  --rx-pcm /tmp/voice-webrtc-in.s16le
+voice stream --sample-rate 48000 --frame-ms 20 \
+  --raw-output /tmp/voice-webrtc-out.s16le \
+  "Hello from the WebRTC sidecar."
+```
 
 ## SDP API
 
@@ -154,4 +169,5 @@ set:
 python3 -m venv /tmp/voice-webrtc-venv
 /tmp/voice-webrtc-venv/bin/pip install -r examples/webrtc-sidecar/requirements.txt pytest
 /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py
+/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_post_voice_stream.py
 ```

--- a/examples/webrtc-sidecar/post_voice_stream.py
+++ b/examples/webrtc-sidecar/post_voice_stream.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Post `voice stream` PCM frames to a live WebRTC sidecar call.
+
+This helper connects the current Rust voice daemon stream surface to the
+sidecar's local HTTP outbound-audio queue:
+
+    voice stream --raw-output - --sample-rate 48000 --frame-ms 20 ...
+      -> POST /calls/{call_id}/audio
+
+It is intentionally stdlib-only so it can be used on machines that have the
+`voice` binary but have not installed the optional `aiortc` sidecar extras.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import subprocess
+import sys
+from typing import BinaryIO
+from urllib import error, parse, request
+
+
+CONTRACT_PATH = Path(__file__).resolve().parents[2] / "docs/contracts/webrtc-sidecar-v1.json"
+
+
+@dataclass(frozen=True)
+class AudioContract:
+    sample_rate: int
+    channels: int
+    frame_ms: int
+    encoding: str
+    frame_bytes: int
+
+
+def load_audio_contract(path: Path = CONTRACT_PATH) -> AudioContract:
+    with path.open(encoding="utf-8") as contract_file:
+        contract = json.load(contract_file)
+
+    audio = contract.get("audio")
+    if not isinstance(audio, dict):
+        raise ValueError("contract audio section must be an object")
+
+    parsed = AudioContract(
+        sample_rate=int(audio["sample_rate"]),
+        channels=int(audio["channels"]),
+        frame_ms=int(audio["frame_ms"]),
+        encoding=str(audio["encoding"]),
+        frame_bytes=int(audio["frame_bytes"]),
+    )
+
+    if parsed.sample_rate <= 0:
+        raise ValueError("contract sample_rate must be positive")
+    if parsed.channels != 1:
+        raise ValueError("sidecar currently expects mono audio")
+    if parsed.frame_ms <= 0:
+        raise ValueError("contract frame_ms must be positive")
+    if parsed.encoding != "pcm_s16le":
+        raise ValueError("sidecar currently expects pcm_s16le audio")
+    if parsed.frame_bytes <= 0 or parsed.frame_bytes % 2 != 0:
+        raise ValueError("contract frame_bytes must contain whole s16le samples")
+
+    return parsed
+
+
+def sidecar_audio_url(sidecar_url: str, call_id: str) -> str:
+    base = sidecar_url.rstrip("/")
+    escaped_call_id = parse.quote(call_id, safe="")
+    return f"{base}/calls/{escaped_call_id}/audio"
+
+
+def build_audio_payload(contract: AudioContract, pcm_frame: bytes) -> dict[str, object]:
+    if not pcm_frame:
+        raise ValueError("pcm_frame must not be empty")
+    if len(pcm_frame) % 2 != 0:
+        raise ValueError("pcm_frame must contain whole s16le samples")
+
+    return {
+        "sample_rate": contract.sample_rate,
+        "channels": contract.channels,
+        "frame_ms": contract.frame_ms,
+        "encoding": contract.encoding,
+        "pcm_s16le_base64": base64.b64encode(pcm_frame).decode("ascii"),
+    }
+
+
+def post_audio_frame(
+    url: str,
+    contract: AudioContract,
+    pcm_frame: bytes,
+    timeout_s: float,
+) -> dict[str, object]:
+    payload = json.dumps(build_audio_payload(contract, pcm_frame)).encode("utf-8")
+    http_request = request.Request(
+        url,
+        data=payload,
+        method="POST",
+        headers={"content-type": "application/json"},
+    )
+    try:
+        with request.urlopen(http_request, timeout=timeout_s) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"sidecar rejected audio frame ({exc.code}): {body}") from exc
+    except error.URLError as exc:
+        raise RuntimeError(f"failed to post audio frame to sidecar: {exc}") from exc
+
+
+def read_exact_or_eof(stream: BinaryIO, size: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = size
+    while remaining > 0:
+        chunk = stream.read(remaining)
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def iter_pcm_frames(stream: BinaryIO, frame_bytes: int):
+    while True:
+        frame = read_exact_or_eof(stream, frame_bytes)
+        if not frame:
+            return
+        if len(frame) < frame_bytes:
+            frame += b"\x00" * (frame_bytes - len(frame))
+        yield frame
+
+
+def build_voice_stream_command(args: argparse.Namespace, contract: AudioContract) -> list[str]:
+    command = [
+        args.voice_bin,
+        "stream",
+        "--sample-rate",
+        str(contract.sample_rate),
+        "--frame-ms",
+        str(contract.frame_ms),
+        "--raw-output",
+        "-",
+        "--voice",
+        args.voice,
+        "--speed",
+        str(args.speed),
+    ]
+
+    if args.markdown:
+        command.append("--markdown")
+    for substitution in args.sub:
+        command.extend(["--sub", substitution])
+    if args.sub_file:
+        command.extend(["--sub-file", args.sub_file])
+    if args.input_file:
+        command.extend(["--input-file", args.input_file])
+    command.extend(args.text)
+    return command
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("call_id", help="sidecar call_id to send outbound audio to")
+    parser.add_argument("text", nargs="*", help="text to stream through voice")
+    parser.add_argument("--sidecar-url", default="http://127.0.0.1:8787")
+    parser.add_argument("--voice-bin", default="voice")
+    parser.add_argument("--voice", default="af_heart")
+    parser.add_argument("--speed", default="1.0")
+    parser.add_argument("--input-file", "-f")
+    parser.add_argument("--markdown", action="store_true")
+    parser.add_argument("--sub", action="append", default=[])
+    parser.add_argument("--sub-file")
+    parser.add_argument("--timeout", type=float, default=5.0)
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args()
+
+    if not args.input_file and not args.text:
+        parser.error("provide text or --input-file")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    contract = load_audio_contract()
+    url = sidecar_audio_url(args.sidecar_url, args.call_id)
+    command = build_voice_stream_command(args, contract)
+
+    if not args.quiet:
+        print(f"posting {contract.frame_bytes}-byte PCM frames to {url}", file=sys.stderr)
+
+    process = subprocess.Popen(command, stdout=subprocess.PIPE)
+    assert process.stdout is not None
+
+    frame_count = 0
+    byte_count = 0
+    try:
+        for frame in iter_pcm_frames(process.stdout, contract.frame_bytes):
+            post_audio_frame(url, contract, frame, args.timeout)
+            frame_count += 1
+            byte_count += len(frame)
+    finally:
+        process.stdout.close()
+
+    return_code = process.wait()
+    if return_code != 0:
+        return return_code
+
+    if not args.quiet:
+        print(
+            f"posted {frame_count} frames ({byte_count} bytes) to {args.call_id}",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/webrtc-sidecar/test_post_voice_stream.py
+++ b/examples/webrtc-sidecar/test_post_voice_stream.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import argparse
+import base64
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import importlib.util
+from io import BytesIO
+import json
+from pathlib import Path
+import sys
+import threading
+
+
+def load_bridge():
+    path = Path(__file__).with_name("post_voice_stream.py")
+    spec = importlib.util.spec_from_file_location("voice_webrtc_post_voice_stream", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_load_audio_contract_matches_sidecar_contract():
+    bridge = load_bridge()
+
+    contract = bridge.load_audio_contract()
+
+    assert contract.sample_rate == 48_000
+    assert contract.channels == 1
+    assert contract.frame_ms == 20
+    assert contract.encoding == "pcm_s16le"
+    assert contract.frame_bytes == 1_920
+
+
+def test_load_audio_contract_rejects_invalid_audio_shape(tmp_path: Path):
+    bridge = load_bridge()
+    contract_path = tmp_path / "contract.json"
+    contract_path.write_text(
+        json.dumps(
+            {
+                "audio": {
+                    "sample_rate": 48_000,
+                    "channels": 2,
+                    "frame_ms": 20,
+                    "encoding": "pcm_s16le",
+                    "frame_bytes": 3_840,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        bridge.load_audio_contract(contract_path)
+    except ValueError as exc:
+        assert "mono" in str(exc)
+    else:
+        raise AssertionError("expected invalid sidecar contract to be rejected")
+
+
+def test_sidecar_audio_url_escapes_call_id():
+    bridge = load_bridge()
+
+    url = bridge.sidecar_audio_url("http://127.0.0.1:8787/", "wamid/call 1")
+
+    assert url == "http://127.0.0.1:8787/calls/wamid%2Fcall%201/audio"
+
+
+def test_iter_pcm_frames_reads_exact_frames_and_pads_final():
+    bridge = load_bridge()
+    stream = BytesIO(b"a" * 5 + b"bb")
+
+    frames = list(bridge.iter_pcm_frames(stream, 5))
+
+    assert frames == [b"aaaaa", b"bb\x00\x00\x00"]
+
+
+def test_build_audio_payload_uses_contract_shape():
+    bridge = load_bridge()
+    contract = bridge.AudioContract(
+        sample_rate=48_000,
+        channels=1,
+        frame_ms=20,
+        encoding="pcm_s16le",
+        frame_bytes=1_920,
+    )
+
+    payload = bridge.build_audio_payload(contract, b"\x01\x00\xff\xff")
+
+    assert payload == {
+        "sample_rate": 48_000,
+        "channels": 1,
+        "frame_ms": 20,
+        "encoding": "pcm_s16le",
+        "pcm_s16le_base64": base64.b64encode(b"\x01\x00\xff\xff").decode("ascii"),
+    }
+
+
+def test_build_audio_payload_rejects_partial_sample():
+    bridge = load_bridge()
+    contract = bridge.AudioContract(
+        sample_rate=48_000,
+        channels=1,
+        frame_ms=20,
+        encoding="pcm_s16le",
+        frame_bytes=1_920,
+    )
+
+    try:
+        bridge.build_audio_payload(contract, b"\x01")
+    except ValueError as exc:
+        assert "whole s16le samples" in str(exc)
+    else:
+        raise AssertionError("expected partial s16le sample to be rejected")
+
+
+def test_post_audio_frame_sends_json_payload_to_sidecar_endpoint():
+    bridge = load_bridge()
+    contract = bridge.AudioContract(
+        sample_rate=48_000,
+        channels=1,
+        frame_ms=20,
+        encoding="pcm_s16le",
+        frame_bytes=1_920,
+    )
+    received: list[tuple[str, dict[str, object]]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            content_length = int(self.headers["content-length"])
+            body = json.loads(self.rfile.read(content_length).decode("utf-8"))
+            received.append((self.path, body))
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"accepted_bytes":2}')
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/calls/call-1/audio"
+
+        response = bridge.post_audio_frame(url, contract, b"\x01\x00", 1.0)
+
+        assert response == {"accepted_bytes": 2}
+        assert received == [
+            (
+                "/calls/call-1/audio",
+                {
+                    "sample_rate": 48_000,
+                    "channels": 1,
+                    "frame_ms": 20,
+                    "encoding": "pcm_s16le",
+                    "pcm_s16le_base64": "AQA=",
+                },
+            )
+        ]
+    finally:
+        server.shutdown()
+        thread.join(timeout=1)
+
+
+def test_build_voice_stream_command_uses_contract_and_handoff_flags():
+    bridge = load_bridge()
+    contract = bridge.AudioContract(
+        sample_rate=48_000,
+        channels=1,
+        frame_ms=20,
+        encoding="pcm_s16le",
+        frame_bytes=1_920,
+    )
+    args = argparse.Namespace(
+        voice_bin="/usr/local/bin/voice",
+        voice="af_heart",
+        speed="1.1",
+        markdown=True,
+        sub=["Hermes=her-meez"],
+        sub_file="/tmp/subs",
+        input_file=None,
+        text=["Hello", "from", "WebRTC"],
+    )
+
+    command = bridge.build_voice_stream_command(args, contract)
+
+    assert command == [
+        "/usr/local/bin/voice",
+        "stream",
+        "--sample-rate",
+        "48000",
+        "--frame-ms",
+        "20",
+        "--raw-output",
+        "-",
+        "--voice",
+        "af_heart",
+        "--speed",
+        "1.1",
+        "--markdown",
+        "--sub",
+        "Hermes=her-meez",
+        "--sub-file",
+        "/tmp/subs",
+        "Hello",
+        "from",
+        "WebRTC",
+    ]


### PR DESCRIPTION
## Summary
- add a stdlib-only `post_voice_stream.py` helper that launches `voice stream --raw-output -` with the sidecar contract sample rate/frame size
- POST each 48 kHz mono 20 ms PCM frame into `POST /calls/{call_id}/audio`
- document the HTTP poster as the primary local sidecar handoff while keeping FIFO smoke tests as a fallback
- add tests for contract loading, frame slicing/padding, URL escaping, HTTP payloads, and voice command construction

This makes the WebRTC sidecar spike easier to drive from the existing voice daemon stream surface without using a FIFO.

## Tests
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_post_voice_stream.py`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py`
- `python3 -m py_compile examples/webrtc-sidecar/post_voice_stream.py examples/webrtc-sidecar/test_post_voice_stream.py`
- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `git diff --check`