### PR TITLE
Pace WebRTC sidecar voice stream posting

### DIFF
--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -105,7 +105,9 @@ The contract includes `voice_surfaces`, a machine-readable map from integration
 mode to command: completed Ogg/Opus voice notes, streamed Ogg/Opus files, raw
 outbound PCM, raw inbound PCM, and file-based stream-transcribe smokes.
 `post_voice_stream.py` validates the raw PCM surface metadata when it is
-present so frame-size or transport drift fails before a live call.
+present so frame-size or transport drift fails before a live call. It posts
+frames on the contract's `frame_ms` cadence, so a fast `voice stream` process
+does not build a large outbound playback queue in the sidecar.
 
 Post a remote offer:
 

--- a/examples/webrtc-sidecar/post_voice_stream.py
+++ b/examples/webrtc-sidecar/post_voice_stream.py
@@ -21,6 +21,7 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+import time
 from typing import BinaryIO
 from urllib import error, parse, request
 
@@ -54,6 +55,35 @@ class SidecarAudioPostError(RuntimeError):
         super().__init__(
             f"sidecar rejected audio frame ({status_code}): {body}"
         )
+
+
+class FramePacer:
+    """Pace fixed-size PCM frames at the sidecar audio contract interval."""
+
+    def __init__(
+        self,
+        frame_ms: int,
+        *,
+        monotonic=time.monotonic,
+        sleep=time.sleep,
+    ) -> None:
+        if frame_ms <= 0:
+            raise ValueError("frame_ms must be positive")
+        self.interval_s = frame_ms / 1_000
+        self.monotonic = monotonic
+        self.sleep = sleep
+        self.next_frame_at: float | None = None
+
+    def wait(self) -> None:
+        now = self.monotonic()
+        if self.next_frame_at is None:
+            self.next_frame_at = now + self.interval_s
+            return
+
+        if now < self.next_frame_at:
+            self.sleep(self.next_frame_at - now)
+            now = self.monotonic()
+        self.next_frame_at = max(self.next_frame_at, now) + self.interval_s
 
 
 def load_audio_contract(
@@ -359,8 +389,10 @@ def main() -> int:
     frame_count = 0
     byte_count = 0
     post_error: Exception | None = None
+    pacer = FramePacer(contract.frame_ms)
     try:
         for frame in iter_pcm_frames(process.stdout, contract.frame_bytes):
+            pacer.wait()
             try:
                 post_audio_frame(url, contract, frame, args.timeout)
             except Exception as exc:

--- a/examples/webrtc-sidecar/test_post_voice_stream.py
+++ b/examples/webrtc-sidecar/test_post_voice_stream.py
@@ -170,6 +170,59 @@ def test_iter_pcm_frames_reads_exact_frames_and_pads_final():
     assert frames == [b"aaaaa", b"bb\x00\x00\x00"]
 
 
+def test_frame_pacer_sends_first_frame_immediately_then_waits():
+    bridge = load_bridge()
+    now = [100.0]
+    sleeps: list[float] = []
+
+    def monotonic():
+        return now[0]
+
+    def sleep(delay: float):
+        sleeps.append(delay)
+        now[0] += delay
+
+    pacer = bridge.FramePacer(20, monotonic=monotonic, sleep=sleep)
+
+    pacer.wait()
+    pacer.wait()
+
+    assert len(sleeps) == 1
+    assert abs(sleeps[0] - 0.02) < 0.000001
+
+
+def test_frame_pacer_catches_up_after_slow_post_without_extra_sleep():
+    bridge = load_bridge()
+    now = [100.0]
+    sleeps: list[float] = []
+
+    def monotonic():
+        return now[0]
+
+    def sleep(delay: float):
+        sleeps.append(delay)
+        now[0] += delay
+
+    pacer = bridge.FramePacer(20, monotonic=monotonic, sleep=sleep)
+
+    pacer.wait()
+    now[0] += 0.050
+    pacer.wait()
+
+    assert sleeps == []
+
+
+def test_frame_pacer_rejects_invalid_frame_duration():
+    bridge = load_bridge()
+
+    try:
+        bridge.FramePacer(0)
+    except ValueError as exc:
+        assert "frame_ms" in str(exc)
+    else:
+        raise AssertionError("expected invalid frame duration to be rejected")
+
+
 def test_build_audio_payload_uses_contract_shape():
     bridge = load_bridge()
     contract = bridge.AudioContract(


### PR DESCRIPTION
## Summary

Paces `examples/webrtc-sidecar/post_voice_stream.py` on the sidecar contract's `frame_ms` cadence before POSTing raw PCM frames to `/calls/{call_id}/audio`.

The helper still sends the first frame immediately, but subsequent frames wait for the next playback slot. If a POST or upstream `voice stream` read is already slower than real time, the pacer catches up without adding extra delay. This keeps a fast `voice stream` process from filling the sidecar outbound queue and adding avoidable live-call latency.

Also documents the behavior in the WebRTC sidecar README.

## Why

Hermes now paces live-call raw TTS frames before posting to the sidecar. This makes the voice-side helper match that runtime behavior, and improves the local WebRTC smoke tools used to validate WhatsApp Calling architecture.

Before this change, the full-duplex smoke could finish with hundreds of KB queued in the sidecar. After this change, the same smoke finished with `queued_tx_bytes: 1920`, one 20 ms frame.

## Validation

- `python3 -m py_compile examples/webrtc-sidecar/post_voice_stream.py examples/webrtc-sidecar/test_post_voice_stream.py`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_post_voice_stream.py` => 15 passed
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar` => 55 passed
- `/tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/full_duplex_loopback_smoke.py --voice-bin /home/ubuntu/.local/bin/voice --timeout 90 --expect-word hello --expect-word world` => passed, transcript `Hello World`, `queued_tx_bytes: 1920`
- `cargo fmt --check`
- `cargo test -p voice-stream` => 12 passed
- `scripts/verify_whatsapp_voice_contract.sh --voice-bin /home/ubuntu/.local/bin/voice --skip-daemon` => passed
