### PR TITLE
Clarify streamed Ogg/Opus output

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ voice say --format ogg-opus -o speech.ogg "Good morning everyone."
 # Stream daemon TTS frames for bridge/WebRTC experiments
 voice stream-contract
 voice stream --sample-rate 48000 --frame-ms 20 --raw-output speech.s16le "Good morning everyone."
-voice stream --sample-rate 48000 --frame-ms 20 --raw-output - "Good morning everyone." \
-  | ffmpeg -f s16le -ar 48000 -ac 1 -i - -c:a libopus speech.ogg
+voice stream --sample-rate 48000 --frame-ms 20 --output streamed.ogg --format ogg-opus "Good morning everyone."
 
 # Replay a WAV through daemon streaming STT
 voice stream-transcribe recording.wav
@@ -155,7 +154,8 @@ Options:
 
 Streams ordered PCM frames from a daemon started with `voice daemon start`. Use
 this for bridge and WebRTC experiments where clients need audio chunks instead
-of a completed WAV file.
+of a completed WAV file. `--raw-output` writes headerless PCM for a sidecar or
+test harness; `--output` writes streamed Ogg/Opus without first creating a WAV.
 
 ```
 Usage: voice stream [OPTIONS] [TEXT]...
@@ -168,6 +168,10 @@ Options:
       --frame-ms <FRAME_MS>        Target frame duration in milliseconds [default: 20]
   -o, --raw-output <PATH>          Write raw signed 16-bit little-endian mono PCM
                                    (use - for stdout)
+      --output <PATH>              Write streamed audio to an Ogg/Opus file
+                                   (use - for stdout with --format ogg-opus)
+      --format <FORMAT>            Output container/codec for --output
+                                   [possible values: ogg-opus]
       --json                       Print full JSON stream events
       --markdown                   Strip markdown/MDX formatting before speaking
       --sub <WORD=REPLACEMENT>     Word substitution (repeatable)

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -193,6 +193,19 @@ impl From<SayOutputFormat> for voice_audio::AudioOutputFormat {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum StreamOutputFormat {
+    OggOpus,
+}
+
+impl From<StreamOutputFormat> for voice_audio::AudioOutputFormat {
+    fn from(format: StreamOutputFormat) -> Self {
+        match format {
+            StreamOutputFormat::OggOpus => Self::OggOpus,
+        }
+    }
+}
+
 #[derive(clap::Args, Debug)]
 struct StreamArgs {
     /// Text to stream
@@ -229,7 +242,7 @@ struct StreamArgs {
 
     /// Output container/codec for --output. Defaults from extension: .ogg, .opus
     #[arg(long = "format", value_enum, requires = "output")]
-    format: Option<SayOutputFormat>,
+    format: Option<StreamOutputFormat>,
 
     /// Print full JSON stream events instead of compact summaries
     #[arg(long)]
@@ -1755,7 +1768,7 @@ fn validate_stream_frame_params(sample_rate: u32, frame_ms: u32) -> Result<(), S
 
 fn resolve_stream_output_format(
     path: &Path,
-    explicit: Option<SayOutputFormat>,
+    explicit: Option<StreamOutputFormat>,
 ) -> Result<voice_audio::AudioOutputFormat, String> {
     let explicit = explicit.map(voice_audio::AudioOutputFormat::from);
     let format = if path.as_os_str() == std::ffi::OsStr::new("-") {
@@ -2389,7 +2402,7 @@ mod tests {
             voice_audio::AudioOutputFormat::OggOpus
         );
         assert_eq!(
-            resolve_stream_output_format(Path::new("reply"), Some(SayOutputFormat::OggOpus))
+            resolve_stream_output_format(Path::new("reply"), Some(StreamOutputFormat::OggOpus))
                 .unwrap(),
             voice_audio::AudioOutputFormat::OggOpus
         );
@@ -2401,7 +2414,8 @@ mod tests {
         assert!(resolve_stream_output_format(Path::new("reply"), None).is_err());
         assert!(resolve_stream_output_format(Path::new("-"), None).is_err());
         assert_eq!(
-            resolve_stream_output_format(Path::new("-"), Some(SayOutputFormat::OggOpus)).unwrap(),
+            resolve_stream_output_format(Path::new("-"), Some(StreamOutputFormat::OggOpus))
+                .unwrap(),
             voice_audio::AudioOutputFormat::OggOpus
         );
     }


### PR DESCRIPTION
## Summary
- give `voice stream --format` its own Ogg/Opus-only value enum so help and clap validation do not advertise unsupported WAV stream output
- update the README stream examples to use native `voice stream --output ... --format ogg-opus` instead of a manual raw PCM to ffmpeg pipeline
- document the distinction between `--raw-output` PCM frames and `--output` streamed Ogg/Opus

## Verification
- `cargo fmt --check`
- `cargo test -p voice`
- `cargo test -p voice-audio stream_ogg_opus_writer_writes_opus_mono_48khz -- --nocapture`
- `cargo test -p voice-audio save_ogg_opus_writes_opus_mono_48khz -- --nocapture`
- `cargo run -q -p voice -- stream --help`
- `cargo run -q -p voice -- stream --output reply.wav --format wav hello` exits with clap error and `[possible values: ogg-opus]`
