### PR TITLE
Require sidecar accept readiness in full-duplex smoke

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -372,7 +372,8 @@ that path.
 4. Prototype a sidecar that accepts a synthetic SDP offer and round-trips PCM.
    The initial `examples/webrtc-sidecar` artifact covers the SDP answer,
    outbound PCM-to-Opus/WebRTC track, inbound decoded PCM sink, and local HTTP
-   send/drain/clear endpoints. Done as a spike.
+   send/drain/clear endpoints. The full-duplex smoke also requires the sidecar
+   answer state to be `ready_for_accept` before media proceeds. Done as a spike.
 5. Wire Hermes WhatsApp Cloud `connect` webhooks to the sidecar.
 6. Build an inbound-call echo bot: WhatsApp audio in, same audio out. The
    local `examples/webrtc-sidecar/echo_sidecar_audio.py` helper now covers the

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -327,7 +327,8 @@ local WebRTC audio drains through `voice stream-transcribe`, while
 WebRTC peer. By default it starts an in-process sidecar; pass `--sidecar-url`
 to exercise an already running sidecar service such as
 `http://127.0.0.1:8787`. It is the closest local smoke to a single WhatsApp
-call turn. It
+call turn. It verifies the sidecar's SDP answer reports `ready_for_accept`
+before the local peer accepts the answer. It
 also queues a small outbound PCM probe on the live call and calls
 `POST /calls/{call_id}/audio/clear`, so the same smoke covers the local
 barge-in/cancellation primitive. It closes the sidecar call and verifies the

--- a/examples/webrtc-sidecar/full_duplex_loopback_smoke.py
+++ b/examples/webrtc-sidecar/full_duplex_loopback_smoke.py
@@ -192,6 +192,38 @@ async def post_offer(
         return body
 
 
+def validate_offer_response(answer: dict[str, Any], call_id: str) -> dict[str, Any]:
+    if answer.get("call_id") != call_id:
+        raise RuntimeError(
+            f"offer response call_id={answer.get('call_id')!r}, expected {call_id!r}"
+        )
+    if answer.get("type") != "answer":
+        raise RuntimeError(f"offer response type must be answer, got {answer.get('type')!r}")
+    if not isinstance(answer.get("sdp"), str) or not answer["sdp"].startswith("v=0"):
+        raise RuntimeError("offer response must include a local SDP answer")
+    if answer.get("audio") != sidecar.audio_contract():
+        raise RuntimeError("offer response audio contract does not match sidecar contract")
+
+    state = answer.get("state")
+    if not isinstance(state, dict):
+        raise RuntimeError("offer response must include sidecar call state")
+    if state.get("ready_for_accept") is not True:
+        raise RuntimeError("sidecar call is not ready_for_accept after local answer")
+
+    readiness = state.get("readiness")
+    if not isinstance(readiness, dict):
+        raise RuntimeError("sidecar call state must include readiness checks")
+    failed = [key for key, value in readiness.items() if value is not True]
+    if failed:
+        raise RuntimeError(f"sidecar readiness checks failed: {failed}")
+
+    return {
+        "type": answer["type"],
+        "ready_for_accept": True,
+        "readiness": readiness,
+    }
+
+
 async def close_sidecar_call(
     session: ClientSession,
     base_url: str,
@@ -247,6 +279,7 @@ async def verify_full_duplex_call(
             result: dict[str, Any] | None = None
             try:
                 answer = await post_offer(session, base_url, call_id, pc)
+                offer = validate_offer_response(answer, call_id)
                 await pc.setRemoteDescription(
                     sidecar.RTCSessionDescription(sdp=answer["sdp"], type=answer["type"])
                 )
@@ -316,6 +349,7 @@ async def verify_full_duplex_call(
                     "max_rx_queue_bytes": status.get("max_rx_queue_bytes"),
                     "max_rx_queue_ms": status.get("max_rx_queue_ms"),
                     "audio": sidecar.audio_contract(),
+                    "offer": offer,
                     "clear_audio": clear_audio if clear_audio is not None else "skipped",
                 }
                 return result

--- a/examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py
+++ b/examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py
@@ -234,6 +234,74 @@ def test_verify_clear_audio_queues_and_clears_live_call():
     assert result["queued_tx_bytes"] == 0
 
 
+def test_validate_offer_response_requires_ready_for_accept():
+    smoke = load_smoke()
+    readiness = {
+        "not_closed": True,
+        "local_sdp_answer": True,
+        "signaling_stable": True,
+        "ice_gathering_complete": True,
+        "outbound_audio_track": True,
+    }
+    answer = {
+        "call_id": "call-1",
+        "type": "answer",
+        "sdp": "v=0\r\n",
+        "audio": smoke.sidecar.audio_contract(),
+        "state": {
+            "ready_for_accept": True,
+            "readiness": readiness,
+        },
+    }
+
+    assert smoke.validate_offer_response(answer, "call-1") == {
+        "type": "answer",
+        "ready_for_accept": True,
+        "readiness": readiness,
+    }
+
+    not_ready = {
+        **answer,
+        "state": {
+            "ready_for_accept": False,
+            "readiness": readiness,
+        },
+    }
+    try:
+        smoke.validate_offer_response(not_ready, "call-1")
+    except RuntimeError as exc:
+        assert "not ready_for_accept" in str(exc)
+    else:
+        raise AssertionError("expected non-ready offer response to be rejected")
+
+
+def test_validate_offer_response_rejects_failed_readiness_check():
+    smoke = load_smoke()
+    answer = {
+        "call_id": "call-1",
+        "type": "answer",
+        "sdp": "v=0\r\n",
+        "audio": smoke.sidecar.audio_contract(),
+        "state": {
+            "ready_for_accept": True,
+            "readiness": {
+                "not_closed": True,
+                "local_sdp_answer": True,
+                "signaling_stable": False,
+                "ice_gathering_complete": True,
+                "outbound_audio_track": True,
+            },
+        },
+    }
+
+    try:
+        smoke.validate_offer_response(answer, "call-1")
+    except RuntimeError as exc:
+        assert "signaling_stable" in str(exc)
+    else:
+        raise AssertionError("expected failed readiness check to be rejected")
+
+
 def test_verify_clear_audio_rejects_uncleared_queue():
     smoke = load_smoke()
 


### PR DESCRIPTION
## Summary
- validate the sidecar `/offer` response before the full-duplex smoke proceeds
- require `state.ready_for_accept` and all readiness booleans to be true
- include the offer readiness summary in the smoke JSON output and docs

## Verification
- `python3 -m py_compile examples/webrtc-sidecar/full_duplex_loopback_smoke.py examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py`
- `/tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/full_duplex_loopback_smoke.py --voice-bin /home/ubuntu/.local/bin/voice --sidecar-url http://127.0.0.1:8787 --timeout 60 --outbound-text "Ready accept service smoke."`
- `scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --hermes-config /home/ubuntu/.hermes/config.yaml --sidecar-url http://127.0.0.1:8787 --skip-hermes-tts-smoke --skip-stt-smoke --run-webrtc-loopback-smoke --webrtc-python /tmp/voice-webrtc-venv/bin/python --text "Ready accept aggregate smoke."`
- `/tmp/voice-webrtc-venv/bin/python -m pytest -q examples/webrtc-sidecar/test_sidecar.py examples/webrtc-sidecar/test_post_voice_stream.py examples/webrtc-sidecar/test_drain_sidecar_audio.py examples/webrtc-sidecar/test_echo_sidecar_audio.py examples/webrtc-sidecar/test_stream_transcribe_loopback_smoke.py examples/webrtc-sidecar/test_full_duplex_loopback_smoke.py`
