### PR TITLE
Expose WebRTC stream contract in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ voice say -o speech.wav "Good morning everyone."
 voice say --format ogg-opus -o speech.ogg "Good morning everyone."
 
 # Stream daemon TTS frames for bridge/WebRTC experiments
+voice stream-contract
 voice stream --sample-rate 48000 --frame-ms 20 --raw-output speech.s16le "Good morning everyone."
 voice stream --sample-rate 48000 --frame-ms 20 --raw-output - "Good morning everyone." \
   | ffmpeg -f s16le -ar 48000 -ac 1 -i - -c:a libopus speech.ogg
@@ -171,6 +172,16 @@ Options:
       --markdown                   Strip markdown/MDX formatting before speaking
       --sub <WORD=REPLACEMENT>     Word substitution (repeatable)
       --sub-file <PATH>            Load substitutions from a file
+```
+
+### `voice stream-contract`
+
+Prints the machine-readable WebRTC sidecar v1 contract generated from the
+`voice-stream` constants. Use this when Hermes, a sidecar, or a test harness is
+installed without a source checkout but still needs the exact PCM frame shape.
+
+```
+Usage: voice stream-contract
 ```
 
 ### `voice stream-transcribe`

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -43,6 +43,7 @@ macro_rules! info {
                   voice phonemes \"ChatGPT uses RuntimeStateDoc\"\n  \
                   voice stream --json \"Hello world\"\n  \
                   voice stream --output reply.ogg --format ogg-opus \"Hello world\"\n  \
+                  voice stream-contract\n  \
                   voice stream-transcribe recording.wav\n  \
                   voice listen\n  \
                   voice listen --continuous\n  \
@@ -78,6 +79,9 @@ enum Command {
 
     /// Replay WAV or raw PCM audio through daemon streaming STT
     StreamTranscribe(StreamTranscribeArgs),
+
+    /// Print the machine-readable WebRTC sidecar stream contract
+    StreamContract,
 
     /// Speak text aloud, then listen for a response (speak + listen in one shot)
     Converse(ConverseArgs),
@@ -847,6 +851,9 @@ fn main() {
         Some(Command::StreamTranscribe(stream_args)) => {
             run_stream_transcribe(stream_args);
         }
+        Some(Command::StreamContract) => {
+            run_stream_contract();
+        }
         None => {
             // Backward compatibility: `voice Hello world` = `voice say Hello world`
             // Also: bare `voice` with piped stdin = `voice say` with stdin
@@ -871,6 +878,11 @@ fn main() {
             }
         }
     }
+}
+
+fn run_stream_contract() {
+    let contract = voice_stream::webrtc_sidecar_contract();
+    println!("{}", serde_json::to_string_pretty(&contract).unwrap());
 }
 
 fn run_daemon(args: DaemonArgs) {

--- a/crates/voice-stream/Cargo.toml
+++ b/crates/voice-stream/Cargo.toml
@@ -9,6 +9,4 @@ repository = "https://github.com/rgbkrk/voice"
 
 [dependencies]
 serde = { workspace = true }
-
-[dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/voice-stream/src/lib.rs
+++ b/crates/voice-stream/src/lib.rs
@@ -29,6 +29,111 @@ pub const WEBRTC_MAX_INBOUND_QUEUE_BYTES: usize =
     WEBRTC_SAMPLE_RATE as usize * WEBRTC_CHANNELS as usize * PCM_S16LE_BYTES_PER_SAMPLE * 10;
 pub const WEBRTC_MAX_DRAIN_WAIT_MS: u32 = 5_000;
 
+/// Machine-readable local WebRTC sidecar contract.
+///
+/// This mirrors `docs/contracts/webrtc-sidecar-v1.json` while deriving the
+/// audio shape from the crate constants. Installed `voice` binaries can print
+/// this value with `voice stream-contract` so Hermes and sidecar processes do
+/// not need a source checkout to discover the PCM boundary.
+pub fn webrtc_sidecar_contract() -> serde_json::Value {
+    serde_json::json!({
+        "contract": "voice.webrtc_sidecar",
+        "version": 1,
+        "status": "experimental",
+        "summary": "Local HTTP/WebRTC bridge contract for WhatsApp Calling and voice streaming experiments.",
+        "audio": {
+            "sample_rate": WEBRTC_SAMPLE_RATE,
+            "channels": WEBRTC_CHANNELS,
+            "frame_ms": WEBRTC_FRAME_MS,
+            "encoding": "pcm_s16le",
+            "bytes_per_sample": PCM_S16LE_BYTES_PER_SAMPLE,
+            "samples_per_frame": WEBRTC_SAMPLES_PER_FRAME,
+            "frame_bytes": WEBRTC_FRAME_BYTES,
+            "default_drain_bytes": WEBRTC_DEFAULT_DRAIN_BYTES,
+            "max_outbound_queue_bytes": WEBRTC_MAX_OUTBOUND_QUEUE_BYTES,
+            "max_inbound_queue_bytes": WEBRTC_MAX_INBOUND_QUEUE_BYTES,
+            "max_drain_wait_ms": WEBRTC_MAX_DRAIN_WAIT_MS
+        },
+        "endpoints": {
+            "contract": {
+                "method": "GET",
+                "path": "/contract",
+                "description": "Return this machine-readable contract."
+            },
+            "health": {
+                "method": "GET",
+                "path": "/health",
+                "description": "Return process health, active call IDs, and the fixed audio shape."
+            },
+            "offer": {
+                "method": "POST",
+                "path": "/offer",
+                "description": "Create or replace a call session from a remote SDP offer and return a local SDP answer."
+            },
+            "call_status": {
+                "method": "GET",
+                "path": "/calls/{call_id}",
+                "description": "Inspect a live call session and queue depths."
+            },
+            "receive_audio": {
+                "method": "GET",
+                "path": "/calls/{call_id}/audio",
+                "query": {
+                    "max_bytes": "Positive byte count aligned to whole s16le samples. Defaults to audio.default_drain_bytes and is capped by audio.max_inbound_queue_bytes.",
+                    "wait_ms": "Optional non-negative long-poll timeout. Capped by audio.max_drain_wait_ms."
+                },
+                "description": "Drain decoded inbound PCM from a live call session."
+            },
+            "send_audio": {
+                "method": "POST",
+                "path": "/calls/{call_id}/audio",
+                "description": "Queue outbound PCM for a live call session."
+            },
+            "close_call": {
+                "method": "POST",
+                "path": "/calls/{call_id}/close",
+                "description": "Close and remove a live call session."
+            }
+        },
+        "payloads": {
+            "send_audio_request": {
+                "sample_rate": "audio.sample_rate",
+                "channels": "audio.channels",
+                "frame_ms": "audio.frame_ms",
+                "encoding": "audio.encoding",
+                "pcm_s16le_base64": "Required base64 encoded signed 16-bit little-endian mono PCM."
+            },
+            "send_audio_response": {
+                "call_id": "Call session identifier.",
+                "accepted_bytes": "Number of outbound PCM bytes accepted into the per-call queue.",
+                "queued_tx_bytes": "Outbound PCM bytes queued after this write.",
+                "max_tx_queue_bytes": "Maximum outbound PCM bytes this sidecar will queue for one call.",
+                "audio": "Full fixed audio contract object defined by audio."
+            },
+            "receive_audio_response": {
+                "call_id": "Call session identifier.",
+                "returned_bytes": "Number of decoded PCM bytes returned.",
+                "queued_rx_bytes": "Remaining inbound decoded PCM bytes queued after this drain.",
+                "pcm_s16le_base64": "Base64 encoded signed 16-bit little-endian mono PCM.",
+                "audio": "Full fixed audio contract object defined by audio."
+            },
+            "audio_shape": {
+                "sample_rate": "audio.sample_rate",
+                "channels": "audio.channels",
+                "frame_ms": "audio.frame_ms",
+                "encoding": "audio.encoding",
+                "bytes_per_sample": "audio.bytes_per_sample",
+                "samples_per_frame": "audio.samples_per_frame",
+                "frame_bytes": "audio.frame_bytes",
+                "default_drain_bytes": "audio.default_drain_bytes",
+                "max_outbound_queue_bytes": "audio.max_outbound_queue_bytes",
+                "max_inbound_queue_bytes": "audio.max_inbound_queue_bytes",
+                "max_drain_wait_ms": "audio.max_drain_wait_ms"
+            }
+        }
+    })
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AudioEncoding {
@@ -394,6 +499,7 @@ mod tests {
             panic!("parse {}: {err}", contract_path.display());
         });
 
+        assert_eq!(contract, webrtc_sidecar_contract());
         assert_eq!(contract["contract"], "voice.webrtc_sidecar");
         assert_eq!(contract["version"], 1);
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -152,6 +152,11 @@ Use `sample_rate: 48000` and `frame_ms: 20` for a WebRTC-friendly stream.
 The WebRTC-friendly constants live in the `voice-stream` crate and are checked
 against the machine-readable sidecar v1 shape in
 [`docs/contracts/webrtc-sidecar-v1.json`](contracts/webrtc-sidecar-v1.json).
+Installed binaries expose the same object with:
+
+```bash
+voice stream-contract
+```
 
 ### STT Input
 

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -139,7 +139,8 @@ The exact transport can be Unix socket, local HTTP, or WebSocket. The first
 implementation should favor debuggability over abstraction. The canonical v1
 PCM and endpoint contract is machine-readable at
 [`docs/contracts/webrtc-sidecar-v1.json`](contracts/webrtc-sidecar-v1.json), and
-the Python sidecar exposes the same object at `GET /contract`.
+installed `voice` binaries print the same object with `voice stream-contract`.
+The Python sidecar exposes the same object at `GET /contract`.
 
 The sidecar HTTP API is a local control plane, not a public web API. It should
 bind to localhost or a private socket, with Hermes as the caller. Only the

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -8,7 +8,8 @@ It accepts a remote SDP offer over local HTTP, creates a WebRTC answer, sends a
 inbound audio to a raw PCM file. `aiortc` handles Opus RTP, ICE, DTLS, and SRTP.
 The machine-readable v1 contract lives at
 [`docs/contracts/webrtc-sidecar-v1.json`](../../docs/contracts/webrtc-sidecar-v1.json)
-and is also exposed by the sidecar at `GET /contract`.
+and can be printed from an installed binary with `voice stream-contract`. It is
+also exposed by the sidecar at `GET /contract`.
 
 This is a spike. It does not call the WhatsApp Graph API, authenticate requests,
 run VAD, or manage Hermes sessions. Hermes should still own WhatsApp Cloud
@@ -89,6 +90,7 @@ Check process health and the fixed local audio contract:
 ```bash
 curl -sS http://127.0.0.1:8787/contract
 curl -sS http://127.0.0.1:8787/health
+voice stream-contract
 ```
 
 Post a remote offer:


### PR DESCRIPTION
## Summary
- add `voice stream-contract` to print the machine-readable WebRTC sidecar v1 contract from the installed binary
- expose the contract from `voice-stream` via constants-derived JSON and assert it exactly matches `docs/contracts/webrtc-sidecar-v1.json`
- document the installed-binary contract path for Hermes, sidecars, and WebRTC tests

## Verification
- `cargo fmt --check`
- `cargo test -p voice-stream` -> 12 passed
- `cargo test -p voice` -> 5 passed, 22 ignored model-dependent JSON-RPC tests
- `target/debug/voice stream-contract > /tmp/voice-stream-contract.json` plus JSON parse/compare against `docs/contracts/webrtc-sidecar-v1.json` -> matched
