### PR TITLE
Add local Hermes voice stack release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
             tests/test_install_webrtc_sidecar_service.py \
             tests/test_macos_release_compare.py \
             tests/test_verify_hermes_voice_config.py \
+            tests/test_verify_local_hermes_voice_stack.py \
             tests/test_verify_webrtc_sidecar_service.py
 
       - run: python -m unittest discover -s tests
@@ -82,4 +83,5 @@ jobs:
           bash -n \
             scripts/install_webrtc_sidecar_service.sh \
             scripts/verify_hermes_command_tts.sh \
+            scripts/verify_local_hermes_voice_stack.sh \
             scripts/verify_whatsapp_voice_contract.sh

--- a/README.md
+++ b/README.md
@@ -352,16 +352,20 @@ For WhatsApp or Telegram voice-note delivery through Hermes, prefer
 Opus output directly. `output_format: wav` remains a compatibility fallback,
 with Hermes converting to OGG/Opus when needed.
 
-Use the local Hermes config verifier before a release or host update:
+Use the local Hermes stack verifier before a release or host update:
 
 ```bash
-scripts/verify_hermes_voice_config.py --config ~/.hermes/config.yaml
+scripts/verify_local_hermes_voice_stack.sh \
+  --voice-bin "$(command -v voice)" \
+  --hermes-config ~/.hermes/config.yaml
 ```
 
