### PR TITLE
Add optional WebRTC media smoke to local stack gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,10 @@ checks, run `scripts/verify_hermes_voice_config.py`,
 `scripts/verify_whatsapp_voice_contract.sh`, or
 `scripts/verify_webrtc_sidecar_service.py` directly.
 
+When the WebRTC Python dependencies are installed, add
+`--run-webrtc-loopback-smoke --webrtc-python /tmp/voice-webrtc-venv/bin/python`
+to run one full-duplex local media turn through the sidecar spike as well.
+
 For lower-level streaming, `stream_speak` emits `tts.started`, `tts.audio`, and
 terminal `tts.ended` / `tts.error` / `tts.cancelled` events over the same daemon
 frame protocol. `stream_transcribe` accepts client-sent `stt.audio` frames and

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -13,10 +13,15 @@ skip_sidecar="${SKIP_SIDECAR:-0}"
 skip_systemd="${SKIP_SYSTEMD:-0}"
 skip_daemon="${SKIP_DAEMON:-0}"
 skip_stt_smoke="${SKIP_STT_SMOKE:-0}"
+run_webrtc_loopback_smoke="${RUN_WEBRTC_LOOPBACK_SMOKE:-0}"
+webrtc_python="${VOICE_WEBRTC_PYTHON:-python3}"
+webrtc_timeout="${VOICE_WEBRTC_TIMEOUT:-60}"
+max_queued_tx_ms="${MAX_QUEUED_TX_MS:-1000}"
 
 hermes_config_verify_script="${HERMES_CONFIG_VERIFY_SCRIPT:-$repo_root/scripts/verify_hermes_voice_config.py}"
 whatsapp_contract_verify_script="${WHATSAPP_CONTRACT_VERIFY_SCRIPT:-$repo_root/scripts/verify_whatsapp_voice_contract.sh}"
 sidecar_service_verify_script="${SIDECAR_SERVICE_VERIFY_SCRIPT:-$repo_root/scripts/verify_webrtc_sidecar_service.py}"
+webrtc_loopback_smoke_script="${WEBRTC_LOOPBACK_SMOKE_SCRIPT:-$repo_root/examples/webrtc-sidecar/full_duplex_loopback_smoke.py}"
 
 usage() {
   cat <<'EOF'
@@ -39,12 +44,17 @@ Options:
   --skip-systemd               skip sidecar/daemon systemd service checks
   --skip-daemon                skip daemon-backed stream checks
   --skip-stt-smoke             skip stream-transcribe smoke
+  --run-webrtc-loopback-smoke  run one local full-duplex WebRTC media turn
+  --webrtc-python PATH         Python used for the WebRTC smoke (default: python3)
+  --webrtc-timeout SECONDS     timeout passed to the WebRTC smoke (default: 60)
+  --max-queued-tx-ms MS        max sidecar queue after WebRTC smoke (default: 1000)
   -h, --help                   show this help
 
 Environment aliases:
   VOICE_BIN, HERMES_CONFIG, SIDECAR_URL, TEXT
   SKIP_HERMES_CONFIG=1, SKIP_HERMES_TTS_SMOKE=1, SKIP_SIDECAR=1
   SKIP_SYSTEMD=1, SKIP_DAEMON=1, SKIP_STT_SMOKE=1
+  RUN_WEBRTC_LOOPBACK_SMOKE=1, VOICE_WEBRTC_PYTHON, VOICE_WEBRTC_TIMEOUT
 EOF
 }
 
