### PR TITLE
Exercise sidecar clear audio in full-duplex smoke

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -380,7 +380,9 @@ that path.
    Cloud call still depends on a calling-enabled number.
 7. Replace echo with STT -> Hermes turn -> `stream_speak` TTS.
 8. Add interruption/barge-in: inbound voice clears queued outbound sidecar PCM
-   and cancels in-flight TTS.
+   and cancels in-flight TTS. The local full-duplex sidecar smoke now exercises
+   `/calls/{call_id}/audio/clear`; Hermes still needs the policy that decides
+   when to invoke it during real calls.
 
 ## Open Questions
 

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -325,8 +325,12 @@ WebRTC-to-STT path without WhatsApp or the Graph API.
 local WebRTC audio drains through `voice stream-transcribe`, while
 `post_voice_stream.py` queues outbound `voice stream` PCM back to the same
 WebRTC peer. It is the closest local smoke to a single WhatsApp call turn. It
-also fails when the sidecar still has more than one second of outbound audio
-queued at the end of the turn; use `--max-queued-tx-ms` to tighten or loosen
-that local latency budget. When available, it uses the sidecar-reported
-`queued_tx_ms` field; older sidecars fall back to deriving the duration from
-`queued_tx_bytes` and the audio contract.
+also queues a small outbound PCM probe on the live call and calls
+`POST /calls/{call_id}/audio/clear`, so the same smoke covers the local
+barge-in/cancellation primitive. Pass `--skip-clear-audio-smoke` when checking
+only media round-trip behavior. The smoke fails when the sidecar still has more
+than one second of outbound audio queued at the end of the turn; use
+`--max-queued-tx-ms` to tighten or loosen that local latency budget. When
+available, it uses the sidecar-reported `queued_tx_ms` field; older sidecars
+fall back to deriving the duration from `queued_tx_bytes` and the audio
+contract.

--- a/examples/webrtc-sidecar/full_duplex_loopback_smoke.py
+++ b/examples/webrtc-sidecar/full_duplex_loopback_smoke.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import base64
 import json
 import os
 from pathlib import Path
@@ -49,6 +50,7 @@ from voice_stream_loopback_smoke import (
 DEFAULT_INBOUND_TEXT = "hello world"
 DEFAULT_OUTBOUND_TEXT = "Hello from a full duplex WebRTC sidecar turn."
 DEFAULT_MAX_QUEUED_TX_MS = 1_000
+DEFAULT_CLEAR_PROBE_MS = 200
 
 
 def pcm_bytes_to_ms(byte_count: object, audio: dict[str, Any]) -> int:
@@ -96,6 +98,61 @@ def validate_queued_tx_budget(call: dict[str, Any], max_queued_tx_ms: int) -> in
             f"({queued_ms} ms > {max_queued_tx_ms} ms)"
         )
     return queued_ms
