### PR TITLE
Validate alpha voice-note flag combinations

### DIFF
--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -465,6 +465,33 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    voice_note_options = [
+        args.send_voice_note,
+        args.voice_note_chat_id is not None,
+        args.wait_inbound_seconds != 0,
+        args.require_inbound_audio,
+        args.drain_bridge_messages,
+    ]
+    if args.skip_voice_note_smoke and any(voice_note_options):
+        parser.error(
+            "voice-note send/receive flags cannot be used with --skip-voice-note-smoke"
+        )
+    if args.wait_inbound_seconds < 0:
+        parser.error("--wait-inbound-seconds must be non-negative")
+    if args.voice_note_chat_id and not args.send_voice_note:
+        parser.error("--voice-note-chat-id requires --send-voice-note")
+    if args.require_inbound_audio and args.wait_inbound_seconds <= 0:
+        parser.error("--require-inbound-audio requires --wait-inbound-seconds")
+    if args.drain_bridge_messages and args.wait_inbound_seconds <= 0:
+        parser.error("--drain-bridge-messages requires --wait-inbound-seconds")
+    if args.wait_inbound_seconds > 0 and not args.drain_bridge_messages:
+        parser.error(
+            "--wait-inbound-seconds polls the bridge /messages queue; "
+            "add --drain-bridge-messages only during an attended receive test"
+        )
+
+
 def human_summary(result: dict[str, Any]) -> None:
     if result["success"]:
         print("ok: WhatsApp alpha readiness passed")
@@ -500,7 +527,9 @@ def human_summary(result: dict[str, Any]) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    validate_args(parser, args)
     result = build_readiness(args)
     if args.json:
         print(json.dumps(result, indent=2, sort_keys=True))

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -72,6 +72,14 @@ def write_fake_helpers(directory: Path, *, cloud_configured: bool = False) -> No
 
 
 class WhatsAppAlphaReadinessTests(unittest.TestCase):
+    def run_invalid(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(SCRIPT_PATH), *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
     def run_readiness(
         self,
         tmp_path: Path,
@@ -172,6 +180,33 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertIn("5.0", command)
         self.assertIn("--require-inbound-audio", command)
         self.assertIn("--drain-bridge-messages", command)
+
+    def test_voice_note_flags_cannot_be_used_when_voice_note_smoke_is_skipped(self):
+        result = self.run_invalid("--skip-voice-note-smoke", "--send-voice-note")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("cannot be used with --skip-voice-note-smoke", result.stderr)
+
+    def test_wait_inbound_requires_explicit_drain_flag(self):
+        result = self.run_invalid("--wait-inbound-seconds", "5")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("add --drain-bridge-messages", result.stderr)
+
+    def test_require_inbound_audio_requires_wait_window(self):
+        result = self.run_invalid("--require-inbound-audio")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn(
+            "--require-inbound-audio requires --wait-inbound-seconds",
+            result.stderr,
+        )
+
+    def test_voice_note_chat_id_requires_real_send(self):
+        result = self.run_invalid("--voice-note-chat-id", "20530681934008@lid")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("--voice-note-chat-id requires --send-voice-note", result.stderr)
 
     def test_require_cloud_calling_fails_when_meta_credentials_are_missing(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- fail fast when alpha readiness voice-note send/receive flags are ignored or unsafe
- require explicit `--drain-bridge-messages` for alpha attended receive polling
- add parser-level tests for invalid alpha voice-note flag combinations

## Tests
- `python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_alpha_readiness.py`
- `python3 -m unittest tests.test_verify_whatsapp_alpha_readiness`
- `python3 -m unittest discover -s tests`
- `scripts/verify_whatsapp_alpha_readiness.py --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --json`
- expected parser failure, no bridge work: `scripts/verify_whatsapp_alpha_readiness.py --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --wait-inbound-seconds 1 --require-inbound-audio`