### PR TITLE
Check MCP daemon detection in macOS release compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,10 +284,12 @@ scripts/macos_release_compare.py --keep
 
 This builds the current CLI, downloads the latest stable release binary, forces
 the benchmark path to run without a daemon, and reports TTS timing plus optional
-STT timing if `eval/recordings/*.wav` fixtures are present. It also synthesizes
-and transcribes `Wait, what. Wait what?` as a file-based articulation smoke for
-issue #110; pass `--skip-articulation-smoke` only when you intentionally want a
-timing-only run.
+STT timing if `eval/recordings/*.wav` fixtures are present. It also verifies
+plain `voice say` and `voice mcp` startup with the daemon deliberately hidden,
+checks that `voice mcp` reports a daemon connection when one is actually
+running, and synthesizes/transcribes `Wait, what. Wait what?` as a file-based
+articulation smoke for issue #110. Pass `--skip-articulation-smoke` only when
+you intentionally want a timing-only run.
 
 ## JSON-RPC server
 

--- a/scripts/macos_release_compare.py
+++ b/scripts/macos_release_compare.py
@@ -3,8 +3,8 @@
 
 The script intentionally forces `VOICE_DAEMON_SOCKET` to a missing path for the
 core benchmarks so it measures the plain CLI/local model path instead of an
-already-running daemon. It also runs separate smoke checks for daemon-backed
-streaming when a daemon is available.
+already-running daemon. It also runs separate smoke checks for MCP daemon
+detection and daemon-backed streaming when a daemon is available.
 """
 
 from __future__ import annotations
@@ -34,6 +34,10 @@ DEFAULT_PHRASES = [
 
 DEFAULT_ARTICULATION_PHRASE = "Wait, what. Wait what?"
 DEFAULT_ARTICULATION_EXPECTED_WORDS = ["wait", "wait", "what", "what"]
+MCP_SMOKE_INPUT = (
+    '{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}\n'
+    '{"jsonrpc":"2.0","method":"tools/list","params":{},"id":2}\n'
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -373,6 +377,17 @@ def missing_expected_words(transcript: str, expected_words: list[str]) -> list[s
     return missing
 
 
+def mcp_initialized(stdout: str) -> bool:
+    return '"serverInfo"' in stdout and '"tools"' in stdout
+
+
+def mcp_connected_to_daemon(stderr: str) -> bool:
+    return (
+        "voice mcp: connected to voice daemon" in stderr
+        or "voice mcp: reconnected to voice daemon" in stderr
+    )
+
+
 def articulation_smoke_check(
     new_voice: Path,
     work_dir: Path,
@@ -447,21 +462,17 @@ def smoke_checks(
         }
     )
 
-    mcp_input = (
-        '{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}\n'
-        '{"jsonrpc":"2.0","method":"tools/list","params":{},"id":2}\n'
-    )
     mcp = run(
         [str(new_voice), "mcp", "-q"],
         env=env,
-        input_text=mcp_input,
+        input_text=MCP_SMOKE_INPUT,
         capture=True,
         timeout=240,
     )
     checks.append(
         {
             "name": "mcp_no_daemon_initializes",
-            "ok": '"serverInfo"' in mcp.stdout and '"tools"' in mcp.stdout,
+            "ok": mcp_initialized(mcp.stdout),
         }
     )
 
@@ -516,6 +527,22 @@ def smoke_checks(
     )
 
     if daemon_available:
+        mcp_daemon = run(
+            [str(new_voice), "mcp"],
+            input_text=MCP_SMOKE_INPUT,
+            capture=True,
+            timeout=240,
+        )
+        checks.append(
+            {
+                "name": "mcp_with_daemon_detects_daemon",
+                "ok": (
+                    mcp_initialized(mcp_daemon.stdout)
+                    and mcp_connected_to_daemon(mcp_daemon.stderr)
+                ),
+            }
+        )
+
         pcm = work_dir / "stream-daemon.pcm"
         run(
             [str(new_voice), "stream", "-o", str(pcm), "Daemon streaming smoke test."],
@@ -530,6 +557,14 @@ def smoke_checks(
             }
         )
     else:
+        checks.append(
+            {
+                "name": "mcp_with_daemon_detects_daemon",
+                "ok": not require_daemon,
+                "skipped": True,
+                "note": "daemon not detected",
+            }
+        )
         checks.append(
             {
                 "name": "stream_with_daemon_writes_pcm",

--- a/tests/test_macos_release_compare.py
+++ b/tests/test_macos_release_compare.py
@@ -48,6 +48,28 @@ class ArticulationSmokeTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "normalize to one token"):
             self.script.missing_expected_words("Wait what", ["wait what"])
 
+    def test_mcp_initialized_requires_initialize_and_tools_output(self):
+        self.assertTrue(
+            self.script.mcp_initialized(
+                '{"result":{"serverInfo":{"name":"voice"}},"id":1}\n'
+                '{"result":{"tools":[]},"id":2}\n'
+            )
+        )
+        self.assertFalse(self.script.mcp_initialized('{"result":{"serverInfo":{}}}'))
+
+    def test_mcp_connected_to_daemon_accepts_startup_and_reconnect_logs(self):
+        self.assertTrue(
+            self.script.mcp_connected_to_daemon(
+                "voice mcp: connected to voice daemon\nvoice mcp server ready\n"
+            )
+        )
+        self.assertTrue(
+            self.script.mcp_connected_to_daemon(
+                "voice mcp: reconnected to voice daemon\n"
+            )
+        )
+        self.assertFalse(self.script.mcp_connected_to_daemon("voice mcp server ready\n"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary\n- add a macOS release-compare smoke check for MCP startup when a daemon is detected\n- keep the existing no-daemon MCP startup check for plain CLI/MCP validation\n- document that the release comparison covers both no-daemon and daemon-detected MCP paths\n\n## Tests\n- python3 -m unittest tests/test_macos_release_compare.py\n- python3 -m py_compile scripts/macos_release_compare.py tests/test_macos_release_compare.py\n- scripts/macos_release_compare.py --help