### PR TITLE
Verify Hermes gateway voice stream service

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -76,6 +76,19 @@ scripts/install_webrtc_sidecar_service.sh --uninstall
 scripts/verify_webrtc_sidecar_service.py --skip-systemd
 ```
 
+If Hermes is installed locally for WhatsApp, verify the running gateway service
+is using the same voice stream contract and sidecar URL:
+
+```bash
+scripts/verify_hermes_gateway_service.py --voice-bin "$(command -v voice)"
+scripts/verify_local_hermes_voice_stack.sh --voice-bin "$(command -v voice)"
+```
+
+The aggregate stack verifier checks the Hermes config, the running
+`hermes-gateway.service` drop-in, CLI/MCP daemon behavior, Ogg/Opus voice-note
+output, raw stream frames, stream STT, and the WebRTC sidecar service. Use
+`--skip-systemd` only for non-service CI-style runs.
+
 ---
 
 The sections below document the manual setup steps performed by

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -101,6 +101,18 @@ Inspect the returned file with `ffprobe`; a voice-compatible WhatsApp path
 should return `.ogg` / Opus audio and should not need another Hermes-side
 conversion.
 
+On a Linux host that has the Hermes gateway installed as a user service, also
+check the live service drop-in:
+
+```bash
+VOICE_BIN=/path/to/voice scripts/verify_hermes_gateway_service.py
+VOICE_BIN=/path/to/voice scripts/verify_local_hermes_voice_stack.sh
+```
+
+The gateway verifier confirms `hermes-gateway.service` is active, points at the
+expected Hermes home, exports `WHATSAPP_CLOUD_CALLING_SIDECAR_URL`, and uses a
+`voice stream --raw-output -` command for the WhatsApp Calling sidecar path.
+
 ## CLI Smoke Test
 
 Use `voice stream` to inspect the streaming event flow:

--- a/scripts/verify_hermes_gateway_service.py
+++ b/scripts/verify_hermes_gateway_service.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Verify the running Hermes gateway is wired to the local voice stream path."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+
+DEFAULT_SERVICE_NAME = "hermes-gateway.service"
+DEFAULT_SIDECAR_URL = "http://127.0.0.1:8787"
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def default_voice_bin() -> str:
+    env_value = os.environ.get("VOICE_BIN")
+    if env_value:
+        return env_value
+    release_bin = repo_root() / "target" / "release" / "voice"
+    if release_bin.is_file() and os.access(release_bin, os.X_OK):
+        return str(release_bin)
+    return "voice"
+
+
+def default_hermes_home() -> str:
+    env_value = os.environ.get("HERMES_HOME")
+    if env_value:
+        return env_value
+    return str(Path.home() / ".hermes")
+
+
+def resolve_executable(value: str, *, label: str) -> str:
+    if "/" in value:
+        path = Path(value).expanduser()
+        if not path.is_file() or not os.access(path, os.X_OK):
+            raise SystemExit(f"{label} is not executable: {path}")
+        return os.path.abspath(os.path.expanduser(value))
+
+    found = shutil.which(value)
+    if not found:
+        raise SystemExit(f"{label} not found on PATH: {value}")
+    return os.path.abspath(found)
+
+
+def resolve_command_executable(value: str) -> str | None:
+    if "/" in value:
+        return os.path.abspath(os.path.expanduser(value))
+    found = shutil.which(value)
+    return os.path.abspath(found) if found else None
+
+
+def run_command(command: list[str], *, timeout: float) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def parse_systemctl_show(output: str) -> dict[str, str]:
+    data: dict[str, str] = {}
+    for line in output.splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        data[key] = value
+    return data
+
+
+def get_service_state(service_name: str, *, timeout: float) -> dict[str, str]:
+    completed = run_command(
+        [
+            "systemctl",
+            "--user",
+            "show",
+            service_name,
+            "-p",
+            "ActiveState",
+            "-p",
+            "SubState",
+            "-p",
+            "MainPID",
+            "-p",
+            "Environment",
+            "-p",
+            "ExecStart",
+            "-p",
+            "WorkingDirectory",
+            "-p",
+            "FragmentPath",
+            "-p",
+            "DropInPaths",
+            "--no-pager",
+        ],
+        timeout=timeout,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise RuntimeError(f"systemctl show failed for {service_name}: {detail}")
+    return parse_systemctl_show(completed.stdout)
+
+
+def parse_systemd_environment(value: str) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for part in shlex.split(value):
+        if "=" not in part:
+            continue
+        key, raw = part.split("=", 1)
+        env[key] = raw
+    return env
+
+
+def parse_exec_start_argv(exec_start: str) -> list[str]:
+    marker = "argv[]="
+    if marker in exec_start:
+        raw = exec_start.split(marker, 1)[1]
+        raw = raw.split(" ;", 1)[0].split(" }", 1)[0]
+        return shlex.split(raw)
+    return shlex.split(exec_start)
+
+
+def option_value(args: list[str], name: str) -> str | None:
+    prefix = f"{name}="
+    for index, arg in enumerate(args):
+        if arg.startswith(prefix):
+            return arg[len(prefix) :]
+        if arg == name and index + 1 < len(args):
+            return args[index + 1]
+    return None
+
+
+def validate_stream_command(command: str, *, voice_bin: str) -> tuple[list[str], dict[str, Any]]:
+    failures: list[str] = []
+    try:
+        args = shlex.split(command)
+    except ValueError as exc:
+        return [f"stream command is not shell-parseable: {exc}"], {}
+
+    summary: dict[str, Any] = {"argv": args}
+    if not args:
+        return ["stream command must not be empty"], summary
+
+    command_voice = resolve_command_executable(args[0])
+    if command_voice != voice_bin:
+        failures.append(
+            f"stream command voice binary={command_voice!r}, expected {voice_bin!r}"
+        )
+
+    if len(args) < 2 or args[1] != "stream":
+        failures.append("stream command must invoke `voice stream`")
+    if "--quiet" not in args:
+        failures.append("stream command must pass --quiet")
+
+    expected_options = {
+        "--sample-rate": "{sample_rate}",
+        "--frame-ms": "{frame_ms}",
+        "--raw-output": "-",
+        "--input-file": "{input_path}",
+    }
+    for option, expected in expected_options.items():
+        actual = option_value(args, option)
+        if actual != expected:
+            failures.append(
+                f"stream command must pass {option} {expected}; got {actual or '<missing>'}"
+            )
+
+    for option in ("--voice", "--speed"):
+        if option_value(args, option) is None:
+            failures.append(f"stream command must pass {option}")
+
+    return failures, summary
+
+
+def validate_service(
+    state: dict[str, str],
+    *,
+    service_name: str,
+    hermes_home: Path,
+    sidecar_url: str,
+    voice_bin: str,
+) -> tuple[list[str], dict[str, Any]]:
+    failures: list[str] = []
+
+    active_state = state.get("ActiveState")
+    if active_state != "active":
+        failures.append(f"{service_name} ActiveState={active_state!r}, expected 'active'")
+
+    try:
+        main_pid = int(state.get("MainPID") or "0")
+    except ValueError:
+        main_pid = 0
+    if main_pid <= 0:
+        failures.append(f"{service_name} MainPID must be positive")
+
+    exec_argv = parse_exec_start_argv(state.get("ExecStart", ""))
+    if not exec_argv:
+        failures.append(f"{service_name} ExecStart is empty")
+    elif not (
+        "hermes" in Path(exec_argv[0]).name
+        or exec_argv[-3:] == ["hermes_cli.main", "gateway", "run"]
+        or exec_argv[-4:] == ["-m", "hermes_cli.main", "gateway", "run"]
+    ):
+        failures.append(f"{service_name} ExecStart must run Hermes gateway")
+
+    working_directory = state.get("WorkingDirectory", "")
+    if working_directory and Path(working_directory).expanduser() != hermes_home:
+        failures.append(
+            f"{service_name} WorkingDirectory={working_directory!r}, "
+            f"expected {str(hermes_home)!r}"
+        )
+
+    env = parse_systemd_environment(state.get("Environment", ""))
+    if env.get("HERMES_HOME") != str(hermes_home):
+        failures.append(
+            f"{service_name} HERMES_HOME={env.get('HERMES_HOME')!r}, "
+            f"expected {str(hermes_home)!r}"
+        )
+    if env.get("WHATSAPP_CLOUD_CALLING_SIDECAR_URL") != sidecar_url:
+        failures.append(
+            f"{service_name} WHATSAPP_CLOUD_CALLING_SIDECAR_URL="
+            f"{env.get('WHATSAPP_CLOUD_CALLING_SIDECAR_URL')!r}, expected {sidecar_url!r}"
+        )
+
+    pythonpath = env.get("PYTHONPATH", "")
+    pythonpath_entries = [Path(part).expanduser() for part in pythonpath.split(":") if part]
+    if not pythonpath_entries:
+        failures.append(f"{service_name} PYTHONPATH must include the local Hermes code path")
+    elif not any(path.exists() for path in pythonpath_entries):
+        failures.append(f"{service_name} PYTHONPATH entries do not exist: {pythonpath!r}")
+
+    stream_command = env.get("WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND")
+    if not stream_command:
+        stream_failures: list[str] = [
+            f"{service_name} WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND is missing"
+        ]
+        stream_summary: dict[str, Any] = {}
+    else:
+        stream_failures, stream_summary = validate_stream_command(
+            stream_command,
+            voice_bin=voice_bin,
+        )
+    failures.extend(f"{service_name}: {failure}" for failure in stream_failures)
+
+    timeout = env.get("WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT")
+    if timeout is not None:
+        try:
+            if float(timeout) <= 0:
+                failures.append(
+                    f"{service_name} WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT "
+                    "must be positive"
+                )
+        except ValueError:
+            failures.append(
+                f"{service_name} WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT "
+                f"is not numeric: {timeout!r}"
+            )
+
+    summary = {
+        "active_state": active_state,
+        "sub_state": state.get("SubState"),
+        "main_pid": main_pid,
+        "exec_start": exec_argv,
+        "working_directory": working_directory,
+        "hermes_home": env.get("HERMES_HOME"),
+        "pythonpath": pythonpath,
+        "sidecar_url": env.get("WHATSAPP_CLOUD_CALLING_SIDECAR_URL"),
+        "stream_command": stream_summary,
+        "fragment_path": state.get("FragmentPath"),
+        "drop_in_paths": state.get("DropInPaths"),
+    }
+    return failures, summary
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--voice-bin", default=default_voice_bin())
+    parser.add_argument("--service-name", default=DEFAULT_SERVICE_NAME)
+    parser.add_argument("--hermes-home", default=default_hermes_home())
+    parser.add_argument("--sidecar-url", default=DEFAULT_SIDECAR_URL)
+    parser.add_argument("--timeout", type=float, default=10.0)
+    parser.add_argument("--json", action="store_true", help="print JSON output")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    voice_bin = resolve_executable(args.voice_bin, label="voice binary")
+    hermes_home = Path(args.hermes_home).expanduser().resolve()
+    sidecar_url = args.sidecar_url.rstrip("/")
+
+    failures: list[str] = []
+    checks: dict[str, Any] = {
+        "service": args.service_name,
+        "voice_bin": voice_bin,
+        "hermes_home": str(hermes_home),
+        "sidecar_url": sidecar_url,
+    }
+    try:
+        state = get_service_state(args.service_name, timeout=args.timeout)
+        service_failures, service_summary = validate_service(
+            state,
+            service_name=args.service_name,
+            hermes_home=hermes_home,
+            sidecar_url=sidecar_url,
+            voice_bin=voice_bin,
+        )
+    except Exception as exc:
+        service_failures = [str(exc)]
+        service_summary = {}
+
+    failures.extend(service_failures)
+    checks["gateway_service"] = {
+        **service_summary,
+        "failures": service_failures,
+    }
+
+    result = {"success": not failures, "checks": checks, "failures": failures}
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    elif failures:
+        print("error: Hermes gateway service verifier failed", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+    else:
+        print("ok: Hermes gateway service verifier passed")
+        print(f"service={args.service_name}:checked")
+        print(f"voice_bin={voice_bin}")
+        print(f"hermes_home={hermes_home}")
+        print(f"sidecar_url={sidecar_url}")
+        print("stream_command=voice stream --raw-output -")
+
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -5,10 +5,12 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 voice_bin="${VOICE_BIN:-}"
 hermes_config="${HERMES_CONFIG:-${HOME:-}/.hermes/config.yaml}"
+hermes_home="${HERMES_HOME:-${HOME:-}/.hermes}"
 sidecar_url="${SIDECAR_URL:-http://127.0.0.1:8787}"
 text="${TEXT:-Local Hermes voice stack smoke test.}"
 skip_hermes_config="${SKIP_HERMES_CONFIG:-0}"
 skip_hermes_tts_smoke="${SKIP_HERMES_TTS_SMOKE:-0}"
+skip_hermes_gateway="${SKIP_HERMES_GATEWAY:-0}"
 skip_sidecar="${SKIP_SIDECAR:-0}"
 skip_systemd="${SKIP_SYSTEMD:-0}"
 skip_cli_mcp="${SKIP_CLI_MCP:-0}"
@@ -20,6 +22,7 @@ webrtc_timeout="${VOICE_WEBRTC_TIMEOUT:-60}"
 max_queued_tx_ms="${MAX_QUEUED_TX_MS:-1000}"
 
 hermes_config_verify_script="${HERMES_CONFIG_VERIFY_SCRIPT:-$repo_root/scripts/verify_hermes_voice_config.py}"
+hermes_gateway_verify_script="${HERMES_GATEWAY_VERIFY_SCRIPT:-$repo_root/scripts/verify_hermes_gateway_service.py}"
 cli_mcp_surface_verify_script="${CLI_MCP_SURFACE_VERIFY_SCRIPT:-$repo_root/scripts/verify_cli_mcp_surface.py}"
 whatsapp_contract_verify_script="${WHATSAPP_CONTRACT_VERIFY_SCRIPT:-$repo_root/scripts/verify_whatsapp_voice_contract.sh}"
 sidecar_service_verify_script="${SIDECAR_SERVICE_VERIFY_SCRIPT:-$repo_root/scripts/verify_webrtc_sidecar_service.py}"
@@ -38,13 +41,15 @@ checks the WebRTC sidecar HTTP contract plus Linux systemd user services.
 Options:
   --voice-bin PATH             installed voice binary to verify
   --hermes-config PATH         Hermes config file (default: ~/.hermes/config.yaml)
+  --hermes-home PATH           Hermes home directory (default: ~/.hermes)
   --sidecar-url URL            sidecar base URL (default: http://127.0.0.1:8787)
   --text TEXT                  smoke text used by TTS checks
   --skip-hermes-config         skip Hermes config validation and TTS command smoke
   --skip-hermes-tts-smoke      validate Hermes config without executing TTS
+  --skip-hermes-gateway        skip running Hermes gateway service verification
   --skip-cli-mcp               skip plain CLI/MCP daemon surface verification
   --skip-sidecar               skip WebRTC sidecar service verification
-  --skip-systemd               skip sidecar/daemon systemd service checks
+  --skip-systemd               skip Hermes gateway, sidecar, and daemon systemd service checks
   --skip-daemon                skip daemon-backed stream checks
   --skip-stt-smoke             skip stream-transcribe smoke
   --run-webrtc-loopback-smoke  run one local full-duplex WebRTC media turn
@@ -56,8 +61,9 @@ Options:
 Environment aliases:
   VOICE_BIN, HERMES_CONFIG, SIDECAR_URL, TEXT
   SKIP_HERMES_CONFIG=1, SKIP_HERMES_TTS_SMOKE=1, SKIP_SIDECAR=1
-  SKIP_SYSTEMD=1, SKIP_CLI_MCP=1, SKIP_DAEMON=1, SKIP_STT_SMOKE=1
-  RUN_WEBRTC_LOOPBACK_SMOKE=1, VOICE_WEBRTC_PYTHON, VOICE_WEBRTC_TIMEOUT
+  SKIP_HERMES_GATEWAY=1, SKIP_SYSTEMD=1, SKIP_CLI_MCP=1
+  SKIP_DAEMON=1, SKIP_STT_SMOKE=1, RUN_WEBRTC_LOOPBACK_SMOKE=1
+  VOICE_WEBRTC_PYTHON, VOICE_WEBRTC_TIMEOUT
 EOF
 }
 
@@ -110,6 +116,11 @@ while [[ $# -gt 0 ]]; do
       hermes_config="$2"
       shift 2
       ;;
+    --hermes-home)
+      [[ $# -ge 2 ]] || fail "--hermes-home requires a path"
+      hermes_home="$2"
+      shift 2
+      ;;
     --sidecar-url)
       [[ $# -ge 2 ]] || fail "--sidecar-url requires a URL"
       sidecar_url="$2"
@@ -126,6 +137,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-hermes-tts-smoke)
       skip_hermes_tts_smoke=1
+      shift
+      ;;
+    --skip-hermes-gateway)
+      skip_hermes_gateway=1
       shift
       ;;
     --skip-sidecar)
@@ -192,6 +207,9 @@ fi
 if [[ "$skip_cli_mcp" != "1" ]]; then
   require_executable "$cli_mcp_surface_verify_script" "CLI/MCP surface verifier"
 fi
+if [[ "$skip_hermes_gateway" != "1" && "$skip_systemd" != "1" ]]; then
+  require_executable "$hermes_gateway_verify_script" "Hermes gateway service verifier"
+fi
 if [[ "$skip_sidecar" != "1" ]]; then
   require_executable "$sidecar_service_verify_script" "WebRTC sidecar verifier"
 fi
@@ -218,6 +236,19 @@ if [[ "$skip_hermes_config" != "1" ]]; then
   hermes_status="checked"
 else
   hermes_status="skipped"
+fi
+
+if [[ "$skip_hermes_gateway" != "1" && "$skip_systemd" != "1" ]]; then
+  gateway_args=(
+    "$hermes_gateway_verify_script"
+    --voice-bin "$voice_bin"
+    --hermes-home "$hermes_home"
+    --sidecar-url "$sidecar_url"
+  )
+  run_step "Hermes gateway voice stream service" "${gateway_args[@]}"
+  hermes_gateway_status="checked"
+else
+  hermes_gateway_status="skipped"
 fi
 
 if [[ "$skip_cli_mcp" != "1" ]]; then
@@ -282,6 +313,7 @@ echo
 echo "ok: local Hermes voice stack verifier passed"
 echo "voice_bin=$voice_bin"
 echo "hermes_config=$hermes_status"
+echo "hermes_gateway=$hermes_gateway_status"
 echo "cli_mcp=$cli_mcp_status"
 echo "whatsapp_contract=checked"
 echo "sidecar_service=$sidecar_status"

--- a/tests/test_verify_hermes_gateway_service.py
+++ b/tests/test_verify_hermes_gateway_service.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "verify_hermes_gateway_service.py"
+
+
+def write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def write_fake_systemctl(
+    path: Path,
+    *,
+    hermes_home: Path,
+    voice_bin: Path,
+    pythonpath: Path,
+    stream_command: str | None = None,
+    active_state: str = "active",
+) -> None:
+    command = stream_command or (
+        f"{voice_bin} stream --quiet --sample-rate {{sample_rate}} "
+        "--frame-ms {frame_ms} --raw-output - --input-file {input_path} "
+        "--voice af_heart --speed 1.0"
+    )
+    body = textwrap.dedent(
+        f"""\
+        #!/usr/bin/env bash
+        set -euo pipefail
+        cat <<'EOF'
+        ActiveState={active_state}
+        SubState=running
+        MainPID=12345
+        ExecStart={{ path={hermes_home}/hermes-agent/venv/bin/python ; argv[]={hermes_home}/hermes-agent/venv/bin/python -m hermes_cli.main gateway run ; ignore_errors=no ; }}
+        Environment=HERMES_HOME={hermes_home} PYTHONPATH={pythonpath} WHATSAPP_CLOUD_CALLING_SIDECAR_URL=http://127.0.0.1:8787 "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND={command}" WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT=180
+        WorkingDirectory={hermes_home}
+        FragmentPath={hermes_home}/systemd/hermes-gateway.service
+        DropInPaths={hermes_home}/systemd/hermes-gateway.service.d/voice-stack.conf
+        EOF
+        """
+    )
+    write_executable(path, body)
+
+
+class HermesGatewayServiceVerifierTests(unittest.TestCase):
+    def test_verifier_accepts_voice_native_gateway_service(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            hermes_home = tmp_path / "hermes"
+            pythonpath = tmp_path / "hermes-agent-voice-stack"
+            bin_dir = tmp_path / "bin"
+            hermes_home.mkdir()
+            pythonpath.mkdir()
+            bin_dir.mkdir()
+            voice = bin_dir / "voice"
+            systemctl = bin_dir / "systemctl"
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+            write_fake_systemctl(
+                systemctl,
+                hermes_home=hermes_home,
+                voice_bin=voice,
+                pythonpath=pythonpath,
+            )
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "--json",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"},
+            )
+
+        payload = json.loads(result.stdout)
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["failures"], [])
+        self.assertEqual(
+            payload["checks"]["gateway_service"]["sidecar_url"],
+            "http://127.0.0.1:8787",
+        )
+
+    def test_verifier_rejects_gateway_without_raw_stream_command(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            hermes_home = tmp_path / "hermes"
+            pythonpath = tmp_path / "hermes-agent-voice-stack"
+            bin_dir = tmp_path / "bin"
+            hermes_home.mkdir()
+            pythonpath.mkdir()
+            bin_dir.mkdir()
+            voice = bin_dir / "voice"
+            systemctl = bin_dir / "systemctl"
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+            write_fake_systemctl(
+                systemctl,
+                hermes_home=hermes_home,
+                voice_bin=voice,
+                pythonpath=pythonpath,
+                stream_command=f"{voice} stream --quiet --input-file {{input_path}}",
+            )
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--hermes-home",
+                    str(hermes_home),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"},
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("stream command must pass --raw-output -", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -66,6 +66,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             tmp_path = Path(tmp)
             log_path = tmp_path / "commands.log"
             hermes = tmp_path / "verify_hermes.py"
+            gateway = tmp_path / "verify_gateway.py"
             cli_mcp = tmp_path / "verify_cli_mcp.py"
             whatsapp = tmp_path / "verify_whatsapp.sh"
             sidecar = tmp_path / "verify_sidecar.py"
@@ -73,6 +74,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             config = tmp_path / "config.yaml"
 
             write_helper(hermes, "hermes", log_path)
+            write_helper(gateway, "gateway", log_path)
             write_helper(cli_mcp, "cli_mcp", log_path)
             write_helper(whatsapp, "whatsapp", log_path)
             write_helper(sidecar, "sidecar", log_path)
@@ -98,6 +100,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 env={
                     **os.environ,
                     "HERMES_CONFIG_VERIFY_SCRIPT": str(hermes),
+                    "HERMES_GATEWAY_VERIFY_SCRIPT": str(gateway),
                     "CLI_MCP_SURFACE_VERIFY_SCRIPT": str(cli_mcp),
                     "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
                     "SIDECAR_SERVICE_VERIFY_SCRIPT": str(sidecar),
@@ -107,6 +110,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             entries = command_log_entries(log_path)
 
         self.assertIn("ok: local Hermes voice stack verifier passed", result.stdout)
+        self.assertIn("hermes_gateway=skipped", result.stdout)
         self.assertIn("cli_mcp=checked", result.stdout)
         self.assertIn("webrtc_loopback=skipped", result.stdout)
         self.assertEqual(
@@ -163,6 +167,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             tmp_path = Path(tmp)
             log_path = tmp_path / "commands.log"
             hermes = tmp_path / "verify_hermes.py"
+            gateway = tmp_path / "verify_gateway.py"
             cli_mcp = tmp_path / "verify_cli_mcp.py"
             whatsapp = tmp_path / "verify_whatsapp.sh"
             sidecar = tmp_path / "verify_sidecar.py"
@@ -170,6 +175,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             config = tmp_path / "config.yaml"
 
             write_helper(hermes, "hermes", log_path)
+            write_helper(gateway, "gateway", log_path)
             write_helper(cli_mcp, "cli_mcp", log_path)
             write_helper(whatsapp, "whatsapp", log_path)
             write_helper(sidecar, "sidecar", log_path)
@@ -184,6 +190,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                     "--hermes-config",
                     str(config),
                     "--skip-hermes-tts-smoke",
+                    "--skip-hermes-gateway",
                     "--skip-sidecar",
                     "--skip-daemon",
                     "--skip-stt-smoke",
@@ -194,6 +201,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 env={
                     **os.environ,
                     "HERMES_CONFIG_VERIFY_SCRIPT": str(hermes),
+                    "HERMES_GATEWAY_VERIFY_SCRIPT": str(gateway),
                     "CLI_MCP_SURFACE_VERIFY_SCRIPT": str(cli_mcp),
                     "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
                     "SIDECAR_SERVICE_VERIFY_SCRIPT": str(sidecar),
@@ -203,6 +211,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             entries = command_log_entries(log_path)
 
         self.assertIn("sidecar_service=skipped", result.stdout)
+        self.assertIn("hermes_gateway=skipped", result.stdout)
         self.assertEqual([entry[0] for entry in entries], ["hermes", "cli_mcp", "whatsapp"])
         self.assertIn("--skip-tts-smoke", entries[0])
         self.assertIn("--skip-daemon", entries[1])
@@ -214,6 +223,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             tmp_path = Path(tmp)
             log_path = tmp_path / "commands.log"
             hermes = tmp_path / "verify_hermes.py"
+            gateway = tmp_path / "verify_gateway.py"
             cli_mcp = tmp_path / "verify_cli_mcp.py"
             whatsapp = tmp_path / "verify_whatsapp.sh"
             sidecar = tmp_path / "verify_sidecar.py"
@@ -223,6 +233,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             config = tmp_path / "config.yaml"
 
             write_helper(hermes, "hermes", log_path)
+            write_helper(gateway, "gateway", log_path)
             write_helper(cli_mcp, "cli_mcp", log_path)
             write_helper(whatsapp, "whatsapp", log_path)
             write_helper(sidecar, "sidecar", log_path)
@@ -257,6 +268,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 env={
                     **os.environ,
                     "HERMES_CONFIG_VERIFY_SCRIPT": str(hermes),
+                    "HERMES_GATEWAY_VERIFY_SCRIPT": str(gateway),
                     "CLI_MCP_SURFACE_VERIFY_SCRIPT": str(cli_mcp),
                     "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
                     "SIDECAR_SERVICE_VERIFY_SCRIPT": str(sidecar),
@@ -269,10 +281,10 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn("webrtc_loopback=checked", result.stdout)
         self.assertEqual(
             [entry[0] for entry in entries],
-            ["hermes", "cli_mcp", "whatsapp", "webrtc"],
+            ["hermes", "gateway", "cli_mcp", "whatsapp", "webrtc"],
         )
         self.assertEqual(
-            entries[3],
+            entries[4],
             [
                 "webrtc",
                 str(smoke),
@@ -292,12 +304,14 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             tmp_path = Path(tmp)
             log_path = tmp_path / "commands.log"
             hermes = tmp_path / "verify_hermes.py"
+            gateway = tmp_path / "verify_gateway.py"
             cli_mcp = tmp_path / "verify_cli_mcp.py"
             whatsapp = tmp_path / "verify_whatsapp.sh"
             sidecar = tmp_path / "verify_sidecar.py"
             voice = tmp_path / "voice"
 
             write_helper(hermes, "hermes", log_path)
+            write_helper(gateway, "gateway", log_path)
             write_helper(cli_mcp, "cli_mcp", log_path)
             write_helper(whatsapp, "whatsapp", log_path)
             write_helper(sidecar, "sidecar", log_path)
@@ -321,6 +335,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 env={
                     **os.environ,
                     "HERMES_CONFIG_VERIFY_SCRIPT": str(hermes),
+                    "HERMES_GATEWAY_VERIFY_SCRIPT": str(gateway),
                     "CLI_MCP_SURFACE_VERIFY_SCRIPT": str(cli_mcp),
                     "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
                     "SIDECAR_SERVICE_VERIFY_SCRIPT": str(sidecar),
@@ -330,8 +345,79 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             entries = command_log_entries(log_path)
 
         self.assertIn("hermes_config=skipped", result.stdout)
+        self.assertIn("hermes_gateway=checked", result.stdout)
         self.assertIn("cli_mcp=skipped", result.stdout)
-        self.assertEqual([entry[0] for entry in entries], ["whatsapp"])
+        self.assertEqual([entry[0] for entry in entries], ["gateway", "whatsapp"])
+
+    def test_gateway_service_check_runs_when_systemd_checks_enabled(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            hermes = tmp_path / "verify_hermes.py"
+            gateway = tmp_path / "verify_gateway.py"
+            cli_mcp = tmp_path / "verify_cli_mcp.py"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            sidecar = tmp_path / "verify_sidecar.py"
+            voice = tmp_path / "voice"
+            config = tmp_path / "config.yaml"
+            hermes_home = tmp_path / "hermes"
+
+            write_helper(hermes, "hermes", log_path)
+            write_helper(gateway, "gateway", log_path)
+            write_helper(cli_mcp, "cli_mcp", log_path)
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_helper(sidecar, "sidecar", log_path)
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+            config.write_text("tts: {}\n", encoding="utf-8")
+            hermes_home.mkdir()
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--hermes-config",
+                    str(config),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "--sidecar-url",
+                    "http://127.0.0.1:9999",
+                    "--skip-daemon",
+                    "--text",
+                    "Stack smoke.",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "HERMES_CONFIG_VERIFY_SCRIPT": str(hermes),
+                    "HERMES_GATEWAY_VERIFY_SCRIPT": str(gateway),
+                    "CLI_MCP_SURFACE_VERIFY_SCRIPT": str(cli_mcp),
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "SIDECAR_SERVICE_VERIFY_SCRIPT": str(sidecar),
+                },
+            )
+
+            entries = command_log_entries(log_path)
+
+        self.assertIn("hermes_gateway=checked", result.stdout)
+        self.assertEqual(
+            [entry[0] for entry in entries],
+            ["hermes", "gateway", "cli_mcp", "whatsapp", "sidecar"],
+        )
+        self.assertEqual(
+            entries[1],
+            [
+                "gateway",
+                "--voice-bin",
+                str(voice),
+                "--hermes-home",
+                str(hermes_home),
+                "--sidecar-url",
+                "http://127.0.0.1:9999",
+            ],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `scripts/verify_hermes_gateway_service.py` to validate the running `hermes-gateway.service` voice stream sidecar wiring
- include the gateway service check in `scripts/verify_local_hermes_voice_stack.sh` unless systemd or gateway checks are skipped
- document the live Hermes gateway verification path and cover it with Python tests

## Verification
- `python3 -m py_compile scripts/verify_hermes_gateway_service.py tests/test_verify_hermes_gateway_service.py tests/test_verify_local_hermes_voice_stack.py`
- `bash -n scripts/verify_local_hermes_voice_stack.sh`
- `python3 -m unittest tests/test_verify_hermes_gateway_service.py tests/test_verify_local_hermes_voice_stack.py`
- `python3 -m unittest discover -s tests`
- `scripts/verify_hermes_gateway_service.py --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --sidecar-url http://127.0.0.1:8787 --json`
- `scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --hermes-config /home/ubuntu/.hermes/config.yaml --sidecar-url http://127.0.0.1:8787`
