### PR TITLE
Add leading articulation release smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,10 @@ scripts/macos_release_compare.py --keep
 
 This builds the current CLI, downloads the latest stable release binary, forces
 the benchmark path to run without a daemon, and reports TTS timing plus optional
-STT timing if `eval/recordings/*.wav` fixtures are present.
+STT timing if `eval/recordings/*.wav` fixtures are present. It also synthesizes
+and transcribes `Wait, what. Wait what?` as a file-based articulation smoke for
+issue #110; pass `--skip-articulation-smoke` only when you intentionally want a
+timing-only run.
 
 ## JSON-RPC server
 

--- a/scripts/macos_release_compare.py
+++ b/scripts/macos_release_compare.py
@@ -13,6 +13,7 @@ import argparse
 import json
 import os
 import platform
+import re
 import shutil
 import statistics
 import struct
@@ -30,6 +31,9 @@ DEFAULT_PHRASES = [
     "The nteract runtime should pronounce technical identifiers clearly.",
     "Streaming audio frames need predictable timing for WebRTC clients.",
 ]
+
+DEFAULT_ARTICULATION_PHRASE = "Wait, what. Wait what?"
+DEFAULT_ARTICULATION_EXPECTED_WORDS = ["wait", "wait", "what", "what"]
 
 
 def parse_args() -> argparse.Namespace:
@@ -58,6 +62,25 @@ def parse_args() -> argparse.Namespace:
         "--require-daemon",
         action="store_true",
         help="Fail if a daemon is not available for the daemon-backed stream smoke check",
