### PR TITLE
Add sidecar outbound audio clear endpoint

### DIFF
--- a/crates/voice-stream/src/lib.rs
+++ b/crates/voice-stream/src/lib.rs
@@ -125,6 +125,11 @@ pub fn webrtc_sidecar_contract() -> serde_json::Value {
                 "path": "/calls/{call_id}/audio",
                 "description": "Queue outbound PCM for a live call session."
             },
+            "clear_audio": {
+                "method": "POST",
+                "path": "/calls/{call_id}/audio/clear",
+                "description": "Drop queued outbound PCM for a live call session without closing the call. Use this for barge-in or call-turn cancellation."
+            },
             "close_call": {
                 "method": "POST",
                 "path": "/calls/{call_id}/close",
@@ -173,6 +178,13 @@ pub fn webrtc_sidecar_contract() -> serde_json::Value {
                 "call_id": "Call session identifier.",
                 "accepted_bytes": "Number of outbound PCM bytes accepted into the per-call queue.",
                 "queued_tx_bytes": "Outbound PCM bytes queued after this write.",
+                "max_tx_queue_bytes": "Maximum outbound PCM bytes this sidecar will queue for one call.",
+                "audio": "Full fixed audio contract object defined by audio."
+            },
+            "clear_audio_response": {
+                "call_id": "Call session identifier.",
+                "dropped_tx_bytes": "Number of queued outbound PCM bytes discarded.",
+                "queued_tx_bytes": "Outbound PCM bytes queued after the clear operation, normally 0.",
                 "max_tx_queue_bytes": "Maximum outbound PCM bytes this sidecar will queue for one call.",
                 "audio": "Full fixed audio contract object defined by audio."
             },
@@ -619,6 +631,10 @@ mod tests {
 
         let payloads = &contract["payloads"];
         assert_eq!(
+            contract["endpoints"]["clear_audio"]["path"],
+            "/calls/{call_id}/audio/clear"
+        );
+        assert_eq!(
             payloads["offer_request"]["call_id"],
             "Required call session identifier from the WhatsApp Calling webhook."
         );
@@ -629,6 +645,10 @@ mod tests {
         assert_eq!(
             payloads["call_state"]["queued_rx_bytes"],
             "Inbound decoded PCM bytes queued for Hermes to drain."
+        );
+        assert_eq!(
+            payloads["clear_audio_response"]["dropped_tx_bytes"],
+            "Number of queued outbound PCM bytes discarded."
         );
         assert_eq!(
             payloads["error_response"]["error"],

--- a/docs/contracts/webrtc-sidecar-v1.json
+++ b/docs/contracts/webrtc-sidecar-v1.json
@@ -92,6 +92,11 @@
       "path": "/calls/{call_id}/audio",
       "description": "Queue outbound PCM for a live call session."
     },
+    "clear_audio": {
+      "method": "POST",
+      "path": "/calls/{call_id}/audio/clear",
+      "description": "Drop queued outbound PCM for a live call session without closing the call. Use this for barge-in or call-turn cancellation."
+    },
     "close_call": {
       "method": "POST",
       "path": "/calls/{call_id}/close",
@@ -140,6 +145,13 @@
       "call_id": "Call session identifier.",
       "accepted_bytes": "Number of outbound PCM bytes accepted into the per-call queue.",
       "queued_tx_bytes": "Outbound PCM bytes queued after this write.",
+      "max_tx_queue_bytes": "Maximum outbound PCM bytes this sidecar will queue for one call.",
+      "audio": "Full fixed audio contract object defined by audio."
+    },
+    "clear_audio_response": {
+      "call_id": "Call session identifier.",
+      "dropped_tx_bytes": "Number of queued outbound PCM bytes discarded.",
+      "queued_tx_bytes": "Outbound PCM bytes queued after the clear operation, normally 0.",
       "max_tx_queue_bytes": "Maximum outbound PCM bytes this sidecar will queue for one call.",
       "audio": "Full fixed audio contract object defined by audio."
     },

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -152,7 +152,8 @@ command.
 
 `voice stream-contract` prints the same machine-readable sidecar contract used
 by the Python WebRTC example. Besides the fixed PCM shape and HTTP endpoint
-schema, the `voice_surfaces` object maps integration modes to commands:
+schema, including the outbound-audio clear endpoint used for barge-in, the
+`voice_surfaces` object maps integration modes to commands:
 `completed_voice_note` for WhatsApp-ready Ogg/Opus files, `streamed_voice_note`
 for Ogg/Opus encoded from daemon frames, `raw_outbound_pcm` for WebRTC TTS
 frames, `raw_inbound_pcm` for decoded WebRTC audio entering STT, and

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -142,11 +142,12 @@ PCM and endpoint contract is machine-readable at
 installed `voice` binaries print the same object with `voice stream-contract`.
 The Python sidecar exposes the same object at `GET /contract`. The contract
 defines the fixed PCM audio shape plus the `/offer`, call-state, audio send,
-audio drain, close, and error payloads Hermes needs to drive WhatsApp Calling
-without hard-coding sidecar response shapes. Its `voice_surfaces` section also
-maps each local integration mode to the expected `voice` command: completed
-Ogg/Opus voice notes, streamed Ogg/Opus files, raw outbound PCM frames, raw
-inbound PCM transcription, and file-based inbound stream smokes.
+audio drain, outbound-audio clear, close, and error payloads Hermes needs to
+drive WhatsApp Calling without hard-coding sidecar response shapes. Its
+`voice_surfaces` section also maps each local integration mode to the expected
+`voice` command: completed Ogg/Opus voice notes, streamed Ogg/Opus files, raw
+outbound PCM frames, raw inbound PCM transcription, and file-based inbound
+stream smokes.
 
 The sidecar HTTP API is a local control plane, not a public web API. It should
 bind to localhost or a private socket, with Hermes as the caller. The Python
@@ -189,11 +190,13 @@ Response:
 
 Debug a live session with `GET /calls/{call_id}`. Drain decoded inbound audio
 with `GET /calls/{call_id}/audio`. Queue outbound audio for the WebRTC track
-with `POST /calls/{call_id}/audio`. Terminate a local session with
-`POST /calls/{call_id}/close`. The outbound queue is deliberately bounded;
-`POST /calls/{call_id}/audio` returns HTTP 429 when the sidecar is already
-holding `max_outbound_queue_bytes` for that call, which lets Hermes pause or
-cancel TTS instead of building an unbounded latency backlog.
+with `POST /calls/{call_id}/audio`. Drop queued outbound audio with
+`POST /calls/{call_id}/audio/clear` when inbound speech should barge in without
+tearing down the call. Terminate a local session with `POST
+/calls/{call_id}/close`. The outbound queue is deliberately bounded; `POST
+/calls/{call_id}/audio` returns HTTP 429 when the sidecar is already holding
+`max_outbound_queue_bytes` for that call, which lets Hermes pause or cancel TTS
+instead of building an unbounded latency backlog.
 
 Runtime events:
 
@@ -272,6 +275,33 @@ that the bridge can be mostly mechanical: Hermes can receive `stream_speak` raw
 frames, base64-encode each frame, and POST them to the sidecar while the WebRTC
 track sends per-call queued audio or silence.
 
+Barge-in / cancellation:
+
+```http
+POST /calls/{call_id}/audio/clear
+```
+
+Response:
+
+```json
+{
+  "call_id": "wamid-call-id",
+  "dropped_tx_bytes": 3840,
+  "queued_tx_bytes": 0,
+  "max_tx_queue_bytes": 960000,
+  "audio": {
+    "sample_rate": 48000,
+    "channels": 1,
+    "frame_ms": 20,
+    "encoding": "pcm_s16le"
+  }
+}
+```
+
+Hermes should call this when it decides inbound speech interrupts an in-flight
+spoken reply. That clears stale PCM already accepted by the sidecar while the
+WebRTC track keeps sending silence until fresh TTS arrives.
+
 ## Implementation Options
 
 ### Python `aiortc`
@@ -320,14 +350,15 @@ that path.
 4. Prototype a sidecar that accepts a synthetic SDP offer and round-trips PCM.
    The initial `examples/webrtc-sidecar` artifact covers the SDP answer,
    outbound PCM-to-Opus/WebRTC track, inbound decoded PCM sink, and local HTTP
-   send/drain endpoints. Done as a spike.
+   send/drain/clear endpoints. Done as a spike.
 5. Wire Hermes WhatsApp Cloud `connect` webhooks to the sidecar.
 6. Build an inbound-call echo bot: WhatsApp audio in, same audio out. The
    local `examples/webrtc-sidecar/echo_sidecar_audio.py` helper now covers the
    sidecar-local drain-and-post loop; exercising it against a real WhatsApp
    Cloud call still depends on a calling-enabled number.
 7. Replace echo with STT -> Hermes turn -> `stream_speak` TTS.
-8. Add interruption/barge-in: inbound voice cancels outbound TTS.
+8. Add interruption/barge-in: inbound voice clears queued outbound sidecar PCM
+   and cancels in-flight TTS.
 
 ## Open Questions
 
@@ -340,5 +371,5 @@ that path.
   sidecar keep one transcript per completed utterance?
 - How much silence should the sidecar send before the agent's first TTS frame
   is ready? WebRTC calls should have media flowing immediately after accept.
-- What barge-in policy should Hermes use: immediate cancel on VAD, cancel after
-  partial transcript, or full-duplex overlap?
+- What barge-in policy should Hermes use: immediate clear/cancel on VAD, cancel
+  after partial transcript, or full-duplex overlap?

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -76,6 +76,8 @@ outbound queue is bounded by the contract's `max_outbound_queue_bytes` value;
 instead of allowing unbounded TTS buffering. If both sources are idle, the
 sidecar sends silence. That is useful for checking SDP, ICE, and call timing
 before TTS is wired in.
+For barge-in or cancellation, `POST /calls/{call_id}/audio/clear` drops queued
+per-call outbound PCM while leaving the WebRTC session alive.
 
 For FIFO-based smoke tests, start the sidecar with `--tx-pcm`:
 
@@ -181,6 +183,29 @@ Response:
   "call_id": "local-test",
   "accepted_bytes": 1920,
   "queued_tx_bytes": 1920,
+  "max_tx_queue_bytes": 960000,
+  "audio": {
+    "sample_rate": 48000,
+    "channels": 1,
+    "frame_ms": 20,
+    "encoding": "pcm_s16le"
+  }
+}
+```
+
+Clear queued outbound PCM without closing the call:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8787/calls/local-test/audio/clear
+```
+
+Response:
+
+```json
+{
+  "call_id": "local-test",
+  "dropped_tx_bytes": 3840,
+  "queued_tx_bytes": 0,
   "max_tx_queue_bytes": 960000,
   "audio": {
     "sample_rate": 48000,

--- a/examples/webrtc-sidecar/sidecar.py
+++ b/examples/webrtc-sidecar/sidecar.py
@@ -232,6 +232,11 @@ class CallPcmSource:
         self.buffer.extend(pcm_s16le)
         return len(pcm_s16le)
 
+    def clear(self) -> int:
+        dropped_bytes = len(self.buffer)
+        self.buffer.clear()
+        return dropped_bytes
+
     def read_frame(self) -> bytes:
         if len(self.buffer) >= FRAME_BYTES:
             frame = bytes(self.buffer[:FRAME_BYTES])
@@ -393,6 +398,17 @@ class CallSession:
             "queued_tx_bytes": self.source.queued_bytes,
             "max_tx_queue_bytes": self.source.max_queue_bytes,
             "queued_rx_bytes": self.inbound.queued_bytes,
+            "audio": audio_contract(),
+        }
+
+    def clear_outbound_audio(self) -> dict[str, Any]:
+        """Drop queued outbound PCM while keeping the WebRTC call alive."""
+        dropped_bytes = self.source.clear()
+        return {
+            "call_id": self.call_id,
+            "dropped_tx_bytes": dropped_bytes,
+            "queued_tx_bytes": self.source.queued_bytes,
+            "max_tx_queue_bytes": self.source.max_queue_bytes,
             "audio": audio_contract(),
         }
 
@@ -615,6 +631,13 @@ def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
             }
         )
 
+    async def clear_audio(request: web.Request) -> web.Response:
+        call_id = request.match_info["call_id"]
+        session = sessions.get(call_id)
+        if session is None:
+            return json_error("unknown call_id", status=404)
+        return web.json_response(session.clear_outbound_audio())
+
     async def close_call(request: web.Request) -> web.Response:
         call_id = request.match_info["call_id"]
         session = sessions.pop(call_id, None)
@@ -634,6 +657,7 @@ def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
     app.router.add_get("/calls/{call_id}", call_status)
     app.router.add_get("/calls/{call_id}/audio", receive_audio)
     app.router.add_post("/calls/{call_id}/audio", send_audio)
+    app.router.add_post("/calls/{call_id}/audio/clear", clear_audio)
     app.router.add_post("/calls/{call_id}/close", close_call)
     app.on_cleanup.append(cleanup)
     return app

--- a/examples/webrtc-sidecar/test_sidecar.py
+++ b/examples/webrtc-sidecar/test_sidecar.py
@@ -134,6 +134,9 @@ def test_contract_endpoint_returns_machine_readable_contract():
             assert body["contract"] == "voice.webrtc_sidecar"
             assert body["version"] == 1
             assert body["audio"]["frame_bytes"] == sidecar.FRAME_BYTES
+            assert body["endpoints"]["clear_audio"]["path"] == (
+                "/calls/{call_id}/audio/clear"
+            )
 
     asyncio.run(run())
 
@@ -189,6 +192,18 @@ def test_call_pcm_source_rejects_overflow():
     else:
         raise AssertionError("expected outbound queue overflow to be rejected")
     assert source.queued_bytes == 4
+
+
+def test_call_pcm_source_clear_drops_queued_audio():
+    sidecar = load_sidecar()
+
+    fallback = sidecar.PcmSource(None)
+    source = sidecar.CallPcmSource(fallback)
+    source.write_frame(b"\x01\x00\x02\x00")
+
+    assert source.clear() == 4
+    assert source.queued_bytes == 0
+    assert source.read_frame() == b"\x00" * sidecar.FRAME_BYTES
 
 
 def test_inbound_pcm_sink_drains_queued_audio():
@@ -332,6 +347,56 @@ def test_audio_endpoint_queues_pcm_for_call():
             frame = source.read_frame()
             assert frame.startswith(b"\x01\x00\xff\xff")
             assert frame[4:] == b"\x00" * (sidecar.FRAME_BYTES - 4)
+
+    asyncio.run(run())
+
+
+def test_clear_audio_endpoint_drops_queued_pcm_for_call():
+    sidecar = load_sidecar()
+
+    class FakeSession:
+        def __init__(self, source) -> None:
+            self.source = source
+
+        def clear_outbound_audio(self):
+            dropped_bytes = self.source.clear()
+            return {
+                "call_id": "call-1",
+                "dropped_tx_bytes": dropped_bytes,
+                "queued_tx_bytes": self.source.queued_bytes,
+                "max_tx_queue_bytes": self.source.max_queue_bytes,
+                "audio": sidecar.audio_contract(),
+            }
+
+        async def close(self) -> None:
+            pass
+
+    async def run():
+        from aiohttp.test_utils import TestClient, TestServer
+
+        fallback = sidecar.PcmSource(None)
+        source = sidecar.CallPcmSource(fallback)
+        source.write_frame(b"\x01\x00\xff\xff")
+        app = sidecar.create_app(fallback, None)
+        app[sidecar.SESSIONS_KEY]["call-1"] = FakeSession(source)
+
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post("/calls/call-1/audio/clear")
+            assert response.status == 200
+            body = await response.json()
+            assert body == {
+                "call_id": "call-1",
+                "dropped_tx_bytes": 4,
+                "queued_tx_bytes": 0,
+                "max_tx_queue_bytes": source.max_queue_bytes,
+                "audio": sidecar.audio_contract(),
+            }
+            assert source.queued_bytes == 0
+
+            missing_response = await client.post("/calls/missing/audio/clear")
+            assert missing_response.status == 404
+            missing_body = await missing_response.json()
+            assert missing_body == {"error": "unknown call_id"}
 
     asyncio.run(run())
 

--- a/scripts/verify_whatsapp_voice_contract.sh
+++ b/scripts/verify_whatsapp_voice_contract.sh
@@ -183,6 +183,23 @@ require(
     "raw_inbound_pcm frame_bytes must be 1920",
 )
 
+endpoints = contract.get("endpoints") or {}
+clear_audio = endpoints.get("clear_audio") or {}
+require(
+    clear_audio.get("method") == "POST",
+    "clear_audio endpoint method must be POST",
+)
+require(
+    clear_audio.get("path") == "/calls/{call_id}/audio/clear",
+    "clear_audio endpoint path must be /calls/{call_id}/audio/clear",
+)
+payloads = contract.get("payloads") or {}
+clear_response = payloads.get("clear_audio_response") or {}
+require(
+    "dropped_tx_bytes" in clear_response,
+    "clear_audio_response must report dropped_tx_bytes",
+)
+
 if expected_path.is_file():
     expected = json.loads(expected_path.read_text(encoding="utf-8"))
     require(contract == expected, f"{contract_path} does not match {expected_path}")


### PR DESCRIPTION
## Summary

Adds a v1 WebRTC sidecar control endpoint for barge-in / cancellation:

- `POST /calls/{call_id}/audio/clear`
- drops queued per-call outbound PCM while keeping the WebRTC session alive
- returns `dropped_tx_bytes`, `queued_tx_bytes`, `max_tx_queue_bytes`, and the fixed audio contract

This updates the checked-in contract JSON, `voice stream-contract`, the Python sidecar implementation, docs, and the WhatsApp contract verifier.

## Why

Hermes can already detect inbound call audio and stream TTS PCM back to the sidecar, but without a queue-clear operation it cannot discard stale already-accepted TTS audio during barge-in without closing the whole call. This endpoint gives Hermes a precise local primitive for the next barge-in step.

## Validation

```text
cargo fmt --check
cargo test -p voice-stream
python3 -m py_compile examples/webrtc-sidecar/sidecar.py examples/webrtc-sidecar/test_sidecar.py
/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py
cargo run -q -p voice -- stream-contract > /tmp/voice-stream-contract.json && python3 - <<'PY'
import json
from pathlib import Path
actual = json.loads(Path('/tmp/voice-stream-contract.json').read_text())
expected = json.loads(Path('docs/contracts/webrtc-sidecar-v1.json').read_text())
assert actual == expected
assert actual['endpoints']['clear_audio']['path'] == '/calls/{call_id}/audio/clear'
assert 'dropped_tx_bytes' in actual['payloads']['clear_audio_response']
print('ok: stream-contract matches checked-in contract with clear_audio')
PY
scripts/verify_whatsapp_voice_contract.sh --voice-bin target/debug/voice --skip-daemon
```
