### PR TITLE
Add WebRTC sidecar echo helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,5 @@ jobs:
           python -m pytest -q \
             examples/webrtc-sidecar/test_sidecar.py \
             examples/webrtc-sidecar/test_post_voice_stream.py \
-            examples/webrtc-sidecar/test_drain_sidecar_audio.py
+            examples/webrtc-sidecar/test_drain_sidecar_audio.py \
+            examples/webrtc-sidecar/test_echo_sidecar_audio.py

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -318,7 +318,10 @@ that path.
    outbound PCM-to-Opus/WebRTC track, inbound decoded PCM sink, and local HTTP
    send/drain endpoints. Done as a spike.
 5. Wire Hermes WhatsApp Cloud `connect` webhooks to the sidecar.
-6. Build an inbound-call echo bot: WhatsApp audio in, same audio out.
+6. Build an inbound-call echo bot: WhatsApp audio in, same audio out. The
+   local `examples/webrtc-sidecar/echo_sidecar_audio.py` helper now covers the
+   sidecar-local drain-and-post loop; exercising it against a real WhatsApp
+   Cloud call still depends on a calling-enabled number.
 7. Replace echo with STT -> Hermes turn -> `stream_speak` TTS.
 8. Add interruption/barge-in: inbound voice cancels outbound TTS.
 

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -145,6 +145,18 @@ By default the drain helper requests the contract's `default_drain_bytes`
 window, currently 96000 bytes or about one second of mono 48 kHz s16le audio.
 Pass `--max-bytes 1920` for exact frame-by-frame polling.
 
+For a minimal live-call echo bot, drain inbound PCM and queue it back to the
+same sidecar call:
+
+```bash
+python examples/webrtc-sidecar/echo_sidecar_audio.py local-test \
+  --stop-after-empty 10
+```
+
+This proves the sidecar's local media bridge before adding STT, Hermes turns,
+or `voice stream` TTS. It exits with code 75 if the outbound queue is full, so
+Hermes can treat that as retryable audio backpressure.
+
 Queue outbound PCM for a live session:
 
 ```bash
@@ -218,6 +230,7 @@ python3 -m venv /tmp/voice-webrtc-venv
 /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py
 /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_post_voice_stream.py
 /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_drain_sidecar_audio.py
+/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_echo_sidecar_audio.py
 ```
 
 `loopback_smoke.py` starts the sidecar in-process, completes a local SDP