-It checks that Hermes' active command provider calls `voice say --format
-ogg-opus`, that the provider is marked `voice_compatible`, that STT routes to
-`voice stream-transcribe --quiet`, and that the configured TTS command writes
-valid mono 48 kHz Ogg/Opus.
+That single gate checks Hermes' active command provider, direct Ogg/Opus voice
+note output, daemon-backed streaming, `stream-transcribe`, and the local WebRTC
+sidecar service. It requires the daemon and sidecar by default. For narrower
+checks, run `scripts/verify_hermes_voice_config.py`,
+`scripts/verify_whatsapp_voice_contract.sh`, or
+`scripts/verify_webrtc_sidecar_service.py` directly.
 
 For lower-level streaming, `stream_speak` emits `tts.started`, `tts.audio`, and
 terminal `tts.ended` / `tts.error` / `tts.cancelled` events over the same daemon

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+voice_bin="${VOICE_BIN:-}"
+hermes_config="${HERMES_CONFIG:-${HOME:-}/.hermes/config.yaml}"
+sidecar_url="${SIDECAR_URL:-http://127.0.0.1:8787}"
+text="${TEXT:-Local Hermes voice stack smoke test.}"
+skip_hermes_config="${SKIP_HERMES_CONFIG:-0}"
+skip_hermes_tts_smoke="${SKIP_HERMES_TTS_SMOKE:-0}"
+skip_sidecar="${SKIP_SIDECAR:-0}"
+skip_systemd="${SKIP_SYSTEMD:-0}"
+skip_daemon="${SKIP_DAEMON:-0}"
+skip_stt_smoke="${SKIP_STT_SMOKE:-0}"
+
+hermes_config_verify_script="${HERMES_CONFIG_VERIFY_SCRIPT:-$repo_root/scripts/verify_hermes_voice_config.py}"
+whatsapp_contract_verify_script="${WHATSAPP_CONTRACT_VERIFY_SCRIPT:-$repo_root/scripts/verify_whatsapp_voice_contract.sh}"
+sidecar_service_verify_script="${SIDECAR_SERVICE_VERIFY_SCRIPT:-$repo_root/scripts/verify_webrtc_sidecar_service.py}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/verify_local_hermes_voice_stack.sh [OPTIONS]
+
+Run the local release gate for a Hermes host that uses voice for WhatsApp-ready
+TTS/STT and WebRTC sidecar streaming.
+
+By default this requires the voice daemon, runs the stream-transcribe smoke, and
+checks the WebRTC sidecar HTTP contract plus Linux systemd user services.
+
+Options:
+  --voice-bin PATH             installed voice binary to verify
+  --hermes-config PATH         Hermes config file (default: ~/.hermes/config.yaml)
+  --sidecar-url URL            sidecar base URL (default: http://127.0.0.1:8787)
+  --text TEXT                  smoke text used by TTS checks
+  --skip-hermes-config         skip Hermes config validation and TTS command smoke
+  --skip-hermes-tts-smoke      validate Hermes config without executing TTS
+  --skip-sidecar               skip WebRTC sidecar service verification
+  --skip-systemd               skip sidecar/daemon systemd service checks
+  --skip-daemon                skip daemon-backed stream checks
+  --skip-stt-smoke             skip stream-transcribe smoke
+  -h, --help                   show this help
+
+Environment aliases:
+  VOICE_BIN, HERMES_CONFIG, SIDECAR_URL, TEXT
+  SKIP_HERMES_CONFIG=1, SKIP_HERMES_TTS_SMOKE=1, SKIP_SIDECAR=1
+  SKIP_SYSTEMD=1, SKIP_DAEMON=1, SKIP_STT_SMOKE=1
+EOF
+}
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_file() {
+  local path="$1"
+  local label="$2"
+  [[ -f "$path" ]] || fail "$label not found: $path"
+}
+
+require_executable() {
+  local path="$1"
+  local label="$2"
+  [[ -x "$path" ]] || fail "$label is not executable: $path"
+}
+
+default_voice_bin() {
+  if [[ -n "$voice_bin" ]]; then
+    printf '%s\n' "$voice_bin"
+  elif command -v voice >/dev/null 2>&1; then
+    command -v voice
+  elif [[ -x "$repo_root/target/release/voice" ]]; then
+    printf '%s\n' "$repo_root/target/release/voice"
+  else
+    printf '%s\n' "voice"
+  fi
+}
+
+run_step() {
+  local label="$1"
+  shift
+  echo
+  echo "==> $label"
+  "$@"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --voice-bin)
+      [[ $# -ge 2 ]] || fail "--voice-bin requires a path"
+      voice_bin="$2"
+      shift 2
+      ;;
+    --hermes-config)
+      [[ $# -ge 2 ]] || fail "--hermes-config requires a path"
+      hermes_config="$2"
+      shift 2
+      ;;
+    --sidecar-url)
+      [[ $# -ge 2 ]] || fail "--sidecar-url requires a URL"
+      sidecar_url="$2"
+      shift 2
+      ;;
+    --text)
+      [[ $# -ge 2 ]] || fail "--text requires a value"
+      text="$2"
+      shift 2
+      ;;
+    --skip-hermes-config)
+      skip_hermes_config=1
+      shift
+      ;;
+    --skip-hermes-tts-smoke)
+      skip_hermes_tts_smoke=1
+      shift
+      ;;
+    --skip-sidecar)
+      skip_sidecar=1
+      shift
+      ;;
+    --skip-systemd)
+      skip_systemd=1
+      shift
+      ;;
+    --skip-daemon)
+      skip_daemon=1
+      shift
+      ;;
+    --skip-stt-smoke)
+      skip_stt_smoke=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option: $1"
+      ;;
+  esac
+done
+
+voice_bin="$(default_voice_bin)"
+if [[ "$voice_bin" == */* ]]; then
+  require_executable "$voice_bin" "voice binary"
+elif ! command -v "$voice_bin" >/dev/null 2>&1; then
+  fail "voice binary not found on PATH: $voice_bin"
+fi
+
+require_executable "$whatsapp_contract_verify_script" "WhatsApp voice contract verifier"
+if [[ "$skip_hermes_config" != "1" ]]; then
+  require_executable "$hermes_config_verify_script" "Hermes voice config verifier"
+  require_file "$hermes_config" "Hermes config"
+fi
+if [[ "$skip_sidecar" != "1" ]]; then
+  require_executable "$sidecar_service_verify_script" "WebRTC sidecar verifier"
+fi
+
+if [[ "$skip_hermes_config" != "1" ]]; then
+  hermes_args=(
+    "$hermes_config_verify_script"
+    --config "$hermes_config"
+    --voice-bin "$voice_bin"
+    --text "$text"
+  )
+  if [[ "$skip_hermes_tts_smoke" == "1" ]]; then
+    hermes_args+=(--skip-tts-smoke)
+  fi
+  run_step "Hermes voice-native config" "${hermes_args[@]}"
+  hermes_status="checked"
+else
+  hermes_status="skipped"
+fi
+
+whatsapp_args=(
+  "$whatsapp_contract_verify_script"
+  --voice-bin "$voice_bin"
+  --text "$text"
+)
+if [[ "$skip_daemon" == "1" ]]; then
+  whatsapp_args+=(--skip-daemon)
+else
+  whatsapp_args+=(--require-daemon)
+  if [[ "$skip_stt_smoke" != "1" ]]; then
+    whatsapp_args+=(--run-stt-smoke)
+  fi
+fi
+run_step "Voice WhatsApp and streaming contract" "${whatsapp_args[@]}"
+
+if [[ "$skip_sidecar" != "1" ]]; then
+  sidecar_args=(
+    "$sidecar_service_verify_script"
+    --voice-bin "$voice_bin"
+    --sidecar-url "$sidecar_url"
+  )
+  if [[ "$skip_systemd" == "1" ]]; then
+    sidecar_args+=(--skip-systemd)
+  fi
+  run_step "Voice WebRTC sidecar service" "${sidecar_args[@]}"
+  sidecar_status="checked"
+else
+  sidecar_status="skipped"
+fi
+
+echo
+echo "ok: local Hermes voice stack verifier passed"
+echo "voice_bin=$voice_bin"
+echo "hermes_config=$hermes_status"
+echo "whatsapp_contract=checked"
+echo "sidecar_service=$sidecar_status"

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "verify_local_hermes_voice_stack.sh"
+
+
+def write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def write_helper(path: Path, label: str, log_path: Path) -> None:
+    write_executable(
+        path,
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            printf '{label}' >> {str(log_path)!r}
+            printf '\\0' >> {str(log_path)!r}
+            printf '%s\\0' "$@" >> {str(log_path)!r}
+            printf '\\n' >> {str(log_path)!r}
+            echo "ok: {label}"
+            """
+        ),
+    )
+
+
+def command_log_entries(log_path: Path) -> list[list[str]]:
+    entries: list[list[str]] = []
+    for line in log_path.read_bytes().splitlines():
+        if not line:
+            continue
+        entries.append(line.decode("utf-8").split("\0")[:-1])
+    return entries
+
+
+class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
+    def test_default_gate_runs_strict_release_checks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            hermes = tmp_path / "verify_hermes.py"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            sidecar = tmp_path / "verify_sidecar.py"
+            voice = tmp_path / "voice"
+            config = tmp_path / "config.yaml"
+
+            write_helper(hermes, "hermes", log_path)
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_helper(sidecar, "sidecar", log_path)
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+            config.write_text("tts: {}\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--hermes-config",
+                    str(config),
+                    "--sidecar-url",
+                    "http://127.0.0.1:9999",
+                    "--skip-systemd",
+                    "--text",
+                    "Stack smoke.",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "HERMES_CONFIG_VERIFY_SCRIPT": str(hermes),
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "SIDECAR_SERVICE_VERIFY_SCRIPT": str(sidecar),
+                },
+            )
+
+            entries = command_log_entries(log_path)
+
+        self.assertIn("ok: local Hermes voice stack verifier passed", result.stdout)
+        self.assertEqual([entry[0] for entry in entries], ["hermes", "whatsapp", "sidecar"])
+        self.assertEqual(
+            entries[0],
+            [
+                "hermes",
+                "--config",
+                str(config),
+                "--voice-bin",
+                str(voice),
+                "--text",
+                "Stack smoke.",
+            ],
+        )
+        self.assertEqual(
+            entries[1],
+            [
+                "whatsapp",
+                "--voice-bin",
+                str(voice),
+                "--text",
+                "Stack smoke.",
+                "--require-daemon",
+                "--run-stt-smoke",
+            ],
+        )
+        self.assertEqual(
+            entries[2],
+            [
+                "sidecar",
+                "--voice-bin",
+                str(voice),
+                "--sidecar-url",
+                "http://127.0.0.1:9999",
+                "--skip-systemd",
+            ],
+        )
+
+    def test_skip_flags_disable_optional_release_checks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            hermes = tmp_path / "verify_hermes.py"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            sidecar = tmp_path / "verify_sidecar.py"
+            voice = tmp_path / "voice"
+            config = tmp_path / "config.yaml"
+
+            write_helper(hermes, "hermes", log_path)
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_helper(sidecar, "sidecar", log_path)
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+            config.write_text("tts: {}\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--hermes-config",
+                    str(config),
+                    "--skip-hermes-tts-smoke",
+                    "--skip-sidecar",
+                    "--skip-daemon",
+                    "--skip-stt-smoke",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "HERMES_CONFIG_VERIFY_SCRIPT": str(hermes),
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "SIDECAR_SERVICE_VERIFY_SCRIPT": str(sidecar),
+                },
+            )
+
+            entries = command_log_entries(log_path)
+
+        self.assertIn("sidecar_service=skipped", result.stdout)
+        self.assertEqual([entry[0] for entry in entries], ["hermes", "whatsapp"])
+        self.assertIn("--skip-tts-smoke", entries[0])
+        self.assertIn("--skip-daemon", entries[1])
+        self.assertNotIn("--run-stt-smoke", entries[1])
+
+    def test_skip_hermes_config_does_not_require_config_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            hermes = tmp_path / "verify_hermes.py"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            sidecar = tmp_path / "verify_sidecar.py"
+            voice = tmp_path / "voice"
+
+            write_helper(hermes, "hermes", log_path)
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_helper(sidecar, "sidecar", log_path)
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--hermes-config",
+                    str(tmp_path / "missing.yaml"),
+                    "--skip-hermes-config",
+                    "--skip-sidecar",
+                    "--skip-daemon",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "HERMES_CONFIG_VERIFY_SCRIPT": str(hermes),
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "SIDECAR_SERVICE_VERIFY_SCRIPT": str(sidecar),
+                },
+            )
+
+            entries = command_log_entries(log_path)
+
+        self.assertIn("hermes_config=skipped", result.stdout)
+        self.assertEqual([entry[0] for entry in entries], ["whatsapp"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a single local Hermes/Voice stack verifier that orchestrates Hermes config, WhatsApp voice contract, daemon/STT, and sidecar checks
- default the gate to require daemon streaming, stream-transcribe smoke, and sidecar service verification
- document the release-gate command and cover wrapper orchestration in tests

## Verification
- bash -n scripts/verify_local_hermes_voice_stack.sh
- python3 -m unittest tests.test_verify_local_hermes_voice_stack
- python3 -m py_compile scripts/macos_release_compare.py scripts/verify_hermes_voice_config.py scripts/verify_webrtc_sidecar_service.py tests/test_install_webrtc_sidecar_service.py tests/test_macos_release_compare.py tests/test_verify_hermes_voice_config.py tests/test_verify_local_hermes_voice_stack.py tests/test_verify_webrtc_sidecar_service.py
- python3 -m unittest discover -s tests
- bash -n scripts/install_webrtc_sidecar_service.sh scripts/verify_hermes_command_tts.sh scripts/verify_local_hermes_voice_stack.sh scripts/verify_whatsapp_voice_contract.sh
- scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-config /home/ubuntu/.hermes/config.yaml