### PR TITLE
Verify cached WhatsApp inbound audio

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -93,6 +93,28 @@ Use `--wait-inbound-seconds N --require-inbound-audio` only during an attended
 test where someone can reply with a real WhatsApp voice note during the wait
 window.
 
+If the bridge has already downloaded inbound WhatsApp audio, validate that
+receive artifact without draining the live `/messages` queue:
+
+```bash
+scripts/verify_whatsapp_inbound_audio_cache.py \
+  --hermes-home ~/.hermes \
+  --require-cache \
+  --run-stt
+```
+
+The bridge writes inbound voice/audio media as `aud_*` files under
+`~/.hermes/audio_cache` by default. The cache verifier checks those files look
+like bridge downloads, validates the audio stream with `ffprobe`, and can replay
+one through `voice stream-transcribe --json`. The full stack gate exposes the
+same receive-side smoke behind an explicit opt-in:
+
+```bash
+scripts/verify_local_hermes_voice_stack.sh \
+  --hermes-home ~/.hermes \
+  --run-whatsapp-inbound-cache-smoke
+```
+
 Cloud/Calling readiness requires these external Meta settings in addition to
 the local sidecar:
 

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -17,6 +17,7 @@ skip_systemd="${SKIP_SYSTEMD:-0}"
 skip_cli_mcp="${SKIP_CLI_MCP:-0}"
 skip_daemon="${SKIP_DAEMON:-0}"
 skip_stt_smoke="${SKIP_STT_SMOKE:-0}"
+run_whatsapp_inbound_cache_smoke="${RUN_WHATSAPP_INBOUND_CACHE_SMOKE:-0}"
 run_webrtc_loopback_smoke="${RUN_WEBRTC_LOOPBACK_SMOKE:-0}"
 webrtc_python="${VOICE_WEBRTC_PYTHON:-python3}"
 webrtc_timeout="${VOICE_WEBRTC_TIMEOUT:-60}"
@@ -24,6 +25,7 @@ max_queued_tx_ms="${MAX_QUEUED_TX_MS:-1000}"
 whatsapp_bridge_url="${WHATSAPP_BRIDGE_URL:-http://127.0.0.1:3000}"
 whatsapp_session_dir="${WHATSAPP_SESSION_DIR:-}"
 whatsapp_env_file="${WHATSAPP_ENV_FILE:-}"
+whatsapp_audio_cache_dir="${WHATSAPP_AUDIO_CACHE_DIR:-}"
 expected_whatsapp_agent_number="${WHATSAPP_AGENT_NUMBER:-}"
 expected_whatsapp_agent_name="${WHATSAPP_AGENT_NAME:-}"
 require_whatsapp_cloud="${REQUIRE_WHATSAPP_CLOUD:-0}"
@@ -34,6 +36,7 @@ hermes_gateway_verify_script="${HERMES_GATEWAY_VERIFY_SCRIPT:-$repo_root/scripts
 cli_mcp_surface_verify_script="${CLI_MCP_SURFACE_VERIFY_SCRIPT:-$repo_root/scripts/verify_cli_mcp_surface.py}"
 whatsapp_contract_verify_script="${WHATSAPP_CONTRACT_VERIFY_SCRIPT:-$repo_root/scripts/verify_whatsapp_voice_contract.sh}"
 whatsapp_bridge_verify_script="${WHATSAPP_BRIDGE_VERIFY_SCRIPT:-$repo_root/scripts/verify_whatsapp_bridge_runtime.py}"
+whatsapp_inbound_cache_verify_script="${WHATSAPP_INBOUND_CACHE_VERIFY_SCRIPT:-$repo_root/scripts/verify_whatsapp_inbound_audio_cache.py}"
 sidecar_service_verify_script="${SIDECAR_SERVICE_VERIFY_SCRIPT:-$repo_root/scripts/verify_webrtc_sidecar_service.py}"
 webrtc_loopback_smoke_script="${WEBRTC_LOOPBACK_SMOKE_SCRIPT:-$repo_root/examples/webrtc-sidecar/full_duplex_loopback_smoke.py}"
 
