### PR TITLE
Add WebRTC sidecar outbound backpressure

### DIFF
--- a/crates/voice-stream/src/lib.rs
+++ b/crates/voice-stream/src/lib.rs
@@ -23,6 +23,8 @@ pub const WEBRTC_SAMPLES_PER_FRAME: usize =
 pub const WEBRTC_FRAME_BYTES: usize =
     WEBRTC_SAMPLES_PER_FRAME * WEBRTC_CHANNELS as usize * PCM_S16LE_BYTES_PER_SAMPLE;
 pub const WEBRTC_DEFAULT_DRAIN_BYTES: usize = WEBRTC_FRAME_BYTES * 50;
+pub const WEBRTC_MAX_OUTBOUND_QUEUE_BYTES: usize =
+    WEBRTC_SAMPLE_RATE as usize * WEBRTC_CHANNELS as usize * PCM_S16LE_BYTES_PER_SAMPLE * 10;
 pub const WEBRTC_MAX_INBOUND_QUEUE_BYTES: usize =
     WEBRTC_SAMPLE_RATE as usize * WEBRTC_CHANNELS as usize * PCM_S16LE_BYTES_PER_SAMPLE * 10;
 pub const WEBRTC_MAX_DRAIN_WAIT_MS: u32 = 5_000;
@@ -404,6 +406,10 @@ mod tests {
         assert_eq!(audio["samples_per_frame"], WEBRTC_SAMPLES_PER_FRAME);
         assert_eq!(audio["frame_bytes"], WEBRTC_FRAME_BYTES);
         assert_eq!(audio["default_drain_bytes"], WEBRTC_DEFAULT_DRAIN_BYTES);
+        assert_eq!(
+            audio["max_outbound_queue_bytes"],
+            WEBRTC_MAX_OUTBOUND_QUEUE_BYTES
+        );
         assert_eq!(
             audio["max_inbound_queue_bytes"],
             WEBRTC_MAX_INBOUND_QUEUE_BYTES

--- a/docs/contracts/webrtc-sidecar-v1.json
+++ b/docs/contracts/webrtc-sidecar-v1.json
@@ -12,6 +12,7 @@
     "samples_per_frame": 960,
     "frame_bytes": 1920,
     "default_drain_bytes": 96000,
+    "max_outbound_queue_bytes": 960000,
     "max_inbound_queue_bytes": 960000,
     "max_drain_wait_ms": 5000
   },
@@ -64,6 +65,13 @@
       "encoding": "audio.encoding",
       "pcm_s16le_base64": "Required base64 encoded signed 16-bit little-endian mono PCM."
     },
+    "send_audio_response": {
+      "call_id": "Call session identifier.",
+      "accepted_bytes": "Number of outbound PCM bytes accepted into the per-call queue.",
+      "queued_tx_bytes": "Outbound PCM bytes queued after this write.",
+      "max_tx_queue_bytes": "Maximum outbound PCM bytes this sidecar will queue for one call.",
+      "audio": "Full fixed audio contract object defined by audio."
+    },
     "receive_audio_response": {
       "call_id": "Call session identifier.",
       "returned_bytes": "Number of decoded PCM bytes returned.",
@@ -80,6 +88,7 @@
       "samples_per_frame": "audio.samples_per_frame",
       "frame_bytes": "audio.frame_bytes",
       "default_drain_bytes": "audio.default_drain_bytes",
+      "max_outbound_queue_bytes": "audio.max_outbound_queue_bytes",
       "max_inbound_queue_bytes": "audio.max_inbound_queue_bytes",
       "max_drain_wait_ms": "audio.max_drain_wait_ms"
     }

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -182,7 +182,10 @@ Response:
 Debug a live session with `GET /calls/{call_id}`. Drain decoded inbound audio
 with `GET /calls/{call_id}/audio`. Queue outbound audio for the WebRTC track
 with `POST /calls/{call_id}/audio`. Terminate a local session with
-`POST /calls/{call_id}/close`.
+`POST /calls/{call_id}/close`. The outbound queue is deliberately bounded;
+`POST /calls/{call_id}/audio` returns HTTP 429 when the sidecar is already
+holding `max_outbound_queue_bytes` for that call, which lets Hermes pause or
+cancel TTS instead of building an unbounded latency backlog.
 
 Runtime events:
 
@@ -223,6 +226,11 @@ Outbound audio:
 
 ```http
 POST /calls/{call_id}/audio
+```
+
+Request:
+
+```json
 {
   "sequence": 17,
   "sample_rate": 48000,
@@ -239,7 +247,8 @@ Response:
 {
   "call_id": "wamid-call-id",
   "accepted_bytes": 1920,
-  "queued_tx_bytes": 3840,
+  "queued_tx_bytes": 1920,
+  "max_tx_queue_bytes": 960000,
   "audio": {
     "sample_rate": 48000,
     "channels": 1,

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -63,9 +63,12 @@ curl -sS -X POST http://127.0.0.1:8787/calls/local-test/audio \
 ```
 
 Each 20 ms frame is 1920 bytes before base64 encoding. HTTP input is queued per
