### PR TITLE
Add WhatsApp alpha readiness profiles

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -85,14 +85,15 @@ and groups failures as voice runtime, Hermes runtime/config, bridge pairing,
 voice-note, live-call local sidecar, or external Meta setup. Use
 `--require-whatsapp-calling` when a host is expected to be ready for real Cloud
 Calling; otherwise missing Meta credentials are reported as external setup
-still required, not as a local Baileys voice-note failure. Add
-`--run-inbound-cache-smoke` when the report should also replay a cached inbound
-WhatsApp voice note through `voice stream-transcribe`:
+still required, not as a local Baileys voice-note failure. The named profiles
+are `unattended`, `cached-receive`, `send`, and `attended-send-receive`. Use
+`cached-receive` when the report should also replay a cached inbound WhatsApp
+voice note through `voice stream-transcribe`:
 
 ```bash
 scripts/verify_whatsapp_alpha_readiness.py \
   --hermes-home ~/.hermes \
-  --run-inbound-cache-smoke
+  --profile cached-receive
 ```
 
 The JSON report includes `pending_gates` for checks that are intentionally not
@@ -110,19 +111,15 @@ override the destination:
 ```bash
 scripts/verify_whatsapp_alpha_readiness.py \
   --hermes-home ~/.hermes \
-  --send-voice-note
+  --profile send
 ```
 
-For a full attended send/receive pass, combine the send flag with the guarded
-receive drain:
+For a full attended send/receive pass, use the guarded receive profile:
 
 ```bash
 scripts/verify_whatsapp_alpha_readiness.py \
   --hermes-home ~/.hermes \
-  --send-voice-note \
-  --wait-inbound-seconds 60 \
-  --require-inbound-audio \
-  --drain-bridge-messages
+  --profile attended-send-receive
 ```
 
 To prove the outbound voice-note path without sending a WhatsApp message, run:

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -15,6 +15,12 @@ from typing import Any
 
 DEFAULT_BRIDGE_URL = "http://127.0.0.1:3000"
 DEFAULT_SIDECAR_URL = "http://127.0.0.1:8787"
