### PR TITLE
Document voice stream contract surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,9 @@ Options:
 
 Prints the machine-readable WebRTC sidecar v1 contract generated from the
 `voice-stream` constants. Use this when Hermes, a sidecar, or a test harness is
-installed without a source checkout but still needs the exact PCM frame shape.
+installed without a source checkout but still needs the exact PCM frame shape
+and the `voice_surfaces` command map for voice notes, raw PCM, WebRTC, and
+streaming smokes.
 
 ```
 Usage: voice stream-contract

--- a/crates/voice-stream/src/lib.rs
+++ b/crates/voice-stream/src/lib.rs
@@ -54,6 +54,42 @@ pub fn webrtc_sidecar_contract() -> serde_json::Value {
             "max_inbound_queue_bytes": WEBRTC_MAX_INBOUND_QUEUE_BYTES,
             "max_drain_wait_ms": WEBRTC_MAX_DRAIN_WAIT_MS
         },
+        "voice_surfaces": {
+            "completed_voice_note": {
+                "command": "voice say --format ogg-opus --output reply.ogg \"hello\"",
+                "output": "audio/ogg; codecs=opus",
+                "transport": "completed_file",
+                "use": "WhatsApp voice notes and other upload paths that need an Ogg/Opus file.",
+                "requires": ["ffmpeg for Ogg/Opus encoding"]
+            },
+            "streamed_voice_note": {
+                "command": "voice stream --output reply.ogg --format ogg-opus \"hello\"",
+                "output": "audio/ogg; codecs=opus",
+                "transport": "daemon_stream_encoded_file",
+                "use": "Smoke tests or integrations that want Ogg/Opus encoded from daemon PCM frames without a WAV intermediate.",
+                "requires": ["voice daemon", "ffmpeg for Ogg/Opus encoding"]
+            },
+            "raw_outbound_pcm": {
+                "command": "voice stream --sample-rate 48000 --frame-ms 20 --raw-output - \"hello\"",
+                "output": "pcm_s16le",
+                "transport": "stdout_pcm_frames",
+                "frame_bytes": WEBRTC_FRAME_BYTES,
+                "use": "Outbound WebRTC sidecar audio; stdout contains headerless fixed-size PCM frames."
+            },
+            "raw_inbound_pcm": {
+                "command": "voice stream-transcribe --raw-input - --sample-rate 48000 --frame-ms 20",
+                "input": "pcm_s16le",
+                "transport": "stdin_pcm_frames",
+                "frame_bytes": WEBRTC_FRAME_BYTES,
+                "use": "Inbound WebRTC sidecar audio after RTP/Opus has been decoded to local PCM."
+            },
+            "file_transcription_smoke": {
+                "command": "voice stream-transcribe recording.ogg",
+                "input": "audio_file",
+                "transport": "decoded_file_to_daemon_frames",
+                "use": "Testing the inbound stream-transcribe contract from WAV, Ogg/Opus, or another audio file."
+            }
+        },
         "endpoints": {
             "contract": {
                 "method": "GET",
@@ -554,6 +590,32 @@ mod tests {
             WEBRTC_MAX_INBOUND_QUEUE_BYTES
         );
         assert_eq!(audio["max_drain_wait_ms"], WEBRTC_MAX_DRAIN_WAIT_MS);
+
+        let surfaces = &contract["voice_surfaces"];
+        assert_eq!(
+            surfaces["completed_voice_note"]["output"],
+            "audio/ogg; codecs=opus"
+        );
+        assert_eq!(
+            surfaces["completed_voice_note"]["transport"],
+            "completed_file"
+        );
+        assert_eq!(
+            surfaces["streamed_voice_note"]["transport"],
+            "daemon_stream_encoded_file"
+        );
+        assert_eq!(
+            surfaces["raw_outbound_pcm"]["frame_bytes"],
+            WEBRTC_FRAME_BYTES
+        );
+        assert_eq!(
+            surfaces["raw_inbound_pcm"]["frame_bytes"],
+            WEBRTC_FRAME_BYTES
+        );
+        assert_eq!(
+            surfaces["file_transcription_smoke"]["transport"],
+            "decoded_file_to_daemon_frames"
+        );
 
         let payloads = &contract["payloads"];
         assert_eq!(

--- a/docs/contracts/webrtc-sidecar-v1.json
+++ b/docs/contracts/webrtc-sidecar-v1.json
@@ -16,6 +16,47 @@
     "max_inbound_queue_bytes": 960000,
     "max_drain_wait_ms": 5000
   },
+  "voice_surfaces": {
+    "completed_voice_note": {
+      "command": "voice say --format ogg-opus --output reply.ogg \"hello\"",
+      "output": "audio/ogg; codecs=opus",
+      "transport": "completed_file",
+      "use": "WhatsApp voice notes and other upload paths that need an Ogg/Opus file.",
+      "requires": [
+        "ffmpeg for Ogg/Opus encoding"
+      ]
+    },
+    "streamed_voice_note": {
+      "command": "voice stream --output reply.ogg --format ogg-opus \"hello\"",
+      "output": "audio/ogg; codecs=opus",
+      "transport": "daemon_stream_encoded_file",
+      "use": "Smoke tests or integrations that want Ogg/Opus encoded from daemon PCM frames without a WAV intermediate.",
+      "requires": [
+        "voice daemon",
+        "ffmpeg for Ogg/Opus encoding"
+      ]
+    },
+    "raw_outbound_pcm": {
+      "command": "voice stream --sample-rate 48000 --frame-ms 20 --raw-output - \"hello\"",
+      "output": "pcm_s16le",
+      "transport": "stdout_pcm_frames",
+      "frame_bytes": 1920,
+      "use": "Outbound WebRTC sidecar audio; stdout contains headerless fixed-size PCM frames."
+    },
+    "raw_inbound_pcm": {
+      "command": "voice stream-transcribe --raw-input - --sample-rate 48000 --frame-ms 20",
+      "input": "pcm_s16le",
+      "transport": "stdin_pcm_frames",
+      "frame_bytes": 1920,
+      "use": "Inbound WebRTC sidecar audio after RTP/Opus has been decoded to local PCM."
+    },
+    "file_transcription_smoke": {
+      "command": "voice stream-transcribe recording.ogg",
+      "input": "audio_file",
+      "transport": "decoded_file_to_daemon_frames",
+      "use": "Testing the inbound stream-transcribe contract from WAV, Ogg/Opus, or another audio file."
+    }
+  },
   "endpoints": {
     "contract": {
       "method": "GET",

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -106,6 +106,7 @@ conversion.
 Use `voice stream` to inspect the streaming event flow:
 
 ```bash
