### PR TITLE
Expand WebRTC sidecar contract payloads

### DIFF
--- a/crates/voice-stream/src/lib.rs
+++ b/crates/voice-stream/src/lib.rs
@@ -96,6 +96,36 @@ pub fn webrtc_sidecar_contract() -> serde_json::Value {
             }
         },
         "payloads": {
+            "offer_request": {
+                "call_id": "Required call session identifier from the WhatsApp Calling webhook.",
+                "type": "Required SDP type. v1 accepts offer.",
+                "sdp": "Required remote SDP offer from WhatsApp. remote_sdp is accepted as an alias by the Python sidecar."
+            },
+            "offer_response": {
+                "call_id": "Call session identifier.",
+                "type": "Local SDP type, usually answer.",
+                "sdp": "Local SDP answer to pass unchanged to WhatsApp pre_accept and accept actions.",
+                "audio": "Full fixed audio contract object defined by audio.",
+                "state": "Current call_state object after local SDP answer creation."
+            },
+            "call_state": {
+                "call_id": "Call session identifier.",
+                "closed": "Whether the local sidecar session has been closed.",
+                "connection_state": "WebRTC peer connection state.",
+                "ice_connection_state": "ICE connection state.",
+                "ice_gathering_state": "ICE gathering state.",
+                "signaling_state": "WebRTC signaling state.",
+                "tasks": "Number of active background media tasks owned by the session.",
+                "queued_tx_bytes": "Outbound PCM bytes queued for WebRTC transmission.",
+                "max_tx_queue_bytes": "Maximum outbound PCM bytes this sidecar will queue for one call.",
+                "queued_rx_bytes": "Inbound decoded PCM bytes queued for Hermes to drain.",
+                "audio": "Full fixed audio contract object defined by audio."
+            },
+            "call_status_response": "The call_state object for the requested call_id.",
+            "close_call_response": {
+                "call_id": "Call session identifier.",
+                "closed": "Always true when the close request succeeds."
+            },
             "send_audio_request": {
                 "sample_rate": "audio.sample_rate",
                 "channels": "audio.channels",
@@ -129,6 +159,9 @@ pub fn webrtc_sidecar_contract() -> serde_json::Value {
                 "max_outbound_queue_bytes": "audio.max_outbound_queue_bytes",
                 "max_inbound_queue_bytes": "audio.max_inbound_queue_bytes",
                 "max_drain_wait_ms": "audio.max_drain_wait_ms"
+            },
+            "error_response": {
+                "error": "Human-readable error message. Non-2xx responses use this shape."
             }
         }
     })
@@ -521,6 +554,24 @@ mod tests {
             WEBRTC_MAX_INBOUND_QUEUE_BYTES
         );
         assert_eq!(audio["max_drain_wait_ms"], WEBRTC_MAX_DRAIN_WAIT_MS);
+
+        let payloads = &contract["payloads"];
+        assert_eq!(
+            payloads["offer_request"]["call_id"],
+            "Required call session identifier from the WhatsApp Calling webhook."
+        );
+        assert_eq!(
+            payloads["offer_response"]["sdp"],
+            "Local SDP answer to pass unchanged to WhatsApp pre_accept and accept actions."
+        );
+        assert_eq!(
+            payloads["call_state"]["queued_rx_bytes"],
+            "Inbound decoded PCM bytes queued for Hermes to drain."
+        );
+        assert_eq!(
+            payloads["error_response"]["error"],
+            "Human-readable error message. Non-2xx responses use this shape."
+        );
     }
 
     #[test]