+
+
+async def verify_clear_audio(
+    session: ClientSession,
+    base_url: str,
+    call_id: str,
+    audio: dict[str, Any],
+    *,
+    duration_ms: int = DEFAULT_CLEAR_PROBE_MS,
+) -> dict[str, Any]:
+    """Queue outbound PCM on a live call, clear it, and verify the queue drains."""
+
+    frame_ms = int(audio.get("frame_ms") or 0)
+    frame_bytes = int(audio.get("frame_bytes") or 0)
+    if frame_ms <= 0 or frame_bytes <= 0:
+        raise RuntimeError("audio contract must include positive frame_ms/frame_bytes")
+    frames = max(1, (duration_ms + frame_ms - 1) // frame_ms)
+    probe = b"\x01\x00" * ((frame_bytes * frames) // 2)
+    payload = {
+        "sample_rate": audio["sample_rate"],
+        "channels": audio["channels"],
+        "frame_ms": audio["frame_ms"],
+        "encoding": audio["encoding"],
+        "pcm_s16le_base64": base64.b64encode(probe).decode("ascii"),
+    }
+
+    async with session.post(f"{base_url}/calls/{call_id}/audio", json=payload) as response:
+        queued = await response.json()
+        if response.status != 200:
+            raise RuntimeError(f"clear probe queue failed ({response.status}): {queued}")
+
+    queued_before_clear = int(queued.get("queued_tx_bytes") or 0)
+    if queued_before_clear <= 0:
+        raise RuntimeError("clear probe did not leave outbound PCM queued")
+
+    async with session.post(f"{base_url}/calls/{call_id}/audio/clear") as response:
+        cleared = await response.json()
+        if response.status != 200:
+            raise RuntimeError(f"clear audio failed ({response.status}): {cleared}")
+
+    dropped = int(cleared.get("dropped_tx_bytes") or 0)
+    remaining = int(cleared.get("queued_tx_bytes") or 0)
+    if dropped <= 0:
+        raise RuntimeError("clear audio reported no dropped outbound PCM")
+    if remaining != 0:
+        raise RuntimeError(f"clear audio left {remaining} queued outbound bytes")
+
+    return {
+        "queued_before_clear_bytes": queued_before_clear,
+        "queued_before_clear_ms": queued.get("queued_tx_ms"),
+        "dropped_tx_bytes": dropped,
+        "dropped_tx_ms": cleared.get("dropped_tx_ms"),
+        "queued_tx_bytes": remaining,
+        "queued_tx_ms": cleared.get("queued_tx_ms"),
+    }
 
 
 async def start_sidecar_app() -> tuple[web.AppRunner, str]:
@@ -201,6 +258,15 @@ async def verify_full_duplex_call(
                 if response.status != 200:
                     raise RuntimeError(f"status failed ({response.status}): {status}")
 
+            clear_audio = None
+            if not args.skip_clear_audio_smoke:
+                clear_audio = await verify_clear_audio(
+                    session,
+                    base_url,
+                    call_id,
+                    status["audio"],
+                )
+
             return {
                 "call_id": call_id,
                 "decoded_pcm": decoded_pcm,
@@ -213,6 +279,7 @@ async def verify_full_duplex_call(
                 "max_rx_queue_bytes": status.get("max_rx_queue_bytes"),
                 "max_rx_queue_ms": status.get("max_rx_queue_ms"),
                 "audio": sidecar.audio_contract(),
+                "clear_audio": clear_audio if clear_audio is not None else "skipped",
             }
     finally:
         await pc.close()
@@ -321,6 +388,11 @@ def parse_args() -> argparse.Namespace:
             "Maximum outbound sidecar queue depth allowed at the end of the "
             "smoke. Set to 0 to require a fully drained queue."
         ),
+    )
+    parser.add_argument(
+        "--skip-clear-audio-smoke",
+        action="store_true",
+        help="skip live-call /audio/clear verification after the media turn",
     )
     args = parser.parse_args()
     if args.max_queued_tx_ms < 0:

--- a/examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py
+++ b/examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py
@@ -29,6 +29,7 @@ def test_parse_args_uses_default_expected_words(monkeypatch):
     assert args.outbound_text.startswith("Hello from a full duplex")
     assert args.expect_word == ["hello", "world"]
     assert args.max_queued_tx_ms == smoke.DEFAULT_MAX_QUEUED_TX_MS
+    assert args.skip_clear_audio_smoke is False
 
 
 def test_parse_args_replaces_default_expected_words(monkeypatch):
@@ -46,6 +47,7 @@ def test_parse_args_replaces_default_expected_words(monkeypatch):
             "two",
             "--max-queued-tx-ms",
             "250",
+            "--skip-clear-audio-smoke",
         ],
     )
 
@@ -54,6 +56,7 @@ def test_parse_args_replaces_default_expected_words(monkeypatch):
     assert args.inbound_text == "testing one two"
     assert args.expect_word == ["testing", "two"]
     assert args.max_queued_tx_ms == 250
+    assert args.skip_clear_audio_smoke is True
 
 
 def test_parse_args_rejects_negative_queue_budget(monkeypatch):
@@ -163,3 +166,114 @@ def test_validate_queued_tx_budget_rejects_excessive_backlog():
         assert "2000 ms > 1000 ms" in str(exc)
     else:
         raise AssertionError("expected excessive queue depth to be rejected")
