### PR TITLE
Add full duplex WebRTC sidecar smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,4 +54,5 @@ jobs:
             examples/webrtc-sidecar/test_post_voice_stream.py \
             examples/webrtc-sidecar/test_drain_sidecar_audio.py \
             examples/webrtc-sidecar/test_echo_sidecar_audio.py \
-            examples/webrtc-sidecar/test_stream_transcribe_loopback_smoke.py
+            examples/webrtc-sidecar/test_stream_transcribe_loopback_smoke.py \
+            examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -232,11 +232,13 @@ python3 -m venv /tmp/voice-webrtc-venv
 /tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/loopback_smoke.py
 /tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/voice_stream_loopback_smoke.py --voice-bin /path/to/voice
 /tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/stream_transcribe_loopback_smoke.py --voice-bin /path/to/voice
+/tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/full_duplex_loopback_smoke.py --voice-bin /path/to/voice
 /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py
 /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_post_voice_stream.py
 /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_drain_sidecar_audio.py
 /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_echo_sidecar_audio.py
 /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_stream_transcribe_loopback_smoke.py
+/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py
 ```
 
 `loopback_smoke.py` starts the sidecar in-process, completes a local SDP
@@ -253,3 +255,8 @@ the Graph API.
 local WebRTC sender into the sidecar, drains the sidecar-decoded PCM, and runs
 `voice stream-transcribe` on that decoded audio. It validates the inbound
 WebRTC-to-STT path without WhatsApp or the Graph API.
+
+`full_duplex_loopback_smoke.py` exercises both directions on one sidecar call:
+local WebRTC audio drains through `voice stream-transcribe`, while
+`post_voice_stream.py` queues outbound `voice stream` PCM back to the same
+WebRTC peer. It is the closest local smoke to a single WhatsApp call turn.

--- a/examples/webrtc-sidecar/full_duplex_loopback_smoke.py
+++ b/examples/webrtc-sidecar/full_duplex_loopback_smoke.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Run one full-duplex local WebRTC sidecar turn.
+
+This smoke proves both live-call media directions on the same sidecar session:
+
+    inbound:  voice stream PCM -> local WebRTC sender -> sidecar drain
+              -> voice stream-transcribe
+
+    outbound: voice stream via post_voice_stream.py -> sidecar outbound queue
+              -> local WebRTC receiver
+
+It does not contact WhatsApp or the Graph API.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+from typing import Any
+
+from aiohttp import ClientSession, web
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import sidecar
+from stream_transcribe_loopback_smoke import (
+    DEFAULT_EXPECT_WORDS,
+    PcmBytesTrack,
+    drain_decoded_pcm,
+    resolve_executable,
+    run_voice_stream,
+    run_voice_stream_transcribe,
+    transcript_has_words,
+)
+from voice_stream_loopback_smoke import (
+    run_post_voice_stream,
+    wait_for_non_silent_track,
+)
+
+
+DEFAULT_INBOUND_TEXT = "hello world"
+DEFAULT_OUTBOUND_TEXT = "Hello from a full duplex WebRTC sidecar turn."
+
+
+async def start_sidecar_app() -> tuple[web.AppRunner, str]:
+    source = sidecar.PcmSource(None)
+    app = sidecar.create_app(source, None)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    host, port = runner.addresses[0][:2]
+    return runner, f"http://{host}:{port}"
+
+
+async def post_offer(
+    session: ClientSession,
+    base_url: str,
+    call_id: str,
+    pc,
+) -> dict[str, Any]:
+    offer = await pc.createOffer()
+    await pc.setLocalDescription(offer)
+    await sidecar.wait_for_ice_complete(pc)
+    assert pc.localDescription is not None
+
+    async with session.post(
+        f"{base_url}/offer",
+        json={
+            "call_id": call_id,
+            "type": pc.localDescription.type,
+            "sdp": pc.localDescription.sdp,
+        },
+    ) as response:
+        body = await response.json()
+        if response.status != 200:
+            raise RuntimeError(f"/offer failed ({response.status}): {body}")
+        return body
+
+
+async def verify_full_duplex_call(
+    *,
+    args: argparse.Namespace,
+    base_url: str,
+    inbound_pcm: bytes,
+) -> dict[str, Any]:
+    call_id = "full-duplex-loopback"
+    pc = sidecar.RTCPeerConnection()
+    track_future = asyncio.get_running_loop().create_future()
+
+    @pc.on("track")
+    def on_track(track) -> None:
+        if track.kind == "audio" and not track_future.done():
+            track_future.set_result(track)
+
+    pc.addTrack(PcmBytesTrack(inbound_pcm))
+    try:
+        async with ClientSession() as session:
+            answer = await post_offer(session, base_url, call_id, pc)
+            await pc.setRemoteDescription(
+                sidecar.RTCSessionDescription(sdp=answer["sdp"], type=answer["type"])
+            )
+            track = await asyncio.wait_for(track_future, timeout=args.timeout)
+
+            post_task = asyncio.create_task(
+                run_post_voice_stream(
+                    call_id=call_id,
+                    sidecar_url=base_url,
+                    voice_bin=args.voice_bin,
+                    text=args.outbound_text,
+                    voice=args.voice,
+                    speed=args.speed,
+                    timeout_s=args.timeout,
+                )
+            )
+            drain_task = asyncio.create_task(
+                drain_decoded_pcm(
+                    session,
+                    base_url,
+                    call_id,
+                    target_bytes=len(inbound_pcm),
+                    timeout_s=args.timeout,
+                )
+            )
+            try:
+                outbound_webrtc_bytes = await wait_for_non_silent_track(
+                    track,
+                    timeout_s=args.timeout,
+                )
+                decoded_pcm = await drain_task
+                return_code, stderr = await post_task
+            except Exception:
+                for task in (post_task, drain_task):
+                    task.cancel()
+                await asyncio.gather(post_task, drain_task, return_exceptions=True)
+                raise
+
+            if return_code != 0:
+                raise RuntimeError(
+                    f"post_voice_stream.py exited with {return_code}: {stderr.strip()}"
+                )
+
+            async with session.get(f"{base_url}/calls/{call_id}") as response:
+                status = await response.json()
+                if response.status != 200:
+                    raise RuntimeError(f"status failed ({response.status}): {status}")
+
+            return {
+                "call_id": call_id,
+                "decoded_pcm": decoded_pcm,
+                "outbound_webrtc_bytes": outbound_webrtc_bytes,
+                "queued_tx_bytes": status.get("queued_tx_bytes"),
+                "queued_rx_bytes": status.get("queued_rx_bytes"),
+                "audio": sidecar.audio_contract(),
+            }
+    finally:
+        await pc.close()
+
+
+async def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
+    voice_bin = resolve_executable(args.voice_bin, label="voice binary")
+    args.voice_bin = voice_bin
+    workdir = (
+        Path(tempfile.mkdtemp(prefix="voice-webrtc-full-duplex."))
+        if args.workdir is None
+        else args.workdir.expanduser().resolve()
+    )
+    workdir.mkdir(parents=True, exist_ok=True)
+    remove_workdir = args.workdir is None and not args.keep_workdir
+
+    inbound_path = workdir / "inbound-source.s16le"
+    decoded_path = workdir / "sidecar-decoded.s16le"
+    runner, base_url = await start_sidecar_app()
+    try:
+        run_voice_stream(
+            voice_bin=voice_bin,
+            output_path=inbound_path,
+            text=args.inbound_text,
+            voice=args.voice,
+            speed=args.speed,
+            timeout_s=args.timeout,
+        )
+        inbound_pcm = inbound_path.read_bytes()
+        if not inbound_pcm or not any(inbound_pcm):
+            raise RuntimeError("voice stream produced empty or silent inbound PCM")
+
+        call = await verify_full_duplex_call(
+            args=args,
+            base_url=base_url,
+            inbound_pcm=inbound_pcm,
+        )
+        decoded_pcm = call.pop("decoded_pcm")
+        decoded_path.write_bytes(decoded_pcm)
+
+        transcript_event = run_voice_stream_transcribe(
+            voice_bin=voice_bin,
+            input_path=decoded_path,
+            timeout_s=args.timeout,
+        )
+        transcript = transcript_event["data"]["text"]
+        if args.expect_word and not transcript_has_words(transcript, args.expect_word):
+            raise RuntimeError(
+                f"transcript {transcript!r} did not contain expected words "
+                f"{args.expect_word!r}"
+            )
+
+        retained = not remove_workdir
+        return {
+            "success": True,
+            "sidecar_url": base_url,
+            "voice_bin": voice_bin,
+            "inbound_text": args.inbound_text,
+            "outbound_text": args.outbound_text,
+            "transcript": transcript,
+            "expect_word": args.expect_word,
+            "source_pcm_bytes": len(inbound_pcm),
+            "decoded_pcm_bytes": len(decoded_pcm),
+            "inbound_path": str(inbound_path) if retained else "<temporary>",
+            "decoded_path": str(decoded_path) if retained else "<temporary>",
+            "retained": retained,
+            **call,
+            "stt": transcript_event["data"],
+        }
+    finally:
+        await runner.cleanup()
+        if remove_workdir:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--voice-bin", default=os.environ.get("VOICE_BIN", "voice"))
+    parser.add_argument("--voice", default="af_heart")
+    parser.add_argument("--speed", default="1.0")
+    parser.add_argument("--timeout", type=float, default=60.0)
+    parser.add_argument("--inbound-text", default=DEFAULT_INBOUND_TEXT)
+    parser.add_argument("--outbound-text", default=DEFAULT_OUTBOUND_TEXT)
+    parser.add_argument(
+        "--expect-word",
+        action="append",
+        default=None,
+        help="word expected in the inbound transcript; repeatable",
+    )
+    parser.add_argument("--workdir", type=Path)
+    parser.add_argument("--keep-workdir", action="store_true")
+    args = parser.parse_args()
+    if args.expect_word is None:
+        args.expect_word = list(DEFAULT_EXPECT_WORDS)
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    result = asyncio.run(run_smoke(args))
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py
+++ b/examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+def load_smoke():
+    path = Path(__file__).with_name("full_duplex_loopback_smoke.py")
+    spec = importlib.util.spec_from_file_location(
+        "voice_webrtc_full_duplex_loopback_smoke",
+        path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_args_uses_default_expected_words(monkeypatch):
+    smoke = load_smoke()
+    monkeypatch.setattr(sys, "argv", ["full_duplex_loopback_smoke.py"])
+
+    args = smoke.parse_args()
+
+    assert args.inbound_text == "hello world"
+    assert args.outbound_text.startswith("Hello from a full duplex")
+    assert args.expect_word == ["hello", "world"]
+
+
+def test_parse_args_replaces_default_expected_words(monkeypatch):
+    smoke = load_smoke()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "full_duplex_loopback_smoke.py",
+            "--inbound-text",
+            "testing one two",
+            "--expect-word",
+            "testing",
+            "--expect-word",
+            "two",
+        ],
+    )
+
+    args = smoke.parse_args()
+
+    assert args.inbound_text == "testing one two"
+    assert args.expect_word == ["testing", "two"]


### PR DESCRIPTION
## Summary
- add an optional full-duplex sidecar smoke that exercises inbound STT and outbound TTS media on the same local WebRTC call
- reuse the existing one-way smoke helpers for voice stream generation, sidecar draining, and outbound queue posting
- document the smoke and add CI-covered parser/import tests

## Validation
- `python3 -m py_compile examples/webrtc-sidecar/full_duplex_loopback_smoke.py examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py`
- `/tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/full_duplex_loopback_smoke.py --voice-bin /home/ubuntu/.local/bin/voice`
  - transcript: `Hello World`
  - outbound_webrtc_bytes: 23040
  - decoded_pcm_bytes: 124992
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/test_drain_sidecar_audio.py examples/webrtc-sidecar/test_echo_sidecar_audio.py examples/webrtc-sidecar/test_stream_transcribe_loopback_smoke.py examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py`
- `/tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/loopback_smoke.py`
- `/tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/voice_stream_loopback_smoke.py --voice-bin /home/ubuntu/.local/bin/voice`
- `/tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/stream_transcribe_loopback_smoke.py --voice-bin /home/ubuntu/.local/bin/voice`
- `git diff --check`