### PR TITLE
Include CLI MCP check in local voice stack gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,10 +365,11 @@ scripts/verify_local_hermes_voice_stack.sh \
   --hermes-config ~/.hermes/config.yaml
 ```
 
-That single gate checks Hermes' active command provider, direct Ogg/Opus voice
-note output, daemon-backed streaming, `stream-transcribe`, and the local WebRTC
-sidecar service. It requires the daemon and sidecar by default. For narrower
-checks, run `scripts/verify_hermes_voice_config.py`,
+That single gate checks plain CLI/MCP daemon behavior, Hermes' active command
+provider, direct Ogg/Opus voice note output, daemon-backed streaming,
+`stream-transcribe`, and the local WebRTC sidecar service. It requires the
+daemon and sidecar by default. For narrower checks, run
+`scripts/verify_cli_mcp_surface.py`, `scripts/verify_hermes_voice_config.py`,
 `scripts/verify_whatsapp_voice_contract.sh`, or
 `scripts/verify_webrtc_sidecar_service.py` directly.
 

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -11,6 +11,7 @@ skip_hermes_config="${SKIP_HERMES_CONFIG:-0}"
 skip_hermes_tts_smoke="${SKIP_HERMES_TTS_SMOKE:-0}"
 skip_sidecar="${SKIP_SIDECAR:-0}"
 skip_systemd="${SKIP_SYSTEMD:-0}"
+skip_cli_mcp="${SKIP_CLI_MCP:-0}"
 skip_daemon="${SKIP_DAEMON:-0}"
 skip_stt_smoke="${SKIP_STT_SMOKE:-0}"
 run_webrtc_loopback_smoke="${RUN_WEBRTC_LOOPBACK_SMOKE:-0}"
@@ -19,6 +20,7 @@ webrtc_timeout="${VOICE_WEBRTC_TIMEOUT:-60}"
 max_queued_tx_ms="${MAX_QUEUED_TX_MS:-1000}"
 
 hermes_config_verify_script="${HERMES_CONFIG_VERIFY_SCRIPT:-$repo_root/scripts/verify_hermes_voice_config.py}"
+cli_mcp_surface_verify_script="${CLI_MCP_SURFACE_VERIFY_SCRIPT:-$repo_root/scripts/verify_cli_mcp_surface.py}"
 whatsapp_contract_verify_script="${WHATSAPP_CONTRACT_VERIFY_SCRIPT:-$repo_root/scripts/verify_whatsapp_voice_contract.sh}"
 sidecar_service_verify_script="${SIDECAR_SERVICE_VERIFY_SCRIPT:-$repo_root/scripts/verify_webrtc_sidecar_service.py}"
 webrtc_loopback_smoke_script="${WEBRTC_LOOPBACK_SMOKE_SCRIPT:-$repo_root/examples/webrtc-sidecar/full_duplex_loopback_smoke.py}"
@@ -40,6 +42,7 @@ Options:
   --text TEXT                  smoke text used by TTS checks
   --skip-hermes-config         skip Hermes config validation and TTS command smoke
   --skip-hermes-tts-smoke      validate Hermes config without executing TTS
+  --skip-cli-mcp               skip plain CLI/MCP daemon surface verification
   --skip-sidecar               skip WebRTC sidecar service verification
   --skip-systemd               skip sidecar/daemon systemd service checks
   --skip-daemon                skip daemon-backed stream checks
@@ -53,7 +56,7 @@ Options:
 Environment aliases:
   VOICE_BIN, HERMES_CONFIG, SIDECAR_URL, TEXT
   SKIP_HERMES_CONFIG=1, SKIP_HERMES_TTS_SMOKE=1, SKIP_SIDECAR=1
-  SKIP_SYSTEMD=1, SKIP_DAEMON=1, SKIP_STT_SMOKE=1
+  SKIP_SYSTEMD=1, SKIP_CLI_MCP=1, SKIP_DAEMON=1, SKIP_STT_SMOKE=1
   RUN_WEBRTC_LOOPBACK_SMOKE=1, VOICE_WEBRTC_PYTHON, VOICE_WEBRTC_TIMEOUT
 EOF
 }
@@ -129,6 +132,10 @@ while [[ $# -gt 0 ]]; do
       skip_sidecar=1
       shift
       ;;
+    --skip-cli-mcp)
+      skip_cli_mcp=1
+      shift
+      ;;
     --skip-systemd)
       skip_systemd=1
       shift
@@ -182,6 +189,9 @@ if [[ "$skip_hermes_config" != "1" ]]; then
   require_executable "$hermes_config_verify_script" "Hermes voice config verifier"
   require_file "$hermes_config" "Hermes config"
 fi
+if [[ "$skip_cli_mcp" != "1" ]]; then
+  require_executable "$cli_mcp_surface_verify_script" "CLI/MCP surface verifier"
+fi
 if [[ "$skip_sidecar" != "1" ]]; then
   require_executable "$sidecar_service_verify_script" "WebRTC sidecar verifier"
 fi
@@ -208,6 +218,22 @@ if [[ "$skip_hermes_config" != "1" ]]; then
   hermes_status="checked"
 else
   hermes_status="skipped"
+fi
+
+if [[ "$skip_cli_mcp" != "1" ]]; then
+  cli_mcp_args=(
+    "$cli_mcp_surface_verify_script"
+    --voice-bin "$voice_bin"
+  )
+  if [[ "$skip_daemon" == "1" ]]; then
+    cli_mcp_args+=(--skip-daemon)
+  else
+    cli_mcp_args+=(--require-daemon)
+  fi
+  run_step "Voice CLI and MCP daemon surfaces" "${cli_mcp_args[@]}"
+  cli_mcp_status="checked"
+else
+  cli_mcp_status="skipped"
 fi
 
 whatsapp_args=(
@@ -256,6 +282,7 @@ echo
 echo "ok: local Hermes voice stack verifier passed"
 echo "voice_bin=$voice_bin"
 echo "hermes_config=$hermes_status"
+echo "cli_mcp=$cli_mcp_status"
 echo "whatsapp_contract=checked"
 echo "sidecar_service=$sidecar_status"
 echo "webrtc_loopback=$webrtc_loopback_status"

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -66,12 +66,14 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             tmp_path = Path(tmp)
             log_path = tmp_path / "commands.log"
             hermes = tmp_path / "verify_hermes.py"
+            cli_mcp = tmp_path / "verify_cli_mcp.py"
             whatsapp = tmp_path / "verify_whatsapp.sh"
             sidecar = tmp_path / "verify_sidecar.py"
             voice = tmp_path / "voice"
             config = tmp_path / "config.yaml"
 
             write_helper(hermes, "hermes", log_path)
+            write_helper(cli_mcp, "cli_mcp", log_path)
             write_helper(whatsapp, "whatsapp", log_path)
             write_helper(sidecar, "sidecar", log_path)
             write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
@@ -96,6 +98,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 env={
                     **os.environ,
                     "HERMES_CONFIG_VERIFY_SCRIPT": str(hermes),
+                    "CLI_MCP_SURFACE_VERIFY_SCRIPT": str(cli_mcp),
                     "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
                     "SIDECAR_SERVICE_VERIFY_SCRIPT": str(sidecar),
                 },
@@ -104,8 +107,12 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             entries = command_log_entries(log_path)
 
         self.assertIn("ok: local Hermes voice stack verifier passed", result.stdout)
+        self.assertIn("cli_mcp=checked", result.stdout)
         self.assertIn("webrtc_loopback=skipped", result.stdout)
-        self.assertEqual([entry[0] for entry in entries], ["hermes", "whatsapp", "sidecar"])
+        self.assertEqual(
+            [entry[0] for entry in entries],
+            ["hermes", "cli_mcp", "whatsapp", "sidecar"],
+        )
         self.assertEqual(
             entries[0],
             [
@@ -121,6 +128,15 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertEqual(
             entries[1],
             [
+                "cli_mcp",
+                "--voice-bin",
+                str(voice),
+                "--require-daemon",
+            ],
+        )
+        self.assertEqual(
+            entries[2],
+            [
                 "whatsapp",
                 "--voice-bin",
                 str(voice),
@@ -131,7 +147,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             ],
         )
         self.assertEqual(
-            entries[2],
+            entries[3],
             [
                 "sidecar",
                 "--voice-bin",
@@ -147,12 +163,14 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             tmp_path = Path(tmp)
             log_path = tmp_path / "commands.log"
             hermes = tmp_path / "verify_hermes.py"
+            cli_mcp = tmp_path / "verify_cli_mcp.py"
             whatsapp = tmp_path / "verify_whatsapp.sh"
             sidecar = tmp_path / "verify_sidecar.py"
             voice = tmp_path / "voice"
             config = tmp_path / "config.yaml"
 
             write_helper(hermes, "hermes", log_path)
+            write_helper(cli_mcp, "cli_mcp", log_path)
             write_helper(whatsapp, "whatsapp", log_path)
             write_helper(sidecar, "sidecar", log_path)
             write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
@@ -176,6 +194,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 env={
                     **os.environ,
                     "HERMES_CONFIG_VERIFY_SCRIPT": str(hermes),
+                    "CLI_MCP_SURFACE_VERIFY_SCRIPT": str(cli_mcp),
                     "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
                     "SIDECAR_SERVICE_VERIFY_SCRIPT": str(sidecar),
                 },
@@ -184,16 +203,18 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             entries = command_log_entries(log_path)
 
         self.assertIn("sidecar_service=skipped", result.stdout)
-        self.assertEqual([entry[0] for entry in entries], ["hermes", "whatsapp"])
+        self.assertEqual([entry[0] for entry in entries], ["hermes", "cli_mcp", "whatsapp"])
         self.assertIn("--skip-tts-smoke", entries[0])
         self.assertIn("--skip-daemon", entries[1])
-        self.assertNotIn("--run-stt-smoke", entries[1])
+        self.assertIn("--skip-daemon", entries[2])
+        self.assertNotIn("--run-stt-smoke", entries[2])
 
     def test_webrtc_loopback_smoke_runs_when_requested(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             log_path = tmp_path / "commands.log"
             hermes = tmp_path / "verify_hermes.py"
+            cli_mcp = tmp_path / "verify_cli_mcp.py"
             whatsapp = tmp_path / "verify_whatsapp.sh"
             sidecar = tmp_path / "verify_sidecar.py"
             python = tmp_path / "python"
@@ -202,6 +223,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             config = tmp_path / "config.yaml"
 
             write_helper(hermes, "hermes", log_path)
+            write_helper(cli_mcp, "cli_mcp", log_path)
             write_helper(whatsapp, "whatsapp", log_path)
             write_helper(sidecar, "sidecar", log_path)
             write_fake_python(python, "webrtc", log_path)
@@ -235,6 +257,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 env={
                     **os.environ,
                     "HERMES_CONFIG_VERIFY_SCRIPT": str(hermes),
+                    "CLI_MCP_SURFACE_VERIFY_SCRIPT": str(cli_mcp),
                     "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
                     "SIDECAR_SERVICE_VERIFY_SCRIPT": str(sidecar),
                     "WEBRTC_LOOPBACK_SMOKE_SCRIPT": str(smoke),
@@ -244,9 +267,12 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             entries = command_log_entries(log_path)
 
         self.assertIn("webrtc_loopback=checked", result.stdout)
-        self.assertEqual([entry[0] for entry in entries], ["hermes", "whatsapp", "webrtc"])
         self.assertEqual(
-            entries[2],
+            [entry[0] for entry in entries],
+            ["hermes", "cli_mcp", "whatsapp", "webrtc"],
+        )
+        self.assertEqual(
+            entries[3],
             [
                 "webrtc",
                 str(smoke),
@@ -266,11 +292,13 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             tmp_path = Path(tmp)
             log_path = tmp_path / "commands.log"
             hermes = tmp_path / "verify_hermes.py"
+            cli_mcp = tmp_path / "verify_cli_mcp.py"
             whatsapp = tmp_path / "verify_whatsapp.sh"
             sidecar = tmp_path / "verify_sidecar.py"
             voice = tmp_path / "voice"
 
             write_helper(hermes, "hermes", log_path)
+            write_helper(cli_mcp, "cli_mcp", log_path)
             write_helper(whatsapp, "whatsapp", log_path)
             write_helper(sidecar, "sidecar", log_path)
             write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
@@ -283,6 +311,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                     "--hermes-config",
                     str(tmp_path / "missing.yaml"),
                     "--skip-hermes-config",
+                    "--skip-cli-mcp",
                     "--skip-sidecar",
                     "--skip-daemon",
                 ],
@@ -292,6 +321,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 env={
                     **os.environ,
                     "HERMES_CONFIG_VERIFY_SCRIPT": str(hermes),
+                    "CLI_MCP_SURFACE_VERIFY_SCRIPT": str(cli_mcp),
                     "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
                     "SIDECAR_SERVICE_VERIFY_SCRIPT": str(sidecar),
                 },
@@ -300,6 +330,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             entries = command_log_entries(log_path)
 
         self.assertIn("hermes_config=skipped", result.stdout)
+        self.assertIn("cli_mcp=skipped", result.stdout)
         self.assertEqual([entry[0] for entry in entries], ["whatsapp"])
 
 


### PR DESCRIPTION
## Summary\n- run the fast CLI/MCP surface verifier from scripts/verify_local_hermes_voice_stack.sh by default\n- pass --require-daemon or --skip-daemon consistently with the aggregate gate\n- document that the local stack gate covers plain CLI/MCP daemon behavior\n\n## Tests\n- python3 -m unittest tests/test_verify_local_hermes_voice_stack.py tests/test_verify_cli_mcp_surface.py\n- python3 -m unittest discover -s tests\n- python3 -m py_compile scripts/verify_cli_mcp_surface.py scripts/verify_hermes_voice_config.py scripts/verify_webrtc_sidecar_service.py tests/test_verify_cli_mcp_surface.py tests/test_verify_local_hermes_voice_stack.py\n- bash -n scripts/verify_local_hermes_voice_stack.sh\n- scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-config /home/ubuntu/.hermes/config.yaml --sidecar-url http://127.0.0.1:8787 --skip-systemd --skip-hermes-tts-smoke