### PR TITLE
Run full-duplex smoke against sidecar service

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -86,8 +86,10 @@ scripts/verify_local_hermes_voice_stack.sh --voice-bin "$(command -v voice)"
 
 The aggregate stack verifier checks the Hermes config, the running
 `hermes-gateway.service` drop-in, CLI/MCP daemon behavior, Ogg/Opus voice-note
-output, raw stream frames, stream STT, and the WebRTC sidecar service. Use
-`--skip-systemd` only for non-service CI-style runs.
+output, raw stream frames, stream STT, and the WebRTC sidecar service. When
+`--run-webrtc-loopback-smoke` is enabled, the media smoke targets the configured
+sidecar service URL instead of an in-process sidecar. Use `--skip-systemd` only
+for non-service CI-style runs.
 
 ---
 

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -324,7 +324,10 @@ WebRTC-to-STT path without WhatsApp or the Graph API.
 `full_duplex_loopback_smoke.py` exercises both directions on one sidecar call:
 local WebRTC audio drains through `voice stream-transcribe`, while
 `post_voice_stream.py` queues outbound `voice stream` PCM back to the same
-WebRTC peer. It is the closest local smoke to a single WhatsApp call turn. It
+WebRTC peer. By default it starts an in-process sidecar; pass `--sidecar-url`
+to exercise an already running sidecar service such as
+`http://127.0.0.1:8787`. It is the closest local smoke to a single WhatsApp
+call turn. It
 also queues a small outbound PCM probe on the live call and calls
 `POST /calls/{call_id}/audio/clear`, so the same smoke covers the local
 barge-in/cancellation primitive. Pass `--skip-clear-audio-smoke` when checking

--- a/examples/webrtc-sidecar/full_duplex_loopback_smoke.py
+++ b/examples/webrtc-sidecar/full_duplex_loopback_smoke.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import shutil
 import sys
 import tempfile
+import uuid
 from typing import Any
 
 from aiohttp import ClientSession, web