+PROFILE_CHOICES = (
+    "unattended",
+    "cached-receive",
+    "send",
+    "attended-send-receive",
+)
 
 META_SETUP_STEPS = (
     "Create or select a WhatsApp Business Platform app and WABA.",
@@ -487,6 +493,7 @@ def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
 
     return {
         "success": success,
+        "profile": args.profile,
         "components": components,
         "by_category": by_category,
         "external_meta_setup": external_meta_setup,
@@ -505,6 +512,15 @@ def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile",
+        choices=PROFILE_CHOICES,
+        default="unattended",
+        help=(
+            "named readiness profile: unattended dry run, cached receive STT, "
+            "real send, or attended send/receive"
+        ),
+    )
     parser.add_argument("--voice-bin", default=default_voice_bin())
     parser.add_argument("--hermes-home", type=Path, default=default_hermes_home())
     parser.add_argument(
@@ -554,6 +570,19 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def apply_profile(args: argparse.Namespace) -> None:
+    if args.profile == "cached-receive":
+        args.run_inbound_cache_smoke = True
+    elif args.profile == "send":
+        args.send_voice_note = True
+    elif args.profile == "attended-send-receive":
+        args.send_voice_note = True
+        if args.wait_inbound_seconds == 0:
+            args.wait_inbound_seconds = 60.0
+        args.require_inbound_audio = True
+        args.drain_bridge_messages = True
+
+
 def validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
     voice_note_options = [
         args.send_voice_note,
@@ -586,6 +615,7 @@ def human_summary(result: dict[str, Any]) -> None:
         print("ok: WhatsApp alpha readiness passed")
     else:
         print("error: WhatsApp alpha readiness failed", file=sys.stderr)
+    print(f"profile={result.get('profile')}")
 
     for item in result["components"]:
         status = "ok" if item["success"] else "failed"
@@ -626,6 +656,7 @@ def human_summary(result: dict[str, Any]) -> None:
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    apply_profile(args)
     validate_args(parser, args)
     result = build_readiness(args)
     if args.json:

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -177,6 +177,34 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             payload["by_category"]["voice_note"]["components"],
         )
 
+    def test_cached_receive_profile_adds_receive_component(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = self.run_readiness(
+                Path(tmp),
+                "--profile",
+                "cached-receive",
+                "--whatsapp-audio-cache-dir",
+                str(Path(tmp) / "audio_cache"),
+            )
+
+        self.assertEqual(payload["profile"], "cached-receive")
+        components = {item["name"]: item for item in payload["components"]}
+        self.assertIn("whatsapp_inbound_cache_stt", components)
+
+    def test_send_profile_posts_real_voice_note(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = self.run_readiness(
+                Path(tmp),
+                "--profile",
+                "send",
+                skip_voice_note_smoke=False,
+            )
+
+        self.assertEqual(payload["profile"], "send")
+        components = {item["name"]: item for item in payload["components"]}
+        self.assertIn("whatsapp_voice_note_send", components)
+        self.assertIn("--send", components["whatsapp_voice_note_send"]["command"])
+
     def test_voice_note_send_receive_flags_are_passed_to_bridge_smoke(self):
         with tempfile.TemporaryDirectory() as tmp:
             payload = self.run_readiness(
@@ -200,6 +228,35 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertIn("20530681934008@lid", command)
         self.assertIn("--wait-inbound-seconds", command)
         self.assertIn("5.0", command)
+        self.assertIn("--require-inbound-audio", command)
+        self.assertIn("--drain-bridge-messages", command)
+
+    def test_attended_send_receive_profile_expands_guarded_receive_flags(self):
+        voice_note_payload = {
+            "success": True,
+            "checks": {
+                "inbound_audio": {
+                    "drains_bridge_messages": True,
+                    "audio_events": [{"mediaType": "ptt"}],
+                }
+            },
+            "failures": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = self.run_readiness(
+                Path(tmp),
+                "--profile",
+                "attended-send-receive",
+                skip_voice_note_smoke=False,
+                voice_note_payload=voice_note_payload,
+            )
+
+        self.assertEqual(payload["profile"], "attended-send-receive")
+        components = {item["name"]: item for item in payload["components"]}
+        command = components["whatsapp_voice_note_send_receive"]["command"]
+        self.assertIn("--send", command)
+        self.assertIn("--wait-inbound-seconds", command)
+        self.assertIn("60.0", command)
         self.assertIn("--require-inbound-audio", command)
         self.assertIn("--drain-bridge-messages", command)
 
@@ -234,6 +291,16 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
 
     def test_voice_note_flags_cannot_be_used_when_voice_note_smoke_is_skipped(self):
         result = self.run_invalid("--skip-voice-note-smoke", "--send-voice-note")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("cannot be used with --skip-voice-note-smoke", result.stderr)
+
+    def test_real_voice_note_profiles_cannot_skip_voice_note_smoke(self):
+        result = self.run_invalid(
+            "--profile",
+            "attended-send-receive",
+            "--skip-voice-note-smoke",
+        )
 
         self.assertEqual(result.returncode, 2)
         self.assertIn("cannot be used with --skip-voice-note-smoke", result.stderr)


### PR DESCRIPTION
## Summary
- add named alpha readiness profiles: `unattended`, `cached-receive`, `send`, and `attended-send-receive`
- expose the selected profile in JSON and human output
- update docs to prefer the safe named profiles over long flag combinations
- cover profile expansion in unit tests

## Tests
- `python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_alpha_readiness.py`
- `python3 -m unittest tests.test_verify_whatsapp_alpha_readiness`
- `python3 -m unittest discover -s tests`
- expected parser failure: `scripts/verify_whatsapp_alpha_readiness.py --profile attended-send-receive --skip-voice-note-smoke`
- `scripts/verify_whatsapp_alpha_readiness.py --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --profile unattended --json`
- `scripts/verify_whatsapp_alpha_readiness.py --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --profile cached-receive --json`