@@ -65,12 +68,16 @@ Options:
   --whatsapp-bridge-url URL    Baileys bridge URL (default: http://127.0.0.1:3000)
   --whatsapp-session-dir PATH  Baileys multi-file auth session directory
   --whatsapp-env-file PATH     Hermes env file with WhatsApp settings
+  --whatsapp-audio-cache-dir PATH
+                               Hermes/bridge audio cache directory
   --expected-whatsapp-agent-number NUMBER
                                require Baileys creds to be paired to this number
   --expected-whatsapp-agent-name NAME
                                require Baileys creds to expose this profile name
   --require-whatsapp-cloud     fail when WhatsApp Cloud credentials are missing
   --require-whatsapp-calling   fail when Cloud Calling credentials/readiness are missing
+  --run-whatsapp-inbound-cache-smoke
+                               transcribe a bridge-downloaded aud_* file from the audio cache
   --run-webrtc-loopback-smoke  run one local full-duplex WebRTC media turn
   --webrtc-python PATH         Python used for the WebRTC smoke (default: python3)
   --webrtc-timeout SECONDS     timeout passed to the WebRTC smoke (default: 60)
@@ -83,9 +90,9 @@ Environment aliases:
   SKIP_HERMES_GATEWAY=1, SKIP_WHATSAPP_BRIDGE=1, SKIP_SYSTEMD=1, SKIP_CLI_MCP=1
   SKIP_DAEMON=1, SKIP_STT_SMOKE=1, RUN_WEBRTC_LOOPBACK_SMOKE=1
   WHATSAPP_BRIDGE_URL, WHATSAPP_SESSION_DIR, WHATSAPP_ENV_FILE
-  WHATSAPP_AGENT_NUMBER, WHATSAPP_AGENT_NAME
+  WHATSAPP_AUDIO_CACHE_DIR, WHATSAPP_AGENT_NUMBER, WHATSAPP_AGENT_NAME
   REQUIRE_WHATSAPP_CLOUD=1, REQUIRE_WHATSAPP_CALLING=1
-  VOICE_WEBRTC_PYTHON, VOICE_WEBRTC_TIMEOUT
+  RUN_WHATSAPP_INBOUND_CACHE_SMOKE=1, VOICE_WEBRTC_PYTHON, VOICE_WEBRTC_TIMEOUT
 EOF
 }
 