--- a/docs/contracts/webrtc-sidecar-v1.json
+++ b/docs/contracts/webrtc-sidecar-v1.json
@@ -58,6 +58,36 @@
     }
   },
   "payloads": {
+    "offer_request": {
+      "call_id": "Required call session identifier from the WhatsApp Calling webhook.",
+      "type": "Required SDP type. v1 accepts offer.",
+      "sdp": "Required remote SDP offer from WhatsApp. remote_sdp is accepted as an alias by the Python sidecar."
+    },
+    "offer_response": {
+      "call_id": "Call session identifier.",
+      "type": "Local SDP type, usually answer.",
+      "sdp": "Local SDP answer to pass unchanged to WhatsApp pre_accept and accept actions.",
+      "audio": "Full fixed audio contract object defined by audio.",
+      "state": "Current call_state object after local SDP answer creation."
+    },
+    "call_state": {
+      "call_id": "Call session identifier.",
+      "closed": "Whether the local sidecar session has been closed.",
+      "connection_state": "WebRTC peer connection state.",
+      "ice_connection_state": "ICE connection state.",
+      "ice_gathering_state": "ICE gathering state.",
+      "signaling_state": "WebRTC signaling state.",
+      "tasks": "Number of active background media tasks owned by the session.",
+      "queued_tx_bytes": "Outbound PCM bytes queued for WebRTC transmission.",
+      "max_tx_queue_bytes": "Maximum outbound PCM bytes this sidecar will queue for one call.",
+      "queued_rx_bytes": "Inbound decoded PCM bytes queued for Hermes to drain.",
+      "audio": "Full fixed audio contract object defined by audio."
+    },
+    "call_status_response": "The call_state object for the requested call_id.",
+    "close_call_response": {
+      "call_id": "Call session identifier.",
+      "closed": "Always true when the close request succeeds."
+    },
     "send_audio_request": {
       "sample_rate": "audio.sample_rate",
       "channels": "audio.channels",
@@ -91,6 +121,9 @@
       "max_outbound_queue_bytes": "audio.max_outbound_queue_bytes",
       "max_inbound_queue_bytes": "audio.max_inbound_queue_bytes",
       "max_drain_wait_ms": "audio.max_drain_wait_ms"
+    },
+    "error_response": {
+      "error": "Human-readable error message. Non-2xx responses use this shape."
     }
   }
 }

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -1,6 +1,6 @@
 # WhatsApp Calling / WebRTC Architecture
 
-Status: planning document, current as of 2026-06-13.
+Status: architecture and spike document, current as of 2026-06-14.
 
 This document describes how `voice` should fit into Hermes + WhatsApp beyond
 file-based voice notes. The short version:
@@ -140,7 +140,10 @@ implementation should favor debuggability over abstraction. The canonical v1
 PCM and endpoint contract is machine-readable at
 [`docs/contracts/webrtc-sidecar-v1.json`](contracts/webrtc-sidecar-v1.json), and
 installed `voice` binaries print the same object with `voice stream-contract`.
-The Python sidecar exposes the same object at `GET /contract`.
+The Python sidecar exposes the same object at `GET /contract`. The contract
+defines the fixed PCM audio shape plus the `/offer`, call-state, audio send,
+audio drain, close, and error payloads Hermes needs to drive WhatsApp Calling
+without hard-coding sidecar response shapes.
 
 The sidecar HTTP API is a local control plane, not a public web API. It should
 bind to localhost or a private socket, with Hermes as the caller. Only the
@@ -306,12 +309,14 @@ that path.
 
 ## PR Sequence
 
-1. Keep direct Ogg/Opus file output in `voice` and Hermes.
-2. Add this architecture document and track open questions.
-3. Add a `voice` streaming STT input API that accepts fixed PCM frames.
+1. Keep direct Ogg/Opus file output in `voice` and Hermes. Done for `voice`;
+   Hermes wiring is staged separately.
+2. Add this architecture document and track open questions. Done.
+3. Add a `voice` streaming STT input API that accepts fixed PCM frames. Done.
 4. Prototype a sidecar that accepts a synthetic SDP offer and round-trips PCM.
    The initial `examples/webrtc-sidecar` artifact covers the SDP answer,
-   outbound PCM-to-Opus/WebRTC track, and inbound decoded PCM sink.
+   outbound PCM-to-Opus/WebRTC track, inbound decoded PCM sink, and local HTTP
+   send/drain endpoints. Done as a spike.
 5. Wire Hermes WhatsApp Cloud `connect` webhooks to the sidecar.
 6. Build an inbound-call echo bot: WhatsApp audio in, same audio out.
 7. Replace echo with STT -> Hermes turn -> `stream_speak` TTS.


### PR DESCRIPTION
## Summary
- expand `voice stream-contract` and `docs/contracts/webrtc-sidecar-v1.json` with `/offer`, call-state, close, and error payload shapes
- pin the new SDP/call-state payload entries in `voice-stream` tests
- update the WhatsApp Calling architecture doc to reflect the current sidecar/STT spike state

## Verification
- `cargo fmt --check`
- `cargo test -p voice-stream`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/test_drain_sidecar_audio.py`
- `diff -u <(jq -S . docs/contracts/webrtc-sidecar-v1.json) <(cargo run -q -p voice -- stream-contract | jq -S .)`
