### PR TITLE
Add WebRTC sidecar inbound audio drain helper

### DIFF
--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -124,6 +124,15 @@ Drain decoded inbound PCM for a live session:
 curl -sS 'http://127.0.0.1:8787/calls/local-test/audio?max_bytes=1920&wait_ms=500'
 ```
 
+For raw PCM output that can be piped into STT tooling:
+
+```bash
+python examples/webrtc-sidecar/drain_sidecar_audio.py local-test \
+  --duration-ms 5000 \
+  --stop-after-empty 3 \
+  --output /tmp/voice-webrtc-in.s16le
+```
+
 Queue outbound PCM for a live session:
 
 ```bash
@@ -158,7 +167,15 @@ voice stream-transcribe \
   --frame-ms 20
 ```
 
-Use `--raw-input -` when piping decoded PCM from another process.
+Use `--raw-input -` when piping decoded PCM from another process:
+
+```bash
+python examples/webrtc-sidecar/drain_sidecar_audio.py local-test \
+  --duration-ms 5000 \
+  --stop-after-empty 3 \
+  --quiet \
+| voice stream-transcribe --raw-input - --sample-rate 48000 --frame-ms 20
+```
 
 ## Tests
 
@@ -170,4 +187,5 @@ python3 -m venv /tmp/voice-webrtc-venv
 /tmp/voice-webrtc-venv/bin/pip install -r examples/webrtc-sidecar/requirements.txt pytest
 /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py
 /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_post_voice_stream.py
+/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_drain_sidecar_audio.py
 ```