--- a/examples/webrtc-sidecar/echo_sidecar_audio.py
+++ b/examples/webrtc-sidecar/echo_sidecar_audio.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Echo decoded inbound sidecar PCM back to the same WebRTC call.
+
+This helper is a minimal local echo bridge:
+
+    GET  /calls/{call_id}/audio -> decoded inbound pcm_s16le
+    POST /calls/{call_id}/audio -> outbound pcm_s16le for the WebRTC track
+
+It proves the first live-call bot shape without involving STT, TTS, Hermes
+sessions, WhatsApp Graph calls, or model inference.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+
+from drain_sidecar_audio import (
+    capped_wait_ms,
+    drain_url,
+    fetch_audio_chunk,
+    validate_drain_shape,
+)
+from post_voice_stream import (
+    SidecarAudioPostError,
+    load_audio_contract,
+    post_audio_frame,
+    sidecar_audio_url,
+)
+
+
+TEMPFAIL_EXIT_CODE = 75
+
+
+def default_max_bytes(configured_max_bytes: int | None, frame_bytes: int) -> int:
+    if configured_max_bytes is not None:
+        return configured_max_bytes
+    return frame_bytes
+
+
+def echo_chunks(
+    *,
+    sidecar_url: str,
+    call_id: str,
+    max_bytes: int | None,
+    wait_ms: int,
+    duration_ms: int | None,
+    stop_after_empty: int,
+    timeout_s: float,
+    quiet: bool,
+) -> int:
+    contract = load_audio_contract()
+    drain_max_bytes = default_max_bytes(max_bytes, contract.frame_bytes)
+    drain_wait_ms = capped_wait_ms(contract, wait_ms)
+    validate_drain_shape(contract, drain_max_bytes, drain_wait_ms)
+    if duration_ms is not None and duration_ms < 0:
+        raise ValueError("duration_ms must be non-negative")
+
+    source_url = drain_url(sidecar_url, call_id, drain_max_bytes, drain_wait_ms)
+    target_url = sidecar_audio_url(sidecar_url, call_id)
+    deadline = (
+        time.monotonic() + (duration_ms / 1_000)
+        if duration_ms is not None
+        else None
+    )
+
+    if not quiet:
+        print(f"echoing inbound PCM from {source_url} to {target_url}", file=sys.stderr)
+
+    chunks = 0
+    bytes_echoed = 0
+    empty_polls = 0
+    while deadline is None or time.monotonic() < deadline:
+        pcm = fetch_audio_chunk(source_url, timeout_s)
+        if not pcm:
+            empty_polls += 1
+            if stop_after_empty and empty_polls >= stop_after_empty:
+                break
+            continue
+
+        empty_polls = 0
+        try:
+            post_audio_frame(target_url, contract, pcm, timeout_s)
+        except SidecarAudioPostError as exc:
+            if exc.retryable:
+                if not quiet:
+                    print(
+                        "sidecar reported outbound audio backpressure; retry later",
+                        file=sys.stderr,
+                    )
+                return TEMPFAIL_EXIT_CODE
+            raise
+        chunks += 1
+        bytes_echoed += len(pcm)
+
+    if not quiet:
+        print(
+            f"echoed {chunks} chunks ({bytes_echoed} bytes) for {call_id}",
+            file=sys.stderr,
+        )
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("call_id", help="sidecar call_id to echo")
+    parser.add_argument("--sidecar-url", default="http://127.0.0.1:8787")
+    parser.add_argument("--max-bytes", type=int, default=None)
+    parser.add_argument("--wait-ms", type=int, default=500)
+    parser.add_argument(
+        "--duration-ms",
+        type=int,
+        help="stop after this wall-clock duration; omit to run until interrupted",
+    )
+    parser.add_argument(
+        "--stop-after-empty",
+        type=int,
+        default=0,
+        help="stop after N consecutive empty long-poll responses; 0 disables",
+    )
+    parser.add_argument("--timeout", type=float, default=5.0)
+    parser.add_argument("--quiet", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        return echo_chunks(
+            sidecar_url=args.sidecar_url,
+            call_id=args.call_id,
+            max_bytes=args.max_bytes,
+            wait_ms=args.wait_ms,
+            duration_ms=args.duration_ms,
+            stop_after_empty=args.stop_after_empty,
+            timeout_s=args.timeout,
+            quiet=args.quiet,
+        )
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/webrtc-sidecar/test_echo_sidecar_audio.py
+++ b/examples/webrtc-sidecar/test_echo_sidecar_audio.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import base64
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import threading
+
+
+def load_bridge_module():
+    path = Path(__file__).with_name("post_voice_stream.py")
+    spec = importlib.util.spec_from_file_location("post_voice_stream", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_drain_module():
+    load_bridge_module()
+    path = Path(__file__).with_name("drain_sidecar_audio.py")
+    spec = importlib.util.spec_from_file_location("drain_sidecar_audio", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_echo():
+    load_drain_module()
+    path = Path(__file__).with_name("echo_sidecar_audio.py")
+    spec = importlib.util.spec_from_file_location("voice_webrtc_echo_sidecar_audio", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_default_max_bytes_prefers_one_webrtc_frame():
+    echo = load_echo()
+
+    assert echo.default_max_bytes(None, 1_920) == 1_920
+    assert echo.default_max_bytes(3_840, 1_920) == 3_840
+
+
+def test_echo_chunks_drains_and_posts_same_pcm(monkeypatch):
+    echo = load_echo()
+    bridge = sys.modules["post_voice_stream"]
+    contract = bridge.AudioContract(
+        sample_rate=48_000,
+        channels=1,
+        frame_ms=20,
+        encoding="pcm_s16le",
+        frame_bytes=1_920,
+        default_drain_bytes=96_000,
+        max_outbound_queue_bytes=960_000,
+        max_drain_wait_ms=5_000,
+    )
+    monkeypatch.setattr(echo, "load_audio_contract", lambda: contract)
+
+    received_posts: list[tuple[str, dict[str, object]]] = []
+    get_count = 0
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            nonlocal get_count
+            get_count += 1
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.end_headers()
+            pcm = b"\x01\x00\xff\xff" if get_count == 1 else b""
+            self.wfile.write(
+                json.dumps(
+                    {
+                        "returned_bytes": len(pcm),
+                        "pcm_s16le_base64": base64.b64encode(pcm).decode("ascii"),
+                    }
+                ).encode("utf-8")
+            )
+
+        def do_POST(self):
+            body = json.loads(self.rfile.read(int(self.headers["content-length"])))
+            received_posts.append((self.path, body))
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"accepted_bytes":4}')
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        sidecar_url = f"http://127.0.0.1:{server.server_port}"
+        exit_code = echo.echo_chunks(
+            sidecar_url=sidecar_url,
+            call_id="call-1",
+            max_bytes=None,
+            wait_ms=1,
+            duration_ms=None,
+            stop_after_empty=1,
+            timeout_s=1.0,
+            quiet=True,
+        )
+
+        assert exit_code == 0
+        assert get_count == 2
+        assert received_posts == [
+            (
+                "/calls/call-1/audio",
+                {
+                    "sample_rate": 48_000,
+                    "channels": 1,
+                    "frame_ms": 20,
+                    "encoding": "pcm_s16le",
+                    "pcm_s16le_base64": "AQD//w==",
+                },
+            )
+        ]
+    finally:
+        server.shutdown()
+        thread.join(timeout=1)
+
+
+def test_echo_chunks_returns_tempfail_on_backpressure(monkeypatch):
+    echo = load_echo()
+    bridge = sys.modules["post_voice_stream"]
+    contract = bridge.AudioContract(
+        sample_rate=48_000,
+        channels=1,
+        frame_ms=20,
+        encoding="pcm_s16le",
+        frame_bytes=1_920,
+        default_drain_bytes=96_000,
+        max_outbound_queue_bytes=960_000,
+        max_drain_wait_ms=5_000,
+    )
+    monkeypatch.setattr(echo, "load_audio_contract", lambda: contract)
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            pcm = b"\x01\x00"
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(
+                json.dumps(
+                    {
+                        "returned_bytes": len(pcm),
+                        "pcm_s16le_base64": base64.b64encode(pcm).decode("ascii"),
+                    }
+                ).encode("utf-8")
+            )
+
+        def do_POST(self):
+            self.send_response(429)
+            self.send_header("content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"error":"outbound PCM queue is full"}')
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        exit_code = echo.echo_chunks(
+            sidecar_url=f"http://127.0.0.1:{server.server_port}",
+            call_id="call-1",
+            max_bytes=None,
+            wait_ms=1,
+            duration_ms=None,
+            stop_after_empty=1,
+            timeout_s=1.0,
+            quiet=True,
+        )
+
+        assert exit_code == echo.TEMPFAIL_EXIT_CODE
+    finally:
+        server.shutdown()
+        thread.join(timeout=1)


### PR DESCRIPTION
## Summary
- add a stdlib echo helper that drains inbound sidecar PCM and posts it back to the same call's outbound queue
- document the helper as the local echo-bot step before STT/Hermes/TTS integration
- add tests for frame-sized drain defaults, echo posting, and retryable backpressure

## Validation
- python3 -m py_compile examples/webrtc-sidecar/echo_sidecar_audio.py examples/webrtc-sidecar/test_echo_sidecar_audio.py
- /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_echo_sidecar_audio.py
- /tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/loopback_smoke.py
- /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/test_drain_sidecar_audio.py examples/webrtc-sidecar/test_echo_sidecar_audio.py
- cargo fmt --all --check
- cargo test -p voice-stream