### PR TITLE
Guard full-duplex sidecar queue latency

### DIFF
--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -292,4 +292,7 @@ WebRTC-to-STT path without WhatsApp or the Graph API.
 `full_duplex_loopback_smoke.py` exercises both directions on one sidecar call:
 local WebRTC audio drains through `voice stream-transcribe`, while
 `post_voice_stream.py` queues outbound `voice stream` PCM back to the same
-WebRTC peer. It is the closest local smoke to a single WhatsApp call turn.
+WebRTC peer. It is the closest local smoke to a single WhatsApp call turn. It
+also fails when the sidecar still has more than one second of outbound audio
+queued at the end of the turn; use `--max-queued-tx-ms` to tighten or loosen
+that local latency budget.

--- a/examples/webrtc-sidecar/full_duplex_loopback_smoke.py
+++ b/examples/webrtc-sidecar/full_duplex_loopback_smoke.py
@@ -48,6 +48,37 @@ from voice_stream_loopback_smoke import (
 
 DEFAULT_INBOUND_TEXT = "hello world"
 DEFAULT_OUTBOUND_TEXT = "Hello from a full duplex WebRTC sidecar turn."
+DEFAULT_MAX_QUEUED_TX_MS = 1_000
+
+
+def queued_tx_ms(queued_tx_bytes: object, audio: dict[str, Any]) -> int:
+    try:
+        queued_bytes = int(queued_tx_bytes or 0)
+        sample_rate = int(audio.get("sample_rate") or 0)
+        channels = int(audio.get("channels") or 0)
+        bytes_per_sample = int(audio.get("bytes_per_sample") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+    bytes_per_second = sample_rate * channels * bytes_per_sample
+    if queued_bytes <= 0 or bytes_per_second <= 0:
+        return 0
+    return round(queued_bytes * 1_000 / bytes_per_second)
+
+
+def validate_queued_tx_budget(call: dict[str, Any], max_queued_tx_ms: int) -> int:
+    if max_queued_tx_ms < 0:
+        raise ValueError("max_queued_tx_ms must be non-negative")
+    audio = call.get("audio")
+    if not isinstance(audio, dict):
+        raise RuntimeError("full-duplex sidecar status did not include audio contract")
+    queued_ms = queued_tx_ms(call.get("queued_tx_bytes"), audio)
+    if queued_ms > max_queued_tx_ms:
+        raise RuntimeError(
+            "sidecar outbound audio queue exceeded budget "
+            f"({queued_ms} ms > {max_queued_tx_ms} ms)"
+        )
+    return queued_ms
 
 
 async def start_sidecar_app() -> tuple[web.AppRunner, str]:
@@ -211,6 +242,10 @@ async def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
                 f"transcript {transcript!r} did not contain expected words "
                 f"{args.expect_word!r}"
             )
+        queued_tx_ms_value = validate_queued_tx_budget(
+            call,
+            args.max_queued_tx_ms,
+        )
 
         retained = not remove_workdir
         return {
@@ -226,6 +261,8 @@ async def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
             "inbound_path": str(inbound_path) if retained else "<temporary>",
             "decoded_path": str(decoded_path) if retained else "<temporary>",
             "retained": retained,
+            "max_queued_tx_ms": args.max_queued_tx_ms,
+            "queued_tx_ms": queued_tx_ms_value,
             **call,
             "stt": transcript_event["data"],
         }
@@ -251,7 +288,18 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--workdir", type=Path)
     parser.add_argument("--keep-workdir", action="store_true")
+    parser.add_argument(
+        "--max-queued-tx-ms",
+        type=int,
+        default=DEFAULT_MAX_QUEUED_TX_MS,
+        help=(
+            "Maximum outbound sidecar queue depth allowed at the end of the "
+            "smoke. Set to 0 to require a fully drained queue."
+        ),
+    )
     args = parser.parse_args()
+    if args.max_queued_tx_ms < 0:
+        parser.error("--max-queued-tx-ms must be non-negative")
     if args.expect_word is None:
         args.expect_word = list(DEFAULT_EXPECT_WORDS)
     return args

--- a/examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py
+++ b/examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py
@@ -28,6 +28,7 @@ def test_parse_args_uses_default_expected_words(monkeypatch):
     assert args.inbound_text == "hello world"
     assert args.outbound_text.startswith("Hello from a full duplex")
     assert args.expect_word == ["hello", "world"]
+    assert args.max_queued_tx_ms == smoke.DEFAULT_MAX_QUEUED_TX_MS
 
 
 def test_parse_args_replaces_default_expected_words(monkeypatch):
@@ -43,6 +44,8 @@ def test_parse_args_replaces_default_expected_words(monkeypatch):
             "testing",
             "--expect-word",
             "two",
+            "--max-queued-tx-ms",
+            "250",
         ],
     )
 