@@ -131,6 +141,25 @@ while [[ $# -gt 0 ]]; do
       skip_stt_smoke=1
       shift
       ;;
+    --run-webrtc-loopback-smoke)
+      run_webrtc_loopback_smoke=1
+      shift
+      ;;
+    --webrtc-python)
+      [[ $# -ge 2 ]] || fail "--webrtc-python requires a path"
+      webrtc_python="$2"
+      shift 2
+      ;;
+    --webrtc-timeout)
+      [[ $# -ge 2 ]] || fail "--webrtc-timeout requires a value"
+      webrtc_timeout="$2"
+      shift 2
+      ;;
+    --max-queued-tx-ms)
+      [[ $# -ge 2 ]] || fail "--max-queued-tx-ms requires a value"
+      max_queued_tx_ms="$2"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -155,6 +184,14 @@ if [[ "$skip_hermes_config" != "1" ]]; then
 fi
 if [[ "$skip_sidecar" != "1" ]]; then
   require_executable "$sidecar_service_verify_script" "WebRTC sidecar verifier"
+fi
+if [[ "$run_webrtc_loopback_smoke" == "1" ]]; then
+  require_file "$webrtc_loopback_smoke_script" "WebRTC full-duplex smoke"
+  if [[ "$webrtc_python" == */* ]]; then
+    require_executable "$webrtc_python" "WebRTC smoke Python"
+  elif ! command -v "$webrtc_python" >/dev/null 2>&1; then
+    fail "WebRTC smoke Python not found on PATH: $webrtc_python"
+  fi
 fi
 
 if [[ "$skip_hermes_config" != "1" ]]; then
@@ -203,9 +240,22 @@ else
   sidecar_status="skipped"
 fi
 
+if [[ "$run_webrtc_loopback_smoke" == "1" ]]; then
+  run_step "Full-duplex WebRTC media smoke" \
+    "$webrtc_python" "$webrtc_loopback_smoke_script" \
+    --voice-bin "$voice_bin" \
+    --timeout "$webrtc_timeout" \
+    --outbound-text "$text" \
+    --max-queued-tx-ms "$max_queued_tx_ms"
+  webrtc_loopback_status="checked"
+else
+  webrtc_loopback_status="skipped"
+fi
+
 echo
 echo "ok: local Hermes voice stack verifier passed"
 echo "voice_bin=$voice_bin"
 echo "hermes_config=$hermes_status"
 echo "whatsapp_contract=checked"
 echo "sidecar_service=$sidecar_status"
+echo "webrtc_loopback=$webrtc_loopback_status"

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -34,6 +34,23 @@ def write_helper(path: Path, label: str, log_path: Path) -> None:
     )
 
 
+def write_fake_python(path: Path, label: str, log_path: Path) -> None:
+    write_executable(
+        path,
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            printf '{label}' >> {str(log_path)!r}
+            printf '\\0' >> {str(log_path)!r}
+            printf '%s\\0' "$@" >> {str(log_path)!r}
+            printf '\\n' >> {str(log_path)!r}
+            echo '{{"success": true}}'
+            """
+        ),
+    )
+
+
 def command_log_entries(log_path: Path) -> list[list[str]]:
     entries: list[list[str]] = []
     for line in log_path.read_bytes().splitlines():
@@ -87,6 +104,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             entries = command_log_entries(log_path)
 
         self.assertIn("ok: local Hermes voice stack verifier passed", result.stdout)
+        self.assertIn("webrtc_loopback=skipped", result.stdout)
         self.assertEqual([entry[0] for entry in entries], ["hermes", "whatsapp", "sidecar"])
         self.assertEqual(
             entries[0],
@@ -170,6 +188,78 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn("--skip-tts-smoke", entries[0])
         self.assertIn("--skip-daemon", entries[1])
         self.assertNotIn("--run-stt-smoke", entries[1])
+
+    def test_webrtc_loopback_smoke_runs_when_requested(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            hermes = tmp_path / "verify_hermes.py"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            sidecar = tmp_path / "verify_sidecar.py"
+            python = tmp_path / "python"
+            smoke = tmp_path / "full_duplex_loopback_smoke.py"
+            voice = tmp_path / "voice"
+            config = tmp_path / "config.yaml"
+
+            write_helper(hermes, "hermes", log_path)
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_helper(sidecar, "sidecar", log_path)
+            write_fake_python(python, "webrtc", log_path)
+            write_executable(smoke, "#!/usr/bin/env python3\n")
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+            config.write_text("tts: {}\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--hermes-config",
+                    str(config),
+                    "--skip-hermes-tts-smoke",
+                    "--skip-sidecar",
+                    "--skip-daemon",
+                    "--run-webrtc-loopback-smoke",
+                    "--webrtc-python",
+                    str(python),
+                    "--webrtc-timeout",
+                    "12.5",
+                    "--max-queued-tx-ms",
+                    "250",
+                    "--text",
+                    "Outbound media smoke.",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "HERMES_CONFIG_VERIFY_SCRIPT": str(hermes),
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "SIDECAR_SERVICE_VERIFY_SCRIPT": str(sidecar),
+                    "WEBRTC_LOOPBACK_SMOKE_SCRIPT": str(smoke),
+                },
+            )
+
+            entries = command_log_entries(log_path)
+
+        self.assertIn("webrtc_loopback=checked", result.stdout)
+        self.assertEqual([entry[0] for entry in entries], ["hermes", "whatsapp", "webrtc"])
+        self.assertEqual(
+            entries[2],
+            [
+                "webrtc",
+                str(smoke),
+                "--voice-bin",
+                str(voice),
+                "--timeout",
+                "12.5",
+                "--outbound-text",
+                "Outbound media smoke.",
+                "--max-queued-tx-ms",
+                "250",
+            ],
+        )
 
     def test_skip_hermes_config_does_not_require_config_file(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- add an opt-in full-duplex WebRTC media smoke to the local Hermes voice stack verifier
- expose Python, timeout, outbound text, and queue budget controls for the media smoke
- document the deeper local media-path check and cover wrapper invocation in tests

## Verification
- bash -n scripts/verify_local_hermes_voice_stack.sh
- python3 -m unittest tests.test_verify_local_hermes_voice_stack
- scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-config /home/ubuntu/.hermes/config.yaml --run-webrtc-loopback-smoke --webrtc-python /tmp/voice-webrtc-venv/bin/python
- python3 -m py_compile scripts/macos_release_compare.py scripts/verify_hermes_voice_config.py scripts/verify_webrtc_sidecar_service.py tests/test_install_webrtc_sidecar_service.py tests/test_macos_release_compare.py tests/test_verify_hermes_voice_config.py tests/test_verify_local_hermes_voice_stack.py tests/test_verify_webrtc_sidecar_service.py
- python3 -m unittest discover -s tests
- bash -n scripts/install_webrtc_sidecar_service.sh scripts/verify_hermes_command_tts.sh scripts/verify_local_hermes_voice_stack.sh scripts/verify_whatsapp_voice_contract.sh