### PR TITLE
Prefer sidecar queue latency in full-duplex smoke

### DIFF
--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -301,4 +301,6 @@ local WebRTC audio drains through `voice stream-transcribe`, while
 WebRTC peer. It is the closest local smoke to a single WhatsApp call turn. It
 also fails when the sidecar still has more than one second of outbound audio
 queued at the end of the turn; use `--max-queued-tx-ms` to tighten or loosen
-that local latency budget.
+that local latency budget. When available, it uses the sidecar-reported
+`queued_tx_ms` field; older sidecars fall back to deriving the duration from
+`queued_tx_bytes` and the audio contract.

--- a/examples/webrtc-sidecar/full_duplex_loopback_smoke.py
+++ b/examples/webrtc-sidecar/full_duplex_loopback_smoke.py
@@ -51,9 +51,9 @@ DEFAULT_OUTBOUND_TEXT = "Hello from a full duplex WebRTC sidecar turn."
 DEFAULT_MAX_QUEUED_TX_MS = 1_000
 
 
-def queued_tx_ms(queued_tx_bytes: object, audio: dict[str, Any]) -> int:
+def pcm_bytes_to_ms(byte_count: object, audio: dict[str, Any]) -> int:
     try:
-        queued_bytes = int(queued_tx_bytes or 0)
+        pcm_bytes = int(byte_count or 0)
         sample_rate = int(audio.get("sample_rate") or 0)
         channels = int(audio.get("channels") or 0)
         bytes_per_sample = int(audio.get("bytes_per_sample") or 0)
@@ -61,9 +61,26 @@ def queued_tx_ms(queued_tx_bytes: object, audio: dict[str, Any]) -> int:
         return 0
 
     bytes_per_second = sample_rate * channels * bytes_per_sample
-    if queued_bytes <= 0 or bytes_per_second <= 0:
+    if pcm_bytes <= 0 or bytes_per_second <= 0:
         return 0
-    return round(queued_bytes * 1_000 / bytes_per_second)
+    return (pcm_bytes * 1_000 + bytes_per_second - 1) // bytes_per_second
+
+
+def queue_ms_from_status(
+    call: dict[str, Any],
+    field_prefix: str,
+    audio: dict[str, Any],
+) -> int:
+    reported_ms = call.get(f"{field_prefix}_ms")
+    if reported_ms is not None:
+        try:
+            parsed_ms = int(reported_ms)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(f"{field_prefix}_ms must be an integer") from exc
+        if parsed_ms < 0:
+            raise RuntimeError(f"{field_prefix}_ms must be non-negative")
+        return parsed_ms
+    return pcm_bytes_to_ms(call.get(f"{field_prefix}_bytes"), audio)
 
 
 def validate_queued_tx_budget(call: dict[str, Any], max_queued_tx_ms: int) -> int:
@@ -72,7 +89,7 @@ def validate_queued_tx_budget(call: dict[str, Any], max_queued_tx_ms: int) -> in
     audio = call.get("audio")
     if not isinstance(audio, dict):
         raise RuntimeError("full-duplex sidecar status did not include audio contract")
-    queued_ms = queued_tx_ms(call.get("queued_tx_bytes"), audio)
+    queued_ms = queue_ms_from_status(call, "queued_tx", audio)
     if queued_ms > max_queued_tx_ms:
         raise RuntimeError(
             "sidecar outbound audio queue exceeded budget "
@@ -189,7 +206,12 @@ async def verify_full_duplex_call(
                 "decoded_pcm": decoded_pcm,
                 "outbound_webrtc_bytes": outbound_webrtc_bytes,
                 "queued_tx_bytes": status.get("queued_tx_bytes"),
+                "queued_tx_ms": status.get("queued_tx_ms"),
                 "queued_rx_bytes": status.get("queued_rx_bytes"),
+                "queued_rx_ms": status.get("queued_rx_ms"),
+                "max_tx_queue_ms": status.get("max_tx_queue_ms"),
+                "max_rx_queue_bytes": status.get("max_rx_queue_bytes"),
+                "max_rx_queue_ms": status.get("max_rx_queue_ms"),
                 "audio": sidecar.audio_contract(),
             }
     finally:
@@ -246,6 +268,8 @@ async def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
             call,
             args.max_queued_tx_ms,
         )
