### PR TITLE
Support Ogg Opus input for STT

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ voice stream-contract
 voice stream --sample-rate 48000 --frame-ms 20 --raw-output speech.s16le "Good morning everyone."
 voice stream --sample-rate 48000 --frame-ms 20 --output streamed.ogg --format ogg-opus "Good morning everyone."
 
-# Replay a WAV through daemon streaming STT
-voice stream-transcribe recording.wav
+# Replay audio through daemon streaming STT
+voice stream-transcribe recording.ogg
 
 # Read from a file, strip markdown
 voice say --markdown -f blog-post.mdx
@@ -84,7 +84,7 @@ voice listen
 voice listen --continuous
 
 # Transcribe an audio file
-voice transcribe recording.wav
+voice transcribe recording.ogg
 
 # JSON-RPC server for agent integration
 voice serve
@@ -190,7 +190,7 @@ Usage: voice stream-contract
 
 ### `voice stream-transcribe`
 
-Replays WAV or raw PCM audio as ordered frames into a daemon started with
+Replays an audio file or raw PCM as ordered frames into a daemon started with
 `voice daemon start`. Use this to smoke-test the inbound STT stream contract
 that WebRTC and bridge clients use.
 
@@ -198,7 +198,7 @@ that WebRTC and bridge clients use.
 Usage: voice stream-transcribe [OPTIONS] [FILE]
 
 Arguments:
-  [FILE]                 Path to WAV audio file
+  [FILE]                 Path to an audio file
 
 Options:
       --raw-input <PATH>           Read raw signed 16-bit little-endian mono PCM
@@ -214,7 +214,8 @@ Options:
 ### `voice transcribe`
 
 ```
-Transcribe a WAV audio file
+Transcribe an audio file. WAV input is decoded directly; Ogg/Opus and other
+compressed formats use `ffmpeg` when available.
 
 Usage: voice transcribe <FILE>
 ```
@@ -338,7 +339,7 @@ For lower-level streaming, `stream_speak` emits `tts.started`, `tts.audio`, and
 terminal `tts.ended` / `tts.error` / `tts.cancelled` events over the same daemon
 frame protocol. `stream_transcribe` accepts client-sent `stt.audio` frames and
 returns a terminal `stt.transcribed` event. Use `voice stream-transcribe` to
-replay a WAV through that inbound stream path. See
+replay WAV or Ogg/Opus audio through that inbound stream path. See
 [docs/streaming.md](docs/streaming.md) for the event schema and Hermes/WebRTC
 notes. See
 [docs/whatsapp-calling-webrtc.md](docs/whatsapp-calling-webrtc.md) for the
