### PR TITLE
Return full WebRTC sidecar audio contract

### DIFF
--- a/docs/contracts/webrtc-sidecar-v1.json
+++ b/docs/contracts/webrtc-sidecar-v1.json
@@ -69,13 +69,19 @@
       "returned_bytes": "Number of decoded PCM bytes returned.",
       "queued_rx_bytes": "Remaining inbound decoded PCM bytes queued after this drain.",
       "pcm_s16le_base64": "Base64 encoded signed 16-bit little-endian mono PCM.",
-      "audio": "Fixed audio shape: sample_rate, channels, frame_ms, encoding."
+      "audio": "Full fixed audio contract object defined by audio."
     },
     "audio_shape": {
       "sample_rate": "audio.sample_rate",
       "channels": "audio.channels",
       "frame_ms": "audio.frame_ms",
-      "encoding": "audio.encoding"
+      "encoding": "audio.encoding",
+      "bytes_per_sample": "audio.bytes_per_sample",
+      "samples_per_frame": "audio.samples_per_frame",
+      "frame_bytes": "audio.frame_bytes",
+      "default_drain_bytes": "audio.default_drain_bytes",
+      "max_inbound_queue_bytes": "audio.max_inbound_queue_bytes",
+      "max_drain_wait_ms": "audio.max_drain_wait_ms"
     }
   }
 }

--- a/examples/webrtc-sidecar/sidecar.py
+++ b/examples/webrtc-sidecar/sidecar.py
@@ -367,12 +367,7 @@ def json_error(message: str, status: int = 400) -> web.Response:
 
 
 def audio_contract() -> dict[str, Any]:
-    return {
-        "sample_rate": SAMPLE_RATE,
-        "channels": CHANNELS,
-        "frame_ms": FRAME_MS,
-        "encoding": str(AUDIO_CONTRACT["encoding"]),
-    }
+    return copy.deepcopy(AUDIO_CONTRACT)
 
 
 def webrtc_contract() -> dict[str, Any]:

--- a/examples/webrtc-sidecar/test_sidecar.py
+++ b/examples/webrtc-sidecar/test_sidecar.py
@@ -62,12 +62,10 @@ def test_audio_contract_is_voice_pcm_shape():
     contract = json.loads(sidecar.CONTRACT_PATH.read_text(encoding="utf-8"))
     audio = contract["audio"]
 
-    assert sidecar.audio_contract() == {
-        "sample_rate": audio["sample_rate"],
-        "channels": audio["channels"],
-        "frame_ms": audio["frame_ms"],
-        "encoding": audio["encoding"],
-    }
+    assert sidecar.audio_contract() == audio
+    mutated = sidecar.audio_contract()
+    mutated["sample_rate"] = 16_000
+    assert sidecar.audio_contract()["sample_rate"] == audio["sample_rate"]
     assert sidecar.SAMPLES_PER_FRAME == audio["samples_per_frame"]
     assert sidecar.FRAME_BYTES == audio["frame_bytes"]
     assert sidecar.DEFAULT_DRAIN_BYTES == audio["default_drain_bytes"]


### PR DESCRIPTION
## Summary
- return the full v1 audio contract from the WebRTC sidecar's runtime audio fields
- keep response helpers immutable by returning a copy of the loaded contract
- update the machine-readable contract payload description and tests

## Tests
- uv run --with pytest --with aiohttp --with aiortc --with av python -m pytest -q examples/webrtc-sidecar/test_sidecar.py examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/test_drain_sidecar_audio.py
- cargo test -p voice-stream
- python3 -m py_compile examples/webrtc-sidecar/sidecar.py examples/webrtc-sidecar/post_voice_stream.py examples/webrtc-sidecar/drain_sidecar_audio.py
- git diff --check