### PR TITLE
Add fast CLI MCP surface verifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,12 @@ jobs:
       - run: |
           python -m py_compile \
             scripts/macos_release_compare.py \
+            scripts/verify_cli_mcp_surface.py \
             scripts/verify_hermes_voice_config.py \
             scripts/verify_webrtc_sidecar_service.py \
             tests/test_install_webrtc_sidecar_service.py \
             tests/test_macos_release_compare.py \
+            tests/test_verify_cli_mcp_surface.py \
             tests/test_verify_hermes_voice_config.py \
             tests/test_verify_local_hermes_voice_stack.py \
             tests/test_verify_webrtc_sidecar_service.py

--- a/README.md
+++ b/README.md
@@ -279,17 +279,20 @@ Before tagging a macOS release, compare the current checkout against the latest
 stable release on local Apple Silicon hardware:
 
 ```bash
+scripts/verify_cli_mcp_surface.py --voice-bin ./target/release/voice
 scripts/macos_release_compare.py --keep
 ```
 
-This builds the current CLI, downloads the latest stable release binary, forces
-the benchmark path to run without a daemon, and reports TTS timing plus optional
-STT timing if `eval/recordings/*.wav` fixtures are present. It also verifies
-plain `voice say` and `voice mcp` startup with the daemon deliberately hidden,
-checks that `voice mcp` reports a daemon connection when one is actually
-running, and synthesizes/transcribes `Wait, what. Wait what?` as a file-based
-articulation smoke for issue #110. Pass `--skip-articulation-smoke` only when
-you intentionally want a timing-only run.
+The fast verifier checks `stream-contract` and MCP startup with the daemon
+deliberately hidden, then checks MCP daemon detection when a daemon is running.
+The macOS comparison builds the current CLI, downloads the latest stable release
+binary, forces the benchmark path to run without a daemon, and reports TTS
+timing plus optional STT timing if `eval/recordings/*.wav` fixtures are present.
+It also verifies plain `voice say` and `voice mcp` startup with the daemon
+deliberately hidden, checks that `voice mcp` reports a daemon connection when
+one is actually running, and synthesizes/transcribes `Wait, what. Wait what?`
+as a file-based articulation smoke for issue #110. Pass
+`--skip-articulation-smoke` only when you intentionally want a timing-only run.
 
 ## JSON-RPC server
 

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -5,6 +5,17 @@ The `voice` CLI still works without it: `voice say -o output.wav ...` falls
 back to local synthesis, `voice mcp` initializes without a daemon, and
 `voice stream` requires a running daemon.
 
+Use the fast verifier when changing CLI, MCP, or daemon detection behavior:
+
+```bash
+scripts/verify_cli_mcp_surface.py --voice-bin "$(command -v voice)"
+```
+
+It checks `voice stream-contract` and `voice mcp` with the daemon deliberately
+hidden, then checks that MCP reports a daemon connection when
+`voice daemon status --json` detects one. Add `--require-daemon` for release
+hosts where the daemon must be installed.
+
 ## Install
 
 Install `voice`, then register the daemon as a system service:

--- a/scripts/verify_cli_mcp_surface.py
+++ b/scripts/verify_cli_mcp_surface.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Verify fast CLI/MCP surfaces with and without the voice daemon.
+
+This is intentionally lighter than ``macos_release_compare.py``: it does not
+run synthesis, transcription, or model loading. It checks the control surfaces
+that should remain usable before and after daemon installation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+from typing import Any
+
+
+MCP_SMOKE_INPUT = (
+    '{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}\n'
+    '{"jsonrpc":"2.0","method":"tools/list","params":{},"id":2}\n'
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify voice CLI/MCP daemon detection surfaces."
+    )
+    parser.add_argument(
+        "--voice-bin",
+        type=Path,
+        default=None,
+        help="voice binary to verify; defaults to target/release/voice or PATH",
+    )
+    parser.add_argument(
+        "--require-daemon",
+        action="store_true",
+        help="fail when no daemon is detected for the MCP daemon smoke",
+    )
+    parser.add_argument(
+        "--skip-daemon",
+        action="store_true",
+        help="skip daemon-detected MCP smoke even if a daemon is running",
+    )
+    parser.add_argument("--timeout", type=float, default=30.0)
+    return parser.parse_args()
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def resolve_voice_bin(explicit: Path | None) -> Path:
+    if explicit is not None:
+        return explicit.expanduser().resolve()
+
+    release_bin = repo_root() / "target" / "release" / "voice"
+    if release_bin.is_file() and os.access(release_bin, os.X_OK):
+        return release_bin
+
+    found = shutil.which("voice")
+    if found:
+        return Path(found).resolve()
+
+    raise SystemExit("voice binary not found; pass --voice-bin")
+
+
+def run_command(
+    command: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    input_text: str | None = None,
+    timeout: float,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        input=input_text,
+        text=True,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def hidden_daemon_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env["VOICE_DAEMON_SOCKET"] = f"/tmp/voice-cli-mcp-missing-{os.getpid()}.sock"
+    return env
+
+
+def mcp_initialized(stdout: str) -> bool:
+    return '"serverInfo"' in stdout and '"tools"' in stdout
+
+
+def mcp_connected_to_daemon(stderr: str) -> bool:
+    return (
+        "voice mcp: connected to voice daemon" in stderr
+        or "voice mcp: reconnected to voice daemon" in stderr
+    )
+
+
+def verify_no_daemon_surfaces(voice_bin: Path, timeout: float) -> list[dict[str, Any]]:
+    env = hidden_daemon_env()
+    checks: list[dict[str, Any]] = []
+
+    contract = run_command(
+        [str(voice_bin), "stream-contract"],
+        env=env,
+        timeout=timeout,
+    )
+    contract_ok = False
+    contract_name = None
+    if contract.returncode == 0:
+        try:
+            contract_json = json.loads(contract.stdout)
+            contract_name = contract_json.get("contract")
+            contract_ok = contract_name == "voice.webrtc_sidecar"
+        except json.JSONDecodeError:
+            contract_ok = False
+    checks.append(
+        {
+            "name": "stream_contract_no_daemon",
+            "ok": contract_ok,
+            "returncode": contract.returncode,
+            "contract": contract_name,
+        }
+    )
+
+    mcp = run_command(
+        [str(voice_bin), "mcp", "-q"],
+        env=env,
+        input_text=MCP_SMOKE_INPUT,
+        timeout=timeout,
+    )
+    checks.append(
+        {
+            "name": "mcp_no_daemon_initializes",
+            "ok": mcp.returncode == 0 and mcp_initialized(mcp.stdout),
+            "returncode": mcp.returncode,
+        }
+    )
+
+    return checks
+
+
+def verify_daemon_surfaces(
+    voice_bin: Path,
+    *,
+    require_daemon: bool,
+    skip_daemon: bool,
+    timeout: float,
+) -> list[dict[str, Any]]:
+    if skip_daemon:
+        return [
+            {
+                "name": "daemon_detected",
+                "ok": True,
+                "skipped": True,
+                "note": "--skip-daemon was provided",
+            },
+            {
+                "name": "mcp_with_daemon_detects_daemon",
+                "ok": True,
+                "skipped": True,
+                "note": "--skip-daemon was provided",
+            },
+        ]
+
+    daemon = run_command(
+        [str(voice_bin), "daemon", "status", "--json"],
+        timeout=timeout,
+    )
+    daemon_available = daemon.returncode == 0
+    checks: list[dict[str, Any]] = [
+        {
+            "name": "daemon_detected",
+            "ok": daemon_available or not require_daemon,
+            "detected": daemon_available,
+            "returncode": daemon.returncode,
+            "note": "MCP daemon smoke runs only when a daemon is detected",
+        }
+    ]
+
+    if not daemon_available:
+        checks.append(
+            {
+                "name": "mcp_with_daemon_detects_daemon",
+                "ok": not require_daemon,
+                "skipped": True,
+                "note": "daemon not detected",
+            }
+        )
+        return checks
+
+    mcp = run_command(
+        [str(voice_bin), "mcp"],
+        input_text=MCP_SMOKE_INPUT,
+        timeout=timeout,
+    )
+    checks.append(
+        {
+            "name": "mcp_with_daemon_detects_daemon",
+            "ok": (
+                mcp.returncode == 0
+                and mcp_initialized(mcp.stdout)
+                and mcp_connected_to_daemon(mcp.stderr)
+            ),
+            "returncode": mcp.returncode,
+        }
+    )
+    return checks
+
+
+def verify(args: argparse.Namespace) -> dict[str, Any]:
+    voice_bin = resolve_voice_bin(args.voice_bin)
+    checks = verify_no_daemon_surfaces(voice_bin, timeout=args.timeout)
+    checks.extend(
+        verify_daemon_surfaces(
+            voice_bin,
+            require_daemon=args.require_daemon,
+            skip_daemon=args.skip_daemon,
+            timeout=args.timeout,
+        )
+    )
+    return {
+        "success": all(bool(check.get("ok")) for check in checks),
+        "voice_bin": str(voice_bin),
+        "checks": checks,
+    }
+
+
+def main() -> int:
+    result = verify(parse_args())
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_verify_cli_mcp_surface.py
+++ b/tests/test_verify_cli_mcp_surface.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+
+import argparse
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "verify_cli_mcp_surface.py"
+
+
+def load_script_module():
+    spec = importlib.util.spec_from_file_location("verify_cli_mcp_surface", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class CliMcpSurfaceVerifierTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.script = load_script_module()
+
+    def make_fake_voice(self, tmp_path: Path) -> Path:
+        fake = tmp_path / "voice"
+        fake.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import json
+                import os
+                import sys
+
+                args = sys.argv[1:]
+                if args == ["stream-contract"]:
+                    print(json.dumps({"contract": "voice.webrtc_sidecar"}))
+                    raise SystemExit(0)
+                if args == ["daemon", "status", "--json"]:
+                    if os.environ.get("VOICE_FAKE_DAEMON") == "1":
+                        print(json.dumps({"running": True}))
+                        raise SystemExit(0)
+                    print("daemon not running", file=sys.stderr)
+                    raise SystemExit(1)
+                if args and args[0] == "mcp":
+                    quiet = "-q" in args
+                    if not quiet and os.environ.get("VOICE_FAKE_DAEMON") == "1":
+                        print("voice mcp: connected to voice daemon", file=sys.stderr)
+                    print('{"result":{"serverInfo":{"name":"voice"}},"id":1}')
+                    print('{"result":{"tools":[]},"id":2}')
+                    raise SystemExit(0)
+                print(f"unexpected args: {args}", file=sys.stderr)
+                raise SystemExit(2)
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake.chmod(0o755)
+        return fake
+
+    def verify_with_fake_voice(
+        self,
+        fake_voice: Path,
+        *,
+        require_daemon: bool = False,
+        skip_daemon: bool = False,
+    ):
+        return self.script.verify(
+            argparse.Namespace(
+                voice_bin=fake_voice,
+                require_daemon=require_daemon,
+                skip_daemon=skip_daemon,
+                timeout=5.0,
+            )
+        )
+
+    def test_no_daemon_surfaces_pass_and_daemon_smoke_skips(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_voice = self.make_fake_voice(Path(tmp))
+
+            result = self.verify_with_fake_voice(fake_voice)
+
+        self.assertTrue(result["success"])
+        checks = {check["name"]: check for check in result["checks"]}
+        self.assertTrue(checks["stream_contract_no_daemon"]["ok"])
+        self.assertTrue(checks["mcp_no_daemon_initializes"]["ok"])
+        self.assertFalse(checks["daemon_detected"]["detected"])
+        self.assertTrue(checks["mcp_with_daemon_detects_daemon"]["skipped"])
+
+    def test_require_daemon_fails_when_daemon_is_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_voice = self.make_fake_voice(Path(tmp))
+
+            result = self.verify_with_fake_voice(fake_voice, require_daemon=True)
+
+        self.assertFalse(result["success"])
+        checks = {check["name"]: check for check in result["checks"]}
+        self.assertFalse(checks["daemon_detected"]["ok"])
+        self.assertFalse(checks["daemon_detected"]["detected"])
+        self.assertFalse(checks["mcp_with_daemon_detects_daemon"]["ok"])
+
+    def test_daemon_detected_path_requires_mcp_connection_log(self):
+        old_value = os.environ.get("VOICE_FAKE_DAEMON")
+        os.environ["VOICE_FAKE_DAEMON"] = "1"
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                fake_voice = self.make_fake_voice(Path(tmp))
+
+                result = self.verify_with_fake_voice(fake_voice)
+        finally:
+            if old_value is None:
+                os.environ.pop("VOICE_FAKE_DAEMON", None)
+            else:
+                os.environ["VOICE_FAKE_DAEMON"] = old_value
+
+        self.assertTrue(result["success"])
+        checks = {check["name"]: check for check in result["checks"]}
+        self.assertTrue(checks["daemon_detected"]["detected"])
+        self.assertTrue(checks["mcp_with_daemon_detects_daemon"]["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- add scripts/verify_cli_mcp_surface.py for fast no-model checks of stream-contract and MCP daemon behavior\n- verify MCP initializes with the daemon socket hidden and reports a daemon connection when one is detected\n- wire the helper into python-helpers CI and document it for daemon/release preflights\n\n## Tests\n- python3 -m unittest discover -s tests\n- python3 -m py_compile scripts/verify_cli_mcp_surface.py tests/test_verify_cli_mcp_surface.py scripts/macos_release_compare.py tests/test_macos_release_compare.py\n- scripts/verify_cli_mcp_surface.py --voice-bin /home/ubuntu/.local/bin/voice --require-daemon\n- scripts/verify_cli_mcp_surface.py --voice-bin /home/ubuntu/.local/bin/voice --skip-daemon