@@ -191,13 +192,25 @@ async def post_offer(
         return body
 
 
+async def close_sidecar_call(
+    session: ClientSession,
+    base_url: str,
+    call_id: str,
+) -> dict[str, Any]:
+    async with session.post(f"{base_url}/calls/{call_id}/close") as response:
+        body = await response.json()
+        if response.status != 200:
+            raise RuntimeError(f"close call failed ({response.status}): {body}")
+        return body
+
+
 async def verify_full_duplex_call(
     *,
     args: argparse.Namespace,
     base_url: str,
     inbound_pcm: bytes,
 ) -> dict[str, Any]:
-    call_id = "full-duplex-loopback"
+    call_id = args.call_id
     pc = sidecar.RTCPeerConnection()
     track_future = asyncio.get_running_loop().create_future()
 
@@ -209,78 +222,91 @@ async def verify_full_duplex_call(
     pc.addTrack(PcmBytesTrack(inbound_pcm))
     try:
         async with ClientSession() as session:
-            answer = await post_offer(session, base_url, call_id, pc)
-            await pc.setRemoteDescription(
-                sidecar.RTCSessionDescription(sdp=answer["sdp"], type=answer["type"])
-            )
-            track = await asyncio.wait_for(track_future, timeout=args.timeout)
-
-            post_task = asyncio.create_task(
-                run_post_voice_stream(
-                    call_id=call_id,
-                    sidecar_url=base_url,
-                    voice_bin=args.voice_bin,
-                    text=args.outbound_text,
-                    voice=args.voice,
-                    speed=args.speed,
-                    timeout_s=args.timeout,
-                )
-            )
-            drain_task = asyncio.create_task(
-                drain_decoded_pcm(
-                    session,
-                    base_url,
-                    call_id,
-                    target_bytes=len(inbound_pcm),
-                    timeout_s=args.timeout,
-                )
-            )
+            result: dict[str, Any] | None = None
             try:
-                outbound_webrtc_bytes = await wait_for_non_silent_track(
-                    track,
-                    timeout_s=args.timeout,
+                answer = await post_offer(session, base_url, call_id, pc)
+                await pc.setRemoteDescription(
+                    sidecar.RTCSessionDescription(sdp=answer["sdp"], type=answer["type"])
                 )
-                decoded_pcm = await drain_task
-                return_code, stderr = await post_task
-            except Exception:
-                for task in (post_task, drain_task):
-                    task.cancel()
-                await asyncio.gather(post_task, drain_task, return_exceptions=True)
-                raise
+                track = await asyncio.wait_for(track_future, timeout=args.timeout)
 
-            if return_code != 0:
-                raise RuntimeError(
-                    f"post_voice_stream.py exited with {return_code}: {stderr.strip()}"
+                post_task = asyncio.create_task(
+                    run_post_voice_stream(
+                        call_id=call_id,
+                        sidecar_url=base_url,
+                        voice_bin=args.voice_bin,
+                        text=args.outbound_text,
+                        voice=args.voice,
+                        speed=args.speed,
+                        timeout_s=args.timeout,
+                    )
                 )
-
-            async with session.get(f"{base_url}/calls/{call_id}") as response:
-                status = await response.json()
-                if response.status != 200:
-                    raise RuntimeError(f"status failed ({response.status}): {status}")
-
-            clear_audio = None
-            if not args.skip_clear_audio_smoke:
-                clear_audio = await verify_clear_audio(
-                    session,
-                    base_url,
-                    call_id,
-                    status["audio"],
+                drain_task = asyncio.create_task(
+                    drain_decoded_pcm(
+                        session,
+                        base_url,
+                        call_id,
+                        target_bytes=len(inbound_pcm),
+                        timeout_s=args.timeout,
+                    )
                 )
+                try:
+                    outbound_webrtc_bytes = await wait_for_non_silent_track(
+                        track,
+                        timeout_s=args.timeout,
+                    )
+                    decoded_pcm = await drain_task
+                    return_code, stderr = await post_task
+                except Exception:
+                    for task in (post_task, drain_task):
+                        task.cancel()
+                    await asyncio.gather(post_task, drain_task, return_exceptions=True)
+                    raise
 
-            return {
-                "call_id": call_id,
-                "decoded_pcm": decoded_pcm,
-                "outbound_webrtc_bytes": outbound_webrtc_bytes,
-                "queued_tx_bytes": status.get("queued_tx_bytes"),
-                "queued_tx_ms": status.get("queued_tx_ms"),
-                "queued_rx_bytes": status.get("queued_rx_bytes"),
-                "queued_rx_ms": status.get("queued_rx_ms"),
-                "max_tx_queue_ms": status.get("max_tx_queue_ms"),
-                "max_rx_queue_bytes": status.get("max_rx_queue_bytes"),
-                "max_rx_queue_ms": status.get("max_rx_queue_ms"),
-                "audio": sidecar.audio_contract(),
-                "clear_audio": clear_audio if clear_audio is not None else "skipped",
-            }
+                if return_code != 0:
+                    raise RuntimeError(
+                        f"post_voice_stream.py exited with {return_code}: {stderr.strip()}"
+                    )
+
+                async with session.get(f"{base_url}/calls/{call_id}") as response:
+                    status = await response.json()
+                    if response.status != 200:
+                        raise RuntimeError(f"status failed ({response.status}): {status}")
+
+                clear_audio = None
+                if not args.skip_clear_audio_smoke:
+                    clear_audio = await verify_clear_audio(
+                        session,
+                        base_url,
+                        call_id,
+                        status["audio"],
+                    )
+
+                result = {
+                    "call_id": call_id,
+                    "decoded_pcm": decoded_pcm,
+                    "outbound_webrtc_bytes": outbound_webrtc_bytes,
+                    "queued_tx_bytes": status.get("queued_tx_bytes"),
+                    "queued_tx_ms": status.get("queued_tx_ms"),
+                    "queued_rx_bytes": status.get("queued_rx_bytes"),
+                    "queued_rx_ms": status.get("queued_rx_ms"),
+                    "max_tx_queue_ms": status.get("max_tx_queue_ms"),
+                    "max_rx_queue_bytes": status.get("max_rx_queue_bytes"),
+                    "max_rx_queue_ms": status.get("max_rx_queue_ms"),
+                    "audio": sidecar.audio_contract(),
+                    "clear_audio": clear_audio if clear_audio is not None else "skipped",
+                }
+                return result
+            finally:
+                try:
+                    close_result = await close_sidecar_call(session, base_url, call_id)
+                except Exception as exc:
+                    if result is not None:
+                        result["close_call"] = {"success": False, "error": str(exc)}
+                        raise
+                else:
+                    if result is not None:
+                        result["close_call"] = close_result
     finally:
         await pc.close()
 
@@ -298,7 +324,11 @@ async def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
 
     inbound_path = workdir / "inbound-source.s16le"
     decoded_path = workdir / "sidecar-decoded.s16le"
-    runner, base_url = await start_sidecar_app()
+    runner: web.AppRunner | None = None
+    if args.sidecar_url:
+        base_url = args.sidecar_url.rstrip("/")
+    else:
+        runner, base_url = await start_sidecar_app()
     try:
         run_voice_stream(
             voice_bin=voice_bin,
@@ -359,7 +389,8 @@ async def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
             "stt": transcript_event["data"],
         }
     finally:
-        await runner.cleanup()
+        if runner is not None:
+            await runner.cleanup()
         if remove_workdir:
             shutil.rmtree(workdir, ignore_errors=True)
 
@@ -367,6 +398,17 @@ async def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--voice-bin", default=os.environ.get("VOICE_BIN", "voice"))
+    parser.add_argument(
+        "--sidecar-url",
+        help=(
+            "use an already running sidecar service instead of starting an "
+            "in-process sidecar"
+        ),
+    )
+    parser.add_argument(
+        "--call-id",
+        help="call ID to use for the smoke; defaults to a unique local ID",
+    )
     parser.add_argument("--voice", default="af_heart")
     parser.add_argument("--speed", default="1.0")
     parser.add_argument("--timeout", type=float, default=60.0)
@@ -399,6 +441,8 @@ def parse_args() -> argparse.Namespace:
         parser.error("--max-queued-tx-ms must be non-negative")
     if args.expect_word is None:
         args.expect_word = list(DEFAULT_EXPECT_WORDS)
+    if args.call_id is None:
+        args.call_id = f"full-duplex-loopback-{uuid.uuid4().hex[:8]}"
     return args
 
 

--- a/examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py
+++ b/examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py
@@ -30,6 +30,8 @@ def test_parse_args_uses_default_expected_words(monkeypatch):
     assert args.expect_word == ["hello", "world"]
     assert args.max_queued_tx_ms == smoke.DEFAULT_MAX_QUEUED_TX_MS
     assert args.skip_clear_audio_smoke is False
+    assert args.sidecar_url is None
+    assert args.call_id.startswith("full-duplex-loopback-")
 
 
 def test_parse_args_replaces_default_expected_words(monkeypatch):
@@ -48,6 +50,10 @@ def test_parse_args_replaces_default_expected_words(monkeypatch):
             "--max-queued-tx-ms",
             "250",
             "--skip-clear-audio-smoke",
+            "--sidecar-url",
+            "http://127.0.0.1:8787/",
+            "--call-id",
+            "call-123",
         ],
     )
 
@@ -57,6 +63,8 @@ def test_parse_args_replaces_default_expected_words(monkeypatch):
     assert args.expect_word == ["testing", "two"]
     assert args.max_queued_tx_ms == 250
     assert args.skip_clear_audio_smoke is True
+    assert args.sidecar_url == "http://127.0.0.1:8787/"
+    assert args.call_id == "call-123"
 
 
 def test_parse_args_rejects_negative_queue_budget(monkeypatch):

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -301,6 +301,7 @@ if [[ "$run_webrtc_loopback_smoke" == "1" ]]; then
   run_step "Full-duplex WebRTC media smoke" \
     "$webrtc_python" "$webrtc_loopback_smoke_script" \
     --voice-bin "$voice_bin" \
+    --sidecar-url "$sidecar_url" \
     --timeout "$webrtc_timeout" \
     --outbound-text "$text" \
     --max-queued-tx-ms "$max_queued_tx_ms"

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -290,6 +290,8 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 str(smoke),
                 "--voice-bin",
                 str(voice),
+                "--sidecar-url",
+                "http://127.0.0.1:8787",
                 "--timeout",
                 "12.5",
                 "--outbound-text",


### PR DESCRIPTION
## Summary
- let `full_duplex_loopback_smoke.py` target an already running sidecar with `--sidecar-url`
- close the sidecar call after the smoke and include the close result in the JSON output
- make `verify_local_hermes_voice_stack.sh --run-webrtc-loopback-smoke` exercise the configured sidecar service URL instead of an in-process sidecar

## Verification
- `bash -n scripts/verify_local_hermes_voice_stack.sh`
- `python3 -m py_compile examples/webrtc-sidecar/full_duplex_loopback_smoke.py examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py tests/test_verify_local_hermes_voice_stack.py`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py`
- `python3 -m unittest tests/test_verify_local_hermes_voice_stack.py`
- `/tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/full_duplex_loopback_smoke.py --voice-bin /home/ubuntu/.local/bin/voice --sidecar-url http://127.0.0.1:8787 --timeout 60 --outbound-text "Running sidecar service smoke."`
- `scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --hermes-config /home/ubuntu/.hermes/config.yaml --sidecar-url http://127.0.0.1:8787 --skip-hermes-tts-smoke --skip-stt-smoke --run-webrtc-loopback-smoke --webrtc-python /tmp/voice-webrtc-venv/bin/python --text "Running sidecar aggregate smoke."`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/test_drain_sidecar_audio.py examples/webrtc-sidecar/test_echo_sidecar_audio.py examples/webrtc-sidecar/test_stream_transcribe_loopback_smoke.py examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py`
- `python3 -m unittest discover -s tests`