-`call_id`; `--tx-pcm` remains a process-level fallback source. If both sources
-are idle, the sidecar sends silence. That is useful for checking SDP, ICE, and
-call timing before TTS is wired in.
+`call_id`; `--tx-pcm` remains a process-level fallback source. The per-call
+outbound queue is bounded by the contract's `max_outbound_queue_bytes` value;
+`POST /calls/{call_id}/audio` returns HTTP 429 when Hermes needs to slow down
+instead of allowing unbounded TTS buffering. If both sources are idle, the
+sidecar sends silence. That is useful for checking SDP, ICE, and call timing
+before TTS is wired in.
 
 For FIFO-based smoke tests, start the sidecar with `--tx-pcm`:
 
@@ -143,6 +146,23 @@ Queue outbound PCM for a live session:
 curl -sS -X POST http://127.0.0.1:8787/calls/local-test/audio \
   -H 'content-type: application/json' \
   -d '{"sample_rate":48000,"channels":1,"frame_ms":20,"encoding":"pcm_s16le","pcm_s16le_base64":"AAAAAA=="}'
+```
+
+Response:
+
+```json
+{
+  "call_id": "local-test",
+  "accepted_bytes": 1920,
+  "queued_tx_bytes": 1920,
+  "max_tx_queue_bytes": 960000,
+  "audio": {
+    "sample_rate": 48000,
+    "channels": 1,
+    "frame_ms": 20,
+    "encoding": "pcm_s16le"
+  }
+}
 ```
 
 Close a session:

--- a/examples/webrtc-sidecar/post_voice_stream.py
+++ b/examples/webrtc-sidecar/post_voice_stream.py
@@ -35,6 +35,7 @@ class AudioContract:
     encoding: str
     frame_bytes: int
     default_drain_bytes: int = 0
+    max_outbound_queue_bytes: int = 0
     max_drain_wait_ms: int = 0
 
 
@@ -55,6 +56,7 @@ def load_audio_contract(path: Path = CONTRACT_PATH) -> AudioContract:
         default_drain_bytes=int(
             audio.get("default_drain_bytes") or audio["frame_bytes"]
         ),
+        max_outbound_queue_bytes=int(audio.get("max_outbound_queue_bytes") or 0),
         max_drain_wait_ms=int(audio.get("max_drain_wait_ms") or 0),
     )
 
@@ -72,6 +74,10 @@ def load_audio_contract(path: Path = CONTRACT_PATH) -> AudioContract:
         raise ValueError("contract default_drain_bytes must be positive")
     if parsed.default_drain_bytes % parsed.frame_bytes != 0:
         raise ValueError("contract default_drain_bytes must align to WebRTC frames")
+    if parsed.max_outbound_queue_bytes <= 0:
+        raise ValueError("contract max_outbound_queue_bytes must be positive")
+    if parsed.max_outbound_queue_bytes < parsed.frame_bytes:
+        raise ValueError("contract max_outbound_queue_bytes must fit one WebRTC frame")
     if parsed.max_drain_wait_ms < 0:
         raise ValueError("contract max_drain_wait_ms must be non-negative")
 

--- a/examples/webrtc-sidecar/sidecar.py
+++ b/examples/webrtc-sidecar/sidecar.py
@@ -61,6 +61,7 @@ def validate_contract(contract: dict[str, Any]) -> None:
     samples_per_frame = int(audio["samples_per_frame"])
     frame_bytes = int(audio["frame_bytes"])
     default_drain_bytes = int(audio["default_drain_bytes"])
+    max_outbound_queue_bytes = int(audio["max_outbound_queue_bytes"])
     max_inbound_queue_bytes = int(audio["max_inbound_queue_bytes"])
     max_drain_wait_ms = int(audio["max_drain_wait_ms"])
     encoding = str(audio["encoding"])
@@ -75,6 +76,7 @@ def validate_contract(contract: dict[str, Any]) -> None:
         samples_per_frame,
         frame_bytes,
         default_drain_bytes,
+        max_outbound_queue_bytes,
         max_inbound_queue_bytes,
         max_drain_wait_ms,
     ) <= 0:
@@ -85,6 +87,8 @@ def validate_contract(contract: dict[str, Any]) -> None:
         raise ValueError("contract frame_bytes does not match audio shape")
     if default_drain_bytes % frame_bytes != 0:
         raise ValueError("contract default_drain_bytes must align to whole frames")
+    if max_outbound_queue_bytes < frame_bytes:
+        raise ValueError("contract max_outbound_queue_bytes is smaller than one frame")
     if max_inbound_queue_bytes < default_drain_bytes:
         raise ValueError("contract max_inbound_queue_bytes is smaller than default drain size")
 
@@ -98,6 +102,7 @@ SAMPLES_PER_FRAME = int(AUDIO_CONTRACT["samples_per_frame"])
 BYTES_PER_SAMPLE = int(AUDIO_CONTRACT["bytes_per_sample"])
 FRAME_BYTES = int(AUDIO_CONTRACT["frame_bytes"])
 DEFAULT_DRAIN_BYTES = int(AUDIO_CONTRACT["default_drain_bytes"])
+MAX_OUTBOUND_QUEUE_BYTES = int(AUDIO_CONTRACT["max_outbound_queue_bytes"])
 MAX_INBOUND_QUEUE_BYTES = int(AUDIO_CONTRACT["max_inbound_queue_bytes"])
 MAX_DRAIN_WAIT_MS = int(AUDIO_CONTRACT["max_drain_wait_ms"])
 
@@ -152,11 +157,20 @@ class PcmSource:
         return frame + (b"\x00" * (FRAME_BYTES - len(frame)))
 
 
+class QueueFullError(RuntimeError):
+    """Raised when a call's outbound PCM queue is full."""
+
+
 class CallPcmSource:
     """Per-call PCM queue with a process-level source as fallback."""
 
-    def __init__(self, fallback: PcmSource) -> None:
+    def __init__(
+        self,
+        fallback: PcmSource,
+        max_queue_bytes: int = MAX_OUTBOUND_QUEUE_BYTES,
+    ) -> None:
         self.fallback = fallback
+        self.max_queue_bytes = max_queue_bytes
         self.buffer = bytearray()
 
     @property
@@ -164,6 +178,8 @@ class CallPcmSource:
         return len(self.buffer)
 
     def write_frame(self, pcm_s16le: bytes) -> int:
+        if len(self.buffer) + len(pcm_s16le) > self.max_queue_bytes:
+            raise QueueFullError("outbound PCM queue is full")
         self.buffer.extend(pcm_s16le)
         return len(pcm_s16le)
 
@@ -326,6 +342,7 @@ class CallSession:
             "signaling_state": self.pc.signalingState,
             "tasks": len(self.tasks),
             "queued_tx_bytes": self.source.queued_bytes,
+            "max_tx_queue_bytes": self.source.max_queue_bytes,
             "queued_rx_bytes": self.inbound.queued_bytes,
             "audio": audio_contract(),
         }
@@ -512,12 +529,16 @@ def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
         except ValueError as exc:
             return json_error(str(exc))
 
-        accepted_bytes = session.source.write_frame(pcm)
+        try:
+            accepted_bytes = session.source.write_frame(pcm)
+        except QueueFullError as exc:
+            return json_error(str(exc), status=429)
         return web.json_response(
             {
                 "call_id": call_id,
                 "accepted_bytes": accepted_bytes,
                 "queued_tx_bytes": session.source.queued_bytes,
+                "max_tx_queue_bytes": session.source.max_queue_bytes,
                 "audio": audio_contract(),
             }
         )

--- a/examples/webrtc-sidecar/test_post_voice_stream.py
+++ b/examples/webrtc-sidecar/test_post_voice_stream.py
@@ -33,6 +33,7 @@ def test_load_audio_contract_matches_sidecar_contract():
     assert contract.encoding == "pcm_s16le"
     assert contract.frame_bytes == 1_920
     assert contract.default_drain_bytes == 96_000
+    assert contract.max_outbound_queue_bytes == 960_000
     assert contract.max_drain_wait_ms == 5_000
 
 

--- a/examples/webrtc-sidecar/test_sidecar.py
+++ b/examples/webrtc-sidecar/test_sidecar.py
@@ -69,9 +69,11 @@ def test_audio_contract_is_voice_pcm_shape():
     assert sidecar.SAMPLES_PER_FRAME == audio["samples_per_frame"]
     assert sidecar.FRAME_BYTES == audio["frame_bytes"]
     assert sidecar.DEFAULT_DRAIN_BYTES == audio["default_drain_bytes"]
+    assert sidecar.MAX_OUTBOUND_QUEUE_BYTES == audio["max_outbound_queue_bytes"]
     assert sidecar.MAX_INBOUND_QUEUE_BYTES == audio["max_inbound_queue_bytes"]
     assert sidecar.MAX_DRAIN_WAIT_MS == audio["max_drain_wait_ms"]
     assert sidecar.FRAME_BYTES == 1920
+    assert sidecar.MAX_OUTBOUND_QUEUE_BYTES == 960_000
 
 
 def test_contract_endpoint_returns_machine_readable_contract():
@@ -129,6 +131,22 @@ def test_call_pcm_source_isolates_per_call_queue():
     frame_a = call_a.read_frame()
     assert frame_a.startswith(b"\x01\x00\xff\xff")
     assert frame_a[4:] == b"\x00" * (sidecar.FRAME_BYTES - 4)
+
+
+def test_call_pcm_source_rejects_overflow():
+    sidecar = load_sidecar()
+
+    fallback = sidecar.PcmSource(None)
+    source = sidecar.CallPcmSource(fallback, max_queue_bytes=4)
+
+    assert source.write_frame(b"\x01\x00\x02\x00") == 4
+    try:
+        source.write_frame(b"\x03\x00")
+    except sidecar.QueueFullError as exc:
+        assert "outbound PCM queue" in str(exc)
+    else:
+        raise AssertionError("expected outbound queue overflow to be rejected")
+    assert source.queued_bytes == 4
 
 
 def test_inbound_pcm_sink_drains_queued_audio():
@@ -191,6 +209,7 @@ def test_call_status_and_close_use_session_snapshot():
             return {
                 "call_id": "call-1",
                 "closed": self.closed,
+                "max_tx_queue_bytes": sidecar.MAX_OUTBOUND_QUEUE_BYTES,
                 "audio": sidecar.audio_contract(),
             }
 
@@ -211,6 +230,7 @@ def test_call_status_and_close_use_session_snapshot():
             assert status_body["call_id"] == "call-1"
             assert status_body["closed"] is False
             assert status_body["audio"] == sidecar.audio_contract()
+            assert status_body["max_tx_queue_bytes"] == sidecar.MAX_OUTBOUND_QUEUE_BYTES
 
             close_response = await client.post("/calls/call-1/close")
             assert close_response.status == 200
@@ -264,10 +284,56 @@ def test_audio_endpoint_queues_pcm_for_call():
             body = await response.json()
             assert body["accepted_bytes"] == 4
             assert body["queued_tx_bytes"] == 4
+            assert body["max_tx_queue_bytes"] == source.max_queue_bytes
+            assert body["audio"] == sidecar.audio_contract()
 
             frame = source.read_frame()
             assert frame.startswith(b"\x01\x00\xff\xff")
             assert frame[4:] == b"\x00" * (sidecar.FRAME_BYTES - 4)
+
+    asyncio.run(run())
+
+
+def test_audio_endpoint_returns_backpressure_when_tx_queue_is_full():
+    sidecar = load_sidecar()
+
+    class FakeSession:
+        def __init__(self, source) -> None:
+            self.source = source
+
+        def snapshot(self):
+            return {
+                "call_id": "call-1",
+                "queued_tx_bytes": self.source.queued_bytes,
+                "max_tx_queue_bytes": self.source.max_queue_bytes,
+                "audio": sidecar.audio_contract(),
+            }
+
+        async def close(self) -> None:
+            pass
+
+    async def run():
+        from aiohttp.test_utils import TestClient, TestServer
+
+        fallback = sidecar.PcmSource(None)
+        source = sidecar.CallPcmSource(fallback, max_queue_bytes=4)
+        source.write_frame(b"\x01\x00\x02\x00")
+        app = sidecar.create_app(fallback, None)
+        app[sidecar.SESSIONS_KEY]["call-1"] = FakeSession(source)
+
+        payload = {
+            "sample_rate": 48000,
+            "channels": 1,
+            "frame_ms": 20,
+            "encoding": "pcm_s16le",
+            "pcm_s16le_base64": base64.b64encode(b"\x03\x00").decode("ascii"),
+        }
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post("/calls/call-1/audio", json=payload)
+            assert response.status == 429
+            body = await response.json()
+            assert body == {"error": "outbound PCM queue is full"}
+            assert source.queued_bytes == 4
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary
- add `max_outbound_queue_bytes` to the WebRTC sidecar v1 audio contract
- bound per-call outbound PCM queues and return HTTP 429 when a caller needs to slow down
- include `max_tx_queue_bytes` in sidecar snapshots and send-audio responses
- document the backpressure behavior for Hermes / WhatsApp Calling integration

## Testing
- `python3 -m json.tool docs/contracts/webrtc-sidecar-v1.json >/dev/null`
- `python3 -m py_compile examples/webrtc-sidecar/sidecar.py examples/webrtc-sidecar/post_voice_stream.py examples/webrtc-sidecar/drain_sidecar_audio.py examples/webrtc-sidecar/test_sidecar.py examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/test_drain_sidecar_audio.py`
- `cargo test -p voice-stream`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/test_drain_sidecar_audio.py`