+        audio = call["audio"]
+        queued_rx_ms_value = queue_ms_from_status(call, "queued_rx", audio)
 
         retained = not remove_workdir
         return {
@@ -262,8 +286,9 @@ async def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
             "decoded_path": str(decoded_path) if retained else "<temporary>",
             "retained": retained,
             "max_queued_tx_ms": args.max_queued_tx_ms,
-            "queued_tx_ms": queued_tx_ms_value,
             **call,
+            "queued_tx_ms": queued_tx_ms_value,
+            "queued_rx_ms": queued_rx_ms_value,
             "stt": transcript_event["data"],
         }
     finally:

--- a/examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py
+++ b/examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py
@@ -76,7 +76,7 @@ def test_parse_args_rejects_negative_queue_budget(monkeypatch):
         raise AssertionError("expected negative queue budget to be rejected")
 
 
-def test_queued_tx_ms_converts_bytes_to_audio_duration():
+def test_pcm_bytes_to_ms_converts_bytes_to_ceiled_audio_duration():
     smoke = load_smoke()
     audio = {
         "sample_rate": 48_000,
@@ -84,14 +84,57 @@ def test_queued_tx_ms_converts_bytes_to_audio_duration():
         "bytes_per_sample": 2,
     }
 
-    assert smoke.queued_tx_ms(1_920, audio) == 20
-    assert smoke.queued_tx_ms(96_000, audio) == 1_000
+    assert smoke.pcm_bytes_to_ms(0, audio) == 0
+    assert smoke.pcm_bytes_to_ms(2, audio) == 1
+    assert smoke.pcm_bytes_to_ms(1_920, audio) == 20
+    assert smoke.pcm_bytes_to_ms(96_000, audio) == 1_000
+
+
+def test_queue_ms_from_status_prefers_sidecar_reported_duration():
+    smoke = load_smoke()
+    audio = {
+        "sample_rate": 48_000,
+        "channels": 1,
+        "bytes_per_sample": 2,
+    }
+    call = {
+        "queued_tx_bytes": 1_920,
+        "queued_tx_ms": 21,
+    }
+
+    assert smoke.queue_ms_from_status(call, "queued_tx", audio) == 21
+
+
+def test_queue_ms_from_status_falls_back_to_byte_duration():
+    smoke = load_smoke()
+    audio = {
+        "sample_rate": 48_000,
+        "channels": 1,
+        "bytes_per_sample": 2,
+    }
+    call = {
+        "queued_rx_bytes": 3_840,
+    }
+
+    assert smoke.queue_ms_from_status(call, "queued_rx", audio) == 40
+
+
+def test_queue_ms_from_status_rejects_invalid_sidecar_duration():
+    smoke = load_smoke()
+
+    try:
+        smoke.queue_ms_from_status({"queued_tx_ms": "soon"}, "queued_tx", {})
+    except RuntimeError as exc:
+        assert "queued_tx_ms must be an integer" in str(exc)
+    else:
+        raise AssertionError("expected invalid sidecar duration to be rejected")
 
 
 def test_validate_queued_tx_budget_returns_duration_when_within_budget():
     smoke = load_smoke()
     call = {
         "queued_tx_bytes": 1_920,
+        "queued_tx_ms": 20,
         "audio": {
             "sample_rate": 48_000,
             "channels": 1,


### PR DESCRIPTION
## Summary
- make full_duplex_loopback_smoke.py prefer sidecar-reported queued_tx_ms/queued_rx_ms
- keep byte-derived duration as a compatibility fallback for older sidecars
- document the behavior and add focused tests for native, fallback, and malformed queue duration values

## Verification
- python3 -m py_compile examples/webrtc-sidecar/full_duplex_loopback_smoke.py examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py
- /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py
- /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py
- /tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/full_duplex_loopback_smoke.py --voice-bin /home/ubuntu/.local/bin/voice --timeout 90 --expect-word hello --expect-word world
- /tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar