### PR TITLE
Advertise pipeable streamed Ogg output

### DIFF
--- a/crates/voice-stream/src/lib.rs
+++ b/crates/voice-stream/src/lib.rs
@@ -69,6 +69,13 @@ pub fn webrtc_sidecar_contract() -> serde_json::Value {
                 "use": "Smoke tests or integrations that want Ogg/Opus encoded from daemon PCM frames without a WAV intermediate.",
                 "requires": ["voice daemon", "ffmpeg for Ogg/Opus encoding"]
             },
+            "streamed_voice_note_stdout": {
+                "command": "voice stream --output - --format ogg-opus \"hello\" > reply.ogg",
+                "output": "audio/ogg; codecs=opus",
+                "transport": "stdout_ogg_opus_stream",
+                "use": "Pipeable daemon-frame Ogg/Opus output for process integrations that want an encoded stream without allocating a named output file.",
+                "requires": ["voice daemon", "ffmpeg for Ogg/Opus encoding"]
+            },
             "raw_outbound_pcm": {
                 "command": "voice stream --sample-rate 48000 --frame-ms 20 --raw-output - \"hello\"",
                 "output": "pcm_s16le",
@@ -632,6 +639,14 @@ mod tests {
         assert_eq!(
             surfaces["streamed_voice_note"]["transport"],
             "daemon_stream_encoded_file"
+        );
+        assert_eq!(
+            surfaces["streamed_voice_note_stdout"]["transport"],
+            "stdout_ogg_opus_stream"
+        );
+        assert_eq!(
+            surfaces["streamed_voice_note_stdout"]["output"],
+            "audio/ogg; codecs=opus"
         );
         assert_eq!(
             surfaces["raw_outbound_pcm"]["frame_bytes"],

--- a/docs/contracts/webrtc-sidecar-v1.json
+++ b/docs/contracts/webrtc-sidecar-v1.json
@@ -36,6 +36,16 @@
         "ffmpeg for Ogg/Opus encoding"
       ]
     },
+    "streamed_voice_note_stdout": {
+      "command": "voice stream --output - --format ogg-opus \"hello\" > reply.ogg",
+      "output": "audio/ogg; codecs=opus",
+      "transport": "stdout_ogg_opus_stream",
+      "use": "Pipeable daemon-frame Ogg/Opus output for process integrations that want an encoded stream without allocating a named output file.",
+      "requires": [
+        "voice daemon",
+        "ffmpeg for Ogg/Opus encoding"
+      ]
+    },
     "raw_outbound_pcm": {
       "command": "voice stream --sample-rate 48000 --frame-ms 20 --raw-output - \"hello\"",
       "output": "pcm_s16le",

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -123,6 +123,7 @@ voice stream "Hello from the stream"
 voice stream --json "Hello from the stream"
 voice say --format ogg-opus -o reply.ogg "Hello"
 voice stream --output streamed.ogg --format ogg-opus "Hello"
+voice stream --output - --format ogg-opus "Hello" > streamed.ogg
 voice stream --sample-rate 48000 --frame-ms 20 --raw-output reply.s16le "Hello"
 voice stream-transcribe recording.ogg
 voice stream-transcribe --raw-input webrtc-in.s16le --sample-rate 48000 --frame-ms 20
@@ -140,12 +141,12 @@ contract, proves `voice say --format ogg-opus` and `.ogg` extension inference
 write real mono 48 kHz Ogg/Opus, verifies misleading `.wav`/`ogg-opus`
 combinations are rejected before writing a file, and, when the daemon is
 running, checks both raw 48 kHz 20 ms PCM streaming and streamed Ogg/Opus
-encoding. Pass `--require-daemon` when the daemon stream path must be covered,
-or `--skip-daemon` for a file-only preflight. Pass `--run-stt-smoke` with
-`--require-daemon` when the inbound WebRTC/STT path must also be covered; it
-creates a tiny WAV fixture and requires `voice stream-transcribe --json` to
-return a terminal `stt.transcribed` event. This is optional because it may lazily
-load the Whisper model.
+encoding to both named files and stdout. Pass `--require-daemon` when the daemon
+stream path must be covered, or `--skip-daemon` for a file-only preflight. Pass
+`--run-stt-smoke` with `--require-daemon` when the inbound WebRTC/STT path must
+also be covered; it creates a tiny WAV fixture and requires
+`voice stream-transcribe --json` to return a terminal `stt.transcribed` event.
+This is optional because it may lazily load the Whisper model.
 
 The raw output is signed 16-bit little-endian mono PCM with no container header.
 Use the event metadata for sample rate, frame duration, and stream ID.
@@ -155,6 +156,9 @@ progress lines move to stderr.
 `--output` is the encoded stream path. It currently accepts `.ogg` / `.opus` or
 `--format ogg-opus`, requires `ffmpeg`, and preserves the daemon's low-latency
 PCM frame contract while producing a valid `audio/ogg; codecs=opus` file.
+Use `--output - --format ogg-opus` to pipe that encoded Ogg stream to stdout;
+`--format` is required with `-` so binary stdout is unambiguous, and `--json`
+cannot be combined with binary stdout.
 Use `--raw-output` when the consumer is a WebRTC sidecar or another process
 that wants raw PCM frames.
 
@@ -171,9 +175,10 @@ by the Python WebRTC example. Besides the fixed PCM shape and HTTP endpoint
 schema, including the outbound-audio clear endpoint used for barge-in, the
 `voice_surfaces` object maps integration modes to commands:
 `completed_voice_note` for WhatsApp-ready Ogg/Opus files, `streamed_voice_note`
-for Ogg/Opus encoded from daemon frames, `raw_outbound_pcm` for WebRTC TTS
-frames, `raw_inbound_pcm` for decoded WebRTC audio entering STT, and
-`file_transcription_smoke` for replaying an audio file through the inbound
+for Ogg/Opus encoded from daemon frames to a named file,
+`streamed_voice_note_stdout` for pipeable Ogg/Opus stdout, `raw_outbound_pcm`
+for WebRTC TTS frames, `raw_inbound_pcm` for decoded WebRTC audio entering STT,
+and `file_transcription_smoke` for replaying an audio file through the inbound
 stream contract.
 
 ## Daemon Protocol

--- a/examples/webrtc-sidecar/README.md
+++ b/examples/webrtc-sidecar/README.md
@@ -125,7 +125,8 @@ voice stream-contract
 
 The contract includes `voice_surfaces`, a machine-readable map from integration
 mode to command: completed Ogg/Opus voice notes, streamed Ogg/Opus files, raw
-outbound PCM, raw inbound PCM, and file-based stream-transcribe smokes.
+outbound PCM, raw inbound PCM, pipeable Ogg/Opus stdout, and file-based
+stream-transcribe smokes.
 `post_voice_stream.py` validates the raw PCM surface metadata when it is
 present so frame-size or transport drift fails before a live call. It posts
 frames on the contract's `frame_ms` cadence, so a fast `voice stream` process

--- a/scripts/verify_webrtc_sidecar_service.py
+++ b/scripts/verify_webrtc_sidecar_service.py
@@ -38,6 +38,7 @@ EXPECTED_AUDIO = {
 REQUIRED_VOICE_SURFACES = (
     "completed_voice_note",
     "streamed_voice_note",
+    "streamed_voice_note_stdout",
     "raw_outbound_pcm",
     "raw_inbound_pcm",
     "file_transcription_smoke",

--- a/scripts/verify_whatsapp_voice_contract.sh
+++ b/scripts/verify_whatsapp_voice_contract.sh
@@ -173,6 +173,7 @@ surfaces = contract.get("voice_surfaces") or {}
 for key in (
     "completed_voice_note",
     "streamed_voice_note",
+    "streamed_voice_note_stdout",
     "raw_outbound_pcm",
     "raw_inbound_pcm",
     "file_transcription_smoke",
@@ -182,6 +183,18 @@ for key in (
 require(
     surfaces["completed_voice_note"].get("output") == "audio/ogg; codecs=opus",
     "completed_voice_note output must be audio/ogg; codecs=opus",
+)
+require(
+    surfaces["streamed_voice_note"].get("transport") == "daemon_stream_encoded_file",
+    "streamed_voice_note transport must be daemon_stream_encoded_file",
+)
+require(
+    surfaces["streamed_voice_note_stdout"].get("output") == "audio/ogg; codecs=opus",
+    "streamed_voice_note_stdout output must be audio/ogg; codecs=opus",
+)
+require(
+    surfaces["streamed_voice_note_stdout"].get("transport") == "stdout_ogg_opus_stream",
+    "streamed_voice_note_stdout transport must be stdout_ogg_opus_stream",
 )
 require(
     surfaces["raw_outbound_pcm"].get("frame_bytes") == 1_920,
@@ -265,6 +278,19 @@ PY
     --format ogg-opus \
     "$text"
   assert_ogg_opus "$streamed_ogg"
+
+  streamed_stdout_ogg="$tmp_dir/streamed-stdout.ogg"
+  streamed_stdout_stderr="$tmp_dir/streamed-stdout.stderr"
+  "$voice_bin" --quiet stream \
+    --sample-rate 48000 \
+    --frame-ms 20 \
+    --output - \
+    --format ogg-opus \
+    "$text" >"$streamed_stdout_ogg" 2>"$streamed_stdout_stderr"
+  assert_ogg_opus "$streamed_stdout_ogg"
+  if [[ -s "$streamed_stdout_stderr" ]]; then
+    fail "quiet stdout Ogg/Opus stream wrote stderr output: $(head -n 1 "$streamed_stdout_stderr")"
+  fi
 
   if [[ "$run_stt_smoke" == "1" ]]; then
     stt_wav="$tmp_dir/stream-transcribe-smoke.wav"

--- a/tests/test_verify_webrtc_sidecar_service.py
+++ b/tests/test_verify_webrtc_sidecar_service.py
@@ -40,6 +40,10 @@ def contract_fixture() -> dict:
                 "output": "audio/ogg; codecs=opus",
                 "transport": "daemon_stream_encoded_file",
             },
+            "streamed_voice_note_stdout": {
+                "output": "audio/ogg; codecs=opus",
+                "transport": "stdout_ogg_opus_stream",
+            },
             "raw_outbound_pcm": {
                 "output": "pcm_s16le",
                 "transport": "stdout_pcm_frames",
@@ -166,6 +170,7 @@ class WebrtcSidecarVerifierTests(unittest.TestCase):
         self.assertIn("ok: voice WebRTC sidecar service verifier passed", result.stdout)
         self.assertIn("contract=matched", result.stdout)
         self.assertIn("systemd=skipped", result.stdout)
+        self.assertIn("sidecar_url=", result.stdout)
 
     def test_verifier_fails_when_sidecar_contract_differs_from_voice(self):
         voice_contract = contract_fixture()


### PR DESCRIPTION
## Summary
- add a first-class streamed_voice_note_stdout surface to the WebRTC/WhatsApp stream contract
- document piping daemon-frame Ogg/Opus with `voice stream --output - --format ogg-opus`
- extend the WhatsApp contract verifier to prove stdout streaming produces real mono 48 kHz Ogg/Opus

## Verification
- cargo fmt --check
- cargo test -p voice-stream
- /tmp/voice-webrtc-venv/bin/python -m pytest examples/webrtc-sidecar/test_sidecar.py examples/webrtc-sidecar/test_post_voice_stream.py -q
- cargo build -p voice
- scripts/verify_whatsapp_voice_contract.sh --voice-bin /home/ubuntu/projects/rgbkrk-voice/target/debug/voice --require-daemon
- cargo test -p voice
- python3 -m py_compile scripts/verify_webrtc_sidecar_service.py
- bash -n scripts/verify_whatsapp_voice_contract.sh
- scripts/verify_cli_mcp_surface.py --voice-bin /home/ubuntu/projects/rgbkrk-voice/target/debug/voice