### PR TITLE
Surface WebRTC sidecar accept readiness

### DIFF
--- a/crates/voice-stream/src/lib.rs
+++ b/crates/voice-stream/src/lib.rs
@@ -152,6 +152,8 @@ pub fn webrtc_sidecar_contract() -> serde_json::Value {
             "call_state": {
                 "call_id": "Call session identifier.",
                 "closed": "Whether the local sidecar session has been closed.",
+                "ready_for_accept": "Whether the sidecar has created a local SDP answer, attached a live outbound audio track, completed ICE gathering, and is ready for Hermes to send the WhatsApp accept action.",
+                "readiness": "Per-condition readiness booleans backing ready_for_accept: not_closed, local_sdp_answer, signaling_stable, ice_gathering_complete, and outbound_audio_track.",
                 "connection_state": "WebRTC peer connection state.",
                 "ice_connection_state": "ICE connection state.",
                 "ice_gathering_state": "ICE gathering state.",
@@ -660,6 +662,14 @@ mod tests {
         assert_eq!(
             payloads["call_state"]["queued_rx_bytes"],
             "Inbound decoded PCM bytes queued for Hermes to drain."
+        );
+        assert_eq!(
+            payloads["call_state"]["ready_for_accept"],
+            "Whether the sidecar has created a local SDP answer, attached a live outbound audio track, completed ICE gathering, and is ready for Hermes to send the WhatsApp accept action."
+        );
+        assert_eq!(
+            payloads["call_state"]["readiness"],
+            "Per-condition readiness booleans backing ready_for_accept: not_closed, local_sdp_answer, signaling_stable, ice_gathering_complete, and outbound_audio_track."
         );
         assert_eq!(
             payloads["call_state"]["queued_tx_ms"],

--- a/docs/contracts/webrtc-sidecar-v1.json
+++ b/docs/contracts/webrtc-sidecar-v1.json
@@ -119,6 +119,8 @@
     "call_state": {
       "call_id": "Call session identifier.",
       "closed": "Whether the local sidecar session has been closed.",
+      "ready_for_accept": "Whether the sidecar has created a local SDP answer, attached a live outbound audio track, completed ICE gathering, and is ready for Hermes to send the WhatsApp accept action.",
+      "readiness": "Per-condition readiness booleans backing ready_for_accept: not_closed, local_sdp_answer, signaling_stable, ice_gathering_complete, and outbound_audio_track.",
       "connection_state": "WebRTC peer connection state.",
       "ice_connection_state": "ICE connection state.",
       "ice_gathering_state": "ICE gathering state.",

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -123,7 +123,9 @@ voice stream-transcribe --raw-input /tmp/voice-webrtc-in.s16le --sample-rate 480
 3. The sidecar creates a peer connection, attaches inbound and outbound audio
    tracks, sets the remote SDP, and creates a local SDP answer.
 4. Hermes calls the Graph API with `action: pre_accept` and the SDP answer.
-5. The sidecar waits until its media path is ready enough to send/receive audio.
+5. Hermes checks the sidecar call state. `ready_for_accept` should be true
+   before `accept`; this means the local SDP answer exists, the outbound audio
+   track is live, ICE gathering completed, and signaling is stable.
 6. Hermes calls the Graph API with `action: accept` and the same SDP answer.
 7. The sidecar starts forwarding inbound PCM to STT and outbound PCM from TTS.
 8. Either side can terminate; Hermes calls `terminate` if it ends locally.
@@ -131,7 +133,9 @@ voice stream-transcribe --raw-input /tmp/voice-webrtc-in.s16le --sample-rate 480
 The important timing rule is that `accept` should not happen before the media
 sender is ready. Meta's troubleshooting docs call out media-flow timing as a
 common failure mode, and their API rejects mismatched SDP answers between
-`pre_accept` and `accept`.
+`pre_accept` and `accept`. `ready_for_accept` is a local readiness signal, not
+proof that the remote WhatsApp peer is connected; connection state still
+progresses after Meta receives the accepted SDP answer.
 
 ## Sidecar API Sketch
 
@@ -180,6 +184,14 @@ Response:
   "state": {
     "call_id": "wamid-call-id",
     "closed": false,
+    "ready_for_accept": true,
+    "readiness": {
+      "not_closed": true,
+      "local_sdp_answer": true,
+      "signaling_stable": true,
+      "ice_gathering_complete": true,
+      "outbound_audio_track": true
+    },
     "connection_state": "new",
     "ice_connection_state": "new",
     "ice_gathering_state": "complete",

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -236,7 +236,11 @@ For WhatsApp Cloud Calling, Hermes should translate a `connect` webhook into a
 local `/offer` call, then pass the returned SDP answer to the Cloud API
 `pre_accept` and `accept` actions. The sidecar should already have an outbound
 audio track attached and ready before Hermes calls `accept`; the track sends
-silence until real TTS PCM arrives.
+silence until real TTS PCM arrives. The `/offer` response and `GET
+/calls/{call_id}` status include `ready_for_accept` plus per-check `readiness`
+booleans. Hermes should treat `ready_for_accept: true` as the local gate before
+it sends the Graph `accept` action; the remote WebRTC connection state can
+still be `new` until Meta applies the accepted SDP answer.
 
 Inbound decoded PCM is kept in a bounded per-call queue and can also be mirrored
 to a raw signed 16-bit little-endian mono sink with `--rx-pcm`. A later bridge

--- a/examples/webrtc-sidecar/sidecar.py
+++ b/examples/webrtc-sidecar/sidecar.py
@@ -366,7 +366,8 @@ class CallSession:
         self.pc = RTCPeerConnection()
         self.tasks: set[asyncio.Task[Any]] = set()
         self.closed = False
-        self.pc.addTrack(VoicePcmAudioTrack(self.source))
+        self.outbound_track = VoicePcmAudioTrack(self.source)
+        self.pc.addTrack(self.outbound_track)
 
         @self.pc.on("track")
         def on_track(track: MediaStreamTrack) -> None:
@@ -392,11 +393,31 @@ class CallSession:
         assert self.pc.localDescription is not None
         return self.pc.localDescription
 
+    def accept_readiness(self) -> dict[str, Any]:
+        """Return checks Hermes can use before sending the Graph accept action."""
+        local_description = self.pc.localDescription
+        checks = {
+            "not_closed": not self.closed,
+            "local_sdp_answer": local_description is not None
+            and local_description.type == "answer",
+            "signaling_stable": self.pc.signalingState == "stable",
+            "ice_gathering_complete": self.pc.iceGatheringState == "complete",
+            "outbound_audio_track": getattr(self.outbound_track, "readyState", "live")
+            == "live",
+        }
+        return {
+            "ready_for_accept": all(checks.values()),
+            "checks": checks,
+        }
+
     def snapshot(self) -> dict[str, Any]:
         """Return call state useful for local health checks and Hermes debugging."""
+        readiness = self.accept_readiness()
         return {
             "call_id": self.call_id,
             "closed": self.closed,
+            "ready_for_accept": readiness["ready_for_accept"],
+            "readiness": readiness["checks"],
             "connection_state": self.pc.connectionState,
             "ice_connection_state": self.pc.iceConnectionState,
             "ice_gathering_state": self.pc.iceGatheringState,

--- a/examples/webrtc-sidecar/test_sidecar.py
+++ b/examples/webrtc-sidecar/test_sidecar.py
@@ -216,6 +216,27 @@ def test_call_pcm_source_clear_drops_queued_audio():
     assert source.read_frame() == b"\x00" * sidecar.FRAME_BYTES
 
 
+def test_call_session_snapshot_reports_accept_readiness_checks():
+    sidecar = load_sidecar()
+
+    async def run():
+        session = sidecar.CallSession("call-1", sidecar.PcmSource(None), None)
+        try:
+            snapshot = session.snapshot()
+            assert snapshot["ready_for_accept"] is False
+            assert snapshot["readiness"] == {
+                "not_closed": True,
+                "local_sdp_answer": False,
+                "signaling_stable": True,
+                "ice_gathering_complete": False,
+                "outbound_audio_track": True,
+            }
+        finally:
+            await session.close()
+
+    asyncio.run(run())
+
+
 def test_inbound_pcm_sink_drains_queued_audio():
     sidecar = load_sidecar()
     sink = sidecar.InboundPcmSink(None, max_queue_bytes=6)
@@ -638,6 +659,14 @@ def test_offer_loopback_receives_http_queued_audio():
                 assert offer_response.status == 200
                 answer = await offer_response.json()
                 assert answer["audio"] == sidecar.audio_contract()
+                assert answer["state"]["ready_for_accept"] is True
+                assert answer["state"]["readiness"] == {
+                    "not_closed": True,
+                    "local_sdp_answer": True,
+                    "signaling_stable": True,
+                    "ice_gathering_complete": True,
+                    "outbound_audio_track": True,
+                }
 
                 pcm_frame = (
                     (12_000).to_bytes(2, byteorder="little", signed=True)


### PR DESCRIPTION
## Summary
- add `ready_for_accept` and per-check `readiness` telemetry to WebRTC sidecar call snapshots
- document the readiness gate for WhatsApp Calling `accept`
- update the generated and checked-in sidecar v1 contract so Hermes can depend on the shape

## Validation
- `cargo test -p voice-stream`
- `/tmp/voice-webrtc-venv/bin/python -m pytest examples/webrtc-sidecar/test_sidecar.py -q`
- `/tmp/voice-webrtc-venv/bin/python -m pytest examples/webrtc-sidecar -q`
- `cargo build -p voice && scripts/verify_whatsapp_voice_contract.sh --voice-bin target/debug/voice --skip-daemon`