### PR TITLE
Add Hermes command TTS validation

### DIFF
--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -60,13 +60,46 @@ media through 48 kHz 20 ms PCM frames. See
 [whatsapp-calling-webrtc.md](whatsapp-calling-webrtc.md).
 
 The repository also includes `examples/hermes-command-tts.sh`, which matches
-Hermes' command-provider argument order:
+Hermes' command-provider argument order and explicitly asks `voice` for
+Ogg/Opus output by default:
 
 ```yaml
 command: /path/to/voice/examples/hermes-command-tts.sh {input_path} {output_path} {voice} {speed}
 ```
 
 Set `VOICE_BIN=/path/to/voice` if `voice` is not on `PATH`.
+Set `VOICE_FORMAT=wav` for a WAV compatibility provider, or set
+`VOICE_FORMAT=` to let `voice` infer the format from `{output_path}`.
+
+Validate the command-provider shape locally before wiring or restarting
+Hermes:
+
+```bash
+VOICE_BIN=/path/to/voice scripts/verify_hermes_command_tts.sh
+```
+
+The script simulates Hermes' `{input_path} {output_path} {voice} {speed}`
+invocation, then checks the result with `ffprobe` to confirm an Ogg container
+with Opus audio, mono, at 48 kHz.
+
+To validate an installed Hermes tree without touching a running gateway, run
+Hermes' TTS tool directly from that install after confirming its config points
+at a voice-native provider:
+
+```bash
+cd ~/.hermes/hermes-agent
+HERMES_HOME=~/.hermes ./venv/bin/python - <<'PY'
+import json
+from tools.tts_tool import text_to_speech_tool
+
+result = text_to_speech_tool("Hermes voice native Ogg Opus smoke test.")
+print(json.dumps(json.loads(result), indent=2, ensure_ascii=False))
+PY
+```
+
+Inspect the returned file with `ffprobe`; a voice-compatible WhatsApp path
+should return `.ogg` / Opus audio and should not need another Hermes-side
+conversion.
 
 ## CLI Smoke Test
 

--- a/examples/hermes-command-tts.sh
+++ b/examples/hermes-command-tts.sh
@@ -6,9 +6,18 @@ out_file="${2:?output file required}"
 voice="${3:-af_heart}"
 speed="${4:-1.0}"
 voice_bin="${VOICE_BIN:-voice}"
+format="${VOICE_FORMAT-ogg-opus}"
 
-exec "$voice_bin" say \
-  --input-file "$text_file" \
-  --output "$out_file" \
-  --voice "$voice" \
+args=(
+  say
+  --input-file "$text_file"
+  --output "$out_file"
+  --voice "$voice"
   --speed "$speed"
+)
+
+if [[ -n "$format" ]]; then
+  args+=(--format "$format")
+fi
+
+exec "$voice_bin" "${args[@]}"

--- a/scripts/verify_hermes_command_tts.sh
+++ b/scripts/verify_hermes_command_tts.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+voice_bin="${VOICE_BIN:-voice}"
+command_script="${HERMES_TTS_COMMAND_SCRIPT:-$repo_root/examples/hermes-command-tts.sh}"
+voice_name="${VOICE_NAME:-${VOICE:-af_heart}}"
+speed="${SPEED:-1.0}"
+text="${TEXT:-Hermes voice command provider smoke test.}"
+keep_output="${KEEP_OUTPUT:-0}"
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required on PATH"
+}
+
+require_command ffprobe
+
+if [[ "$voice_bin" == */* ]]; then
+  [[ -x "$voice_bin" ]] || fail "VOICE_BIN is not executable: $voice_bin"
+else
+  require_command "$voice_bin"
+fi
+
+[[ -x "$command_script" ]] || fail "Hermes command-provider script is not executable: $command_script"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/voice-hermes-tts.XXXXXX")"
+input_path="$tmp_dir/input.txt"
+output_path="${OUTPUT:-$tmp_dir/reply.ogg}"
+
+cleanup() {
+  if [[ -z "${OUTPUT:-}" && "$keep_output" != "1" ]]; then
+    rm -rf "$tmp_dir"
+  else
+    rm -f "$input_path"
+    rmdir "$tmp_dir" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+printf '%s\n' "$text" >"$input_path"
+
+VOICE_BIN="$voice_bin" "$command_script" "$input_path" "$output_path" "$voice_name" "$speed"
+
+[[ -s "$output_path" ]] || fail "command provider did not write audio: $output_path"
+
+magic="$(head -c 4 "$output_path" || true)"
+[[ "$magic" == "OggS" ]] || fail "expected Ogg container magic, got: ${magic:-<empty>}"
+
+probe="$(
+  ffprobe -v error \
+    -select_streams a:0 \
+    -show_entries stream=codec_name,sample_rate,channels \
+    -of default=noprint_wrappers=1 \
+    "$output_path"
+)"
+
+probe_value() {
+  local key="$1"
+  printf '%s\n' "$probe" | sed -n "s/^${key}=//p" | head -n 1
+}
+
+codec="$(probe_value codec_name)"
+sample_rate="$(probe_value sample_rate)"
+channels="$(probe_value channels)"
+
+[[ "$codec" == "opus" ]] || fail "expected Opus codec, got: ${codec:-<missing>}"
+[[ "$sample_rate" == "48000" ]] || fail "expected 48 kHz sample rate, got: ${sample_rate:-<missing>}"
+[[ "$channels" == "1" ]] || fail "expected mono audio, got channels=${channels:-<missing>}"
+
+echo "ok: Hermes command-provider output is Ogg/Opus mono 48 kHz"
+echo "voice_bin=$voice_bin"
+echo "command_script=$command_script"
+if [[ -z "${OUTPUT:-}" && "$keep_output" != "1" ]]; then
+  echo "output=<temporary; set KEEP_OUTPUT=1 or OUTPUT=/path/reply.ogg to retain>"
+else
+  echo "output=$output_path"
+fi


### PR DESCRIPTION
## Summary
- make the Hermes command-provider wrapper request Ogg/Opus explicitly by default
- add a smoke script that simulates Hermes' command-provider invocation and verifies Ogg/Opus mono 48 kHz output with ffprobe
- document local Hermes validation without restarting the running gateway

## Validation
- VOICE_BIN=/home/ubuntu/.local/bin/voice scripts/verify_hermes_command_tts.sh
- cargo fmt --all --check
- cargo test -p voice-audio
- cargo test -p voice
- Installed Hermes TTS tool returned voice_compatible=true and ffprobe confirmed codec_name=opus, sample_rate=48000, channels=1