### PR TITLE
Document alpha inbound cache readiness

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -85,7 +85,15 @@ and groups failures as voice runtime, Hermes runtime/config, bridge pairing,
 voice-note, live-call local sidecar, or external Meta setup. Use
 `--require-whatsapp-calling` when a host is expected to be ready for real Cloud
 Calling; otherwise missing Meta credentials are reported as external setup
-still required, not as a local Baileys voice-note failure.
+still required, not as a local Baileys voice-note failure. Add
+`--run-inbound-cache-smoke` when the report should also replay a cached inbound
+WhatsApp voice note through `voice stream-transcribe`:
+
+```bash
+scripts/verify_whatsapp_alpha_readiness.py \
+  --hermes-home ~/.hermes \
+  --run-inbound-cache-smoke
+```
 
 To prove the outbound voice-note path without sending a WhatsApp message, run:
 

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -119,6 +119,27 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         )
         self.assertTrue(payload["external_meta_setup"]["setup_steps"])
 
+    def test_inbound_cache_smoke_adds_receive_component(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = self.run_readiness(
+                Path(tmp),
+                "--run-inbound-cache-smoke",
+                "--whatsapp-audio-cache-dir",
+                str(Path(tmp) / "audio_cache"),
+            )
+
+        self.assertTrue(payload["success"])
+        components = {item["name"]: item for item in payload["components"]}
+        self.assertIn("whatsapp_inbound_cache_stt", components)
+        inbound = components["whatsapp_inbound_cache_stt"]
+        self.assertEqual(inbound["category"], "voice_note")
+        self.assertIn("--require-cache", inbound["command"])
+        self.assertIn("--run-stt", inbound["command"])
+        self.assertIn(
+            "whatsapp_inbound_cache_stt",
+            payload["by_category"]["voice_note"]["components"],
+        )
+
     def test_require_cloud_calling_fails_when_meta_credentials_are_missing(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)


### PR DESCRIPTION
## Summary
- document `--run-inbound-cache-smoke` on the categorized WhatsApp alpha readiness command
- add unit coverage that the receive-side cached audio STT component is included in the alpha report when requested

## Tests
- `python3 -m unittest tests.test_verify_whatsapp_alpha_readiness`
- `scripts/verify_whatsapp_alpha_readiness.py --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --run-inbound-cache-smoke`