@@ -204,6 +211,11 @@ while [[ $# -gt 0 ]]; do
       whatsapp_env_file="$2"
       shift 2
       ;;
+    --whatsapp-audio-cache-dir)
+      [[ $# -ge 2 ]] || fail "--whatsapp-audio-cache-dir requires a path"
+      whatsapp_audio_cache_dir="$2"
+      shift 2
+      ;;
     --expected-whatsapp-agent-number)
       [[ $# -ge 2 ]] || fail "--expected-whatsapp-agent-number requires a value"
       expected_whatsapp_agent_number="$2"
@@ -220,6 +232,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --require-whatsapp-calling)
       require_whatsapp_calling=1
+      shift
+      ;;
+    --run-whatsapp-inbound-cache-smoke)
+      run_whatsapp_inbound_cache_smoke=1
       shift
       ;;
     --run-webrtc-loopback-smoke)
@@ -261,6 +277,9 @@ fi
 require_executable "$whatsapp_contract_verify_script" "WhatsApp voice contract verifier"
 if [[ "$skip_whatsapp_bridge" != "1" ]]; then
   require_executable "$whatsapp_bridge_verify_script" "WhatsApp bridge runtime verifier"
+fi
+if [[ "$run_whatsapp_inbound_cache_smoke" == "1" ]]; then
+  require_executable "$whatsapp_inbound_cache_verify_script" "WhatsApp inbound audio cache verifier"
 fi
 if [[ "$skip_hermes_config" != "1" ]]; then
   require_executable "$hermes_config_verify_script" "Hermes voice config verifier"
@@ -377,6 +396,23 @@ else
   whatsapp_bridge_status="skipped"
 fi
 
+if [[ "$run_whatsapp_inbound_cache_smoke" == "1" ]]; then
+  whatsapp_inbound_cache_args=(
+    "$whatsapp_inbound_cache_verify_script"
+    --voice-bin "$voice_bin"
+    --hermes-home "$hermes_home"
+    --require-cache
+    --run-stt
+  )
+  if [[ -n "$whatsapp_audio_cache_dir" ]]; then
+    whatsapp_inbound_cache_args+=(--audio-cache-dir "$whatsapp_audio_cache_dir")
+  fi
+  run_step "WhatsApp inbound cached audio STT smoke" "${whatsapp_inbound_cache_args[@]}"
+  whatsapp_inbound_cache_status="checked"
+else
+  whatsapp_inbound_cache_status="skipped"
+fi
+
 if [[ "$skip_sidecar" != "1" ]]; then
   sidecar_args=(
     "$sidecar_service_verify_script"
@@ -413,5 +449,6 @@ echo "hermes_gateway=$hermes_gateway_status"
 echo "cli_mcp=$cli_mcp_status"
 echo "whatsapp_contract=checked"
 echo "whatsapp_bridge=$whatsapp_bridge_status"
+echo "whatsapp_inbound_cache=$whatsapp_inbound_cache_status"
 echo "sidecar_service=$sidecar_status"
 echo "webrtc_loopback=$webrtc_loopback_status"

--- a/scripts/verify_whatsapp_inbound_audio_cache.py
+++ b/scripts/verify_whatsapp_inbound_audio_cache.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Verify cached inbound WhatsApp audio downloaded by the local bridge."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def default_hermes_home() -> Path:
+    return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+
+
+def default_voice_bin() -> str:
+    env_value = os.environ.get("VOICE_BIN")
+    if env_value:
+        return env_value
+    release_bin = repo_root() / "target" / "release" / "voice"
+    if release_bin.is_file() and os.access(release_bin, os.X_OK):
+        return str(release_bin)
+    found = shutil.which("voice")
+    return found or "voice"
+
+
+def resolve_executable(value: str, *, label: str) -> str:
+    if "/" in value:
+        path = Path(value).expanduser()
+        if not path.is_file() or not os.access(path, os.X_OK):
+            raise SystemExit(f"{label} is not executable: {path}")
+        return str(path.resolve())
+    found = shutil.which(value)
+    if not found:
+        raise SystemExit(f"{label} not found on PATH: {value}")
+    return str(Path(found).resolve())
+
+
+def run_command(command: list[str], *, timeout: float) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def discover_audio_files(audio_cache_dir: Path) -> list[Path]:
+    if not audio_cache_dir.is_dir():
+        return []
+    files = [
+        path
+        for path in audio_cache_dir.iterdir()
+        if path.is_file()
+        and path.name.startswith("aud_")
+        and path.suffix.lower() in {".ogg", ".opus", ".m4a"}
+    ]
+    return sorted(files, key=lambda path: path.stat().st_mtime, reverse=True)
+
+
+def probe_audio(path: Path, *, timeout: float, skip_ffprobe: bool) -> tuple[dict[str, Any], list[str]]:
+    failures: list[str] = []
+    probe: dict[str, Any] = {
+        "path": str(path),
+        "name": path.name,
+        "size_bytes": path.stat().st_size if path.is_file() else 0,
+        "magic": None,
+        "ffprobe": None,
+    }
+    if not path.is_file():
+        return probe, [f"inbound audio file not found: {path}"]
+    if not path.name.startswith("aud_"):
+        failures.append(
+            f"inbound audio file name must start with aud_ to match bridge downloads: {path.name}"
+        )
+    if probe["size_bytes"] <= 64:
+        failures.append(f"inbound audio file is too small: {probe['size_bytes']} bytes")
+
+    with path.open("rb") as handle:
+        probe["magic"] = handle.read(4).decode("ascii", errors="replace")
+
+    ffprobe = shutil.which("ffprobe")
+    if skip_ffprobe or not ffprobe:
+        probe["ffprobe"] = {"skipped": True, "reason": "ffprobe unavailable or skipped"}
+        return probe, failures
+
+    completed = run_command(
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-select_streams",
+            "a:0",
+            "-show_entries",
+            "stream=codec_name,sample_rate,channels,duration",
+            "-of",
+            "json",
+            str(path),
+        ],
+        timeout=timeout,
+    )
+    probe["ffprobe"] = {
+        "returncode": completed.returncode,
+        "stderr": completed.stderr.strip(),
+    }
+    if completed.returncode != 0:
+        failures.append(f"ffprobe failed for {path}: {completed.stderr.strip()}")
+        return probe, failures
+
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        failures.append(f"ffprobe did not return JSON for {path}: {exc}")
+        return probe, failures
+
+    stream = (payload.get("streams") or [{}])[0]
+    probe["ffprobe"]["stream"] = stream
+    codec = str(stream.get("codec_name") or "")
+    if not codec:
+        failures.append(f"ffprobe found no audio codec for {path}")
+    channels = int(stream.get("channels") or 0)
+    if channels <= 0:
+        failures.append(f"ffprobe found no audio channels for {path}")
+    return probe, failures
+
+
+def transcribe_audio(
+    voice_bin: str,
+    path: Path,
+    *,
+    timeout: float,
+) -> tuple[dict[str, Any], list[str]]:
+    command = [voice_bin, "--quiet", "stream-transcribe", "--json", str(path)]
+    completed = run_command(command, timeout=timeout)
+    result: dict[str, Any] = {
+        "command": command,
+        "returncode": completed.returncode,
+        "stderr": completed.stderr.strip(),
+        "events": [],
+        "terminal_event": None,
+    }
+    failures: list[str] = []
+    if completed.returncode != 0:
+        failures.append(f"voice stream-transcribe failed for {path}: {completed.stderr.strip()}")
+        return result, failures
+
+    for line in completed.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as exc:
+            failures.append(f"stream-transcribe emitted non-JSON line: {exc}")
+            continue
+        result["events"].append(event)
+        if event.get("event") in {"stt.transcribed", "stt.error"}:
+            result["terminal_event"] = event
+
+    terminal = result.get("terminal_event")
+    if not terminal:
+        failures.append("stream-transcribe did not emit a terminal STT event")
+    elif terminal.get("event") != "stt.transcribed":
+        failures.append(f"stream-transcribe terminal event was {terminal.get('event')!r}")
+    else:
+        data = terminal.get("data") or {}
+        if not str(data.get("text") or "").strip():
+            failures.append("stream-transcribe produced an empty transcript")
+        if int(data.get("frames") or 0) <= 0:
+            failures.append("stream-transcribe reported no audio frames")
+        if int(data.get("audio_duration_ms") or 0) <= 0:
+            failures.append("stream-transcribe reported no audio duration")
+    return result, failures
+
+
+def verify(args: argparse.Namespace) -> dict[str, Any]:
+    hermes_home = args.hermes_home.expanduser().resolve()
+    audio_cache_dir = (
+        args.audio_cache_dir.expanduser().resolve()
+        if args.audio_cache_dir
+        else hermes_home / "audio_cache"
+    )
+    voice_bin = resolve_executable(args.voice_bin, label="voice binary")
+
+    failures: list[str] = []
+    warnings: list[str] = []
+    selected_files: list[Path]
+    discovered = discover_audio_files(audio_cache_dir)
+    if args.audio_file:
+        selected_files = [path.expanduser().resolve() for path in args.audio_file]
+    else:
+        selected_files = discovered[: args.max_files]
+
+    if not selected_files:
+        message = f"no bridge-downloaded inbound audio files found in {audio_cache_dir}"
+        if args.require_cache:
+            failures.append(message)
+        else:
+            warnings.append(message)
+
+    checks: dict[str, Any] = {
+        "hermes_home": str(hermes_home),
+        "audio_cache_dir": str(audio_cache_dir),
+        "voice_bin": voice_bin,
+        "discovered_count": len(discovered),
+        "selected_files": [str(path) for path in selected_files],
+        "audio": [],
+    }
+
+    for path in selected_files:
+        audio_check: dict[str, Any] = {"path": str(path)}
+        probe, probe_failures = probe_audio(
+            path,
+            timeout=args.timeout,
+            skip_ffprobe=args.skip_ffprobe,
+        )
+        audio_check["probe"] = probe
+        failures.extend(probe_failures)
+
+        if args.run_stt and not probe_failures:
+            stt, stt_failures = transcribe_audio(
+                voice_bin,
+                path,
+                timeout=args.stt_timeout,
+            )
+            audio_check["stt"] = stt
+            failures.extend(stt_failures)
+        else:
+            audio_check["stt"] = {
+                "skipped": True,
+                "reason": "pass --run-stt" if not args.run_stt else "probe failed",
+            }
+        checks["audio"].append(audio_check)
+
+    return {
+        "success": not failures,
+        "checks": checks,
+        "failures": failures,
+        "warnings": warnings,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--voice-bin", default=default_voice_bin())
+    parser.add_argument("--hermes-home", type=Path, default=default_hermes_home())
+    parser.add_argument("--audio-cache-dir", type=Path, default=None)
+    parser.add_argument("--audio-file", type=Path, action="append", default=None)
+    parser.add_argument("--max-files", type=int, default=1)
+    parser.add_argument("--require-cache", action="store_true")
+    parser.add_argument("--run-stt", action="store_true")
+    parser.add_argument("--skip-ffprobe", action="store_true")
+    parser.add_argument("--timeout", type=float, default=15.0)
+    parser.add_argument("--stt-timeout", type=float, default=120.0)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def human_summary(result: dict[str, Any]) -> None:
+    checks = result["checks"]
+    if result["success"]:
+        print("ok: WhatsApp inbound audio cache verifier passed")
+    else:
+        print("error: WhatsApp inbound audio cache verifier failed", file=sys.stderr)
+        for failure in result["failures"]:
+            print(f"- {failure}", file=sys.stderr)
+
+    print(f"audio_cache_dir={checks['audio_cache_dir']}")
+    print(f"discovered_count={checks['discovered_count']}")
+    for index, audio in enumerate(checks["audio"], start=1):
+        probe = audio.get("probe") or {}
+        stream = ((probe.get("ffprobe") or {}).get("stream") or {})
+        print(
+            f"audio[{index}]={probe.get('path')} "
+            f"size={probe.get('size_bytes')} "
+            f"codec={stream.get('codec_name') or '<unknown>'} "
+            f"sample_rate={stream.get('sample_rate') or '<unknown>'} "
+            f"channels={stream.get('channels') or '<unknown>'}"
+        )
+        stt = audio.get("stt") or {}
+        if stt.get("skipped"):
+            print(f"stt[{index}]=skipped reason={stt.get('reason')}")
+        else:
+            terminal = stt.get("terminal_event") or {}
+            data = terminal.get("data") or {}
+            text = str(data.get("text") or "")
+            print(
+                f"stt[{index}]=frames={data.get('frames')} "
+                f"duration_ms={data.get('audio_duration_ms')} "
+                f"text_chars={len(text)}"
+            )
+    for warning in result["warnings"]:
+        print(f"warning: {warning}", file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    result = verify(args)
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        human_summary(result)
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -116,6 +116,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn("hermes_gateway=skipped", result.stdout)
         self.assertIn("cli_mcp=checked", result.stdout)
         self.assertIn("whatsapp_bridge=checked", result.stdout)
+        self.assertIn("whatsapp_inbound_cache=skipped", result.stdout)
         self.assertIn("webrtc_loopback=skipped", result.stdout)
         self.assertEqual(
             [entry[0] for entry in entries],
@@ -229,6 +230,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn("sidecar_service=skipped", result.stdout)
         self.assertIn("hermes_gateway=skipped", result.stdout)
         self.assertIn("whatsapp_bridge=skipped", result.stdout)
+        self.assertIn("whatsapp_inbound_cache=skipped", result.stdout)
         self.assertEqual([entry[0] for entry in entries], ["hermes", "cli_mcp", "whatsapp"])
         self.assertIn("--skip-tts-smoke", entries[0])
         self.assertIn("--skip-daemon", entries[1])
@@ -318,6 +320,83 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 "Outbound media smoke.",
                 "--max-queued-tx-ms",
                 "250",
+            ],
+        )
+
+    def test_whatsapp_inbound_cache_smoke_runs_when_requested(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            hermes = tmp_path / "verify_hermes.py"
+            gateway = tmp_path / "verify_gateway.py"
+            cli_mcp = tmp_path / "verify_cli_mcp.py"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            bridge = tmp_path / "verify_whatsapp_bridge.py"
+            inbound = tmp_path / "verify_inbound_cache.py"
+            sidecar = tmp_path / "verify_sidecar.py"
+            voice = tmp_path / "voice"
+            audio_cache = tmp_path / "audio_cache"
+
+            write_helper(hermes, "hermes", log_path)
+            write_helper(gateway, "gateway", log_path)
+            write_helper(cli_mcp, "cli_mcp", log_path)
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_helper(bridge, "bridge", log_path)
+            write_helper(inbound, "inbound", log_path)
+            write_helper(sidecar, "sidecar", log_path)
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+            audio_cache.mkdir()
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--hermes-config",
+                    str(tmp_path / "missing.yaml"),
+                    "--hermes-home",
+                    str(tmp_path / "hermes"),
+                    "--skip-hermes-config",
+                    "--skip-hermes-gateway",
+                    "--skip-cli-mcp",
+                    "--skip-sidecar",
+                    "--skip-daemon",
+                    "--skip-whatsapp-bridge",
+                    "--run-whatsapp-inbound-cache-smoke",
+                    "--whatsapp-audio-cache-dir",
+                    str(audio_cache),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "HERMES_CONFIG_VERIFY_SCRIPT": str(hermes),
+                    "HERMES_GATEWAY_VERIFY_SCRIPT": str(gateway),
+                    "CLI_MCP_SURFACE_VERIFY_SCRIPT": str(cli_mcp),
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "WHATSAPP_BRIDGE_VERIFY_SCRIPT": str(bridge),
+                    "WHATSAPP_INBOUND_CACHE_VERIFY_SCRIPT": str(inbound),
+                    "SIDECAR_SERVICE_VERIFY_SCRIPT": str(sidecar),
+                },
+            )
+
+            entries = command_log_entries(log_path)
+
+        self.assertIn("whatsapp_inbound_cache=checked", result.stdout)
+        self.assertEqual([entry[0] for entry in entries], ["whatsapp", "inbound"])
+        self.assertEqual(
+            entries[1],
+            [
+                "inbound",
+                "--voice-bin",
+                str(voice),
+                "--hermes-home",
+                str(tmp_path / "hermes"),
+                "--require-cache",
+                "--run-stt",
+                "--audio-cache-dir",
+                str(audio_cache),
             ],
         )
 

--- a/tests/test_verify_whatsapp_inbound_audio_cache.py
+++ b/tests/test_verify_whatsapp_inbound_audio_cache.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+import argparse
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "verify_whatsapp_inbound_audio_cache.py"
+
+
+def load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "verify_whatsapp_inbound_audio_cache", SCRIPT_PATH
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_fake_voice(path: Path) -> None:
+    path.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            print('{"event":"stt.transcribed","data":{"text":"hello from whatsapp","frames":12,"audio_duration_ms":240,"tokens":3}}')
+            """
+        ),
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def write_audio(path: Path) -> None:
+    path.write_bytes(b"OggS" + (b"\0" * 128))
+
+
+def make_args(tmp_path: Path, **overrides):
+    hermes_home = tmp_path / "hermes"
+    audio_cache = hermes_home / "audio_cache"
+    audio_cache.mkdir(parents=True)
+    voice = tmp_path / "voice"
+    write_fake_voice(voice)
+    values = {
+        "voice_bin": str(voice),
+        "hermes_home": hermes_home,
+        "audio_cache_dir": None,
+        "audio_file": None,
+        "max_files": 1,
+        "require_cache": False,
+        "run_stt": False,
+        "skip_ffprobe": True,
+        "timeout": 1.0,
+        "stt_timeout": 1.0,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+class WhatsAppInboundAudioCacheVerifierTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.script = load_script_module()
+
+    def test_discovers_bridge_downloaded_audio_without_draining_bridge(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(tmp_path)
+            write_audio(args.hermes_home / "audio_cache" / "aud_abc123.ogg")
+            write_audio(args.hermes_home / "audio_cache" / "tts_ignored.ogg")
+
+            result = self.script.verify(args)
+
+        self.assertTrue(result["success"], result["failures"])
+        self.assertEqual(result["checks"]["discovered_count"], 1)
+        self.assertTrue(result["checks"]["selected_files"][0].endswith("aud_abc123.ogg"))
+        self.assertTrue(result["checks"]["audio"][0]["stt"]["skipped"])
+
+    def test_run_stt_transcribes_cached_inbound_audio(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(tmp_path, run_stt=True)
+            write_audio(args.hermes_home / "audio_cache" / "aud_abc123.ogg")
+
+            result = self.script.verify(args)
+
+        self.assertTrue(result["success"], result["failures"])
+        terminal = result["checks"]["audio"][0]["stt"]["terminal_event"]
+        self.assertEqual(terminal["event"], "stt.transcribed")
+        self.assertEqual(terminal["data"]["text"], "hello from whatsapp")
+
+    def test_explicit_audio_file_must_look_like_bridge_download(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            audio = tmp_path / "not_bridge.ogg"
+            write_audio(audio)
+            args = make_args(tmp_path, audio_file=[audio])
+
+            result = self.script.verify(args)
+
+        self.assertFalse(result["success"])
+        self.assertIn("must start with aud_", "\n".join(result["failures"]))
+
+    def test_require_cache_fails_when_no_inbound_audio_exists(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self.script.verify(make_args(Path(tmp), require_cache=True))
+
+        self.assertFalse(result["success"])
+        self.assertIn("no bridge-downloaded inbound audio", "\n".join(result["failures"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `scripts/verify_whatsapp_inbound_audio_cache.py` for non-disruptive receive-side checks against bridge-downloaded `aud_*` files
- optionally replay cached inbound WhatsApp audio through `voice stream-transcribe --json`
- expose the receive-side smoke from `verify_local_hermes_voice_stack.sh` via `--run-whatsapp-inbound-cache-smoke`
- document the cached-audio path alongside the attended live `/messages` receive check

## Verification
- `python3 -m unittest tests.test_verify_whatsapp_inbound_audio_cache tests.test_verify_local_hermes_voice_stack`
- `python3 -m unittest tests.test_verify_whatsapp_inbound_audio_cache tests.test_verify_local_hermes_voice_stack tests.test_verify_whatsapp_voice_note_bridge tests.test_verify_whatsapp_bridge_runtime tests.test_verify_hermes_voice_config`
- `python3 -m py_compile scripts/verify_whatsapp_inbound_audio_cache.py && bash -n scripts/verify_local_hermes_voice_stack.sh`
- `scripts/verify_whatsapp_inbound_audio_cache.py --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --require-cache --run-stt --stt-timeout 180`
- `scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --expected-whatsapp-agent-number 13236478455 --expected-whatsapp-agent-name Quill --skip-sidecar --skip-stt-smoke --run-whatsapp-inbound-cache-smoke`

Live local result: found 3 bridge-downloaded inbound `aud_*` files in `/home/ubuntu/.hermes/audio_cache`; the newest validated as Opus 48 kHz mono and transcribed through `voice` with 241 frames / 4813 ms of audio. Human output reports transcript length, not transcript text.