### PR TITLE
Verify sidecar call removal after full-duplex smoke

### DIFF
--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -330,10 +330,11 @@ to exercise an already running sidecar service such as
 call turn. It
 also queues a small outbound PCM probe on the live call and calls
 `POST /calls/{call_id}/audio/clear`, so the same smoke covers the local
-barge-in/cancellation primitive. Pass `--skip-clear-audio-smoke` when checking
-only media round-trip behavior. The smoke fails when the sidecar still has more
-than one second of outbound audio queued at the end of the turn; use
-`--max-queued-tx-ms` to tighten or loosen that local latency budget. When
-available, it uses the sidecar-reported `queued_tx_ms` field; older sidecars
-fall back to deriving the duration from `queued_tx_bytes` and the audio
-contract.
+barge-in/cancellation primitive. It closes the sidecar call and verifies the
+session is removed from both `GET /calls/{call_id}` and `/health`. Pass
+`--skip-clear-audio-smoke` when checking only media round-trip behavior. The
+smoke fails when the sidecar still has more than one second of outbound audio
+queued at the end of the turn; use `--max-queued-tx-ms` to tighten or loosen
+that local latency budget. When available, it uses the sidecar-reported
+`queued_tx_ms` field; older sidecars fall back to deriving the duration from
+`queued_tx_bytes` and the audio contract.

--- a/examples/webrtc-sidecar/full_duplex_loopback_smoke.py
+++ b/examples/webrtc-sidecar/full_duplex_loopback_smoke.py
@@ -201,7 +201,29 @@ async def close_sidecar_call(
         body = await response.json()
         if response.status != 200:
             raise RuntimeError(f"close call failed ({response.status}): {body}")
-        return body
+
+    async with session.get(f"{base_url}/calls/{call_id}") as response:
+        status_after_close = await response.json()
+        if response.status != 404:
+            raise RuntimeError(
+                "call status still exists after close "
+                f"({response.status}): {status_after_close}"
+            )
+
+    async with session.get(f"{base_url}/health") as response:
+        health = await response.json()
+        if response.status != 200:
+            raise RuntimeError(f"health after close failed ({response.status}): {health}")
+    call_ids = health.get("call_ids")
+    if isinstance(call_ids, list) and call_id in call_ids:
+        raise RuntimeError(f"call_id {call_id!r} still present in /health after close")
+
+    return {
+        "call_id": body.get("call_id", call_id),
+        "closed": body.get("closed"),
+        "status_after_close": "not_found",
+        "removed_from_health": True,
+    }
 
 
 async def verify_full_duplex_call(

--- a/examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py
+++ b/examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py
@@ -285,3 +285,77 @@ def test_verify_clear_audio_rejects_uncleared_queue():
         assert "reported no dropped" in str(exc)
     else:
         raise AssertionError("expected uncleared queue to be rejected")
+
+
+def test_close_sidecar_call_verifies_session_removed():
+    smoke = load_smoke()
+
+    async def run():
+        from aiohttp import web
+        from aiohttp.test_utils import TestClient, TestServer
+
+        async def close_call(_request):
+            return web.json_response({"call_id": "call-1", "closed": True})
+
+        async def call_status(_request):
+            return web.json_response({"error": "unknown call_id"}, status=404)
+
+        async def health(_request):
+            return web.json_response({"ok": True, "sessions": 0, "call_ids": []})
+
+        app = web.Application()
+        app.router.add_post("/calls/call-1/close", close_call)
+        app.router.add_get("/calls/call-1", call_status)
+        app.router.add_get("/health", health)
+
+        async with TestClient(TestServer(app)) as client:
+            return await smoke.close_sidecar_call(
+                client.session,
+                str(client.make_url("/")).rstrip("/"),
+                "call-1",
+            )
+
+    result = smoke.asyncio.run(run())
+
+    assert result == {
+        "call_id": "call-1",
+        "closed": True,
+        "status_after_close": "not_found",
+        "removed_from_health": True,
+    }
+
+
+def test_close_sidecar_call_rejects_session_that_still_exists():
+    smoke = load_smoke()
+
+    async def run():
+        from aiohttp import web
+        from aiohttp.test_utils import TestClient, TestServer
+
+        async def close_call(_request):
+            return web.json_response({"call_id": "call-1", "closed": True})
+
+        async def call_status(_request):
+            return web.json_response({"call_id": "call-1", "closed": False})
+
+        async def health(_request):
+            return web.json_response({"ok": True, "sessions": 1, "call_ids": ["call-1"]})
+
+        app = web.Application()
+        app.router.add_post("/calls/call-1/close", close_call)
+        app.router.add_get("/calls/call-1", call_status)
+        app.router.add_get("/health", health)
+
+        async with TestClient(TestServer(app)) as client:
+            await smoke.close_sidecar_call(
+                client.session,
+                str(client.make_url("/")).rstrip("/"),
+                "call-1",
+            )
+
+    try:
+        smoke.asyncio.run(run())
+    except RuntimeError as exc:
+        assert "still exists after close" in str(exc)
+    else:
+        raise AssertionError("expected lingering call status to be rejected")


### PR DESCRIPTION
## Summary
- make the full-duplex WebRTC smoke verify `/calls/{call_id}` returns 404 after close
- verify `/health` no longer lists the closed call ID
- document that the smoke now covers close/terminate cleanup in addition to media and clear-audio behavior

## Verification
- `python3 -m py_compile examples/webrtc-sidecar/full_duplex_loopback_smoke.py examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py`
- `/tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/full_duplex_loopback_smoke.py --voice-bin /home/ubuntu/.local/bin/voice --sidecar-url http://127.0.0.1:8787 --timeout 60 --outbound-text "Close cleanup service smoke."`
- `scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --hermes-config /home/ubuntu/.hermes/config.yaml --sidecar-url http://127.0.0.1:8787 --skip-hermes-tts-smoke --skip-stt-smoke --run-webrtc-loopback-smoke --webrtc-python /tmp/voice-webrtc-venv/bin/python --text "Close cleanup aggregate smoke."`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/test_drain_sidecar_audio.py examples/webrtc-sidecar/test_echo_sidecar_audio.py examples/webrtc-sidecar/test_stream_transcribe_loopback_smoke.py examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py`
