### PR TITLE
Use WebRTC sidecar drain defaults from contract

### DIFF
--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -121,7 +121,7 @@ curl -sS http://127.0.0.1:8787/calls/local-test
 Drain decoded inbound PCM for a live session:
 
 ```bash
-curl -sS 'http://127.0.0.1:8787/calls/local-test/audio?max_bytes=1920&wait_ms=500'
+curl -sS 'http://127.0.0.1:8787/calls/local-test/audio?wait_ms=500'
 ```
 
 For raw PCM output that can be piped into STT tooling:
@@ -132,6 +132,10 @@ python examples/webrtc-sidecar/drain_sidecar_audio.py local-test \
   --stop-after-empty 3 \
   --output /tmp/voice-webrtc-in.s16le
 ```
+
+By default the drain helper requests the contract's `default_drain_bytes`
+window, currently 96000 bytes or about one second of mono 48 kHz s16le audio.
+Pass `--max-bytes 1920` for exact frame-by-frame polling.
 
 Queue outbound PCM for a live session:
 

--- a/examples/webrtc-sidecar/drain_sidecar_audio.py
+++ b/examples/webrtc-sidecar/drain_sidecar_audio.py
@@ -43,6 +43,18 @@ def validate_drain_shape(contract: AudioContract, max_bytes: int, wait_ms: int) 
         raise ValueError("wait_ms must be non-negative")
 
 
+def default_max_bytes(contract: AudioContract, configured_max_bytes: int | None) -> int:
+    if configured_max_bytes is not None:
+        return configured_max_bytes
+    return contract.default_drain_bytes
+
+
+def capped_wait_ms(contract: AudioContract, wait_ms: int) -> int:
+    if contract.max_drain_wait_ms <= 0:
+        return wait_ms
+    return min(wait_ms, contract.max_drain_wait_ms)
+
+
 def decode_audio_response(body: dict[str, object]) -> bytes:
     payload = str(body.get("pcm_s16le_base64") or "")
     try:
@@ -104,12 +116,13 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     contract = load_audio_contract()
-    max_bytes = args.max_bytes or contract.frame_bytes
-    validate_drain_shape(contract, max_bytes, args.wait_ms)
+    max_bytes = default_max_bytes(contract, args.max_bytes)
+    wait_ms = capped_wait_ms(contract, args.wait_ms)
+    validate_drain_shape(contract, max_bytes, wait_ms)
     if args.duration_ms is not None and args.duration_ms < 0:
         raise ValueError("duration_ms must be non-negative")
 
-    url = drain_url(args.sidecar_url, args.call_id, max_bytes, args.wait_ms)
+    url = drain_url(args.sidecar_url, args.call_id, max_bytes, wait_ms)
     deadline = (
         time.monotonic() + (args.duration_ms / 1_000)
         if args.duration_ms is not None

--- a/examples/webrtc-sidecar/post_voice_stream.py
+++ b/examples/webrtc-sidecar/post_voice_stream.py
@@ -34,6 +34,8 @@ class AudioContract:
     frame_ms: int
     encoding: str
     frame_bytes: int
+    default_drain_bytes: int = 0
+    max_drain_wait_ms: int = 0
 
 
 def load_audio_contract(path: Path = CONTRACT_PATH) -> AudioContract:
@@ -50,6 +52,10 @@ def load_audio_contract(path: Path = CONTRACT_PATH) -> AudioContract:
         frame_ms=int(audio["frame_ms"]),
         encoding=str(audio["encoding"]),
         frame_bytes=int(audio["frame_bytes"]),
+        default_drain_bytes=int(
+            audio.get("default_drain_bytes") or audio["frame_bytes"]
+        ),
+        max_drain_wait_ms=int(audio.get("max_drain_wait_ms") or 0),
     )
 
     if parsed.sample_rate <= 0:
@@ -62,6 +68,12 @@ def load_audio_contract(path: Path = CONTRACT_PATH) -> AudioContract:
         raise ValueError("sidecar currently expects pcm_s16le audio")
     if parsed.frame_bytes <= 0 or parsed.frame_bytes % 2 != 0:
         raise ValueError("contract frame_bytes must contain whole s16le samples")
+    if parsed.default_drain_bytes <= 0:
+        raise ValueError("contract default_drain_bytes must be positive")
+    if parsed.default_drain_bytes % parsed.frame_bytes != 0:
+        raise ValueError("contract default_drain_bytes must align to WebRTC frames")
+    if parsed.max_drain_wait_ms < 0:
+        raise ValueError("contract max_drain_wait_ms must be non-negative")
 
     return parsed
 

--- a/examples/webrtc-sidecar/test_drain_sidecar_audio.py
+++ b/examples/webrtc-sidecar/test_drain_sidecar_audio.py
@@ -40,6 +40,8 @@ def audio_contract():
         frame_ms=20,
         encoding="pcm_s16le",
         frame_bytes=1_920,
+        default_drain_bytes=96_000,
+        max_drain_wait_ms=5_000,
     )
 
 
@@ -74,6 +76,16 @@ def test_validate_drain_shape_requires_whole_webrtc_frames():
         assert "non-negative" in str(exc)
     else:
         raise AssertionError("expected negative wait_ms to be rejected")
+
+
+def test_drain_defaults_use_contract_window_and_cap_wait():
+    drain = load_drain()
+    contract = audio_contract()
+
+    assert drain.default_max_bytes(contract, None) == 96_000
+    assert drain.default_max_bytes(contract, 1_920) == 1_920
+    assert drain.capped_wait_ms(contract, 250) == 250
+    assert drain.capped_wait_ms(contract, 10_000) == 5_000
 
 
 def test_decode_audio_response_validates_returned_bytes():

--- a/examples/webrtc-sidecar/test_post_voice_stream.py
+++ b/examples/webrtc-sidecar/test_post_voice_stream.py
@@ -32,6 +32,8 @@ def test_load_audio_contract_matches_sidecar_contract():
     assert contract.frame_ms == 20
     assert contract.encoding == "pcm_s16le"
     assert contract.frame_bytes == 1_920
+    assert contract.default_drain_bytes == 96_000
+    assert contract.max_drain_wait_ms == 5_000
 
 
 def test_load_audio_contract_rejects_invalid_audio_shape(tmp_path: Path):
@@ -46,6 +48,7 @@ def test_load_audio_contract_rejects_invalid_audio_shape(tmp_path: Path):
                     "frame_ms": 20,
                     "encoding": "pcm_s16le",
                     "frame_bytes": 3_840,
+                    "default_drain_bytes": 3_840,
                 }
             }
         ),


### PR DESCRIPTION
## Summary
- parse the richer WebRTC sidecar audio contract in the helper scripts
- make inbound drain default to the contract's default_drain_bytes window instead of a single 20 ms frame
- cap drain wait values with max_drain_wait_ms and document frame-by-frame override

## Tests
- uv run --with pytest --with aiohttp --with aiortc --with av python -m pytest -q examples/webrtc-sidecar/test_sidecar.py examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/test_drain_sidecar_audio.py
- python3 -m py_compile examples/webrtc-sidecar/post_voice_stream.py examples/webrtc-sidecar/drain_sidecar_audio.py
- git diff --check