+
+
+def test_verify_clear_audio_queues_and_clears_live_call():
+    smoke = load_smoke()
+
+    async def run():
+        from aiohttp import web
+        from aiohttp.test_utils import TestClient, TestServer
+
+        state = {"queued": 0}
+        audio = {
+            "sample_rate": 48_000,
+            "channels": 1,
+            "frame_ms": 20,
+            "encoding": "pcm_s16le",
+            "frame_bytes": 1_920,
+        }
+
+        async def queue_audio(request):
+            body = await request.json()
+            pcm = smoke.base64.b64decode(body["pcm_s16le_base64"])
+            state["queued"] += len(pcm)
+            return web.json_response(
+                {
+                    "queued_tx_bytes": state["queued"],
+                    "queued_tx_ms": 200,
+                }
+            )
+
+        async def clear_audio(_request):
+            dropped = state["queued"]
+            state["queued"] = 0
+            return web.json_response(
+                {
+                    "dropped_tx_bytes": dropped,
+                    "dropped_tx_ms": 200,
+                    "queued_tx_bytes": 0,
+                    "queued_tx_ms": 0,
+                }
+            )
+
+        app = web.Application()
+        app.router.add_post("/calls/call-1/audio", queue_audio)
+        app.router.add_post("/calls/call-1/audio/clear", clear_audio)
+
+        async with TestClient(TestServer(app)) as client:
+            return await smoke.verify_clear_audio(
+                client.session,
+                str(client.make_url("/")).rstrip("/"),
+                "call-1",
+                audio,
+            )
+
+    result = smoke.asyncio.run(run())
+
+    assert result["queued_before_clear_bytes"] > 0
+    assert result["dropped_tx_bytes"] == result["queued_before_clear_bytes"]
+    assert result["queued_tx_bytes"] == 0
+
+
+def test_verify_clear_audio_rejects_uncleared_queue():
+    smoke = load_smoke()
+
+    async def run():
+        from aiohttp import web
+        from aiohttp.test_utils import TestClient, TestServer
+
+        audio = {
+            "sample_rate": 48_000,
+            "channels": 1,
+            "frame_ms": 20,
+            "encoding": "pcm_s16le",
+            "frame_bytes": 1_920,
+        }
+
+        async def queue_audio(request):
+            body = await request.json()
+            pcm = smoke.base64.b64decode(body["pcm_s16le_base64"])
+            return web.json_response(
+                {
+                    "queued_tx_bytes": len(pcm),
+                    "queued_tx_ms": 200,
+                }
+            )
+
+        async def clear_audio(_request):
+            return web.json_response(
+                {
+                    "dropped_tx_bytes": 0,
+                    "queued_tx_bytes": 1_920,
+                }
+            )
+
+        app = web.Application()
+        app.router.add_post("/calls/call-1/audio", queue_audio)
+        app.router.add_post("/calls/call-1/audio/clear", clear_audio)
+
+        async with TestClient(TestServer(app)) as client:
+            await smoke.verify_clear_audio(
+                client.session,
+                str(client.make_url("/")).rstrip("/"),
+                "call-1",
+                audio,
+            )
+
+    try:
+        smoke.asyncio.run(run())
+    except RuntimeError as exc:
+        assert "reported no dropped" in str(exc)
+    else:
+        raise AssertionError("expected uncleared queue to be rejected")


### PR DESCRIPTION
## Summary
- make the full-duplex WebRTC sidecar smoke exercise `/calls/{call_id}/audio/clear` on a live call session
- fail the smoke when the clear probe does not drop queued outbound PCM or leaves queued bytes behind
- document the clear-audio smoke as local coverage for the barge-in/cancellation primitive

## Verification
- `python3 -m py_compile examples/webrtc-sidecar/full_duplex_loopback_smoke.py examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/test_drain_sidecar_audio.py examples/webrtc-sidecar/test_echo_sidecar_audio.py examples/webrtc-sidecar/test_stream_transcribe_loopback_smoke.py examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py`
- `/tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/full_duplex_loopback_smoke.py --voice-bin /home/ubuntu/.local/bin/voice --timeout 60 --outbound-text "Local clear audio smoke."`
- `scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --hermes-config /home/ubuntu/.hermes/config.yaml --sidecar-url http://127.0.0.1:8787 --skip-hermes-tts-smoke --skip-stt-smoke --run-webrtc-loopback-smoke --webrtc-python /tmp/voice-webrtc-venv/bin/python --text "Local clear audio gate smoke."`