@@ -50,3 +53,70 @@ def test_parse_args_replaces_default_expected_words(monkeypatch):
 
     assert args.inbound_text == "testing one two"
     assert args.expect_word == ["testing", "two"]
+    assert args.max_queued_tx_ms == 250
+
+
+def test_parse_args_rejects_negative_queue_budget(monkeypatch):
+    smoke = load_smoke()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "full_duplex_loopback_smoke.py",
+            "--max-queued-tx-ms",
+            "-1",
+        ],
+    )
+
+    try:
+        smoke.parse_args()
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("expected negative queue budget to be rejected")
+
+
+def test_queued_tx_ms_converts_bytes_to_audio_duration():
+    smoke = load_smoke()
+    audio = {
+        "sample_rate": 48_000,
+        "channels": 1,
+        "bytes_per_sample": 2,
+    }
+
+    assert smoke.queued_tx_ms(1_920, audio) == 20
+    assert smoke.queued_tx_ms(96_000, audio) == 1_000
+
+
+def test_validate_queued_tx_budget_returns_duration_when_within_budget():
+    smoke = load_smoke()
+    call = {
+        "queued_tx_bytes": 1_920,
+        "audio": {
+            "sample_rate": 48_000,
+            "channels": 1,
+            "bytes_per_sample": 2,
+        },
+    }
+
+    assert smoke.validate_queued_tx_budget(call, 20) == 20
+
+
+def test_validate_queued_tx_budget_rejects_excessive_backlog():
+    smoke = load_smoke()
+    call = {
+        "queued_tx_bytes": 192_000,
+        "audio": {
+            "sample_rate": 48_000,
+            "channels": 1,
+            "bytes_per_sample": 2,
+        },
+    }
+
+    try:
+        smoke.validate_queued_tx_budget(call, 1_000)
+    except RuntimeError as exc:
+        assert "exceeded budget" in str(exc)
+        assert "2000 ms > 1000 ms" in str(exc)
+    else:
+        raise AssertionError("expected excessive queue depth to be rejected")


### PR DESCRIPTION
## Summary

Adds a latency regression guard to `examples/webrtc-sidecar/full_duplex_loopback_smoke.py`.

The smoke now converts the sidecar's final `queued_tx_bytes` into queued outbound audio duration and fails if it exceeds `--max-queued-tx-ms`.

Default budget: `1000` ms.

The JSON result now includes:

- `max_queued_tx_ms`
- `queued_tx_ms`

The README documents the new guard and override flag.

## Why

PR #155 paces `post_voice_stream.py` so the sidecar does not accumulate a multi-second outbound queue. The full-duplex smoke already proved media worked, but it would still pass if the queue regressed to several seconds of buffered audio. This PR makes that latency property explicit and testable.

On this machine the real smoke ended with `queued_tx_ms: 0`, `queued_tx_bytes: 0`.

## Validation

- `python3 -m py_compile examples/webrtc-sidecar/full_duplex_loopback_smoke.py examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py` => 6 passed
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar` => 59 passed
- `/tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/full_duplex_loopback_smoke.py --voice-bin /home/ubuntu/.local/bin/voice --timeout 90 --expect-word hello --expect-word world` => passed, transcript `Hello world.`, `queued_tx_ms: 0`, `queued_tx_bytes: 0`
- `cargo fmt --check`
- `cargo test -p voice-stream` => 12 passed
- `scripts/verify_whatsapp_voice_contract.sh --voice-bin /home/ubuntu/.local/bin/voice --skip-daemon` => passed
