### PR TITLE
Reject non-loopback sidecar service hosts

### DIFF
--- a/scripts/install_webrtc_sidecar_service.sh
+++ b/scripts/install_webrtc_sidecar_service.sh
@@ -29,7 +29,7 @@ Options:
   --voice-bin PATH      voice binary exposed to the sidecar as VOICE_BIN
   --python-bin PATH     Python used to create the venv (default: python3)
   --venv PATH           sidecar venv path (default: XDG data dir)
-  --host HOST           sidecar bind host (default: 127.0.0.1)
+  --host HOST           sidecar bind host; must be loopback (default: 127.0.0.1)
   --port PORT           sidecar bind port (default: 8787)
   --rx-pcm PATH         optional inbound PCM mirror path (default: XDG state dir)
   --service-name NAME   systemd user unit name (default: voice-webrtc-sidecar.service)
@@ -113,6 +113,24 @@ resolve_voice_bin() {
   else
     fail "voice binary not found; pass --voice-bin PATH or install voice on PATH"
   fi
+}
+
+is_loopback_host() {
+  case "$1" in
+    localhost|127.*|::1)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+validate_bind_host() {
+  if is_loopback_host "$host"; then
+    return
+  fi
+  fail "refusing non-loopback --host '$host'; the sidecar control plane must bind to localhost"
 }
 
 render_unit() {
@@ -233,6 +251,7 @@ sidecar_script="$repo_root/examples/webrtc-sidecar/sidecar.py"
 requirements="$repo_root/examples/webrtc-sidecar/requirements.txt"
 [[ -f "$sidecar_script" ]] || fail "sidecar script not found: $sidecar_script"
 [[ -f "$requirements" ]] || fail "requirements file not found: $requirements"
+validate_bind_host
 
 if [[ -z "$venv" ]]; then
   venv="$(default_data_home)/voice/webrtc-sidecar-venv"

--- a/tests/test_install_webrtc_sidecar_service.py
+++ b/tests/test_install_webrtc_sidecar_service.py
@@ -63,6 +63,36 @@ class WebrtcSidecarServiceInstallTests(unittest.TestCase):
         self.assertIn("Restart=on-failure", unit)
         self.assertIn("WantedBy=default.target", unit)
 
+    def test_print_unit_rejects_non_loopback_host(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--print-unit",
+                    "--repo-root",
+                    str(REPO_ROOT),
+                    "--voice-bin",
+                    "/opt/voice/bin/voice",
+                    "--host",
+                    "0.0.0.0",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "HOME": str(tmp_path),
+                    "XDG_CONFIG_HOME": str(tmp_path / "config"),
+                    "XDG_DATA_HOME": str(tmp_path / "data"),
+                    "XDG_STATE_HOME": str(tmp_path / "state"),
+                },
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("refusing non-loopback --host '0.0.0.0'", result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- reject non-loopback `--host` values in `install_webrtc_sidecar_service.sh` before rendering or writing a user unit
- keep the installer aligned with the Python sidecar's localhost-only control-plane default
- add a regression test for `--host 0.0.0.0`

## Local validation

- `bash -n scripts/install_webrtc_sidecar_service.sh`
- `python3 -m unittest tests.test_install_webrtc_sidecar_service`
- `python3 -m unittest discover -s tests`
- `scripts/install_webrtc_sidecar_service.sh --print-unit --voice-bin /home/ubuntu/.local/bin/voice --venv /tmp/voice-webrtc-venv --rx-pcm /home/ubuntu/.hermes/voice-webrtc-sidecar/inbound.s16le > /tmp/voice-sidecar.generated.service && systemd-analyze verify /tmp/voice-sidecar.generated.service`
- `scripts/verify_webrtc_sidecar_service.py --voice-bin /home/ubuntu/.local/bin/voice --sidecar-url http://127.0.0.1:8787`
- `git diff --check`
