### PR TITLE
Test WebRTC sidecar examples in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,22 @@ jobs:
       - run: cargo clippy --workspace -- -D warnings
 
       - run: cargo test --workspace
+
+  sidecar-python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: python -m pip install --upgrade pip
+
+      - run: python -m pip install -r examples/webrtc-sidecar/requirements.txt pytest
+
+      - run: |
+          python -m pytest -q \
+            examples/webrtc-sidecar/test_sidecar.py \
+            examples/webrtc-sidecar/test_post_voice_stream.py \
+            examples/webrtc-sidecar/test_drain_sidecar_audio.py


### PR DESCRIPTION
## Summary
- add a `sidecar-python` CI job on Ubuntu
- install the optional WebRTC sidecar dependencies and pytest
- run the sidecar loopback tests plus the outbound/inbound helper tests from #128/#129

This makes the live-call spike surface part of CI instead of relying on manual optional test runs.

## Tests
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/test_drain_sidecar_audio.py`
- `python3 -m py_compile examples/webrtc-sidecar/post_voice_stream.py examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/drain_sidecar_audio.py examples/webrtc-sidecar/test_drain_sidecar_audio.py`
- `cargo fmt --check`
- `git diff --check`