### PR TITLE
Verify full stream contract in CLI MCP check

### DIFF
--- a/scripts/verify_cli_mcp_surface.py
+++ b/scripts/verify_cli_mcp_surface.py
@@ -51,6 +51,10 @@ def repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
+def expected_contract_path() -> Path:
+    return repo_root() / "docs" / "contracts" / "webrtc-sidecar-v1.json"
+
+
 def resolve_voice_bin(explicit: Path | None) -> Path:
     if explicit is not None:
         return explicit.expanduser().resolve()
@@ -105,6 +109,7 @@ def mcp_connected_to_daemon(stderr: str) -> bool:
 def verify_no_daemon_surfaces(voice_bin: Path, timeout: float) -> list[dict[str, Any]]:
     env = hidden_daemon_env()
     checks: list[dict[str, Any]] = []
+    expected_path = expected_contract_path()
 
     contract = run_command(
         [str(voice_bin), "stream-contract"],
@@ -113,19 +118,29 @@ def verify_no_daemon_surfaces(voice_bin: Path, timeout: float) -> list[dict[str,
     )
     contract_ok = False
     contract_name = None
+    contract_matches_expected = None
+    contract_error = None
     if contract.returncode == 0:
         try:
             contract_json = json.loads(contract.stdout)
             contract_name = contract_json.get("contract")
             contract_ok = contract_name == "voice.webrtc_sidecar"
+            if expected_path.is_file():
+                expected = json.loads(expected_path.read_text(encoding="utf-8"))
+                contract_matches_expected = contract_json == expected
+                contract_ok = contract_ok and contract_matches_expected
         except json.JSONDecodeError:
             contract_ok = False
+            contract_error = "stream-contract did not return JSON"
     checks.append(
         {
             "name": "stream_contract_no_daemon",
             "ok": contract_ok,
             "returncode": contract.returncode,
             "contract": contract_name,
+            "expected_path": str(expected_path),
+            "matches_expected": contract_matches_expected,
+            "error": contract_error,
         }
     )
 

--- a/tests/test_macos_release_compare.py
+++ b/tests/test_macos_release_compare.py
@@ -10,6 +10,7 @@ import unittest
 
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "macos_release_compare.py"
+CONTRACT_PATH = Path(__file__).resolve().parents[1] / "docs" / "contracts" / "webrtc-sidecar-v1.json"
 
 
 def load_script_module():
@@ -75,9 +76,8 @@ class ArticulationSmokeTests(unittest.TestCase):
 
     def make_fake_voice(self, tmp_path: Path) -> Path:
         fake = tmp_path / "voice"
-        fake.write_text(
-            textwrap.dedent(
-                """\
+        body = textwrap.dedent(
+            """\
                 #!/usr/bin/env python3
                 import json
                 import os
@@ -86,7 +86,7 @@ class ArticulationSmokeTests(unittest.TestCase):
 
                 args = sys.argv[1:]
                 if args == ["stream-contract"]:
-                    print(json.dumps({"contract": "voice.webrtc_sidecar"}))
+                    print(Path("__CONTRACT_PATH__").read_text(encoding="utf-8"))
                     raise SystemExit(0)
                 if args == ["daemon", "status", "--json"]:
                     if os.environ.get("VOICE_FAKE_DAEMON") == "1":
@@ -115,9 +115,8 @@ class ArticulationSmokeTests(unittest.TestCase):
                 print(f"unexpected args: {args}", file=sys.stderr)
                 raise SystemExit(2)
                 """
-            ),
-            encoding="utf-8",
-        )
+        ).replace("__CONTRACT_PATH__", str(CONTRACT_PATH))
+        fake.write_text(body, encoding="utf-8")
         fake.chmod(0o755)
         return fake
 

--- a/tests/test_verify_cli_mcp_surface.py
+++ b/tests/test_verify_cli_mcp_surface.py
@@ -12,6 +12,7 @@ import unittest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "verify_cli_mcp_surface.py"
+CONTRACT_PATH = REPO_ROOT / "docs" / "contracts" / "webrtc-sidecar-v1.json"
 
 
 def load_script_module():
@@ -29,11 +30,17 @@ class CliMcpSurfaceVerifierTests(unittest.TestCase):
     def setUpClass(cls):
         cls.script = load_script_module()
 
-    def make_fake_voice(self, tmp_path: Path) -> Path:
+    def make_fake_voice(self, tmp_path: Path, *, matching_contract: bool = True) -> Path:
         fake = tmp_path / "voice"
-        fake.write_text(
-            textwrap.dedent(
-                """\
+        if matching_contract:
+            contract_snippet = (
+                "from pathlib import Path\n"
+                f"    print(Path({str(CONTRACT_PATH)!r}).read_text(encoding='utf-8'))\n"
+            )
+        else:
+            contract_snippet = 'print(json.dumps({"contract": "voice.webrtc_sidecar"}))\n'
+        body = textwrap.dedent(
+            """\
                 #!/usr/bin/env python3
                 import json
                 import os
@@ -41,7 +48,7 @@ class CliMcpSurfaceVerifierTests(unittest.TestCase):
 
                 args = sys.argv[1:]
                 if args == ["stream-contract"]:
-                    print(json.dumps({"contract": "voice.webrtc_sidecar"}))
+                    __CONTRACT_SNIPPET__
                     raise SystemExit(0)
                 if args == ["daemon", "status", "--json"]:
                     if os.environ.get("VOICE_FAKE_DAEMON") == "1":
@@ -59,9 +66,8 @@ class CliMcpSurfaceVerifierTests(unittest.TestCase):
                 print(f"unexpected args: {args}", file=sys.stderr)
                 raise SystemExit(2)
                 """
-            ),
-            encoding="utf-8",
-        )
+        ).replace("__CONTRACT_SNIPPET__", contract_snippet)
+        fake.write_text(body, encoding="utf-8")
         fake.chmod(0o755)
         return fake
 
@@ -90,9 +96,21 @@ class CliMcpSurfaceVerifierTests(unittest.TestCase):
         self.assertTrue(result["success"])
         checks = {check["name"]: check for check in result["checks"]}
         self.assertTrue(checks["stream_contract_no_daemon"]["ok"])
+        self.assertTrue(checks["stream_contract_no_daemon"]["matches_expected"])
         self.assertTrue(checks["mcp_no_daemon_initializes"]["ok"])
         self.assertFalse(checks["daemon_detected"]["detected"])
         self.assertTrue(checks["mcp_with_daemon_detects_daemon"]["skipped"])
+
+    def test_no_daemon_contract_must_match_checked_in_contract(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_voice = self.make_fake_voice(Path(tmp), matching_contract=False)
+
+            result = self.verify_with_fake_voice(fake_voice)
+
+        self.assertFalse(result["success"])
+        checks = {check["name"]: check for check in result["checks"]}
+        self.assertFalse(checks["stream_contract_no_daemon"]["ok"])
+        self.assertFalse(checks["stream_contract_no_daemon"]["matches_expected"])
 
     def test_require_daemon_fails_when_daemon_is_missing(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary\n- make scripts/verify_cli_mcp_surface.py compare voice stream-contract output against docs/contracts/webrtc-sidecar-v1.json when available\n- surface matches_expected/expected_path in verifier JSON\n- update release-compare and CLI/MCP fake-binary tests to emit the checked-in contract and cover mismatch failure\n\n## Tests\n- python3 -m unittest tests/test_verify_cli_mcp_surface.py tests/test_macos_release_compare.py\n- python3 -m unittest discover -s tests\n- python3 -m py_compile scripts/verify_cli_mcp_surface.py scripts/macos_release_compare.py tests/test_verify_cli_mcp_surface.py tests/test_macos_release_compare.py\n- scripts/verify_cli_mcp_surface.py --voice-bin target/debug/voice --skip-daemon