### PR TITLE
Verify local WhatsApp bridge runtime

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -40,6 +40,50 @@ file-based voice notes. The short version:
 
 The streaming frame contract is documented in [streaming.md](streaming.md).
 
+## Local WhatsApp Runtime Check
+
+The local Hermes bridge uses Baileys multi-file auth, not the WhatsApp Cloud
+API. A paired Baileys session is enough for text messages, inbound voice-note
+downloads, and outbound native voice notes. It is not proof that the Meta Cloud
+webhook or WhatsApp Calling product is configured.
+
+Use the voice-owned verifier to inspect the local bridge without printing auth
+keys or session material:
+
+```bash
+scripts/verify_whatsapp_bridge_runtime.py --hermes-home ~/.hermes
+```
+
+The verifier checks:
+
+- the bridge health endpoint is connected
+- `~/.hermes/whatsapp/session/creds.json` has a paired WhatsApp identity
+- the running `whatsapp-bridge/bridge.js` process uses the expected session
+- LID-to-phone mapping files match the paired identity
+- WhatsApp Cloud and Calling environment keys are present or missing
+
+For a full local release gate, use:
+
+```bash
+scripts/verify_local_hermes_voice_stack.sh --hermes-home ~/.hermes
+```
+
+That command verifies installed `voice`, daemon-aware CLI/MCP behavior,
+WhatsApp-ready Ogg/Opus output, the Baileys bridge identity, the Hermes gateway
+voice-stream service, and the WebRTC sidecar contract. Add
+`--require-whatsapp-cloud` or `--require-whatsapp-calling` only when the host is
+expected to have real Meta Cloud credentials.
+
+Cloud/Calling readiness requires these external Meta settings in addition to
+the local sidecar:
+
+- `WHATSAPP_CLOUD_PHONE_NUMBER_ID`
+- `WHATSAPP_CLOUD_ACCESS_TOKEN`
+- `WHATSAPP_CLOUD_APP_SECRET`
+- `WHATSAPP_CLOUD_VERIFY_TOKEN`
+- `WHATSAPP_CLOUD_CALLING_SIDECAR_URL`
+- `WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND`
+
 ## Deployment Split
 
 ### Voice Notes

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -12,6 +12,7 @@ skip_hermes_config="${SKIP_HERMES_CONFIG:-0}"
 skip_hermes_tts_smoke="${SKIP_HERMES_TTS_SMOKE:-0}"
 skip_hermes_gateway="${SKIP_HERMES_GATEWAY:-0}"
 skip_sidecar="${SKIP_SIDECAR:-0}"
+skip_whatsapp_bridge="${SKIP_WHATSAPP_BRIDGE:-0}"
 skip_systemd="${SKIP_SYSTEMD:-0}"
 skip_cli_mcp="${SKIP_CLI_MCP:-0}"
 skip_daemon="${SKIP_DAEMON:-0}"
@@ -20,11 +21,19 @@ run_webrtc_loopback_smoke="${RUN_WEBRTC_LOOPBACK_SMOKE:-0}"
 webrtc_python="${VOICE_WEBRTC_PYTHON:-python3}"
 webrtc_timeout="${VOICE_WEBRTC_TIMEOUT:-60}"
 max_queued_tx_ms="${MAX_QUEUED_TX_MS:-1000}"
+whatsapp_bridge_url="${WHATSAPP_BRIDGE_URL:-http://127.0.0.1:3000}"
+whatsapp_session_dir="${WHATSAPP_SESSION_DIR:-}"
+whatsapp_env_file="${WHATSAPP_ENV_FILE:-}"
+expected_whatsapp_agent_number="${WHATSAPP_AGENT_NUMBER:-}"
+expected_whatsapp_agent_name="${WHATSAPP_AGENT_NAME:-}"
+require_whatsapp_cloud="${REQUIRE_WHATSAPP_CLOUD:-0}"
+require_whatsapp_calling="${REQUIRE_WHATSAPP_CALLING:-0}"
 
 hermes_config_verify_script="${HERMES_CONFIG_VERIFY_SCRIPT:-$repo_root/scripts/verify_hermes_voice_config.py}"
 hermes_gateway_verify_script="${HERMES_GATEWAY_VERIFY_SCRIPT:-$repo_root/scripts/verify_hermes_gateway_service.py}"
 cli_mcp_surface_verify_script="${CLI_MCP_SURFACE_VERIFY_SCRIPT:-$repo_root/scripts/verify_cli_mcp_surface.py}"
 whatsapp_contract_verify_script="${WHATSAPP_CONTRACT_VERIFY_SCRIPT:-$repo_root/scripts/verify_whatsapp_voice_contract.sh}"
+whatsapp_bridge_verify_script="${WHATSAPP_BRIDGE_VERIFY_SCRIPT:-$repo_root/scripts/verify_whatsapp_bridge_runtime.py}"
 sidecar_service_verify_script="${SIDECAR_SERVICE_VERIFY_SCRIPT:-$repo_root/scripts/verify_webrtc_sidecar_service.py}"
 webrtc_loopback_smoke_script="${WEBRTC_LOOPBACK_SMOKE_SCRIPT:-$repo_root/examples/webrtc-sidecar/full_duplex_loopback_smoke.py}"
 
@@ -48,10 +57,20 @@ Options:
   --skip-hermes-tts-smoke      validate Hermes config without executing TTS
   --skip-hermes-gateway        skip running Hermes gateway service verification
   --skip-cli-mcp               skip plain CLI/MCP daemon surface verification
+  --skip-whatsapp-bridge       skip local WhatsApp bridge identity verification
   --skip-sidecar               skip WebRTC sidecar service verification
   --skip-systemd               skip Hermes gateway, sidecar, and daemon systemd service checks
   --skip-daemon                skip daemon-backed stream checks
   --skip-stt-smoke             skip stream-transcribe smoke
