### PR TITLE
Report WebRTC sidecar queue latency

### DIFF
--- a/crates/voice-stream/src/lib.rs
+++ b/crates/voice-stream/src/lib.rs
@@ -158,8 +158,13 @@ pub fn webrtc_sidecar_contract() -> serde_json::Value {
                 "signaling_state": "WebRTC signaling state.",
                 "tasks": "Number of active background media tasks owned by the session.",
                 "queued_tx_bytes": "Outbound PCM bytes queued for WebRTC transmission.",
+                "queued_tx_ms": "Approximate outbound PCM duration queued for WebRTC transmission, rounded up to whole milliseconds.",
                 "max_tx_queue_bytes": "Maximum outbound PCM bytes this sidecar will queue for one call.",
+                "max_tx_queue_ms": "Maximum outbound PCM duration this sidecar will queue for one call, rounded up to whole milliseconds.",
                 "queued_rx_bytes": "Inbound decoded PCM bytes queued for Hermes to drain.",
+                "queued_rx_ms": "Approximate inbound decoded PCM duration queued for Hermes to drain, rounded up to whole milliseconds.",
+                "max_rx_queue_bytes": "Maximum inbound decoded PCM bytes this sidecar will retain for one call.",
+                "max_rx_queue_ms": "Maximum inbound decoded PCM duration this sidecar will retain for one call, rounded up to whole milliseconds.",
                 "audio": "Full fixed audio contract object defined by audio."
             },
             "call_status_response": "The call_state object for the requested call_id.",
