### PR TITLE
Expose real voice-note checks in alpha readiness

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -95,6 +95,29 @@ scripts/verify_whatsapp_alpha_readiness.py \
   --run-inbound-cache-smoke
 ```
 
+The same alpha report can also drive the real bridge voice-note operation when
+running an attended test. Add `--send-voice-note` to post the generated
+Ogg/Opus note to `WHATSAPP_HOME_CHANNEL`, or pass `--voice-note-chat-id` to
+override the destination:
+
+```bash
+scripts/verify_whatsapp_alpha_readiness.py \
+  --hermes-home ~/.hermes \
+  --send-voice-note
+```
+
+For a full attended send/receive pass, combine the send flag with the guarded
+receive drain:
+
+```bash
+scripts/verify_whatsapp_alpha_readiness.py \
+  --hermes-home ~/.hermes \
+  --send-voice-note \
+  --wait-inbound-seconds 60 \
+  --require-inbound-audio \
+  --drain-bridge-messages
+```
+
 To prove the outbound voice-note path without sending a WhatsApp message, run:
 
 ```bash

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -246,23 +246,43 @@ def build_components(args: argparse.Namespace) -> list[dict[str, Any]]:
     )
 
     if not args.skip_voice_note_smoke:
+        voice_note_cmd = [
+            script_path("verify_whatsapp_voice_note_bridge.py"),
+            "--voice-bin",
+            voice_bin,
+            "--hermes-home",
+            str(hermes_home),
+            "--bridge-url",
+            args.bridge_url,
+            "--text",
+            args.text,
+            "--json",
+        ]
+        voice_note_name = "whatsapp_voice_note_dry_run"
+        if args.voice_note_chat_id:
+            voice_note_cmd.extend(["--chat-id", args.voice_note_chat_id])
+        if args.send_voice_note:
+            voice_note_cmd.append("--send")
+            voice_note_name = "whatsapp_voice_note_send"
+        if args.wait_inbound_seconds > 0:
+            voice_note_cmd.extend(
+                ["--wait-inbound-seconds", str(args.wait_inbound_seconds)]
+            )
+            if args.send_voice_note:
+                voice_note_name = "whatsapp_voice_note_send_receive"
+            else:
+                voice_note_name = "whatsapp_voice_note_receive"
+            if args.require_inbound_audio:
+                voice_note_cmd.append("--require-inbound-audio")
+            if args.drain_bridge_messages:
+                voice_note_cmd.append("--drain-bridge-messages")
+        voice_note_timeout = args.voice_timeout + args.wait_inbound_seconds + args.timeout
         components.append(
             component(
-                name="whatsapp_voice_note_dry_run",
+                name=voice_note_name,
                 category="voice_note",
-                command=[
-                    script_path("verify_whatsapp_voice_note_bridge.py"),
-                    "--voice-bin",
-                    voice_bin,
-                    "--hermes-home",
-                    str(hermes_home),
-                    "--bridge-url",
-                    args.bridge_url,
-                    "--text",
-                    args.text,
-                    "--json",
-                ],
-                timeout=args.voice_timeout,
+                command=voice_note_cmd,
+                timeout=voice_note_timeout,
                 parse_json=True,
             )
         )
@@ -417,6 +437,26 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--skip-sidecar", action="store_true")
     parser.add_argument("--skip-hermes-tts-smoke", action="store_true")
     parser.add_argument("--skip-voice-note-smoke", action="store_true")