@@ -480,7 +481,7 @@ fn main() -> voice_tts::Result<()> {
 ```rust
 fn main() -> voice_stt::Result<()> {
     let mut model = voice_stt::load_model("distil-whisper/distil-large-v3")?;
-    let result = voice_stt::transcribe(&mut model, "audio.wav")?;
+    let result = voice_stt::transcribe(&mut model, "audio.ogg")?;
     println!("{}", result.text);
     Ok(())
 }

--- a/crates/voice-cli/README.md
+++ b/crates/voice-cli/README.md
@@ -54,7 +54,7 @@ voice listen
 voice listen --continuous
 
 # Transcribe an audio file
-voice transcribe recording.wav
+voice transcribe recording.ogg
 
 # JSON-RPC 2.0 server on stdin/stdout
 voice serve -v am_michael
@@ -73,7 +73,7 @@ Commands:
   stream      Stream TTS audio chunks from the voice daemon
   converse    Speak text aloud, then listen for a response
   listen      Record from microphone and transcribe (speech-to-text)
-  transcribe  Transcribe a WAV audio file
+  transcribe  Transcribe an audio file
   serve       Run as a JSON-RPC 2.0 server on stdin/stdout
   mcp         Run as an MCP server on stdin/stdout
   daemon      Inspect and control a running voice daemon
@@ -153,6 +153,8 @@ Options:
 ### `voice transcribe`
 
 ```
+Transcribe an audio file
+
 Usage: voice transcribe <FILE>
 ```
 

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -132,56 +132,11 @@ pub fn load_wav_sound(path: &std::path::Path) -> Result<CachedSound, String> {
     })
 }
 
-pub fn load_transcription_wav(path: &Path) -> Result<TranscriptionAudio, String> {
-    let reader = hound::WavReader::open(path)
-        .map_err(|e| format!("Failed to open {}: {e}", path.display()))?;
-
-    let spec = reader.spec();
-    let channels = spec.channels as usize;
-    let sample_rate = spec.sample_rate;
-
-    if sample_rate == 0 {
-        return Err("Invalid WAV: sample rate is 0".to_string());
-    }
-    if channels == 0 {
-        return Err("Invalid WAV: channel count is 0".to_string());
-    }
-
-    let samples: Vec<f32> = match spec.sample_format {
-        hound::SampleFormat::Int => {
-            let bits = spec.bits_per_sample;
-            if bits == 0 || bits > 32 {
-                return Err(format!(
-                    "Unsupported bits_per_sample {bits}; expected 1..=32"
-                ));
-            }
-            let max_val = (1u32 << (bits - 1)) as f32;
-            reader
-                .into_samples::<i32>()
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|e| format!("Failed to read WAV samples: {e}"))?
-                .into_iter()
-                .map(|s| s as f32 / max_val)
-                .collect()
-        }
-        hound::SampleFormat::Float => reader
-            .into_samples::<f32>()
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| format!("Failed to read WAV samples: {e}"))?,
-    };
-
-    let mono = if channels > 1 {
-        samples
-            .chunks(channels)
-            .map(|frame| frame.iter().sum::<f32>() / channels as f32)
-            .collect()
-    } else {
-        samples
-    };
-
+pub fn load_transcription_audio(path: &Path) -> Result<TranscriptionAudio, String> {
+    let audio = voice_stt::load_audio_file(path).map_err(|e| e.to_string())?;
     Ok(TranscriptionAudio {
-        samples: mono,
-        sample_rate,
+        samples: audio.samples,
+        sample_rate: audio.sample_rate,
     })
 }
 
@@ -1470,7 +1425,7 @@ pub fn listen_and_transcribe_vad_warm(
     transcribe_samples(model, &samples, sample_rate)
 }
 
-/// Transcribe a WAV file and print the result.
+/// Transcribe an audio file and print the result.
 ///
 /// Entry point for `voice --transcribe <file>`.
 pub fn transcribe_file(path: &Path) {
@@ -1480,7 +1435,7 @@ pub fn transcribe_file(path: &Path) {
         eprintln!("Transcribing: {}", path.display());
     }
 
-    let audio = match load_transcription_wav(path) {
+    let audio = match load_transcription_audio(path) {
         Ok(audio) => audio,
         Err(e) => {
             eprintln!("{e}");

--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -44,10 +44,10 @@ macro_rules! info {
                   voice stream --json \"Hello world\"\n  \
                   voice stream --output reply.ogg --format ogg-opus \"Hello world\"\n  \
                   voice stream-contract\n  \
-                  voice stream-transcribe recording.wav\n  \
+                  voice stream-transcribe recording.ogg\n  \
                   voice listen\n  \
                   voice listen --continuous\n  \
-                  voice transcribe recording.wav\n  \
+                  voice transcribe recording.ogg\n  \
                   voice daemon start --tts-only\n  \
                   voice daemon status\n  \
                   voice serve -v am_michael"
@@ -77,7 +77,7 @@ enum Command {
     /// Stream TTS audio chunks from the voice daemon
     Stream(StreamArgs),
 
-    /// Replay WAV or raw PCM audio through daemon streaming STT
+    /// Replay an audio file or raw PCM through daemon streaming STT
     StreamTranscribe(StreamTranscribeArgs),
 
     /// Print the machine-readable WebRTC sidecar stream contract
@@ -89,7 +89,7 @@ enum Command {
     /// Record from microphone and transcribe (speech-to-text)
     Listen(ListenArgs),
 
-    /// Transcribe a WAV audio file
+    /// Transcribe an audio file
     Transcribe(TranscribeArgs),
 
     /// Run as a JSON-RPC 2.0 server on stdin/stdout
@@ -264,7 +264,7 @@ struct StreamArgs {
 
 #[derive(clap::Args, Debug)]
 struct StreamTranscribeArgs {
-    /// Path to WAV audio file
+    /// Path to an audio file
     #[arg(required_unless_present = "raw_input", conflicts_with = "raw_input")]
     file: Option<PathBuf>,
 
@@ -326,7 +326,7 @@ struct ListenArgs {
 
 #[derive(clap::Args, Debug)]
 struct TranscribeArgs {
-    /// Path to WAV audio file
+    /// Path to an audio file
     file: PathBuf,
 }
 
@@ -1690,8 +1690,8 @@ fn load_stream_transcribe_input(
     let file = stream_args
         .file
         .as_ref()
-        .ok_or_else(|| "Path to WAV audio file or --raw-input is required".to_string())?;
-    let audio = listen::load_transcription_wav(file)?;
+        .ok_or_else(|| "Path to an audio file or --raw-input is required".to_string())?;
+    let audio = listen::load_transcription_audio(file)?;
     validate_stream_frame_params(audio.sample_rate, stream_args.frame_ms)
         .map_err(|e| format!("voice stream-transcribe: {e}"))?;
     let frames =
@@ -2418,5 +2418,91 @@ mod tests {
                 .unwrap(),
             voice_audio::AudioOutputFormat::OggOpus
         );
+    }
+
+    #[test]
+    fn stream_transcribe_input_accepts_ogg_opus_files() {
+        if !command_available("ffmpeg") {
+            eprintln!(
+                "skipping stream-transcribe Ogg/Opus input test because ffmpeg is not on PATH"
+            );
+            return;
+        }
+
+        let wav_path = temp_audio_path("stream_transcribe_source", "wav");
+        let ogg_path = temp_audio_path("stream_transcribe_source", "ogg");
+        let sample_rate = 24_000u32;
+        let samples: Vec<f32> = (0..sample_rate / 10)
+            .map(|i| (2.0 * std::f32::consts::PI * 440.0 * i as f32 / sample_rate as f32).sin())
+            .collect();
+
+        {
+            let spec = hound::WavSpec {
+                channels: 1,
+                sample_rate,
+                bits_per_sample: 32,
+                sample_format: hound::SampleFormat::Float,
+            };
+            let mut writer = hound::WavWriter::create(&wav_path, spec).unwrap();
+            for sample in &samples {
+                writer.write_sample(*sample).unwrap();
+            }
+            writer.finalize().unwrap();
+        }
+
+        let encode = std::process::Command::new("ffmpeg")
+            .arg("-hide_banner")
+            .arg("-loglevel")
+            .arg("error")
+            .arg("-y")
+            .arg("-i")
+            .arg(&wav_path)
+            .arg("-ac")
+            .arg("1")
+            .arg("-ar")
+            .arg("48000")
+            .arg("-c:a")
+            .arg("libopus")
+            .arg(&ogg_path)
+            .output()
+            .unwrap();
+
+        if !encode.status.success() {
+            eprintln!(
+                "skipping stream-transcribe Ogg/Opus input test because ffmpeg encode failed: {}",
+                String::from_utf8_lossy(&encode.stderr)
+            );
+            let _ = std::fs::remove_file(&wav_path);
+            let _ = std::fs::remove_file(&ogg_path);
+            return;
+        }
+
+        let args = StreamTranscribeArgs {
+            file: Some(ogg_path.clone()),
+            raw_input: None,
+            sample_rate: 48_000,
+            frame_ms: 20,
+            json: false,
+        };
+        let input = load_stream_transcribe_input(&args).unwrap();
+        let _ = std::fs::remove_file(&wav_path);
+        let _ = std::fs::remove_file(&ogg_path);
+
+        assert_eq!(input.sample_rate, 16_000);
+        assert!(input.sample_count > 0);
+        assert!(!input.frames.is_empty());
+    }
+
+    fn temp_audio_path(label: &str, ext: &str) -> PathBuf {
+        let pid = std::process::id();
+        let tid = std::thread::current().id();
+        std::env::temp_dir().join(format!("voice_cli_{label}_{pid}_{tid:?}.{ext}"))
+    }
+
+    fn command_available(command: &str) -> bool {
+        std::process::Command::new(command)
+            .arg("-version")
+            .output()
+            .is_ok()
     }
 }

--- a/crates/voice-stt/examples/transcribe.rs
+++ b/crates/voice-stt/examples/transcribe.rs
@@ -1,25 +1,23 @@
-//! Example: transcribe a WAV file using Whisper.
+//! Example: transcribe an audio file using Whisper.
 //!
 //! Usage:
-//!     cargo run -p voice-stt --example transcribe -- /path/to/audio.wav
+//!     cargo run -p voice-stt --example transcribe -- /path/to/audio.ogg
 //!
-//! The WAV file must be 16kHz mono (16-bit or 32-bit float).
 //! Generate a test file with:
-//!     voice -o test.wav "Hello, this is a test."
-//!     ffmpeg -i test.wav -ar 16000 -acodec pcm_s16le test_16k.wav
+//!     voice say --format ogg-opus -o test.ogg "Hello, this is a test."
 
 use std::env;
+use std::path::Path;
 use std::time::Instant;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        eprintln!("Usage: {} <audio.wav>", args[0]);
+        eprintln!("Usage: {} <audio-file>", args[0]);
         eprintln!();
-        eprintln!("The WAV file must be 16kHz mono.");
+        eprintln!("WAV input is decoded directly; compressed formats use ffmpeg.");
         eprintln!("Generate a test file with:");
-        eprintln!("  voice -o test.wav \"Hello, this is a test.\"");
-        eprintln!("  ffmpeg -i test.wav -ar 16000 -acodec pcm_s16le test_16k.wav");
+        eprintln!("  voice say --format ogg-opus -o test.ogg \"Hello, this is a test.\"");
         std::process::exit(1);
     }
     let audio_path = &args[1];
@@ -35,17 +33,17 @@ fn main() {
     eprintln!("Transcribing: {audio_path}");
     let t1 = Instant::now();
 
-    // Load the WAV file
-    let samples = load_wav_16k(audio_path);
-    let duration_secs = samples.len() as f64 / 16000.0;
+    let audio = voice_stt::load_audio_file(Path::new(audio_path)).expect("Failed to decode audio");
+    let duration_secs = audio.samples.len() as f64 / audio.sample_rate as f64;
     eprintln!(
-        "Audio: {:.2}s ({} samples at 16kHz)",
+        "Audio: {:.2}s ({} samples at {}Hz)",
         duration_secs,
-        samples.len()
+        audio.samples.len(),
+        audio.sample_rate
     );
 
-    let result =
-        voice_stt::transcribe_audio(&mut model, &samples, 16000).expect("Transcription failed");
+    let result = voice_stt::transcribe_audio(&mut model, &audio.samples, audio.sample_rate)
+        .expect("Transcription failed");
 
     let elapsed = t1.elapsed().as_secs_f64();
     let rtf = elapsed / duration_secs;
@@ -58,50 +56,4 @@ fn main() {
         elapsed
     );
     eprintln!("RTF: {:.2}x (< 1.0 = faster than real-time)", rtf);
-}
-
-/// Load a 16kHz WAV file as mono f32 samples.
-///
-/// Handles both 16-bit integer and 32-bit float WAV formats.
-fn load_wav_16k(path: &str) -> Vec<f32> {
-    let reader = hound::WavReader::open(path).unwrap_or_else(|e| {
-        eprintln!("Failed to open {path}: {e}");
-        std::process::exit(1);
-    });
-
-    let spec = reader.spec();
-    if spec.sample_rate != 16000 {
-        eprintln!(
-            "Error: WAV sample rate is {}Hz, expected 16000Hz.",
-            spec.sample_rate
-        );
-        eprintln!("Convert with: ffmpeg -i {path} -ar 16000 -acodec pcm_s16le output_16k.wav");
-        std::process::exit(1);
-    }
-
-    let channels = spec.channels as usize;
-
-    let samples: Vec<f32> = match spec.sample_format {
-        hound::SampleFormat::Int => {
-            let max_val = (1u32 << (spec.bits_per_sample - 1)) as f32;
-            reader
-                .into_samples::<i32>()
-                .map(|s| s.unwrap_or(0) as f32 / max_val)
-                .collect()
-        }
-        hound::SampleFormat::Float => reader
-            .into_samples::<f32>()
-            .map(|s| s.unwrap_or(0.0))
-            .collect(),
-    };
-
-    // Mix to mono if needed
-    if channels > 1 {
-        samples
-            .chunks(channels)
-            .map(|frame| frame.iter().sum::<f32>() / channels as f32)
-            .collect()
-    } else {
-        samples
-    }
 }

--- a/crates/voice-stt/src/lib.rs
+++ b/crates/voice-stt/src/lib.rs
@@ -6,7 +6,7 @@
 //! use voice_stt::{load_model, transcribe, TranscribeResult};
 //!
 //! let mut model = load_model("distil-whisper/distil-medium.en").unwrap();
-//! let result = transcribe(&mut model, "audio.wav").unwrap();
+//! let result = transcribe(&mut model, "audio.ogg").unwrap();
 //! println!("{}", result.text);
 //! ```
 //!
@@ -25,6 +25,7 @@ pub mod builtin;
 pub mod error;
 
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use candle_core::{DType, Device};
 use candle_nn::VarBuilder;
@@ -40,6 +41,15 @@ pub struct TranscribeResult {
     /// Token IDs generated (including special tokens).
     pub tokens: Vec<u32>,
     /// Sample rate of the model input (always 16000 for Whisper).
+    pub sample_rate: u32,
+}
+
+/// Decoded mono audio samples suitable for STT.
+#[derive(Debug, Clone)]
+pub struct AudioData {
+    /// Mono f32 samples in the range `[-1.0, 1.0]`.
+    pub samples: Vec<f32>,
+    /// Sample rate of `samples`.
     pub sample_rate: u32,
 }
 
@@ -175,14 +185,15 @@ pub fn load_tokenizer(path_or_repo: &str) -> Result<tokenizers::Tokenizer> {
 
 /// Transcribe an audio file.
 ///
-/// Loads the audio file as WAV (16-bit PCM or 32-bit float), converts to
-/// 16kHz mono f32, and runs greedy decoding.
+/// Loads WAV directly. If the input is another container/codec such as
+/// Ogg/Opus, falls back to `ffmpeg` and decodes to mono f32 audio before
+/// running greedy decoding.
 pub fn transcribe(
     model: &mut WhisperModel,
     audio_path: impl AsRef<Path>,
 ) -> Result<TranscribeResult> {
-    let samples = load_wav_as_f32(audio_path.as_ref())?;
-    transcribe_audio(model, &samples, 16000)
+    let audio = load_audio_file(audio_path.as_ref())?;
+    transcribe_audio(model, &audio.samples, audio.sample_rate)
 }
 
 /// Transcribe raw audio samples.
@@ -242,30 +253,58 @@ fn download_weights(repo_id: &str) -> Result<PathBuf> {
         .map_err(|e| SttError::Hub(e.to_string()))
 }
 
-/// Load a WAV file and return mono f32 samples at 16kHz.
+/// Load an audio file and return mono f32 samples.
 ///
-/// Handles both 16-bit integer and 32-bit float WAV formats.
-/// Multi-channel audio is mixed down to mono by averaging.
-pub(crate) fn load_wav_as_f32(path: &Path) -> Result<Vec<f32>> {
+/// WAV input is decoded in-process. Other formats are decoded with `ffmpeg`
+/// into 16 kHz mono float PCM so WhatsApp-ready Ogg/Opus files can be
+/// transcribed without a manual conversion step.
+pub fn load_audio_file(path: &Path) -> Result<AudioData> {
+    match load_wav_audio_file(path) {
+        Ok(audio) => Ok(audio),
+        Err(wav_error) => decode_audio_with_ffmpeg(path).map_err(|ffmpeg_error| {
+            SttError::Audio(format!(
+                "Failed to decode {} as WAV ({wav_error}); ffmpeg fallback also failed: {ffmpeg_error}",
+                path.display()
+            ))
+        }),
+    }
+}
+
+fn load_wav_audio_file(path: &Path) -> Result<AudioData> {
     let reader = hound::WavReader::open(path)
         .map_err(|e| SttError::Audio(format!("Failed to open {}: {e}", path.display())))?;
 
     let spec = reader.spec();
     let channels = spec.channels as usize;
 
+    if spec.sample_rate == 0 {
+        return Err(SttError::Audio("Invalid WAV: sample rate is 0".into()));
+    }
+    if channels == 0 {
+        return Err(SttError::Audio("Invalid WAV: channel count is 0".into()));
+    }
+
     let samples: Vec<f32> = match spec.sample_format {
         hound::SampleFormat::Int => {
             let bits = spec.bits_per_sample;
+            if bits == 0 || bits > 32 {
+                return Err(SttError::Audio(format!(
+                    "Unsupported bits_per_sample {bits}; expected 1..=32"
+                )));
+            }
             let max_val = (1u32 << (bits - 1)) as f32;
             reader
                 .into_samples::<i32>()
-                .map(|s| s.unwrap_or(0) as f32 / max_val)
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(|e| SttError::Audio(format!("Failed to read WAV samples: {e}")))?
+                .into_iter()
+                .map(|s| s as f32 / max_val)
                 .collect()
         }
         hound::SampleFormat::Float => reader
             .into_samples::<f32>()
-            .map(|s| s.unwrap_or(0.0))
-            .collect(),
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| SttError::Audio(format!("Failed to read WAV samples: {e}")))?,
     };
 
     // Mix down to mono if multi-channel
@@ -278,14 +317,58 @@ pub(crate) fn load_wav_as_f32(path: &Path) -> Result<Vec<f32>> {
         samples
     };
 
-    // Resample to 16kHz if needed
-    let mono = if spec.sample_rate != 16000 {
-        resample(&mono, spec.sample_rate, 16000)
-    } else {
-        mono
-    };
+    Ok(AudioData {
+        samples: mono,
+        sample_rate: spec.sample_rate,
+    })
+}
 
-    Ok(mono)
+fn decode_audio_with_ffmpeg(path: &Path) -> Result<AudioData> {
+    let output = Command::new("ffmpeg")
+        .arg("-hide_banner")
+        .arg("-loglevel")
+        .arg("error")
+        .arg("-i")
+        .arg(path)
+        .arg("-f")
+        .arg("f32le")
+        .arg("-ac")
+        .arg("1")
+        .arg("-ar")
+        .arg("16000")
+        .arg("pipe:1")
+        .output()
+        .map_err(|e| SttError::Audio(format!("spawn ffmpeg: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(SttError::Audio(format!(
+            "ffmpeg exited with {}: {}",
+            output.status,
+            stderr.trim()
+        )));
+    }
+
+    if output.stdout.is_empty() {
+        return Err(SttError::Audio("ffmpeg produced no audio samples".into()));
+    }
+    if output.stdout.len() % std::mem::size_of::<f32>() != 0 {
+        return Err(SttError::Audio(format!(
+            "ffmpeg produced {} bytes, not a whole number of f32 samples",
+            output.stdout.len()
+        )));
+    }
+
+    let samples = output
+        .stdout
+        .chunks_exact(4)
+        .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+        .collect();
+
+    Ok(AudioData {
+        samples,
+        sample_rate: 16000,
+    })
 }
 
 /// High-quality audio resampling using rubato's sinc interpolation.
@@ -512,7 +595,7 @@ mod tests {
             writer.finalize().unwrap();
         }
 
-        let loaded = load_wav_as_f32(&path).unwrap();
+        let loaded = load_audio_file(&path).unwrap().samples;
         let _ = std::fs::remove_file(&path);
 
         assert_eq!(loaded.len(), expected_f32.len());
@@ -544,7 +627,7 @@ mod tests {
             writer.finalize().unwrap();
         }
 
-        let loaded = load_wav_as_f32(&path).unwrap();
+        let loaded = load_audio_file(&path).unwrap().samples;
         let _ = std::fs::remove_file(&path);
 
         assert_eq!(loaded.len(), f32_samples.len());
@@ -556,9 +639,116 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_load_audio_file_preserves_wav_sample_rate() {
+        let path = temp_wav_path("audio_file_wav");
+        let sample_rate = 24_000u32;
+        let f32_samples: Vec<f32> = vec![0.0, 0.25, -0.25, 0.5, -0.5];
+
+        {
+            let spec = hound::WavSpec {
+                channels: 1,
+                sample_rate,
+                bits_per_sample: 32,
+                sample_format: hound::SampleFormat::Float,
+            };
+            let mut writer = hound::WavWriter::create(&path, spec).unwrap();
+            for &s in &f32_samples {
+                writer.write_sample(s).unwrap();
+            }
+            writer.finalize().unwrap();
+        }
+
+        let loaded = load_audio_file(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(loaded.sample_rate, sample_rate);
+        assert_eq!(loaded.samples.len(), f32_samples.len());
+        for (i, (got, want)) in loaded.samples.iter().zip(f32_samples.iter()).enumerate() {
+            assert!(
+                (got - want).abs() < 1e-6,
+                "sample {i}: got {got}, want {want}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_load_audio_file_decodes_ogg_opus_with_ffmpeg() {
+        if !command_available("ffmpeg") {
+            eprintln!("skipping Ogg/Opus decode test because ffmpeg is not on PATH");
+            return;
+        }
+
+        let wav_path = temp_wav_path("ogg_source");
+        let ogg_path = temp_audio_path("ogg_opus", "ogg");
+        let sample_rate = 24_000u32;
+        let samples: Vec<f32> = (0..sample_rate / 4)
+            .map(|i| (2.0 * PI * 440.0 * i as f32 / sample_rate as f32).sin() * 0.25)
+            .collect();
+
+        {
+            let spec = hound::WavSpec {
+                channels: 1,
+                sample_rate,
+                bits_per_sample: 32,
+                sample_format: hound::SampleFormat::Float,
+            };
+            let mut writer = hound::WavWriter::create(&wav_path, spec).unwrap();
+            for &sample in &samples {
+                writer.write_sample(sample).unwrap();
+            }
+            writer.finalize().unwrap();
+        }
+
+        let encode = Command::new("ffmpeg")
+            .arg("-hide_banner")
+            .arg("-loglevel")
+            .arg("error")
+            .arg("-y")
+            .arg("-i")
+            .arg(&wav_path)
+            .arg("-ac")
+            .arg("1")
+            .arg("-ar")
+            .arg("48000")
+            .arg("-c:a")
+            .arg("libopus")
+            .arg(&ogg_path)
+            .output()
+            .unwrap();
+
+        if !encode.status.success() {
+            eprintln!(
+                "skipping Ogg/Opus decode test because ffmpeg encode failed: {}",
+                String::from_utf8_lossy(&encode.stderr)
+            );
+            let _ = std::fs::remove_file(&wav_path);
+            let _ = std::fs::remove_file(&ogg_path);
+            return;
+        }
+
+        let loaded = load_audio_file(&ogg_path).unwrap();
+        let _ = std::fs::remove_file(&wav_path);
+        let _ = std::fs::remove_file(&ogg_path);
+
+        assert_eq!(loaded.sample_rate, 16_000);
+        assert!(!loaded.samples.is_empty());
+        let rms = (loaded.samples.iter().map(|s| s * s).sum::<f32>() / loaded.samples.len() as f32)
+            .sqrt();
+        assert!(rms > 0.01, "decoded Ogg/Opus RMS is too low: {rms}");
+    }
+
     fn temp_wav_path(label: &str) -> std::path::PathBuf {
+        temp_audio_path(label, "wav")
+    }
+
+    fn temp_audio_path(label: &str, ext: &str) -> std::path::PathBuf {
         let pid = std::process::id();
         let tid = std::thread::current().id();
-        std::path::PathBuf::from(format!("/tmp/voice_test_{label}_{pid}_{tid:?}.wav"))
+        std::path::PathBuf::from(format!("/tmp/voice_test_{label}_{pid}_{tid:?}.{ext}"))
+    }
+
+    fn command_available(command: &str) -> bool {
+        Command::new(command).arg("-version").output().is_ok()
     }
 }

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -78,9 +78,9 @@ voice stream --json "Hello from the stream"
 voice say --format ogg-opus -o reply.ogg "Hello"
 voice stream --output streamed.ogg --format ogg-opus "Hello"
 voice stream --sample-rate 48000 --frame-ms 20 --raw-output reply.s16le "Hello"
-voice stream-transcribe recording.wav
+voice stream-transcribe recording.ogg
 voice stream-transcribe --raw-input webrtc-in.s16le --sample-rate 48000 --frame-ms 20
-voice stream-transcribe --json recording.wav
+voice stream-transcribe --json recording.ogg
 ```
 
 The raw output is signed 16-bit little-endian mono PCM with no container header.
@@ -94,11 +94,13 @@ PCM frame contract while producing a valid `audio/ogg; codecs=opus` file.
 Use `--raw-output` when the consumer is a WebRTC sidecar or another process
 that wants raw PCM frames.
 
-`voice stream-transcribe` reads a WAV file or explicit raw `pcm_s16le` input,
+`voice stream-transcribe` reads an audio file or explicit raw `pcm_s16le` input,
 splits it into the same ordered PCM frames a WebRTC sidecar would send, and
-returns the terminal STT event from the daemon. Use `--raw-input -` to pipe
-decoded WebRTC PCM directly from another process. It is a transport smoke test;
-`voice transcribe` remains the direct file transcription command.
+returns the terminal STT event from the daemon. WAV input is decoded directly;
+Ogg/Opus and other compressed formats use `ffmpeg` when available. Use
+`--raw-input -` to pipe decoded WebRTC PCM directly from another process. It is
+a transport smoke test; `voice transcribe` remains the direct file transcription
+command.
 
 ## Daemon Protocol
 


### PR DESCRIPTION
## Summary

- add `voice_stt::load_audio_file()` for shared audio-file decoding
- keep WAV decoding in-process and fall back to `ffmpeg` for Ogg/Opus and other compressed inputs
- wire `voice transcribe` and file-based `voice stream-transcribe` through the shared loader
- update README/streaming docs and the `voice-stt` example away from WAV-only wording

This came out of checking the leading-`Wait` issue: generated Ogg/Opus output could not be fed back into `voice transcribe` for Whisper verification. This PR fixes that format gap, but does not claim to fix #110's articulation/prosody issue.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p voice-stt`
- `cargo test -p voice`
- `cargo test -p voice-daemon`
- `cargo test --workspace --exclude voice-tray`

The non-tray workspace test run still emits pre-existing unused-variable warnings in `voice-kokoro` tests.
