### PR TITLE
Reuse CLI MCP verifier in release compare

### DIFF
--- a/scripts/macos_release_compare.py
+++ b/scripts/macos_release_compare.py
@@ -25,6 +25,17 @@ import time
 import wave
 from pathlib import Path
 
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from verify_cli_mcp_surface import (
+    mcp_connected_to_daemon,
+    mcp_initialized,
+    verify_daemon_surfaces,
+    verify_no_daemon_surfaces,
+)
+
 
 DEFAULT_PHRASES = [
     "Hermes is checking whether voice synthesis still starts quickly.",
@@ -34,10 +45,6 @@ DEFAULT_PHRASES = [
 
 DEFAULT_ARTICULATION_PHRASE = "Wait, what. Wait what?"
 DEFAULT_ARTICULATION_EXPECTED_WORDS = ["wait", "wait", "what", "what"]
-MCP_SMOKE_INPUT = (
-    '{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}\n'
-    '{"jsonrpc":"2.0","method":"tools/list","params":{},"id":2}\n'
-)
 
 
 def parse_args() -> argparse.Namespace:
@@ -377,17 +384,6 @@ def missing_expected_words(transcript: str, expected_words: list[str]) -> list[s
     return missing
 
 
-def mcp_initialized(stdout: str) -> bool:
-    return '"serverInfo"' in stdout and '"tools"' in stdout
-
-
-def mcp_connected_to_daemon(stderr: str) -> bool:
-    return (
-        "voice mcp: connected to voice daemon" in stderr
-        or "voice mcp: reconnected to voice daemon" in stderr
-    )
-
-
 def articulation_smoke_check(
     new_voice: Path,
     work_dir: Path,
@@ -462,19 +458,7 @@ def smoke_checks(
         }
     )
 
-    mcp = run(
-        [str(new_voice), "mcp", "-q"],
-        env=env,
-        input_text=MCP_SMOKE_INPUT,
-        capture=True,
-        timeout=240,
-    )
-    checks.append(
-        {
-            "name": "mcp_no_daemon_initializes",
-            "ok": mcp_initialized(mcp.stdout),
-        }
-    )
+    checks.extend(verify_no_daemon_surfaces(new_voice, timeout=240))
 
     stream = run(
         [str(new_voice), "stream", "-o", str(work_dir / "no-daemon-stream.pcm"), "No daemon."],
@@ -510,39 +494,19 @@ def smoke_checks(
             )
         )
 
-    daemon = subprocess.run(
-        [str(new_voice), "daemon", "status", "--json"],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+    daemon_checks = verify_daemon_surfaces(
+        new_voice,
+        require_daemon=require_daemon,
+        skip_daemon=False,
+        timeout=240,
     )
-    daemon_available = daemon.returncode == 0
-    checks.append(
-        {
-            "name": "daemon_detected",
-            "ok": daemon_available or not require_daemon,
-            "detected": daemon_available,
-            "note": "daemon stream check runs only when a daemon is detected",
-        }
+    checks.extend(daemon_checks)
+    daemon_available = any(
+        check.get("name") == "daemon_detected" and check.get("detected")
+        for check in daemon_checks
     )
 
     if daemon_available:
-        mcp_daemon = run(
-            [str(new_voice), "mcp"],
-            input_text=MCP_SMOKE_INPUT,
-            capture=True,
-            timeout=240,
-        )
-        checks.append(
-            {
-                "name": "mcp_with_daemon_detects_daemon",
-                "ok": (
-                    mcp_initialized(mcp_daemon.stdout)
-                    and mcp_connected_to_daemon(mcp_daemon.stderr)
-                ),
-            }
-        )
-
         pcm = work_dir / "stream-daemon.pcm"
         run(
             [str(new_voice), "stream", "-o", str(pcm), "Daemon streaming smoke test."],

--- a/tests/test_macos_release_compare.py
+++ b/tests/test_macos_release_compare.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 
 import importlib.util
+import os
 from pathlib import Path
 import sys
+import tempfile
+import textwrap
 import unittest
 
 
@@ -69,6 +72,102 @@ class ArticulationSmokeTests(unittest.TestCase):
             )
         )
         self.assertFalse(self.script.mcp_connected_to_daemon("voice mcp server ready\n"))
+
+    def make_fake_voice(self, tmp_path: Path) -> Path:
+        fake = tmp_path / "voice"
+        fake.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import json
+                import os
+                from pathlib import Path
+                import sys
+
+                args = sys.argv[1:]
+                if args == ["stream-contract"]:
+                    print(json.dumps({"contract": "voice.webrtc_sidecar"}))
+                    raise SystemExit(0)
+                if args == ["daemon", "status", "--json"]:
+                    if os.environ.get("VOICE_FAKE_DAEMON") == "1":
+                        print(json.dumps({"running": True}))
+                        raise SystemExit(0)
+                    print("daemon not running", file=sys.stderr)
+                    raise SystemExit(1)
+                if args and args[0] == "mcp":
+                    quiet = "-q" in args
+                    if not quiet and os.environ.get("VOICE_FAKE_DAEMON") == "1":
+                        print("voice mcp: connected to voice daemon", file=sys.stderr)
+                    print('{"result":{"serverInfo":{"name":"voice"}},"id":1}')
+                    print('{"result":{"tools":[]},"id":2}')
+                    raise SystemExit(0)
+                if args and args[0] == "say":
+                    out = Path(args[args.index("-o") + 1])
+                    out.write_bytes(b"RIFF" + (b"0" * 64))
+                    raise SystemExit(0)
+                if args and args[0] == "stream":
+                    if os.environ.get("VOICE_FAKE_DAEMON") == "1":
+                        out = Path(args[args.index("-o") + 1])
+                        out.write_bytes(b"pcm")
+                        raise SystemExit(0)
+                    print("daemon not running", file=sys.stderr)
+                    raise SystemExit(1)
+                print(f"unexpected args: {args}", file=sys.stderr)
+                raise SystemExit(2)
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake.chmod(0o755)
+        return fake
+
+    def smoke_checks_with_fake_voice(self, fake_voice: Path, work_dir: Path):
+        return self.script.smoke_checks(
+            fake_voice,
+            work_dir,
+            require_daemon=False,
+            skip_articulation_smoke=True,
+            articulation_phrase=self.script.DEFAULT_ARTICULATION_PHRASE,
+            articulation_expected_words=self.script.DEFAULT_ARTICULATION_EXPECTED_WORDS,
+        )
+
+    def test_smoke_checks_include_shared_cli_mcp_no_daemon_contract(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            fake_voice = self.make_fake_voice(tmp_path)
+
+            checks = self.smoke_checks_with_fake_voice(fake_voice, tmp_path)
+
+        by_name = {check["name"]: check for check in checks}
+        self.assertTrue(by_name["stream_contract_no_daemon"]["ok"])
+        self.assertEqual(
+            by_name["stream_contract_no_daemon"]["contract"],
+            "voice.webrtc_sidecar",
+        )
+        self.assertTrue(by_name["mcp_no_daemon_initializes"]["ok"])
+        self.assertTrue(by_name["stream_no_daemon_fails_fast"]["ok"])
+        self.assertFalse(by_name["daemon_detected"]["detected"])
+        self.assertTrue(by_name["mcp_with_daemon_detects_daemon"]["skipped"])
+
+    def test_smoke_checks_include_shared_cli_mcp_daemon_detection(self):
+        old_value = os.environ.get("VOICE_FAKE_DAEMON")
+        os.environ["VOICE_FAKE_DAEMON"] = "1"
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                tmp_path = Path(tmp)
+                fake_voice = self.make_fake_voice(tmp_path)
+
+                checks = self.smoke_checks_with_fake_voice(fake_voice, tmp_path)
+        finally:
+            if old_value is None:
+                os.environ.pop("VOICE_FAKE_DAEMON", None)
+            else:
+                os.environ["VOICE_FAKE_DAEMON"] = old_value
+
+        by_name = {check["name"]: check for check in checks}
+        self.assertTrue(by_name["daemon_detected"]["detected"])
+        self.assertTrue(by_name["mcp_with_daemon_detects_daemon"]["ok"])
+        self.assertTrue(by_name["stream_with_daemon_writes_pcm"]["ok"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary\n- make macos_release_compare.py reuse the shared CLI/MCP verifier helpers\n- add stream-contract no-daemon coverage to the release comparison smoke checks\n- test release smoke behavior with a fake voice binary for no-daemon and daemon-detected paths\n\n## Tests\n- python3 -m unittest tests/test_macos_release_compare.py tests/test_verify_cli_mcp_surface.py\n- python3 -m unittest discover -s tests\n- python3 -m py_compile scripts/macos_release_compare.py scripts/verify_cli_mcp_surface.py tests/test_macos_release_compare.py tests/test_verify_cli_mcp_surface.py\n- scripts/verify_cli_mcp_surface.py --voice-bin target/debug/voice --skip-daemon