--- a/examples/webrtc-sidecar/drain_sidecar_audio.py
+++ b/examples/webrtc-sidecar/drain_sidecar_audio.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Drain decoded inbound PCM from a WebRTC sidecar call.
+
+The sidecar exposes decoded WebRTC audio as local HTTP long-poll responses:
+
+    GET /calls/{call_id}/audio?max_bytes=1920&wait_ms=500
+
+This helper writes the returned raw pcm_s16le bytes to a file or stdout. For a
+bounded STT smoke test, pipe stdout into:
+
+    voice stream-transcribe --raw-input - --sample-rate 48000 --frame-ms 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import json
+from pathlib import Path
+import sys
+import time
+from urllib import error, parse, request
+
+from post_voice_stream import AudioContract, load_audio_contract, sidecar_audio_url
+
+
+def drain_url(sidecar_url: str, call_id: str, max_bytes: int, wait_ms: int) -> str:
+    query = parse.urlencode({"max_bytes": max_bytes, "wait_ms": wait_ms})
+    return f"{sidecar_audio_url(sidecar_url, call_id)}?{query}"
+
+
+def validate_drain_shape(contract: AudioContract, max_bytes: int, wait_ms: int) -> None:
+    if max_bytes <= 0:
+        raise ValueError("max_bytes must be positive")
+    if max_bytes % 2 != 0:
+        raise ValueError("max_bytes must contain whole s16le samples")
+    if max_bytes % contract.frame_bytes != 0:
+        raise ValueError(
+            f"max_bytes should align to {contract.frame_bytes}-byte WebRTC frames"
+        )
+    if wait_ms < 0:
+        raise ValueError("wait_ms must be non-negative")
+
+
+def decode_audio_response(body: dict[str, object]) -> bytes:
+    payload = str(body.get("pcm_s16le_base64") or "")
+    try:
+        pcm = base64.b64decode(payload, validate=True)
+    except binascii.Error as exc:
+        raise ValueError("pcm_s16le_base64 is not valid base64") from exc
+
+    returned_bytes = body.get("returned_bytes")
+    if returned_bytes is not None and int(returned_bytes) != len(pcm):
+        raise ValueError("returned_bytes does not match decoded PCM length")
+    if len(pcm) % 2 != 0:
+        raise ValueError("decoded PCM must contain whole s16le samples")
+    return pcm
+
+
+def fetch_audio_chunk(url: str, timeout_s: float) -> bytes:
+    try:
+        with request.urlopen(url, timeout=timeout_s) as response:
+            body = json.loads(response.read().decode("utf-8"))
+    except error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"sidecar rejected audio drain ({exc.code}): {body}") from exc
+    except error.URLError as exc:
+        raise RuntimeError(f"failed to drain sidecar audio: {exc}") from exc
+    return decode_audio_response(body)
+
+
+def output_stream(path: str):
+    if path == "-":
+        return sys.stdout.buffer
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    return output_path.open("wb")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("call_id", help="sidecar call_id to drain inbound audio from")
+    parser.add_argument("--sidecar-url", default="http://127.0.0.1:8787")
+    parser.add_argument("--output", "-o", default="-", help="raw PCM output path or '-'")
+    parser.add_argument("--max-bytes", type=int, default=None)
+    parser.add_argument("--wait-ms", type=int, default=500)
+    parser.add_argument(
+        "--duration-ms",
+        type=int,
+        help="stop after this wall-clock duration; omit to run until interrupted",
+    )
+    parser.add_argument(
+        "--stop-after-empty",
+        type=int,
+        default=0,
+        help="stop after N consecutive empty long-poll responses; 0 disables",
+    )
+    parser.add_argument("--timeout", type=float, default=5.0)
+    parser.add_argument("--quiet", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    contract = load_audio_contract()
+    max_bytes = args.max_bytes or contract.frame_bytes
+    validate_drain_shape(contract, max_bytes, args.wait_ms)
+    if args.duration_ms is not None and args.duration_ms < 0:
+        raise ValueError("duration_ms must be non-negative")
+
+    url = drain_url(args.sidecar_url, args.call_id, max_bytes, args.wait_ms)
+    deadline = (
+        time.monotonic() + (args.duration_ms / 1_000)
+        if args.duration_ms is not None
+        else None
+    )
+
+    if not args.quiet:
+        print(f"draining inbound PCM from {url}", file=sys.stderr)
+
+    chunks = 0
+    bytes_written = 0
+    empty_polls = 0
+    stream = output_stream(args.output)
+    should_close = stream is not sys.stdout.buffer
+    try:
+        while deadline is None or time.monotonic() < deadline:
+            pcm = fetch_audio_chunk(url, args.timeout)
+            if not pcm:
+                empty_polls += 1
+                if args.stop_after_empty and empty_polls >= args.stop_after_empty:
+                    break
+                continue
+
+            empty_polls = 0
+            stream.write(pcm)
+            stream.flush()
+            chunks += 1
+            bytes_written += len(pcm)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if should_close:
+            stream.close()
+
+    if not args.quiet:
+        print(
+            f"drained {chunks} chunks ({bytes_written} bytes) from {args.call_id}",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/webrtc-sidecar/test_drain_sidecar_audio.py
+++ b/examples/webrtc-sidecar/test_drain_sidecar_audio.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import base64
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import threading
+
+
+def load_bridge_module():
+    path = Path(__file__).with_name("post_voice_stream.py")
+    spec = importlib.util.spec_from_file_location("post_voice_stream", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_drain():
+    load_bridge_module()
+    path = Path(__file__).with_name("drain_sidecar_audio.py")
+    spec = importlib.util.spec_from_file_location("voice_webrtc_drain_sidecar_audio", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def audio_contract():
+    bridge = sys.modules["post_voice_stream"]
+    return bridge.AudioContract(
+        sample_rate=48_000,
+        channels=1,
+        frame_ms=20,
+        encoding="pcm_s16le",
+        frame_bytes=1_920,
+    )
+
+
+def test_drain_url_escapes_call_id_and_uses_audio_query():
+    drain = load_drain()
+
+    url = drain.drain_url("http://127.0.0.1:8787/", "wamid/call 1", 1_920, 500)
+
+    assert (
+        url
+        == "http://127.0.0.1:8787/calls/wamid%2Fcall%201/audio?max_bytes=1920&wait_ms=500"
+    )
+
+
+def test_validate_drain_shape_requires_whole_webrtc_frames():
+    drain = load_drain()
+    contract = audio_contract()
+
+    drain.validate_drain_shape(contract, 1_920, 500)
+    drain.validate_drain_shape(contract, 3_840, 0)
+
+    try:
+        drain.validate_drain_shape(contract, 960, 500)
+    except ValueError as exc:
+        assert "align" in str(exc)
+    else:
+        raise AssertionError("expected non-frame-aligned drain size to be rejected")
+
+    try:
+        drain.validate_drain_shape(contract, 1_920, -1)
+    except ValueError as exc:
+        assert "non-negative" in str(exc)
+    else:
+        raise AssertionError("expected negative wait_ms to be rejected")
+
+
+def test_decode_audio_response_validates_returned_bytes():
+    drain = load_drain()
+
+    pcm = drain.decode_audio_response(
+        {
+            "returned_bytes": 2,
+            "pcm_s16le_base64": base64.b64encode(b"\x01\x00").decode("ascii"),
+        }
+    )
+
+    assert pcm == b"\x01\x00"
+
+    try:
+        drain.decode_audio_response(
+            {
+                "returned_bytes": 4,
+                "pcm_s16le_base64": base64.b64encode(b"\x01\x00").decode("ascii"),
+            }
+        )
+    except ValueError as exc:
+        assert "returned_bytes" in str(exc)
+    else:
+        raise AssertionError("expected returned byte mismatch to be rejected")
+
+
+def test_fetch_audio_chunk_reads_sidecar_json_response():
+    drain = load_drain()
+    received_paths: list[str] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            received_paths.append(self.path)
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(
+                json.dumps(
+                    {
+                        "returned_bytes": 2,
+                        "pcm_s16le_base64": base64.b64encode(b"\x02\x00").decode(
+                            "ascii"
+                        ),
+                    }
+                ).encode("utf-8")
+            )
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/calls/call-1/audio?max_bytes=1920&wait_ms=1"
+
+        pcm = drain.fetch_audio_chunk(url, 1.0)
+
+        assert pcm == b"\x02\x00"
+        assert received_paths == ["/calls/call-1/audio?max_bytes=1920&wait_ms=1"]
+    finally:
+        server.shutdown()
+        thread.join(timeout=1)


### PR DESCRIPTION
## Summary
- add a stdlib-only `drain_sidecar_audio.py` helper for long-polling decoded inbound PCM from `GET /calls/{call_id}/audio`
- write raw `pcm_s16le` to a file or stdout so it can feed `voice stream-transcribe --raw-input -`
- document bounded inbound drain/STT smoke-test flows in the sidecar README
- add tests for URL construction, frame-aligned drain validation, response decoding, and a local HTTP fetch

This complements #128: outbound TTS can now be posted into the sidecar, and inbound WebRTC PCM can be drained into the existing voice STT stream surface.

## Tests
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/test_drain_sidecar_audio.py examples/webrtc-sidecar/test_sidecar.py`
- `python3 -m py_compile examples/webrtc-sidecar/post_voice_stream.py examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/drain_sidecar_audio.py examples/webrtc-sidecar/test_drain_sidecar_audio.py`
- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `git diff --check`