+    parser.add_argument(
+        "--send-voice-note",
+        action="store_true",
+        help="post a real WhatsApp voice note through the local bridge",
+    )
+    parser.add_argument(
+        "--voice-note-chat-id",
+        default=None,
+        help="override WHATSAPP_HOME_CHANNEL for the real voice-note send",
+    )
+    parser.add_argument("--wait-inbound-seconds", type=float, default=0.0)
+    parser.add_argument("--require-inbound-audio", action="store_true")
+    parser.add_argument(
+        "--drain-bridge-messages",
+        action="store_true",
+        help=(
+            "allow attended inbound receive polling via the bridge /messages "
+            "endpoint; this consumes queued bridge messages"
+        ),
+    )
     parser.add_argument("--run-stt-smoke", action="store_true")
     parser.add_argument("--run-inbound-cache-smoke", action="store_true")
     parser.add_argument("--require-whatsapp-cloud", action="store_true")

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -72,7 +72,12 @@ def write_fake_helpers(directory: Path, *, cloud_configured: bool = False) -> No
 
 
 class WhatsAppAlphaReadinessTests(unittest.TestCase):
-    def run_readiness(self, tmp_path: Path, *args: str) -> dict:
+    def run_readiness(
+        self,
+        tmp_path: Path,
+        *args: str,
+        skip_voice_note_smoke: bool = True,
+    ) -> dict:
         helpers = tmp_path / "helpers"
         helpers.mkdir()
         write_fake_helpers(helpers)
@@ -80,22 +85,24 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
         config = tmp_path / "config.yaml"
         config.write_text("tts: {}\n", encoding="utf-8")
+        command = [
+            str(SCRIPT_PATH),
+            "--voice-bin",
+            str(voice),
+            "--hermes-home",
+            str(tmp_path / "hermes"),
+            "--hermes-config",
+            str(config),
+            "--skip-systemd",
+            "--skip-daemon",
+            "--skip-sidecar",
+            "--json",
+        ]
+        if skip_voice_note_smoke:
+            command.append("--skip-voice-note-smoke")
+        command.extend(args)
         result = subprocess.run(
-            [
-                str(SCRIPT_PATH),
-                "--voice-bin",
-                str(voice),
-                "--hermes-home",
-                str(tmp_path / "hermes"),
-                "--hermes-config",
-                str(config),
-                "--skip-systemd",
-                "--skip-daemon",
-                "--skip-sidecar",
-                "--skip-voice-note-smoke",
-                "--json",
-                *args,
-            ],
+            command,
             capture_output=True,
             text=True,
             check=False,
@@ -139,6 +146,32 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             "whatsapp_inbound_cache_stt",
             payload["by_category"]["voice_note"]["components"],
         )
+
+    def test_voice_note_send_receive_flags_are_passed_to_bridge_smoke(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = self.run_readiness(
+                Path(tmp),
+                "--send-voice-note",
+                "--voice-note-chat-id",
+                "20530681934008@lid",
+                "--wait-inbound-seconds",
+                "5",
+                "--require-inbound-audio",
+                "--drain-bridge-messages",
+                skip_voice_note_smoke=False,
+            )
+
+        self.assertTrue(payload["success"])
+        components = {item["name"]: item for item in payload["components"]}
+        self.assertIn("whatsapp_voice_note_send_receive", components)
+        command = components["whatsapp_voice_note_send_receive"]["command"]
+        self.assertIn("--send", command)
+        self.assertIn("--chat-id", command)
+        self.assertIn("20530681934008@lid", command)
+        self.assertIn("--wait-inbound-seconds", command)
+        self.assertIn("5.0", command)
+        self.assertIn("--require-inbound-audio", command)
+        self.assertIn("--drain-bridge-messages", command)
 
     def test_require_cloud_calling_fails_when_meta_credentials_are_missing(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- add alpha-readiness flags to run the real WhatsApp voice-note bridge send path
- add guarded attended receive flags to the same categorized readiness report
- document dry, cached receive, real send, and attended send/receive alpha profiles
- cover command composition for the real bridge path in unit tests

## Tests
- `python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_alpha_readiness.py`
- `python3 -m unittest tests.test_verify_whatsapp_alpha_readiness`
- `python3 -m unittest discover -s tests`
- `scripts/verify_whatsapp_alpha_readiness.py --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --json`
- expected guarded failure, no queue drain: `scripts/verify_whatsapp_alpha_readiness.py --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --wait-inbound-seconds 1 --require-inbound-audio`