### PR TITLE
Report pending WhatsApp alpha gates

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -95,6 +95,13 @@ scripts/verify_whatsapp_alpha_readiness.py \
   --run-inbound-cache-smoke
 ```
 
+The JSON report includes `pending_gates` for checks that are intentionally not
+part of unattended local readiness: fresh attended inbound receive, WhatsApp
+Cloud API credentials, and WhatsApp Cloud Calling. A default local pass can
+still report `pending_gates.attended_fresh_receive.status=pending_attended`
+until someone sends a fresh WhatsApp voice note during the guarded receive
+window.
+
 The same alpha report can also drive the real bridge voice-note operation when
 running an attended test. Add `--send-voice-note` to post the generated
 Ogg/Opus note to `WHATSAPP_HOME_CHANNEL`, or pass `--voice-note-chat-id` to

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -345,6 +345,86 @@ def bridge_cloud_summary(components: list[dict[str, Any]]) -> dict[str, Any]:
     return {}
 
 
+def attended_receive_gate(
+    components: list[dict[str, Any]],
+    *,
+    hermes_home: Path,
+) -> dict[str, Any]:
+    receive_names = {"whatsapp_voice_note_receive", "whatsapp_voice_note_send_receive"}
+    cached_receive_verified = any(
+        item["name"] == "whatsapp_inbound_cache_stt" and item.get("success")
+        for item in components
+    )
+
+    gate: dict[str, Any] = {
+        "status": "pending_attended",
+        "component": None,
+        "cached_receive_verified": cached_receive_verified,
+        "requires_operator": True,
+        "drains_bridge_messages": True,
+        "reason": "fresh WhatsApp inbound voice-note receive has not been run",
+        "command": [
+            "scripts/verify_whatsapp_alpha_readiness.py",
+            "--hermes-home",
+            str(hermes_home),
+            "--send-voice-note",
+            "--wait-inbound-seconds",
+            "60",
+            "--require-inbound-audio",
+            "--drain-bridge-messages",
+        ],
+    }
+
+    for item in components:
+        if item["name"] not in receive_names:
+            continue
+        summary = item.get("summary") or {}
+        checks = summary.get("checks") or {}
+        inbound = checks.get("inbound_audio") or {}
+        audio_events = inbound.get("audio_events") or []
+        gate["component"] = item["name"]
+        gate["drains_bridge_messages"] = bool(inbound.get("drains_bridge_messages"))
+        if item.get("success") and audio_events:
+            gate["status"] = "verified"
+            gate["requires_operator"] = False
+            gate["reason"] = "fresh WhatsApp inbound audio event observed"
+            gate["audio_events"] = len(audio_events)
+        elif item.get("success"):
+            gate["status"] = "not_verified"
+            gate["reason"] = "receive polling completed without fresh audio-event evidence"
+            gate["audio_events"] = len(audio_events)
+        else:
+            gate["status"] = "failed"
+            gate["reason"] = "fresh receive verifier failed"
+            gate["failures"] = item.get("failures") or []
+        break
+    return gate
+
+
+def external_meta_gate(external_meta_setup: dict[str, Any]) -> dict[str, Any]:
+    cloud_missing = [str(key) for key in external_meta_setup.get("cloud_missing") or []]
+    calling_missing = [
+        str(key) for key in external_meta_setup.get("calling_missing") or []
+    ]
+    cloud_configured = bool(external_meta_setup.get("cloud_configured"))
+    calling_ready = bool(external_meta_setup.get("calling_ready"))
+    return {
+        "whatsapp_cloud": {
+            "status": "configured" if cloud_configured else "external_setup_required",
+            "missing": cloud_missing,
+        },
+        "whatsapp_cloud_calling": {
+            "status": "ready" if calling_ready else "external_setup_required",
+            "missing": calling_missing,
+            "setup_steps": (
+                []
+                if calling_ready
+                else list(external_meta_setup.get("setup_steps") or META_SETUP_STEPS)
+            ),
+        },
+    }
+
+
 def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
     components = build_components(args)
     required_failures = [
@@ -397,11 +477,20 @@ def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
             }
         )
 
+    pending_gates = {
+        "attended_fresh_receive": attended_receive_gate(
+            components,
+            hermes_home=args.hermes_home.expanduser().resolve(),
+        ),
+        **external_meta_gate(external_meta_setup),
+    }
+
     return {
         "success": success,
         "components": components,
         "by_category": by_category,
         "external_meta_setup": external_meta_setup,
+        "pending_gates": pending_gates,
         "failures": [
             {
                 "name": item["name"],
@@ -506,6 +595,14 @@ def human_summary(result: dict[str, Any]) -> None:
                 print(f"  - {failure}", file=sys.stderr)
 
     external = result["external_meta_setup"]
+    pending = result.get("pending_gates") or {}
+    attended = pending.get("attended_fresh_receive") or {}
+    if attended:
+        print(
+            "attended_fresh_receive="
+            f"{attended.get('status')} cached_receive_verified="
+            f"{attended.get('cached_receive_verified')}"
+        )
     print(
         "whatsapp_cloud="
         + ("configured" if external["cloud_configured"] else "not_configured")

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -39,14 +39,22 @@ def ok_shell(path: Path) -> None:
     )
 
 
-def write_fake_helpers(directory: Path, *, cloud_configured: bool = False) -> None:
+def write_fake_helpers(
+    directory: Path,
+    *,
+    cloud_configured: bool = False,
+    voice_note_payload: dict | None = None,
+) -> None:
     ok_shell(directory / "verify_hermes_voice_config.py")
     ok_shell(directory / "verify_whatsapp_voice_contract.sh")
     success_payload = {"success": True, "checks": {}, "failures": []}
     json_script(directory / "verify_hermes_gateway_service.py", success_payload)
     json_script(directory / "verify_cli_mcp_surface.py", success_payload)
     json_script(directory / "verify_webrtc_sidecar_service.py", success_payload)
-    json_script(directory / "verify_whatsapp_voice_note_bridge.py", success_payload)
+    json_script(
+        directory / "verify_whatsapp_voice_note_bridge.py",
+        voice_note_payload or success_payload,
+    )
     json_script(directory / "verify_whatsapp_inbound_audio_cache.py", success_payload)
 
     cloud_missing = [] if cloud_configured else [
@@ -85,10 +93,11 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         tmp_path: Path,
         *args: str,
         skip_voice_note_smoke: bool = True,
+        voice_note_payload: dict | None = None,
     ) -> dict:
         helpers = tmp_path / "helpers"
         helpers.mkdir()
-        write_fake_helpers(helpers)
+        write_fake_helpers(helpers, voice_note_payload=voice_note_payload)
         voice = tmp_path / "voice"
         write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
         config = tmp_path / "config.yaml"
@@ -133,6 +142,19 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             payload["external_meta_setup"]["cloud_missing"],
         )
         self.assertTrue(payload["external_meta_setup"]["setup_steps"])
+        gates = payload["pending_gates"]
+        self.assertEqual(
+            gates["attended_fresh_receive"]["status"],
+            "pending_attended",
+        )
+        self.assertEqual(
+            gates["whatsapp_cloud_calling"]["status"],
+            "external_setup_required",
+        )
+        self.assertIn(
+            "WHATSAPP_CLOUD_ACCESS_TOKEN",
+            gates["whatsapp_cloud_calling"]["missing"],
+        )
 
     def test_inbound_cache_smoke_adds_receive_component(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -180,6 +202,35 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertIn("5.0", command)
         self.assertIn("--require-inbound-audio", command)
         self.assertIn("--drain-bridge-messages", command)
+
+    def test_verified_attended_receive_gate_requires_audio_event_evidence(self):
+        voice_note_payload = {
+            "success": True,
+            "checks": {
+                "inbound_audio": {
+                    "drains_bridge_messages": True,
+                    "audio_events": [{"mediaType": "ptt"}],
+                }
+            },
+            "failures": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = self.run_readiness(
+                Path(tmp),
+                "--send-voice-note",
+                "--wait-inbound-seconds",
+                "5",
+                "--require-inbound-audio",
+                "--drain-bridge-messages",
+                skip_voice_note_smoke=False,
+                voice_note_payload=voice_note_payload,
+            )
+
+        gate = payload["pending_gates"]["attended_fresh_receive"]
+        self.assertEqual(gate["status"], "verified")
+        self.assertEqual(gate["component"], "whatsapp_voice_note_send_receive")
+        self.assertEqual(gate["audio_events"], 1)
+        self.assertFalse(gate["requires_operator"])
 
     def test_voice_note_flags_cannot_be_used_when_voice_note_smoke_is_skipped(self):
         result = self.run_invalid("--skip-voice-note-smoke", "--send-voice-note")


### PR DESCRIPTION
## Summary
- add `pending_gates` to the WhatsApp alpha readiness JSON report
- distinguish unattended local readiness from attended fresh receive and external Meta Cloud/Calling setup
- mark fresh receive verified only when a receive component reports inbound audio-event evidence
- document the new pending gate fields

## Tests
- `python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_alpha_readiness.py`
- `python3 -m unittest tests.test_verify_whatsapp_alpha_readiness`
- `python3 -m unittest discover -s tests`
- `scripts/verify_whatsapp_alpha_readiness.py --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --json`
- `scripts/verify_whatsapp_alpha_readiness.py --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --run-inbound-cache-smoke --json`