+    )
+    parser.add_argument(
+        "--skip-articulation-smoke",
+        action="store_true",
+        help="Skip generated-audio STT smoke for leading-word articulation",
+    )
+    parser.add_argument(
+        "--articulation-phrase",
+        default=DEFAULT_ARTICULATION_PHRASE,
+        help="Phrase to synthesize and transcribe for the articulation smoke",
+    )
+    parser.add_argument(
+        "--articulation-expected-word",
+        action="append",
+        default=None,
+        help=(
+            "Expected word in the articulation transcript; repeat to require "
+            "multiple occurrences. Defaults to wait, wait, what, what."
+        ),
     )
     parser.add_argument(
         "--threshold",
@@ -331,8 +354,74 @@ def compare_summary(
     return f"{kind}: {status}, new/old mean elapsed = {ratio:.2f}x", ok
 
 
+def normalized_words(text: str) -> list[str]:
+    return re.findall(r"[a-z0-9]+", text.lower())
+
+
+def missing_expected_words(transcript: str, expected_words: list[str]) -> list[str]:
+    available = normalized_words(transcript)
+    missing: list[str] = []
+    for word in expected_words:
+        normalized = normalized_words(word)
+        if len(normalized) != 1:
+            raise ValueError(f"expected word must normalize to one token: {word!r}")
+        token = normalized[0]
+        if token in available:
+            available.remove(token)
+        else:
+            missing.append(token)
+    return missing
+
+
+def articulation_smoke_check(
+    new_voice: Path,
+    work_dir: Path,
+    *,
+    phrase: str,
+    expected_words: list[str],
+) -> dict[str, object]:
+    env = missing_daemon_env(work_dir)
+    wav = work_dir / "smoke-leading-articulation.wav"
+    run(
+        [
+            str(new_voice),
+            "say",
+            "-q",
+            "--deterministic",
+            "-o",
+            str(wav),
+            phrase,
+        ],
+        env=env,
+        timeout=240,
+    )
+    transcript = run(
+        [str(new_voice), "transcribe", "-q", str(wav)],
+        env=env,
+        capture=True,
+        timeout=300,
+    ).stdout.strip()
+    missing = missing_expected_words(transcript, expected_words)
+    return {
+        "name": "leading_articulation_transcribes_expected_words",
+        "ok": not missing,
+        "path": str(wav),
+        "phrase": phrase,
+        "expected_words": expected_words,
+        "transcript": transcript,
+        "missing_words": missing,
+        "note": "guards issue #110: leading 'Wait, what. Wait what?' articulation",
+    }
+
+
 def smoke_checks(
-    new_voice: Path, work_dir: Path, *, require_daemon: bool
+    new_voice: Path,
+    work_dir: Path,
+    *,
+    require_daemon: bool,
+    skip_articulation_smoke: bool,
+    articulation_phrase: str,
+    articulation_expected_words: list[str],
 ) -> list[dict[str, object]]:
     checks: list[dict[str, object]] = []
     env = missing_daemon_env(work_dir)
@@ -390,6 +479,25 @@ def smoke_checks(
             "note": "voice stream is daemon-backed only",
         }
     )
+
+    if skip_articulation_smoke:
+        checks.append(
+            {
+                "name": "leading_articulation_transcribes_expected_words",
+                "ok": True,
+                "skipped": True,
+                "note": "skipped by --skip-articulation-smoke",
+            }
+        )
+    else:
+        checks.append(
+            articulation_smoke_check(
+                new_voice,
+                work_dir,
+                phrase=articulation_phrase,
+                expected_words=articulation_expected_words,
+            )
+        )
 
     daemon = subprocess.run(
         [str(new_voice), "daemon", "status", "--json"],
@@ -477,7 +585,17 @@ def main() -> int:
         "stt:new": summarize(all_rows, "stt", "new"),
     }
 
-    checks = smoke_checks(new_voice, work_dir, require_daemon=args.require_daemon)
+    articulation_expected_words = (
+        args.articulation_expected_word or DEFAULT_ARTICULATION_EXPECTED_WORDS
+    )
+    checks = smoke_checks(
+        new_voice,
+        work_dir,
+        require_daemon=args.require_daemon,
+        skip_articulation_smoke=args.skip_articulation_smoke,
+        articulation_phrase=args.articulation_phrase,
+        articulation_expected_words=articulation_expected_words,
+    )
     comparisons = []
     ok = True
     for kind in ["tts", "stt"]:

--- a/tests/test_macos_release_compare.py
+++ b/tests/test_macos_release_compare.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "macos_release_compare.py"
+
+
+def load_script_module():
+    spec = importlib.util.spec_from_file_location("macos_release_compare", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class ArticulationSmokeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.script = load_script_module()
+
+    def test_missing_expected_words_accounts_for_repeated_words(self):
+        transcript = "Wait what, wait what?"
+
+        missing = self.script.missing_expected_words(
+            transcript,
+            ["wait", "wait", "what", "what"],
+        )
+
+        self.assertEqual(missing, [])
+
+    def test_missing_expected_words_reports_missing_duplicate(self):
+        transcript = "Wait, wait, what?"
+
+        missing = self.script.missing_expected_words(
+            transcript,
+            ["wait", "wait", "what", "what"],
+        )
+
+        self.assertEqual(missing, ["what"])
+
+    def test_expected_word_must_normalize_to_one_token(self):
+        with self.assertRaisesRegex(ValueError, "normalize to one token"):
+            self.script.missing_expected_words("Wait what", ["wait what"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a generated-audio STT smoke to `scripts/macos_release_compare.py` for issue #110
- synthesize `Wait, what. Wait what?` without the daemon and require two `wait` and two `what` tokens in the transcript
- document the new macOS release gate and add stdlib unit tests for repeated-word accounting

## Validation

- `python3 -m py_compile scripts/macos_release_compare.py tests/test_macos_release_compare.py`
- `python3 -m unittest tests.test_macos_release_compare`
- `scripts/macos_release_compare.py --old-voice target/release/voice --new-voice target/release/voice --iters 1 --skip-stt --work-dir /tmp/voice-release-compare-smoke.DbCD7Q` -> passed, articulation transcript: `Wait what, wait what?`
- `git diff --check`

This does not close #110 by itself; it makes the macOS pre-release script catch that regression shape before tagging.