+voice stream-contract
 voice stream "Hello from the stream"
 voice stream --json "Hello from the stream"
 voice say --format ogg-opus -o reply.ogg "Hello"
@@ -134,6 +135,15 @@ Ogg/Opus and other compressed formats use `ffmpeg` when available. Use
 `--raw-input -` to pipe decoded WebRTC PCM directly from another process. It is
 a transport smoke test; `voice transcribe` remains the direct file transcription
 command.
+
+`voice stream-contract` prints the same machine-readable sidecar contract used
+by the Python WebRTC example. Besides the fixed PCM shape and HTTP endpoint
+schema, the `voice_surfaces` object maps integration modes to commands:
+`completed_voice_note` for WhatsApp-ready Ogg/Opus files, `streamed_voice_note`
+for Ogg/Opus encoded from daemon frames, `raw_outbound_pcm` for WebRTC TTS
+frames, `raw_inbound_pcm` for decoded WebRTC audio entering STT, and
+`file_transcription_smoke` for replaying an audio file through the inbound
+stream contract.
 
 ## Daemon Protocol
 

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -143,7 +143,10 @@ installed `voice` binaries print the same object with `voice stream-contract`.
 The Python sidecar exposes the same object at `GET /contract`. The contract
 defines the fixed PCM audio shape plus the `/offer`, call-state, audio send,
 audio drain, close, and error payloads Hermes needs to drive WhatsApp Calling
-without hard-coding sidecar response shapes.
+without hard-coding sidecar response shapes. Its `voice_surfaces` section also
+maps each local integration mode to the expected `voice` command: completed
+Ogg/Opus voice notes, streamed Ogg/Opus files, raw outbound PCM frames, raw
+inbound PCM transcription, and file-based inbound stream smokes.
 
 The sidecar HTTP API is a local control plane, not a public web API. It should
 bind to localhost or a private socket, with Hermes as the caller. The Python

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -99,6 +99,10 @@ curl -sS http://127.0.0.1:8787/health
 voice stream-contract
 ```
 
+The contract includes `voice_surfaces`, a machine-readable map from integration
+mode to command: completed Ogg/Opus voice notes, streamed Ogg/Opus files, raw
+outbound PCM, raw inbound PCM, and file-based stream-transcribe smokes.
+
 Post a remote offer:
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a `voice_surfaces` section to the machine-readable WebRTC sidecar contract printed by `voice stream-contract` and checked in at `docs/contracts/webrtc-sidecar-v1.json`.

The new metadata maps integration modes to the expected `voice` command:

- `completed_voice_note`: Ogg/Opus file output for WhatsApp voice notes
- `streamed_voice_note`: Ogg/Opus encoded from daemon stream frames
- `raw_outbound_pcm`: 48 kHz 20 ms PCM frames for WebRTC TTS
- `raw_inbound_pcm`: decoded WebRTC PCM entering `stream-transcribe`
- `file_transcription_smoke`: file replay through the inbound stream contract

This keeps the existing v1 audio and endpoint contract intact while making the transport surface discoverable from an installed `voice` binary.

## Validation

```text
cargo test -p voice-stream
cargo test -p voice --bin voice -- resolve_stream_output_format_accepts_ogg_opus_paths resolve_stream_output_format_rejects_wav_and_stdout_without_format
cargo run -q -p voice -- stream-contract | jq '.voice_surfaces | {completed_voice_note,raw_outbound_pcm,raw_inbound_pcm}'
/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/test_drain_sidecar_audio
git diff --check
```
