### PR TITLE
Handle WebRTC post helper backpressure

### DIFF
--- a/examples/webrtc-sidecar/post_voice_stream.py
+++ b/examples/webrtc-sidecar/post_voice_stream.py
@@ -25,6 +25,7 @@ from urllib import error, parse, request
 
 
 CONTRACT_PATH = Path(__file__).resolve().parents[2] / "docs/contracts/webrtc-sidecar-v1.json"
+TEMPFAIL_EXIT_CODE = 75
 
 
 @dataclass(frozen=True)
@@ -37,6 +38,18 @@ class AudioContract:
     default_drain_bytes: int = 0
     max_outbound_queue_bytes: int = 0
     max_drain_wait_ms: int = 0
+
+
+class SidecarAudioPostError(RuntimeError):
+    """Raised when the sidecar rejects an outbound PCM frame."""
+
+    def __init__(self, status_code: int, body: str) -> None:
+        self.status_code = status_code
+        self.body = body
+        self.retryable = status_code == 429
+        super().__init__(
+            f"sidecar rejected audio frame ({status_code}): {body}"
+        )
 
 
 def load_audio_contract(path: Path = CONTRACT_PATH) -> AudioContract:
@@ -123,9 +136,22 @@ def post_audio_frame(
             return json.loads(response.read().decode("utf-8"))
     except error.HTTPError as exc:
         body = exc.read().decode("utf-8", errors="replace")
-        raise RuntimeError(f"sidecar rejected audio frame ({exc.code}): {body}") from exc
+        raise SidecarAudioPostError(exc.code, body) from exc
     except error.URLError as exc:
         raise RuntimeError(f"failed to post audio frame to sidecar: {exc}") from exc
+
+
+def stop_voice_process(process: subprocess.Popen[bytes], timeout_s: float = 2.0) -> int:
+    """Terminate a still-running `voice stream` child and return its exit code."""
+    if process.poll() is not None:
+        return int(process.returncode or 0)
+
+    process.terminate()
+    try:
+        return process.wait(timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        return process.wait()
 
 
 def read_exact_or_eof(stream: BinaryIO, size: int) -> bytes:
@@ -213,13 +239,31 @@ def main() -> int:
 
     frame_count = 0
     byte_count = 0
+    post_error: Exception | None = None
     try:
         for frame in iter_pcm_frames(process.stdout, contract.frame_bytes):
-            post_audio_frame(url, contract, frame, args.timeout)
+            try:
+                post_audio_frame(url, contract, frame, args.timeout)
+            except Exception as exc:
+                post_error = exc
+                break
             frame_count += 1
             byte_count += len(frame)
     finally:
         process.stdout.close()
+
+    if post_error is not None:
+        return_code = stop_voice_process(process)
+        if not args.quiet:
+            print(f"{post_error}", file=sys.stderr)
+            if isinstance(post_error, SidecarAudioPostError) and post_error.retryable:
+                print(
+                    "sidecar reported outbound audio backpressure; retry later",
+                    file=sys.stderr,
+                )
+        if isinstance(post_error, SidecarAudioPostError) and post_error.retryable:
+            return TEMPFAIL_EXIT_CODE
+        return return_code if return_code else 1
 
     return_code = process.wait()
     if return_code != 0:

--- a/examples/webrtc-sidecar/test_post_voice_stream.py
+++ b/examples/webrtc-sidecar/test_post_voice_stream.py
@@ -170,6 +170,77 @@ def test_post_audio_frame_sends_json_payload_to_sidecar_endpoint():
         thread.join(timeout=1)
 
 
+def test_post_audio_frame_marks_429_as_retryable_backpressure():
+    bridge = load_bridge()
+    contract = bridge.AudioContract(
+        sample_rate=48_000,
+        channels=1,
+        frame_ms=20,
+        encoding="pcm_s16le",
+        frame_bytes=1_920,
+    )
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.send_response(429)
+            self.send_header("content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"error":"outbound PCM queue is full"}')
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/calls/call-1/audio"
+
+        try:
+            bridge.post_audio_frame(url, contract, b"\x01\x00", 1.0)
+        except bridge.SidecarAudioPostError as exc:
+            assert exc.status_code == 429
+            assert exc.retryable is True
+            assert "outbound PCM queue is full" in exc.body
+        else:
+            raise AssertionError("expected 429 to raise a typed sidecar error")
+    finally:
+        server.shutdown()
+        thread.join(timeout=1)
+
+
+def test_stop_voice_process_terminates_running_child():
+    bridge = load_bridge()
+
+    class FakeProcess:
+        def __init__(self):
+            self.returncode = None
+            self.terminated = False
+            self.killed = False
+
+        def poll(self):
+            return self.returncode
+
+        def terminate(self):
+            self.terminated = True
+            self.returncode = -15
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+        def kill(self):
+            self.killed = True
+            self.returncode = -9
+
+    process = FakeProcess()
+
+    return_code = bridge.stop_voice_process(process)
+
+    assert return_code == -15
+    assert process.terminated is True
+    assert process.killed is False
+
+
 def test_build_voice_stream_command_uses_contract_and_handoff_flags():
     bridge = load_bridge()
     contract = bridge.AudioContract(


### PR DESCRIPTION
## Summary
- add a typed sidecar post error so HTTP 429 from `/calls/{call_id}/audio` is treated as retryable outbound audio backpressure
- stop the child `voice stream` process when posting to the sidecar fails mid-stream
- cover the 429/backpressure path and child cleanup behavior in the post helper tests

## Verification
- `python3 -m py_compile examples/webrtc-sidecar/post_voice_stream.py examples/webrtc-sidecar/test_post_voice_stream.py`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_post_voice_stream.py` -> 10 passed
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/test_drain_sidecar_audio.py` -> 32 passed
- `cargo test -p voice-stream` -> 12 passed

Note: Ruff is not installed in `/tmp/voice-webrtc-venv`, so I could not run a Python lint check from this environment.