+  --whatsapp-bridge-url URL    Baileys bridge URL (default: http://127.0.0.1:3000)
+  --whatsapp-session-dir PATH  Baileys multi-file auth session directory
+  --whatsapp-env-file PATH     Hermes env file with WhatsApp settings
+  --expected-whatsapp-agent-number NUMBER
+                               require Baileys creds to be paired to this number
+  --expected-whatsapp-agent-name NAME
+                               require Baileys creds to expose this profile name
+  --require-whatsapp-cloud     fail when WhatsApp Cloud credentials are missing
+  --require-whatsapp-calling   fail when Cloud Calling credentials/readiness are missing
   --run-webrtc-loopback-smoke  run one local full-duplex WebRTC media turn
   --webrtc-python PATH         Python used for the WebRTC smoke (default: python3)
   --webrtc-timeout SECONDS     timeout passed to the WebRTC smoke (default: 60)
@@ -61,8 +80,11 @@ Options:
 Environment aliases:
   VOICE_BIN, HERMES_CONFIG, SIDECAR_URL, TEXT
   SKIP_HERMES_CONFIG=1, SKIP_HERMES_TTS_SMOKE=1, SKIP_SIDECAR=1
-  SKIP_HERMES_GATEWAY=1, SKIP_SYSTEMD=1, SKIP_CLI_MCP=1
+  SKIP_HERMES_GATEWAY=1, SKIP_WHATSAPP_BRIDGE=1, SKIP_SYSTEMD=1, SKIP_CLI_MCP=1
   SKIP_DAEMON=1, SKIP_STT_SMOKE=1, RUN_WEBRTC_LOOPBACK_SMOKE=1
+  WHATSAPP_BRIDGE_URL, WHATSAPP_SESSION_DIR, WHATSAPP_ENV_FILE
+  WHATSAPP_AGENT_NUMBER, WHATSAPP_AGENT_NAME
+  REQUIRE_WHATSAPP_CLOUD=1, REQUIRE_WHATSAPP_CALLING=1
   VOICE_WEBRTC_PYTHON, VOICE_WEBRTC_TIMEOUT
 EOF
 }
@@ -147,6 +169,10 @@ while [[ $# -gt 0 ]]; do
       skip_sidecar=1
       shift
       ;;
+    --skip-whatsapp-bridge)
+      skip_whatsapp_bridge=1
+      shift
+      ;;
     --skip-cli-mcp)
       skip_cli_mcp=1
       shift
@@ -161,6 +187,39 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-stt-smoke)
       skip_stt_smoke=1
