### PR TITLE
Guard WebRTC sidecar control bind address

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -146,9 +146,10 @@ audio drain, close, and error payloads Hermes needs to drive WhatsApp Calling
 without hard-coding sidecar response shapes.
 
 The sidecar HTTP API is a local control plane, not a public web API. It should
-bind to localhost or a private socket, with Hermes as the caller. Only the
-WebRTC media negotiation needs normal network access for ICE, DTLS, SRTP, and
-possibly TURN.
+bind to localhost or a private socket, with Hermes as the caller. The Python
+spike rejects non-loopback `--host` values unless `--allow-nonlocal` is passed
+explicitly. Only the WebRTC media negotiation needs normal network access for
+ICE, DTLS, SRTP, and possibly TURN.
 
 ```http
 POST /offer

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -20,6 +20,9 @@ webhooks and Graph actions such as `pre_accept`, `accept`, and `terminate`.
 Do not expose the HTTP control API publicly; bind it to localhost or a private
 socket and let only the local Hermes process call it. The WebRTC media path may
 still need normal outbound ICE/STUN/TURN network access.
+The example enforces that by default: `--host` must be a loopback address such
+as `127.0.0.1`, `::1`, or `localhost`. Use `--allow-nonlocal` only behind a
+trusted local network or private socket boundary.
 
 ## Install
 

--- a/examples/webrtc-sidecar/sidecar.py
+++ b/examples/webrtc-sidecar/sidecar.py
@@ -18,6 +18,7 @@ import base64
 import binascii
 import copy
 from fractions import Fraction
+import ipaddress
 import json
 import logging
 import os
@@ -133,6 +134,26 @@ DEFAULT_DRAIN_BYTES = int(AUDIO_CONTRACT["default_drain_bytes"])
 MAX_OUTBOUND_QUEUE_BYTES = int(AUDIO_CONTRACT["max_outbound_queue_bytes"])
 MAX_INBOUND_QUEUE_BYTES = int(AUDIO_CONTRACT["max_inbound_queue_bytes"])
 MAX_DRAIN_WAIT_MS = int(AUDIO_CONTRACT["max_drain_wait_ms"])
+LOCAL_HOSTNAMES = {"localhost"}
+
+
+def is_loopback_host(host: str) -> bool:
+    if host in LOCAL_HOSTNAMES:
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def validate_bind_host(host: str, *, allow_nonlocal: bool = False) -> None:
+    if allow_nonlocal or is_loopback_host(host):
+        return
+    raise ValueError(
+        "refusing to bind the sidecar control plane to non-loopback host "
+        f"{host!r}; use --allow-nonlocal only behind a trusted local network "
+        "or private socket boundary"
+    )
 
 
 class PcmSource:
@@ -618,10 +639,15 @@ def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
     return app
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8787)
+    parser.add_argument(
+        "--allow-nonlocal",
+        action="store_true",
+        help="allow the local HTTP control plane to bind to a non-loopback host",
+    )
     parser.add_argument(
         "--tx-pcm",
         help="raw pcm_s16le mono 48 kHz source path, FIFO, or '-' for stdin",
@@ -635,7 +661,12 @@ def parse_args() -> argparse.Namespace:
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
     )
-    return parser.parse_args()
+    args = parser.parse_args(argv)
+    try:
+        validate_bind_host(args.host, allow_nonlocal=args.allow_nonlocal)
+    except ValueError as exc:
+        parser.error(str(exc))
+    return args
 
 
 def main() -> None:

--- a/examples/webrtc-sidecar/test_sidecar.py
+++ b/examples/webrtc-sidecar/test_sidecar.py
@@ -95,6 +95,29 @@ def test_load_contract_falls_back_to_voice_stream_contract(monkeypatch, tmp_path
     assert calls == [(["/opt/voice", "stream-contract"], True, True, 5, True)]
 
 
+def test_sidecar_bind_host_defaults_to_loopback_only():
+    sidecar = load_sidecar()
+
+    for host in ("127.0.0.1", "127.10.20.30", "::1", "localhost"):
+        sidecar.validate_bind_host(host)
+
+    for host in ("0.0.0.0", "::", "192.168.1.10", "example.com"):
+        with pytest.raises(ValueError, match="non-loopback host"):
+            sidecar.validate_bind_host(host)
+
+
+def test_parse_args_requires_explicit_nonlocal_bind_opt_in():
+    sidecar = load_sidecar()
+
+    with pytest.raises(SystemExit):
+        sidecar.parse_args(["--host", "0.0.0.0"])
+
+    args = sidecar.parse_args(["--host", "0.0.0.0", "--allow-nonlocal"])
+
+    assert args.host == "0.0.0.0"
+    assert args.allow_nonlocal is True
+
+
 def test_contract_endpoint_returns_machine_readable_contract():
     sidecar = load_sidecar()
 


### PR DESCRIPTION
## Summary
- reject non-loopback `--host` values by default for the Python WebRTC sidecar control API
- add an explicit `--allow-nonlocal` opt-in for trusted/private deployments
- document the bind behavior in the sidecar README and WhatsApp Calling architecture doc

## Validation
- `python3 -m py_compile examples/webrtc-sidecar/sidecar.py examples/webrtc-sidecar/test_sidecar.py`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/test_drain_sidecar_audio.py examples/webrtc-sidecar/test_echo_sidecar_audio.py`