### PR TITLE
Load sidecar contract from voice command

### DIFF
--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -10,6 +10,9 @@ The machine-readable v1 contract lives at
 [`docs/contracts/webrtc-sidecar-v1.json`](../../docs/contracts/webrtc-sidecar-v1.json)
 and can be printed from an installed binary with `voice stream-contract`. It is
 also exposed by the sidecar at `GET /contract`.
+When the checked-in JSON is not present, the Python sidecar helpers fall back to
+`$VOICE_BIN stream-contract` or `voice stream-contract` so a packaged sidecar can
+discover the same PCM contract from an installed binary.
 
 This is a spike. It does not call the WhatsApp Graph API, authenticate requests,
 run VAD, or manage Hermes sessions. Hermes should still own WhatsApp Cloud

--- a/examples/webrtc-sidecar/post_voice_stream.py
+++ b/examples/webrtc-sidecar/post_voice_stream.py
@@ -17,6 +17,7 @@ import argparse
 import base64
 from dataclasses import dataclass
 import json
+import os
 from pathlib import Path
 import subprocess
 import sys
@@ -52,9 +53,15 @@ class SidecarAudioPostError(RuntimeError):
         )
 
 
-def load_audio_contract(path: Path = CONTRACT_PATH) -> AudioContract:
-    with path.open(encoding="utf-8") as contract_file:
-        contract = json.load(contract_file)
+def load_audio_contract(
+    path: Path = CONTRACT_PATH,
+    voice_bin: str | None = None,
+) -> AudioContract:
+    if path.exists():
+        with path.open(encoding="utf-8") as contract_file:
+            contract = json.load(contract_file)
+    else:
+        contract = load_contract_from_voice(voice_bin)
 
     audio = contract.get("audio")
     if not isinstance(audio, dict):
@@ -95,6 +102,27 @@ def load_audio_contract(path: Path = CONTRACT_PATH) -> AudioContract:
         raise ValueError("contract max_drain_wait_ms must be non-negative")
 
     return parsed
+
+
+def load_contract_from_voice(voice_bin: str | None = None) -> dict[str, object]:
+    command = [voice_bin or os.environ.get("VOICE_BIN", "voice"), "stream-contract"]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        )
+    except (
+        FileNotFoundError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+    ) as exc:
+        raise RuntimeError(
+            "could not load WebRTC contract from docs JSON or `voice stream-contract`"
+        ) from exc
+    return json.loads(result.stdout)
 
 
 def sidecar_audio_url(sidecar_url: str, call_id: str) -> str:

--- a/examples/webrtc-sidecar/sidecar.py
+++ b/examples/webrtc-sidecar/sidecar.py
@@ -23,6 +23,7 @@ import logging
 import os
 from pathlib import Path
 import signal
+import subprocess
 import sys
 from typing import Any
 
@@ -42,11 +43,38 @@ LOGGER = logging.getLogger("voice-webrtc-sidecar")
 CONTRACT_PATH = Path(__file__).resolve().parents[2] / "docs/contracts/webrtc-sidecar-v1.json"
 
 
-def load_contract() -> dict[str, Any]:
-    with CONTRACT_PATH.open(encoding="utf-8") as contract_file:
-        contract = json.load(contract_file)
+def load_contract(
+    path: Path = CONTRACT_PATH,
+    voice_bin: str | None = None,
+) -> dict[str, Any]:
+    if path.exists():
+        with path.open(encoding="utf-8") as contract_file:
+            contract = json.load(contract_file)
+    else:
+        contract = load_contract_from_voice(voice_bin)
     validate_contract(contract)
     return contract
+
+
+def load_contract_from_voice(voice_bin: str | None = None) -> dict[str, Any]:
+    command = [voice_bin or os.environ.get("VOICE_BIN", "voice"), "stream-contract"]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        )
+    except (
+        FileNotFoundError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+    ) as exc:
+        raise RuntimeError(
+            "could not load WebRTC contract from docs JSON or `voice stream-contract`"
+        ) from exc
+    return json.loads(result.stdout)
 
 
 def validate_contract(contract: dict[str, Any]) -> None:

--- a/examples/webrtc-sidecar/test_post_voice_stream.py
+++ b/examples/webrtc-sidecar/test_post_voice_stream.py
@@ -37,6 +37,41 @@ def test_load_audio_contract_matches_sidecar_contract():
     assert contract.max_drain_wait_ms == 5_000
 
 
+def test_load_audio_contract_falls_back_to_voice_stream_contract(monkeypatch, tmp_path: Path):
+    bridge = load_bridge()
+    calls = []
+    contract_json = {
+        "audio": {
+            "sample_rate": 48_000,
+            "channels": 1,
+            "frame_ms": 20,
+            "encoding": "pcm_s16le",
+            "frame_bytes": 1_920,
+            "default_drain_bytes": 96_000,
+            "max_outbound_queue_bytes": 960_000,
+            "max_drain_wait_ms": 5_000,
+        }
+    }
+
+    class Completed:
+        stdout = json.dumps(contract_json)
+
+    def fake_run(command, *, capture_output, text, timeout, check):
+        calls.append((command, capture_output, text, timeout, check))
+        return Completed()
+
+    monkeypatch.setattr(bridge.subprocess, "run", fake_run)
+
+    contract = bridge.load_audio_contract(
+        tmp_path / "missing.json",
+        voice_bin="/opt/voice",
+    )
+
+    assert contract.sample_rate == 48_000
+    assert contract.frame_bytes == 1_920
+    assert calls == [(["/opt/voice", "stream-contract"], True, True, 5, True)]
+
+
 def test_load_audio_contract_rejects_invalid_audio_shape(tmp_path: Path):
     bridge = load_bridge()
     contract_path = tmp_path / "contract.json"

--- a/examples/webrtc-sidecar/test_sidecar.py
+++ b/examples/webrtc-sidecar/test_sidecar.py
@@ -76,6 +76,25 @@ def test_audio_contract_is_voice_pcm_shape():
     assert sidecar.MAX_OUTBOUND_QUEUE_BYTES == 960_000
 
 
+def test_load_contract_falls_back_to_voice_stream_contract(monkeypatch, tmp_path: Path):
+    sidecar = load_sidecar()
+    calls = []
+
+    class Completed:
+        stdout = json.dumps(sidecar.CONTRACT)
+
+    def fake_run(command, *, capture_output, text, timeout, check):
+        calls.append((command, capture_output, text, timeout, check))
+        return Completed()
+
+    monkeypatch.setattr(sidecar.subprocess, "run", fake_run)
+
+    contract = sidecar.load_contract(tmp_path / "missing.json", voice_bin="/opt/voice")
+
+    assert contract == sidecar.CONTRACT
+    assert calls == [(["/opt/voice", "stream-contract"], True, True, 5, True)]
+
+
 def test_contract_endpoint_returns_machine_readable_contract():
     sidecar = load_sidecar()
 


### PR DESCRIPTION
## Summary
- make the Python WebRTC sidecar and stdlib helpers fall back to `voice stream-contract` when `docs/contracts/webrtc-sidecar-v1.json` is unavailable
- honor `$VOICE_BIN` for packaged sidecars that need to point at a specific installed binary
- document the fallback path and cover it in sidecar/helper tests

## Verification
- `python3 -m py_compile examples/webrtc-sidecar/sidecar.py examples/webrtc-sidecar/post_voice_stream.py examples/webrtc-sidecar/drain_sidecar_audio.py examples/webrtc-sidecar/test_sidecar.py examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/test_drain_sidecar_audio.py`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/test_drain_sidecar_audio.py` -> 34 passed