+      shift
+      ;;
+    --whatsapp-bridge-url)
+      [[ $# -ge 2 ]] || fail "--whatsapp-bridge-url requires a URL"
+      whatsapp_bridge_url="$2"
+      shift 2
+      ;;
+    --whatsapp-session-dir)
+      [[ $# -ge 2 ]] || fail "--whatsapp-session-dir requires a path"
+      whatsapp_session_dir="$2"
+      shift 2
+      ;;
+    --whatsapp-env-file)
+      [[ $# -ge 2 ]] || fail "--whatsapp-env-file requires a path"
+      whatsapp_env_file="$2"
+      shift 2
+      ;;
+    --expected-whatsapp-agent-number)
+      [[ $# -ge 2 ]] || fail "--expected-whatsapp-agent-number requires a value"
+      expected_whatsapp_agent_number="$2"
+      shift 2
+      ;;
+    --expected-whatsapp-agent-name)
+      [[ $# -ge 2 ]] || fail "--expected-whatsapp-agent-name requires a value"
+      expected_whatsapp_agent_name="$2"
+      shift 2
+      ;;
+    --require-whatsapp-cloud)
+      require_whatsapp_cloud=1
+      shift
+      ;;
+    --require-whatsapp-calling)
+      require_whatsapp_calling=1
       shift
       ;;
     --run-webrtc-loopback-smoke)
@@ -200,6 +259,9 @@ elif ! command -v "$voice_bin" >/dev/null 2>&1; then
 fi
 
 require_executable "$whatsapp_contract_verify_script" "WhatsApp voice contract verifier"
+if [[ "$skip_whatsapp_bridge" != "1" ]]; then
+  require_executable "$whatsapp_bridge_verify_script" "WhatsApp bridge runtime verifier"
+fi
 if [[ "$skip_hermes_config" != "1" ]]; then
   require_executable "$hermes_config_verify_script" "Hermes voice config verifier"
   require_file "$hermes_config" "Hermes config"
@@ -282,6 +344,39 @@ else
 fi
 run_step "Voice WhatsApp and streaming contract" "${whatsapp_args[@]}"
 
+if [[ "$skip_whatsapp_bridge" != "1" ]]; then
+  whatsapp_bridge_args=(
+    "$whatsapp_bridge_verify_script"
+    --hermes-home "$hermes_home"
+    --bridge-url "$whatsapp_bridge_url"
+  )
+  if [[ -n "$whatsapp_session_dir" ]]; then
+    whatsapp_bridge_args+=(--session-dir "$whatsapp_session_dir")
+  fi
+  if [[ -n "$whatsapp_env_file" ]]; then
+    whatsapp_bridge_args+=(--env-file "$whatsapp_env_file")
+  fi
+  if [[ -n "$expected_whatsapp_agent_number" ]]; then
+    whatsapp_bridge_args+=(--expected-agent-number "$expected_whatsapp_agent_number")
+  fi
+  if [[ -n "$expected_whatsapp_agent_name" ]]; then
+    whatsapp_bridge_args+=(--expected-agent-name "$expected_whatsapp_agent_name")
+  fi
+  if [[ "$skip_systemd" == "1" ]]; then
+    whatsapp_bridge_args+=(--skip-systemd)
+  fi
+  if [[ "$require_whatsapp_cloud" == "1" ]]; then
+    whatsapp_bridge_args+=(--require-whatsapp-cloud)
+  fi
+  if [[ "$require_whatsapp_calling" == "1" ]]; then
+    whatsapp_bridge_args+=(--require-whatsapp-calling)
+  fi
+  run_step "WhatsApp bridge identity and credential readiness" "${whatsapp_bridge_args[@]}"
+  whatsapp_bridge_status="checked"
+else
+  whatsapp_bridge_status="skipped"
+fi
+
 if [[ "$skip_sidecar" != "1" ]]; then
   sidecar_args=(
     "$sidecar_service_verify_script"
@@ -317,5 +412,6 @@ echo "hermes_config=$hermes_status"
 echo "hermes_gateway=$hermes_gateway_status"
 echo "cli_mcp=$cli_mcp_status"
 echo "whatsapp_contract=checked"
+echo "whatsapp_bridge=$whatsapp_bridge_status"
 echo "sidecar_service=$sidecar_status"
 echo "webrtc_loopback=$webrtc_loopback_status"

--- a/scripts/verify_whatsapp_bridge_runtime.py
+++ b/scripts/verify_whatsapp_bridge_runtime.py
@@ -1,0 +1,615 @@
+#!/usr/bin/env python3
+"""Verify the local WhatsApp bridge identity without exposing credentials."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import subprocess
+import sys
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+DEFAULT_BRIDGE_URL = "http://127.0.0.1:3000"
+DEFAULT_SERVICE_NAME = "hermes-gateway.service"
+
+WHATSAPP_CLOUD_REQUIRED_ENV = (
+    "WHATSAPP_CLOUD_PHONE_NUMBER_ID",
+    "WHATSAPP_CLOUD_ACCESS_TOKEN",
+    "WHATSAPP_CLOUD_APP_SECRET",
+    "WHATSAPP_CLOUD_VERIFY_TOKEN",
+)
+WHATSAPP_CLOUD_OPTIONAL_ENV = (
+    "WHATSAPP_CLOUD_APP_ID",
+    "WHATSAPP_CLOUD_WABA_ID",
+    "WHATSAPP_CLOUD_ALLOWED_USERS",
+    "WHATSAPP_CLOUD_ALLOW_ALL_USERS",
+    "WHATSAPP_CLOUD_HOME_CHANNEL",
+    "WHATSAPP_CLOUD_WEBHOOK_HOST",
+    "WHATSAPP_CLOUD_WEBHOOK_PORT",
+    "WHATSAPP_CLOUD_WEBHOOK_PATH",
+    "WHATSAPP_CLOUD_API_VERSION",
+)
+WHATSAPP_CALLING_ENV = (
+    "WHATSAPP_CLOUD_CALLING_SIDECAR_URL",
+    "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND",
+    "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT",
+)
+
+
+def default_hermes_home() -> Path:
+    return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+
+
+def normalize_whatsapp_identifier(value: Any) -> str | None:
+    if value is None:
+        return None
+    local = str(value).strip()
+    if not local:
+        return None
+    local = local.split("@", 1)[0]
+    local = local.split(":", 1)[0]
+    digits = re.sub(r"\D", "", local)
+    return digits or None
+
+
+def parse_env_file(path: Path) -> dict[str, str]:
+    env: dict[str, str] = {}
+    if not path.is_file():
+        return env
+
+    for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            continue
+        if (
+            len(value) >= 2
+            and value[0] == value[-1]
+            and value[0] in {"'", '"'}
+        ):
+            value = value[1:-1]
+        env[key] = value
+    return env
+
+
+def parse_systemd_environment(value: str) -> dict[str, str]:
+    env: dict[str, str] = {}
+    try:
+        parts = shlex.split(value)
+    except ValueError:
+        return env
+    for part in parts:
+        if "=" not in part:
+            continue
+        key, raw = part.split("=", 1)
+        env[key] = raw
+    return env
+
+
+def get_systemd_service_env(
+    service_name: str,
+    *,
+    timeout: float,
+) -> tuple[dict[str, str], str | None]:
+    completed = subprocess.run(
+        [
+            "systemctl",
+            "--user",
+            "show",
+            service_name,
+            "-p",
+            "Environment",
+            "--no-pager",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        stdin=subprocess.DEVNULL,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        return {}, detail or f"systemctl show failed for {service_name}"
+
+    for line in completed.stdout.splitlines():
+        if line.startswith("Environment="):
+            return parse_systemd_environment(line.split("=", 1)[1]), None
+    return {}, None
+
+
+def read_json_file(path: Path) -> tuple[Any | None, str | None]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), None
+    except FileNotFoundError:
+        return None, f"file not found: {path}"
+    except json.JSONDecodeError as exc:
+        return None, f"invalid JSON in {path}: {exc}"
+    except OSError as exc:
+        return None, f"could not read {path}: {exc}"
+
+
+def session_artifact_counts(session_dir: Path) -> dict[str, int]:
+    counts = {
+        "pre_key": 0,
+        "session": 0,
+        "app_state_sync_key": 0,
+        "lid_mapping": 0,
+        "tctoken": 0,
+        "sender_key": 0,
+        "other_json": 0,
+    }
+    if not session_dir.is_dir():
+        return counts
+
+    for path in session_dir.iterdir():
+        if not path.is_file():
+            continue
+        name = path.name
+        if name.startswith("pre-key-") and name.endswith(".json"):
+            counts["pre_key"] += 1
+        elif name.startswith("session-") and name.endswith(".json"):
+            counts["session"] += 1
+        elif name.startswith("app-state-sync-key-") and name.endswith(".json"):
+            counts["app_state_sync_key"] += 1
+        elif name.startswith("lid-mapping-") and name.endswith(".json"):
+            counts["lid_mapping"] += 1
+        elif name.startswith("tctoken-") and name.endswith(".json"):
+            counts["tctoken"] += 1
+        elif name.startswith("sender-key-") and name.endswith(".json"):
+            counts["sender_key"] += 1
+        elif name.endswith(".json") and name != "creds.json":
+            counts["other_json"] += 1
+    return counts
+
+
+def extract_identity(creds: dict[str, Any]) -> dict[str, Any]:
+    me = creds.get("me") if isinstance(creds.get("me"), dict) else {}
+    raw_id = me.get("id")
+    raw_lid = me.get("lid")
+    return {
+        "name": me.get("name"),
+        "id": raw_id,
+        "number": normalize_whatsapp_identifier(raw_id),
+        "lid": raw_lid,
+        "lid_number": normalize_whatsapp_identifier(raw_lid),
+        "platform": creds.get("platform"),
+        "account_sync_counter": creds.get("accountSyncCounter"),
+    }
+
+
+def read_lid_json(path: Path) -> str | None:
+    payload, _ = read_json_file(path)
+    if payload is None:
+        return None
+    return normalize_whatsapp_identifier(payload)
+
+
+def verify_lid_mapping(
+    session_dir: Path,
+    *,
+    phone_number: str | None,
+    lid_number: str | None,
+) -> dict[str, Any]:
+    if not phone_number or not lid_number:
+        return {
+            "checked": False,
+            "ok": False,
+            "reason": "missing phone number or LID in Baileys credentials",
+        }
+
+    forward_path = session_dir / f"lid-mapping-{phone_number}.json"
+    reverse_path = session_dir / f"lid-mapping-{lid_number}_reverse.json"
+    forward = read_lid_json(forward_path)
+    reverse = read_lid_json(reverse_path)
+    return {
+        "checked": True,
+        "ok": forward == lid_number and reverse == phone_number,
+        "forward_path": str(forward_path),
+        "reverse_path": str(reverse_path),
+        "forward_present": forward is not None,
+        "reverse_present": reverse is not None,
+    }
+
+
+def option_value(args: list[str], name: str) -> str | None:
+    prefix = f"{name}="
+    for index, arg in enumerate(args):
+        if arg.startswith(prefix):
+            return arg[len(prefix) :]
+        if arg == name and index + 1 < len(args):
+            return args[index + 1]
+    return None
+
+
+def find_bridge_processes(*, port: int | None = None) -> list[dict[str, Any]]:
+    processes: list[dict[str, Any]] = []
+    proc = Path("/proc")
+    if not proc.is_dir():
+        return processes
+
+    for child in proc.iterdir():
+        if not child.name.isdigit():
+            continue
+        try:
+            raw = (child / "cmdline").read_bytes()
+        except OSError:
+            continue
+        if not raw:
+            continue
+        argv = [part.decode("utf-8", errors="replace") for part in raw.split(b"\0") if part]
+        if not any(arg.endswith("bridge.js") and "whatsapp-bridge" in arg for arg in argv):
+            continue
+        process_port = option_value(argv, "--port")
+        if port is not None and process_port is not None:
+            try:
+                if int(process_port) != port:
+                    continue
+            except ValueError:
+                continue
+        script_path = next(
+            (
+                arg
+                for arg in argv
+                if arg.endswith("bridge.js") and "whatsapp-bridge" in arg
+            ),
+            None,
+        )
+        processes.append(
+            {
+                "pid": int(child.name),
+                "script": script_path,
+                "port": process_port,
+                "session": option_value(argv, "--session"),
+                "mode": option_value(argv, "--mode"),
+            }
+        )
+    return processes
+
+
+def fetch_bridge_health(bridge_url: str, *, timeout: float) -> tuple[dict[str, Any] | None, str | None]:
+    url = bridge_url.rstrip("/") + "/health"
+    try:
+        request = Request(url, headers={"Accept": "application/json"})
+        with urlopen(request, timeout=timeout) as response:
+            body = response.read()
+    except HTTPError as exc:
+        return None, f"bridge health returned HTTP {exc.code}"
+    except URLError as exc:
+        return None, f"bridge health request failed: {exc.reason}"
+    except OSError as exc:
+        return None, f"bridge health request failed: {exc}"
+
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        return None, f"bridge health did not return JSON: {exc}"
+    if not isinstance(payload, dict):
+        return None, "bridge health JSON must be an object"
+    return payload, None
+
+
+def env_presence(env_sources: dict[str, dict[str, str]], keys: tuple[str, ...]) -> dict[str, Any]:
+    key_status: dict[str, Any] = {}
+    for key in keys:
+        sources = [
+            source
+            for source, values in env_sources.items()
+            if values.get(key) not in (None, "")
+        ]
+        key_status[key] = {
+            "present": bool(sources),
+            "sources": sources,
+        }
+    return key_status
+
+
+def missing_env_keys(env_sources: dict[str, dict[str, str]], keys: tuple[str, ...]) -> list[str]:
+    return [
+        key
+        for key, status in env_presence(env_sources, keys).items()
+        if not status["present"]
+    ]
+
+
+def build_cloud_summary(env_sources: dict[str, dict[str, str]]) -> dict[str, Any]:
+    required_presence = env_presence(env_sources, WHATSAPP_CLOUD_REQUIRED_ENV)
+    optional_presence = env_presence(env_sources, WHATSAPP_CLOUD_OPTIONAL_ENV)
+    calling_presence = env_presence(env_sources, WHATSAPP_CALLING_ENV)
+    cloud_missing = [
+        key for key, status in required_presence.items() if not status["present"]
+    ]
+    sidecar_missing = [
+        key
+        for key in (
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_URL",
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND",
+        )
+        if not calling_presence[key]["present"]
+    ]
+    calling_missing = cloud_missing + sidecar_missing
+    return {
+        "cloud_configured": not cloud_missing,
+        "cloud_missing": cloud_missing,
+        "cloud_required": required_presence,
+        "cloud_optional": optional_presence,
+        "calling_sidecar_configured": not sidecar_missing,
+        "calling_ready": not calling_missing,
+        "calling_missing": calling_missing,
+        "calling": calling_presence,
+    }
+
+
+def port_from_url(url: str) -> int | None:
+    match = re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*://[^/:]+:(\d+)(?:/|$)", url)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def verify(args: argparse.Namespace) -> dict[str, Any]:
+    hermes_home = args.hermes_home.expanduser().resolve()
+    session_dir = (
+        args.session_dir.expanduser().resolve()
+        if args.session_dir
+        else hermes_home / "whatsapp" / "session"
+    )
+    env_file = args.env_file.expanduser().resolve() if args.env_file else hermes_home / ".env"
+    bridge_url = args.bridge_url.rstrip("/")
+
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    env_sources = {"env_file": parse_env_file(env_file)}
+    service_env_error = None
+    if not args.skip_systemd:
+        service_env, service_env_error = get_systemd_service_env(
+            args.service_name,
+            timeout=args.timeout,
+        )
+        env_sources["systemd_service"] = service_env
+        if service_env_error:
+            warnings.append(
+                f"could not inspect {args.service_name} environment: {service_env_error}"
+            )
+
+    expected_agent_number = normalize_whatsapp_identifier(args.expected_agent_number)
+    expected_agent_name = args.expected_agent_name
+    expected_mode = args.expected_mode or env_sources["env_file"].get("WHATSAPP_MODE")
+
+    if not session_dir.is_dir():
+        failures.append(f"WhatsApp session directory not found: {session_dir}")
+
+    creds_path = session_dir / "creds.json"
+    creds_payload, creds_error = read_json_file(creds_path)
+    if creds_error:
+        failures.append(f"Baileys credentials are not readable: {creds_error}")
+        identity: dict[str, Any] = {}
+    elif not isinstance(creds_payload, dict):
+        failures.append(f"Baileys credentials must be a JSON object: {creds_path}")
+        identity = {}
+    else:
+        identity = extract_identity(creds_payload)
+        if not identity.get("number"):
+            failures.append("Baileys credentials do not contain me.id")
+        if expected_agent_number and identity.get("number") != expected_agent_number:
+            failures.append(
+                "Baileys paired number "
+                f"{identity.get('number')!r} does not match expected "
+                f"{expected_agent_number!r}"
+            )
+        if expected_agent_name and identity.get("name") != expected_agent_name:
+            failures.append(
+                "Baileys paired name "
+                f"{identity.get('name')!r} does not match expected "
+                f"{expected_agent_name!r}"
+            )
+
+    counts = session_artifact_counts(session_dir)
+    if counts["session"] <= 0:
+        failures.append("Baileys session has no peer session files")
+    if counts["pre_key"] <= 0:
+        failures.append("Baileys session has no pre-key files")
+
+    lid_mapping = verify_lid_mapping(
+        session_dir,
+        phone_number=identity.get("number"),
+        lid_number=identity.get("lid_number"),
+    )
+    if lid_mapping["checked"] and not lid_mapping["ok"]:
+        failures.append("Baileys LID mapping does not match the paired identity")
+    elif not lid_mapping["checked"]:
+        warnings.append(str(lid_mapping["reason"]))
+
+    if args.skip_bridge_health:
+        bridge_health = {"skipped": True}
+    else:
+        bridge_health_payload, bridge_health_error = fetch_bridge_health(
+            bridge_url,
+            timeout=args.timeout,
+        )
+        if bridge_health_error:
+            failures.append(bridge_health_error)
+            bridge_health = {}
+        else:
+            bridge_health = bridge_health_payload or {}
+            if bridge_health.get("status") != "connected":
+                failures.append(
+                    f"WhatsApp bridge status={bridge_health.get('status')!r}, "
+                    "expected 'connected'"
+                )
+
+    bridge_port = port_from_url(bridge_url)
+    if args.skip_process_check:
+        bridge_process = {"skipped": True}
+    else:
+        candidates = find_bridge_processes(port=bridge_port)
+        bridge_process = {"candidates": candidates}
+        if not candidates:
+            failures.append("no running whatsapp-bridge/bridge.js process found")
+        else:
+            matching_session = [
+                process
+                for process in candidates
+                if process.get("session")
+                and Path(str(process["session"])).expanduser().resolve() == session_dir
+            ]
+            selected = matching_session[0] if matching_session else candidates[0]
+            bridge_process["selected"] = selected
+            process_session = selected.get("session")
+            if process_session:
+                resolved = Path(str(process_session)).expanduser().resolve()
+                if resolved != session_dir:
+                    failures.append(
+                        f"bridge process session={resolved}, expected {session_dir}"
+                    )
+            else:
+                warnings.append("bridge process does not expose --session in argv")
+            process_mode = selected.get("mode")
+            if expected_mode and process_mode and process_mode != expected_mode:
+                failures.append(
+                    f"bridge process mode={process_mode!r}, expected {expected_mode!r}"
+                )
+
+    cloud = build_cloud_summary(env_sources)
+    if args.require_whatsapp_cloud and not cloud["cloud_configured"]:
+        failures.append(
+            "WhatsApp Cloud credentials missing: "
+            + ", ".join(cloud["cloud_missing"])
+        )
+    if args.require_whatsapp_calling and not cloud["calling_ready"]:
+        failures.append(
+            "WhatsApp Cloud Calling not ready; missing: "
+            + ", ".join(cloud["calling_missing"])
+        )
+
+    checks: dict[str, Any] = {
+        "hermes_home": str(hermes_home),
+        "env_file": str(env_file),
+        "bridge_url": bridge_url,
+        "session_dir": str(session_dir),
+        "expected_agent_number": expected_agent_number,
+        "expected_agent_name": expected_agent_name,
+        "expected_mode": expected_mode,
+        "baileys_identity": identity,
+        "session_artifacts": counts,
+        "lid_mapping": lid_mapping,
+        "bridge_health": bridge_health,
+        "bridge_process": bridge_process,
+        "env_key_sources": {
+            source: sorted(key for key in values if key.startswith("WHATSAPP"))
+            for source, values in env_sources.items()
+        },
+        "whatsapp_cloud": cloud,
+    }
+    return {
+        "success": not failures,
+        "checks": checks,
+        "failures": failures,
+        "warnings": warnings,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hermes-home", type=Path, default=default_hermes_home())
+    parser.add_argument("--session-dir", type=Path, default=None)
+    parser.add_argument("--env-file", type=Path, default=None)
+    parser.add_argument("--bridge-url", default=os.environ.get("WHATSAPP_BRIDGE_URL", DEFAULT_BRIDGE_URL))
+    parser.add_argument("--service-name", default=DEFAULT_SERVICE_NAME)
+    parser.add_argument("--expected-agent-number", default=os.environ.get("WHATSAPP_AGENT_NUMBER"))
+    parser.add_argument("--expected-agent-name", default=os.environ.get("WHATSAPP_AGENT_NAME"))
+    parser.add_argument("--expected-mode", default=None)
+    parser.add_argument("--timeout", type=float, default=10.0)
+    parser.add_argument("--skip-bridge-health", action="store_true")
+    parser.add_argument("--skip-process-check", action="store_true")
+    parser.add_argument("--skip-systemd", action="store_true")
+    parser.add_argument("--require-whatsapp-cloud", action="store_true")
+    parser.add_argument("--require-whatsapp-calling", action="store_true")
+    parser.add_argument("--json", action="store_true", help="print JSON output")
+    return parser
+
+
+def human_summary(result: dict[str, Any]) -> None:
+    checks = result["checks"]
+    identity = checks.get("baileys_identity") or {}
+    health = checks.get("bridge_health") or {}
+    process = (checks.get("bridge_process") or {}).get("selected") or {}
+    cloud = checks.get("whatsapp_cloud") or {}
+
+    if result["success"]:
+        print("ok: WhatsApp bridge runtime verifier passed")
+    else:
+        print("error: WhatsApp bridge runtime verifier failed", file=sys.stderr)
+        for failure in result["failures"]:
+            print(f"- {failure}", file=sys.stderr)
+
+    print(
+        "bridge="
+        f"{checks.get('bridge_url')} status={health.get('status', 'unknown')} "
+        f"queue={health.get('queueLength', 'unknown')}"
+    )
+    print(
+        "baileys_session=paired "
+        f"name={identity.get('name') or '<unknown>'} "
+        f"number={identity.get('number') or '<unknown>'} "
+        f"lid={identity.get('lid_number') or '<unknown>'} "
+        f"platform={identity.get('platform') or '<unknown>'}"
+    )
+    if process:
+        print(
+            "bridge_process="
+            f"pid={process.get('pid')} mode={process.get('mode') or '<unknown>'} "
+            f"session={process.get('session') or '<unknown>'}"
+        )
+    print(
+        "session_artifacts="
+        + ",".join(
+            f"{key}={value}"
+            for key, value in sorted((checks.get("session_artifacts") or {}).items())
+        )
+    )
+    print(
+        "whatsapp_cloud="
+        + ("configured" if cloud.get("cloud_configured") else "not_configured")
+        + " missing="
+        + (",".join(cloud.get("cloud_missing") or []) or "none")
+    )
+    print(
+        "calling_sidecar="
+        + ("configured" if cloud.get("calling_sidecar_configured") else "not_configured")
+        + " calling_ready="
+        + ("yes" if cloud.get("calling_ready") else "no")
+        + " missing="
+        + (",".join(cloud.get("calling_missing") or []) or "none")
+    )
+    for warning in result["warnings"]:
+        print(f"warning: {warning}", file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    result = verify(args)
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        human_summary(result)
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -69,6 +69,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             gateway = tmp_path / "verify_gateway.py"
             cli_mcp = tmp_path / "verify_cli_mcp.py"
             whatsapp = tmp_path / "verify_whatsapp.sh"
+            bridge = tmp_path / "verify_whatsapp_bridge.py"
             sidecar = tmp_path / "verify_sidecar.py"
             voice = tmp_path / "voice"
             config = tmp_path / "config.yaml"
@@ -77,6 +78,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             write_helper(gateway, "gateway", log_path)
             write_helper(cli_mcp, "cli_mcp", log_path)
             write_helper(whatsapp, "whatsapp", log_path)
+            write_helper(bridge, "bridge", log_path)
             write_helper(sidecar, "sidecar", log_path)
             write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
             config.write_text("tts: {}\n", encoding="utf-8")
@@ -103,6 +105,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                     "HERMES_GATEWAY_VERIFY_SCRIPT": str(gateway),
                     "CLI_MCP_SURFACE_VERIFY_SCRIPT": str(cli_mcp),
                     "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "WHATSAPP_BRIDGE_VERIFY_SCRIPT": str(bridge),
                     "SIDECAR_SERVICE_VERIFY_SCRIPT": str(sidecar),
                 },
             )
@@ -112,10 +115,11 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn("ok: local Hermes voice stack verifier passed", result.stdout)
         self.assertIn("hermes_gateway=skipped", result.stdout)
         self.assertIn("cli_mcp=checked", result.stdout)
+        self.assertIn("whatsapp_bridge=checked", result.stdout)
         self.assertIn("webrtc_loopback=skipped", result.stdout)
         self.assertEqual(
             [entry[0] for entry in entries],
-            ["hermes", "cli_mcp", "whatsapp", "sidecar"],
+            ["hermes", "cli_mcp", "whatsapp", "bridge", "sidecar"],
         )
         self.assertEqual(
             entries[0],
@@ -152,6 +156,17 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         )
         self.assertEqual(
             entries[3],
+            [
+                "bridge",
+                "--hermes-home",
+                str(Path.home() / ".hermes"),
+                "--bridge-url",
+                "http://127.0.0.1:3000",
+                "--skip-systemd",
+            ],
+        )
+        self.assertEqual(
+            entries[4],
             [
                 "sidecar",
                 "--voice-bin",
@@ -192,6 +207,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                     "--skip-hermes-tts-smoke",
                     "--skip-hermes-gateway",
                     "--skip-sidecar",
+                    "--skip-whatsapp-bridge",
                     "--skip-daemon",
                     "--skip-stt-smoke",
                 ],
@@ -212,6 +228,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
 
         self.assertIn("sidecar_service=skipped", result.stdout)
         self.assertIn("hermes_gateway=skipped", result.stdout)
+        self.assertIn("whatsapp_bridge=skipped", result.stdout)
         self.assertEqual([entry[0] for entry in entries], ["hermes", "cli_mcp", "whatsapp"])
         self.assertIn("--skip-tts-smoke", entries[0])
         self.assertIn("--skip-daemon", entries[1])
@@ -226,6 +243,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             gateway = tmp_path / "verify_gateway.py"
             cli_mcp = tmp_path / "verify_cli_mcp.py"
             whatsapp = tmp_path / "verify_whatsapp.sh"
+            bridge = tmp_path / "verify_whatsapp_bridge.py"
             sidecar = tmp_path / "verify_sidecar.py"
             python = tmp_path / "python"
             smoke = tmp_path / "full_duplex_loopback_smoke.py"
@@ -236,6 +254,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             write_helper(gateway, "gateway", log_path)
             write_helper(cli_mcp, "cli_mcp", log_path)
             write_helper(whatsapp, "whatsapp", log_path)
+            write_helper(bridge, "bridge", log_path)
             write_helper(sidecar, "sidecar", log_path)
             write_fake_python(python, "webrtc", log_path)
             write_executable(smoke, "#!/usr/bin/env python3\n")
@@ -271,6 +290,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                     "HERMES_GATEWAY_VERIFY_SCRIPT": str(gateway),
                     "CLI_MCP_SURFACE_VERIFY_SCRIPT": str(cli_mcp),
                     "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "WHATSAPP_BRIDGE_VERIFY_SCRIPT": str(bridge),
                     "SIDECAR_SERVICE_VERIFY_SCRIPT": str(sidecar),
                     "WEBRTC_LOOPBACK_SMOKE_SCRIPT": str(smoke),
                 },
@@ -281,10 +301,10 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn("webrtc_loopback=checked", result.stdout)
         self.assertEqual(
             [entry[0] for entry in entries],
-            ["hermes", "gateway", "cli_mcp", "whatsapp", "webrtc"],
+            ["hermes", "gateway", "cli_mcp", "whatsapp", "bridge", "webrtc"],
         )
         self.assertEqual(
-            entries[4],
+            entries[5],
             [
                 "webrtc",
                 str(smoke),
@@ -309,6 +329,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             gateway = tmp_path / "verify_gateway.py"
             cli_mcp = tmp_path / "verify_cli_mcp.py"
             whatsapp = tmp_path / "verify_whatsapp.sh"
+            bridge = tmp_path / "verify_whatsapp_bridge.py"
             sidecar = tmp_path / "verify_sidecar.py"
             voice = tmp_path / "voice"
 
@@ -316,6 +337,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             write_helper(gateway, "gateway", log_path)
             write_helper(cli_mcp, "cli_mcp", log_path)
             write_helper(whatsapp, "whatsapp", log_path)
+            write_helper(bridge, "bridge", log_path)
             write_helper(sidecar, "sidecar", log_path)
             write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
 
@@ -340,6 +362,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                     "HERMES_GATEWAY_VERIFY_SCRIPT": str(gateway),
                     "CLI_MCP_SURFACE_VERIFY_SCRIPT": str(cli_mcp),
                     "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "WHATSAPP_BRIDGE_VERIFY_SCRIPT": str(bridge),
                     "SIDECAR_SERVICE_VERIFY_SCRIPT": str(sidecar),
                 },
             )
@@ -349,7 +372,8 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn("hermes_config=skipped", result.stdout)
         self.assertIn("hermes_gateway=checked", result.stdout)
         self.assertIn("cli_mcp=skipped", result.stdout)
-        self.assertEqual([entry[0] for entry in entries], ["gateway", "whatsapp"])
+        self.assertIn("whatsapp_bridge=checked", result.stdout)
+        self.assertEqual([entry[0] for entry in entries], ["gateway", "whatsapp", "bridge"])
 
     def test_gateway_service_check_runs_when_systemd_checks_enabled(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -359,6 +383,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             gateway = tmp_path / "verify_gateway.py"
             cli_mcp = tmp_path / "verify_cli_mcp.py"
             whatsapp = tmp_path / "verify_whatsapp.sh"
+            bridge = tmp_path / "verify_whatsapp_bridge.py"
             sidecar = tmp_path / "verify_sidecar.py"
             voice = tmp_path / "voice"
             config = tmp_path / "config.yaml"
@@ -368,6 +393,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             write_helper(gateway, "gateway", log_path)
             write_helper(cli_mcp, "cli_mcp", log_path)
             write_helper(whatsapp, "whatsapp", log_path)
+            write_helper(bridge, "bridge", log_path)
             write_helper(sidecar, "sidecar", log_path)
             write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
             config.write_text("tts: {}\n", encoding="utf-8")
@@ -397,6 +423,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                     "HERMES_GATEWAY_VERIFY_SCRIPT": str(gateway),
                     "CLI_MCP_SURFACE_VERIFY_SCRIPT": str(cli_mcp),
                     "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "WHATSAPP_BRIDGE_VERIFY_SCRIPT": str(bridge),
                     "SIDECAR_SERVICE_VERIFY_SCRIPT": str(sidecar),
                 },
             )
@@ -406,7 +433,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn("hermes_gateway=checked", result.stdout)
         self.assertEqual(
             [entry[0] for entry in entries],
-            ["hermes", "gateway", "cli_mcp", "whatsapp", "sidecar"],
+            ["hermes", "gateway", "cli_mcp", "whatsapp", "bridge", "sidecar"],
         )
         self.assertEqual(
             entries[1],

--- a/tests/test_verify_whatsapp_bridge_runtime.py
+++ b/tests/test_verify_whatsapp_bridge_runtime.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "verify_whatsapp_bridge_runtime.py"
+
+
+def load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "verify_whatsapp_bridge_runtime", SCRIPT_PATH
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_json(path: Path, payload) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def write_baileys_session(session_dir: Path) -> None:
+    session_dir.mkdir(parents=True)
+    write_json(
+        session_dir / "creds.json",
+        {
+            "me": {
+                "id": "13236478455:2@s.whatsapp.net",
+                "name": "Quill",
+                "lid": "186999436771390:2@lid",
+            },
+            "platform": "smbi",
+            "accountSyncCounter": 1,
+        },
+    )
+    write_json(session_dir / "pre-key-1.json", {})
+    write_json(session_dir / "session-186999436771390_1.0.json", {})
+    write_json(session_dir / "app-state-sync-key-AAAA.json", {})
+    write_json(session_dir / "lid-mapping-13236478455.json", "186999436771390")
+    write_json(session_dir / "lid-mapping-186999436771390_reverse.json", "13236478455")
+
+
+def make_args(tmp_path: Path, **overrides):
+    hermes_home = tmp_path / "hermes"
+    session_dir = hermes_home / "whatsapp" / "session"
+    env_file = hermes_home / ".env"
+    values = {
+        "hermes_home": hermes_home,
+        "session_dir": session_dir,
+        "env_file": env_file,
+        "bridge_url": "http://127.0.0.1:3000",
+        "service_name": "hermes-gateway.service",
+        "expected_agent_number": "13236478455",
+        "expected_agent_name": "Quill",
+        "expected_mode": None,
+        "timeout": 1.0,
+        "skip_bridge_health": True,
+        "skip_process_check": True,
+        "skip_systemd": True,
+        "require_whatsapp_cloud": False,
+        "require_whatsapp_calling": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+class WhatsAppBridgeRuntimeVerifierTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.script = load_script_module()
+
+    def test_baileys_identity_passes_and_reports_missing_cloud_credentials(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(tmp_path)
+            write_baileys_session(args.session_dir)
+            args.env_file.parent.mkdir(parents=True, exist_ok=True)
+            args.env_file.write_text(
+                "WHATSAPP_ENABLED=true\nWHATSAPP_MODE=bot\n",
+                encoding="utf-8",
+            )
+
+            result = self.script.verify(args)
+
+        self.assertTrue(result["success"], result["failures"])
+        checks = result["checks"]
+        self.assertEqual(checks["baileys_identity"]["name"], "Quill")
+        self.assertEqual(checks["baileys_identity"]["number"], "13236478455")
+        self.assertEqual(checks["baileys_identity"]["lid_number"], "186999436771390")
+        self.assertTrue(checks["lid_mapping"]["ok"])
+        self.assertFalse(checks["whatsapp_cloud"]["cloud_configured"])
+        self.assertIn(
+            "WHATSAPP_CLOUD_ACCESS_TOKEN",
+            checks["whatsapp_cloud"]["cloud_missing"],
+        )
+
+    def test_expected_agent_number_mismatch_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(tmp_path, expected_agent_number="15551234567")
+            write_baileys_session(args.session_dir)
+            args.env_file.parent.mkdir(parents=True, exist_ok=True)
+            args.env_file.write_text("WHATSAPP_MODE=bot\n", encoding="utf-8")
+
+            result = self.script.verify(args)
+
+        self.assertFalse(result["success"])
+        self.assertIn("does not match expected", "\n".join(result["failures"]))
+
+    def test_require_cloud_fails_when_cloud_credentials_are_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(tmp_path, require_whatsapp_cloud=True)
+            write_baileys_session(args.session_dir)
+            args.env_file.parent.mkdir(parents=True, exist_ok=True)
+            args.env_file.write_text("WHATSAPP_MODE=bot\n", encoding="utf-8")
+
+            result = self.script.verify(args)
+
+        self.assertFalse(result["success"])
+        self.assertIn("WhatsApp Cloud credentials missing", "\n".join(result["failures"]))
+
+    def test_cloud_calling_summary_merges_env_file_and_systemd_sources(self):
+        summary = self.script.build_cloud_summary(
+            {
+                "env_file": {
+                    "WHATSAPP_CLOUD_PHONE_NUMBER_ID": "phone-id",
+                    "WHATSAPP_CLOUD_ACCESS_TOKEN": "token",
+                    "WHATSAPP_CLOUD_APP_SECRET": "secret",
+                    "WHATSAPP_CLOUD_VERIFY_TOKEN": "verify",
+                },
+                "systemd_service": {
+                    "WHATSAPP_CLOUD_CALLING_SIDECAR_URL": "http://127.0.0.1:8787",
+                    "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND": "voice stream",
+                },
+            }
+        )
+
+        self.assertTrue(summary["cloud_configured"])
+        self.assertTrue(summary["calling_sidecar_configured"])
+        self.assertTrue(summary["calling_ready"])
+        self.assertEqual(summary["calling_missing"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a voice-owned WhatsApp bridge runtime verifier for Baileys identity, LID mapping, bridge health/process, and Cloud/Calling key presence
- wire the verifier into `scripts/verify_local_hermes_voice_stack.sh` with skip/require flags
- document the Baileys voice-note vs WhatsApp Cloud/Calling readiness split

## Verification
- `python3 -m unittest tests.test_verify_whatsapp_bridge_runtime tests.test_verify_local_hermes_voice_stack`
- `bash -n scripts/verify_local_hermes_voice_stack.sh scripts/verify_whatsapp_voice_contract.sh`
- `scripts/verify_whatsapp_bridge_runtime.py --hermes-home /home/ubuntu/.hermes --expected-agent-number 13236478455 --expected-agent-name Quill --json`
- `scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --run-webrtc-loopback-smoke --webrtc-python /tmp/voice-webrtc-venv/bin/python --expected-whatsapp-agent-number 13236478455 --expected-whatsapp-agent-name Quill`

Live local result: Baileys bridge is connected and paired as Quill; Cloud/Calling sidecar command is configured, but `WHATSAPP_CLOUD_PHONE_NUMBER_ID`, `WHATSAPP_CLOUD_ACCESS_TOKEN`, `WHATSAPP_CLOUD_APP_SECRET`, and `WHATSAPP_CLOUD_VERIFY_TOKEN` are not present on disk.