### PR TITLE
Run CLI MCP surface verifier in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
 
       - run: cargo test --workspace
 
+      - run: cargo build -p voice
+
+      - run: scripts/verify_cli_mcp_surface.py --voice-bin target/debug/voice --skip-daemon
+
   sidecar-python:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary\n- build the real voice binary in the macOS CI check job\n- run scripts/verify_cli_mcp_surface.py against target/debug/voice with the daemon path skipped\n- gives CI coverage for stream-contract and MCP no-daemon startup on the actual binary\n\n## Tests\n- scripts/verify_cli_mcp_surface.py --voice-bin target/debug/voice --skip-daemon