@@ -177,21 +182,31 @@ pub fn webrtc_sidecar_contract() -> serde_json::Value {
             "send_audio_response": {
                 "call_id": "Call session identifier.",
                 "accepted_bytes": "Number of outbound PCM bytes accepted into the per-call queue.",
+                "accepted_ms": "Approximate outbound PCM duration accepted into the per-call queue, rounded up to whole milliseconds.",
                 "queued_tx_bytes": "Outbound PCM bytes queued after this write.",
+                "queued_tx_ms": "Approximate outbound PCM duration queued after this write, rounded up to whole milliseconds.",
                 "max_tx_queue_bytes": "Maximum outbound PCM bytes this sidecar will queue for one call.",
+                "max_tx_queue_ms": "Maximum outbound PCM duration this sidecar will queue for one call, rounded up to whole milliseconds.",
                 "audio": "Full fixed audio contract object defined by audio."
             },
             "clear_audio_response": {
                 "call_id": "Call session identifier.",
                 "dropped_tx_bytes": "Number of queued outbound PCM bytes discarded.",
+                "dropped_tx_ms": "Approximate queued outbound PCM duration discarded, rounded up to whole milliseconds.",
                 "queued_tx_bytes": "Outbound PCM bytes queued after the clear operation, normally 0.",
+                "queued_tx_ms": "Approximate outbound PCM duration queued after the clear operation, normally 0.",
                 "max_tx_queue_bytes": "Maximum outbound PCM bytes this sidecar will queue for one call.",
+                "max_tx_queue_ms": "Maximum outbound PCM duration this sidecar will queue for one call, rounded up to whole milliseconds.",
                 "audio": "Full fixed audio contract object defined by audio."
             },
             "receive_audio_response": {
                 "call_id": "Call session identifier.",
                 "returned_bytes": "Number of decoded PCM bytes returned.",
+                "returned_ms": "Approximate decoded PCM duration returned, rounded up to whole milliseconds.",
                 "queued_rx_bytes": "Remaining inbound decoded PCM bytes queued after this drain.",
+                "queued_rx_ms": "Approximate inbound decoded PCM duration queued after this drain, rounded up to whole milliseconds.",
+                "max_rx_queue_bytes": "Maximum inbound decoded PCM bytes this sidecar will retain for one call.",
+                "max_rx_queue_ms": "Maximum inbound decoded PCM duration this sidecar will retain for one call, rounded up to whole milliseconds.",
                 "pcm_s16le_base64": "Base64 encoded signed 16-bit little-endian mono PCM.",
                 "audio": "Full fixed audio contract object defined by audio."
             },
@@ -647,8 +662,36 @@ mod tests {
             "Inbound decoded PCM bytes queued for Hermes to drain."
         );
         assert_eq!(
+            payloads["call_state"]["queued_tx_ms"],
+            "Approximate outbound PCM duration queued for WebRTC transmission, rounded up to whole milliseconds."
+        );
+        assert_eq!(
+            payloads["call_state"]["max_rx_queue_ms"],
+            "Maximum inbound decoded PCM duration this sidecar will retain for one call, rounded up to whole milliseconds."
+        );
+        assert_eq!(
+            payloads["call_state"]["max_rx_queue_bytes"],
+            "Maximum inbound decoded PCM bytes this sidecar will retain for one call."
+        );
+        assert_eq!(
+            payloads["send_audio_response"]["accepted_ms"],
+            "Approximate outbound PCM duration accepted into the per-call queue, rounded up to whole milliseconds."
+        );
+        assert_eq!(
             payloads["clear_audio_response"]["dropped_tx_bytes"],
             "Number of queued outbound PCM bytes discarded."
+        );
+        assert_eq!(
+            payloads["clear_audio_response"]["dropped_tx_ms"],
+            "Approximate queued outbound PCM duration discarded, rounded up to whole milliseconds."
+        );
+        assert_eq!(
+            payloads["receive_audio_response"]["returned_ms"],
+            "Approximate decoded PCM duration returned, rounded up to whole milliseconds."
+        );
+        assert_eq!(
+            payloads["receive_audio_response"]["max_rx_queue_bytes"],
+            "Maximum inbound decoded PCM bytes this sidecar will retain for one call."
         );
         assert_eq!(
             payloads["error_response"]["error"],

--- a/docs/contracts/webrtc-sidecar-v1.json
+++ b/docs/contracts/webrtc-sidecar-v1.json
@@ -125,8 +125,13 @@
       "signaling_state": "WebRTC signaling state.",
       "tasks": "Number of active background media tasks owned by the session.",
       "queued_tx_bytes": "Outbound PCM bytes queued for WebRTC transmission.",
+      "queued_tx_ms": "Approximate outbound PCM duration queued for WebRTC transmission, rounded up to whole milliseconds.",
       "max_tx_queue_bytes": "Maximum outbound PCM bytes this sidecar will queue for one call.",
+      "max_tx_queue_ms": "Maximum outbound PCM duration this sidecar will queue for one call, rounded up to whole milliseconds.",
       "queued_rx_bytes": "Inbound decoded PCM bytes queued for Hermes to drain.",
+      "queued_rx_ms": "Approximate inbound decoded PCM duration queued for Hermes to drain, rounded up to whole milliseconds.",
+      "max_rx_queue_bytes": "Maximum inbound decoded PCM bytes this sidecar will retain for one call.",
+      "max_rx_queue_ms": "Maximum inbound decoded PCM duration this sidecar will retain for one call, rounded up to whole milliseconds.",
       "audio": "Full fixed audio contract object defined by audio."
     },
     "call_status_response": "The call_state object for the requested call_id.",
@@ -144,21 +149,31 @@
     "send_audio_response": {
       "call_id": "Call session identifier.",
       "accepted_bytes": "Number of outbound PCM bytes accepted into the per-call queue.",
+      "accepted_ms": "Approximate outbound PCM duration accepted into the per-call queue, rounded up to whole milliseconds.",
       "queued_tx_bytes": "Outbound PCM bytes queued after this write.",
+      "queued_tx_ms": "Approximate outbound PCM duration queued after this write, rounded up to whole milliseconds.",
       "max_tx_queue_bytes": "Maximum outbound PCM bytes this sidecar will queue for one call.",
+      "max_tx_queue_ms": "Maximum outbound PCM duration this sidecar will queue for one call, rounded up to whole milliseconds.",
       "audio": "Full fixed audio contract object defined by audio."
     },
     "clear_audio_response": {
       "call_id": "Call session identifier.",
       "dropped_tx_bytes": "Number of queued outbound PCM bytes discarded.",
+      "dropped_tx_ms": "Approximate queued outbound PCM duration discarded, rounded up to whole milliseconds.",
       "queued_tx_bytes": "Outbound PCM bytes queued after the clear operation, normally 0.",
+      "queued_tx_ms": "Approximate outbound PCM duration queued after the clear operation, normally 0.",
       "max_tx_queue_bytes": "Maximum outbound PCM bytes this sidecar will queue for one call.",
+      "max_tx_queue_ms": "Maximum outbound PCM duration this sidecar will queue for one call, rounded up to whole milliseconds.",
       "audio": "Full fixed audio contract object defined by audio."
     },
     "receive_audio_response": {
       "call_id": "Call session identifier.",
       "returned_bytes": "Number of decoded PCM bytes returned.",
+      "returned_ms": "Approximate decoded PCM duration returned, rounded up to whole milliseconds.",
       "queued_rx_bytes": "Remaining inbound decoded PCM bytes queued after this drain.",
+      "queued_rx_ms": "Approximate inbound decoded PCM duration queued after this drain, rounded up to whole milliseconds.",
+      "max_rx_queue_bytes": "Maximum inbound decoded PCM bytes this sidecar will retain for one call.",
+      "max_rx_queue_ms": "Maximum inbound decoded PCM duration this sidecar will retain for one call, rounded up to whole milliseconds.",
       "pcm_s16le_base64": "Base64 encoded signed 16-bit little-endian mono PCM.",
       "audio": "Full fixed audio contract object defined by audio."
     },

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -219,7 +219,11 @@ Response:
 {
   "call_id": "wamid-call-id",
   "returned_bytes": 1920,
+  "returned_ms": 20,
   "queued_rx_bytes": 3840,
+  "queued_rx_ms": 40,
+  "max_rx_queue_bytes": 960000,
+  "max_rx_queue_ms": 10000,
   "pcm_s16le_base64": "...",
   "audio": {
     "sample_rate": 48000,
@@ -258,8 +262,11 @@ Response:
 {
   "call_id": "wamid-call-id",
   "accepted_bytes": 1920,
+  "accepted_ms": 20,
   "queued_tx_bytes": 1920,
+  "queued_tx_ms": 20,
   "max_tx_queue_bytes": 960000,
+  "max_tx_queue_ms": 10000,
   "audio": {
     "sample_rate": 48000,
     "channels": 1,
@@ -287,8 +294,11 @@ Response:
 {
   "call_id": "wamid-call-id",
   "dropped_tx_bytes": 3840,
+  "dropped_tx_ms": 40,
   "queued_tx_bytes": 0,
+  "queued_tx_ms": 0,
   "max_tx_queue_bytes": 960000,
+  "max_tx_queue_ms": 10000,
   "audio": {
     "sample_rate": 48000,
     "channels": 1,

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -184,8 +184,11 @@ Response:
 {
   "call_id": "local-test",
   "accepted_bytes": 1920,
+  "accepted_ms": 20,
   "queued_tx_bytes": 1920,
+  "queued_tx_ms": 20,
   "max_tx_queue_bytes": 960000,
+  "max_tx_queue_ms": 10000,
   "audio": {
     "sample_rate": 48000,
     "channels": 1,
@@ -207,8 +210,11 @@ Response:
 {
   "call_id": "local-test",
   "dropped_tx_bytes": 3840,
+  "dropped_tx_ms": 40,
   "queued_tx_bytes": 0,
+  "queued_tx_ms": 0,
   "max_tx_queue_bytes": 960000,
+  "max_tx_queue_ms": 10000,
   "audio": {
     "sample_rate": 48000,
     "channels": 1,

--- a/examples/webrtc-sidecar/sidecar.py
+++ b/examples/webrtc-sidecar/sidecar.py
@@ -135,6 +135,7 @@ MAX_OUTBOUND_QUEUE_BYTES = int(AUDIO_CONTRACT["max_outbound_queue_bytes"])
 MAX_INBOUND_QUEUE_BYTES = int(AUDIO_CONTRACT["max_inbound_queue_bytes"])
 MAX_DRAIN_WAIT_MS = int(AUDIO_CONTRACT["max_drain_wait_ms"])
 LOCAL_HOSTNAMES = {"localhost"}
+PCM_BYTES_PER_SECOND = SAMPLE_RATE * CHANNELS * BYTES_PER_SAMPLE
 
 
 def is_loopback_host(host: str) -> bool:
@@ -154,6 +155,12 @@ def validate_bind_host(host: str, *, allow_nonlocal: bool = False) -> None:
         f"{host!r}; use --allow-nonlocal only behind a trusted local network "
         "or private socket boundary"
     )
+
+
+def pcm_bytes_to_ms(byte_count: int) -> int:
+    if byte_count <= 0:
+        return 0
+    return (byte_count * 1_000 + PCM_BYTES_PER_SECOND - 1) // PCM_BYTES_PER_SECOND
 
 
 class PcmSource:
@@ -396,8 +403,13 @@ class CallSession:
             "signaling_state": self.pc.signalingState,
             "tasks": len(self.tasks),
             "queued_tx_bytes": self.source.queued_bytes,
+            "queued_tx_ms": pcm_bytes_to_ms(self.source.queued_bytes),
             "max_tx_queue_bytes": self.source.max_queue_bytes,
+            "max_tx_queue_ms": pcm_bytes_to_ms(self.source.max_queue_bytes),
             "queued_rx_bytes": self.inbound.queued_bytes,
+            "queued_rx_ms": pcm_bytes_to_ms(self.inbound.queued_bytes),
+            "max_rx_queue_bytes": self.inbound.max_queue_bytes,
+            "max_rx_queue_ms": pcm_bytes_to_ms(self.inbound.max_queue_bytes),
             "audio": audio_contract(),
         }
 
@@ -407,8 +419,11 @@ class CallSession:
         return {
             "call_id": self.call_id,
             "dropped_tx_bytes": dropped_bytes,
+            "dropped_tx_ms": pcm_bytes_to_ms(dropped_bytes),
             "queued_tx_bytes": self.source.queued_bytes,
+            "queued_tx_ms": pcm_bytes_to_ms(self.source.queued_bytes),
             "max_tx_queue_bytes": self.source.max_queue_bytes,
+            "max_tx_queue_ms": pcm_bytes_to_ms(self.source.max_queue_bytes),
             "audio": audio_contract(),
         }
 
@@ -602,8 +617,11 @@ def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
             {
                 "call_id": call_id,
                 "accepted_bytes": accepted_bytes,
+                "accepted_ms": pcm_bytes_to_ms(accepted_bytes),
                 "queued_tx_bytes": session.source.queued_bytes,
+                "queued_tx_ms": pcm_bytes_to_ms(session.source.queued_bytes),
                 "max_tx_queue_bytes": session.source.max_queue_bytes,
+                "max_tx_queue_ms": pcm_bytes_to_ms(session.source.max_queue_bytes),
                 "audio": audio_contract(),
             }
         )
@@ -625,7 +643,11 @@ def create_app(source: PcmSource, rx_pcm: str | None) -> web.Application:
             {
                 "call_id": call_id,
                 "returned_bytes": len(pcm),
+                "returned_ms": pcm_bytes_to_ms(len(pcm)),
                 "queued_rx_bytes": session.inbound.queued_bytes,
+                "queued_rx_ms": pcm_bytes_to_ms(session.inbound.queued_bytes),
+                "max_rx_queue_bytes": session.inbound.max_queue_bytes,
+                "max_rx_queue_ms": pcm_bytes_to_ms(session.inbound.max_queue_bytes),
                 "pcm_s16le_base64": base64.b64encode(pcm).decode("ascii"),
                 "audio": audio_contract(),
             }

--- a/examples/webrtc-sidecar/test_sidecar.py
+++ b/examples/webrtc-sidecar/test_sidecar.py
@@ -74,6 +74,16 @@ def test_audio_contract_is_voice_pcm_shape():
     assert sidecar.MAX_DRAIN_WAIT_MS == audio["max_drain_wait_ms"]
     assert sidecar.FRAME_BYTES == 1920
     assert sidecar.MAX_OUTBOUND_QUEUE_BYTES == 960_000
+    assert sidecar.PCM_BYTES_PER_SECOND == 96_000
+
+
+def test_pcm_bytes_to_ms_reports_ceiled_audio_duration():
+    sidecar = load_sidecar()
+
+    assert sidecar.pcm_bytes_to_ms(0) == 0
+    assert sidecar.pcm_bytes_to_ms(2) == 1
+    assert sidecar.pcm_bytes_to_ms(sidecar.FRAME_BYTES) == sidecar.FRAME_MS
+    assert sidecar.pcm_bytes_to_ms(sidecar.MAX_OUTBOUND_QUEUE_BYTES) == 10_000
 
 
 def test_load_contract_falls_back_to_voice_stream_contract(monkeypatch, tmp_path: Path):
@@ -340,8 +350,13 @@ def test_audio_endpoint_queues_pcm_for_call():
             assert response.status == 200
             body = await response.json()
             assert body["accepted_bytes"] == 4
+            assert body["accepted_ms"] == 1
             assert body["queued_tx_bytes"] == 4
+            assert body["queued_tx_ms"] == 1
             assert body["max_tx_queue_bytes"] == source.max_queue_bytes
+            assert body["max_tx_queue_ms"] == sidecar.pcm_bytes_to_ms(
+                source.max_queue_bytes
+            )
             assert body["audio"] == sidecar.audio_contract()
 
             frame = source.read_frame()
@@ -363,8 +378,11 @@ def test_clear_audio_endpoint_drops_queued_pcm_for_call():
             return {
                 "call_id": "call-1",
                 "dropped_tx_bytes": dropped_bytes,
+                "dropped_tx_ms": sidecar.pcm_bytes_to_ms(dropped_bytes),
                 "queued_tx_bytes": self.source.queued_bytes,
+                "queued_tx_ms": sidecar.pcm_bytes_to_ms(self.source.queued_bytes),
                 "max_tx_queue_bytes": self.source.max_queue_bytes,
+                "max_tx_queue_ms": sidecar.pcm_bytes_to_ms(self.source.max_queue_bytes),
                 "audio": sidecar.audio_contract(),
             }
 
@@ -387,8 +405,11 @@ def test_clear_audio_endpoint_drops_queued_pcm_for_call():
             assert body == {
                 "call_id": "call-1",
                 "dropped_tx_bytes": 4,
+                "dropped_tx_ms": 1,
                 "queued_tx_bytes": 0,
+                "queued_tx_ms": 0,
                 "max_tx_queue_bytes": source.max_queue_bytes,
+                "max_tx_queue_ms": sidecar.pcm_bytes_to_ms(source.max_queue_bytes),
                 "audio": sidecar.audio_contract(),
             }
             assert source.queued_bytes == 0
@@ -513,7 +534,13 @@ def test_audio_endpoint_drains_inbound_pcm_for_call():
             body = await response.json()
             assert body["call_id"] == "call-1"
             assert body["returned_bytes"] == 2
+            assert body["returned_ms"] == 1
             assert body["queued_rx_bytes"] == 2
+            assert body["queued_rx_ms"] == 1
+            assert body["max_rx_queue_bytes"] == session.inbound.max_queue_bytes
+            assert body["max_rx_queue_ms"] == sidecar.pcm_bytes_to_ms(
+                session.inbound.max_queue_bytes
+            )
             assert base64.b64decode(body["pcm_s16le_base64"]) == b"\x01\x00"
             assert body["audio"] == sidecar.audio_contract()
 


### PR DESCRIPTION
## Summary
- add millisecond queue-duration fields to WebRTC sidecar status/audio responses
- document the new fields in the sidecar contract, README, and WhatsApp Calling architecture notes
- assert the latency fields in Python and Rust contract tests

## Verification
- python3 -m py_compile examples/webrtc-sidecar/sidecar.py examples/webrtc-sidecar/test_sidecar.py
- /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py
- /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar
- cargo fmt --check
- cargo test -p voice-stream
- cargo build --release -p voice
- scripts/verify_whatsapp_voice_contract.sh --voice-bin target/release/voice --skip-daemon
- /tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/full_duplex_loopback_smoke.py --voice-bin target/release/voice --timeout 90 --expect-word hello --expect-word world