### PR TITLE
Add WhatsApp alpha profile to stack verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,12 @@ daemon and sidecar by default. For narrower checks, run
 `scripts/verify_whatsapp_voice_contract.sh`, or
 `scripts/verify_webrtc_sidecar_service.py` directly.
 
+To include the categorized WhatsApp alpha report in the same command, add
+`--whatsapp-alpha-profile unattended`, `cached-receive`, `send`, or
+`attended-send-receive`. The `send` and `attended-send-receive` profiles perform
+real bridge operations, and `attended-send-receive` drains the bridge message
+queue while waiting for a fresh inbound voice note.
+
 When the WebRTC Python dependencies are installed, add
 `--run-webrtc-loopback-smoke --webrtc-python /tmp/voice-webrtc-venv/bin/python`
 to run one full-duplex local media turn through the sidecar spike as well.

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -74,6 +74,20 @@ voice-stream service, and the WebRTC sidecar contract. Add
 `--require-whatsapp-cloud` or `--require-whatsapp-calling` only when the host is
 expected to have real Meta Cloud credentials.
 
+The same stack gate can run the categorized alpha report as an explicit opt-in:
+
+```bash
+scripts/verify_local_hermes_voice_stack.sh \
+  --hermes-home ~/.hermes \
+  --whatsapp-alpha-profile cached-receive
+```
+
+Use `--whatsapp-alpha-profile send` only when it is acceptable to post a real
+voice note through the paired bridge. Use
+`--whatsapp-alpha-profile attended-send-receive` only during an attended test;
+that profile waits for fresh inbound audio and drains the bridge `/messages`
+queue.
+
 For a categorized alpha-readiness report, use:
 
 ```bash

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -18,6 +18,7 @@ skip_cli_mcp="${SKIP_CLI_MCP:-0}"
 skip_daemon="${SKIP_DAEMON:-0}"
 skip_stt_smoke="${SKIP_STT_SMOKE:-0}"
 run_whatsapp_inbound_cache_smoke="${RUN_WHATSAPP_INBOUND_CACHE_SMOKE:-0}"
+whatsapp_alpha_profile="${WHATSAPP_ALPHA_PROFILE:-}"
 run_webrtc_loopback_smoke="${RUN_WEBRTC_LOOPBACK_SMOKE:-0}"
 webrtc_python="${VOICE_WEBRTC_PYTHON:-python3}"
 webrtc_timeout="${VOICE_WEBRTC_TIMEOUT:-60}"
@@ -37,6 +38,7 @@ cli_mcp_surface_verify_script="${CLI_MCP_SURFACE_VERIFY_SCRIPT:-$repo_root/scrip
 whatsapp_contract_verify_script="${WHATSAPP_CONTRACT_VERIFY_SCRIPT:-$repo_root/scripts/verify_whatsapp_voice_contract.sh}"
 whatsapp_bridge_verify_script="${WHATSAPP_BRIDGE_VERIFY_SCRIPT:-$repo_root/scripts/verify_whatsapp_bridge_runtime.py}"
 whatsapp_inbound_cache_verify_script="${WHATSAPP_INBOUND_CACHE_VERIFY_SCRIPT:-$repo_root/scripts/verify_whatsapp_inbound_audio_cache.py}"
+whatsapp_alpha_readiness_script="${WHATSAPP_ALPHA_READINESS_SCRIPT:-$repo_root/scripts/verify_whatsapp_alpha_readiness.py}"
 sidecar_service_verify_script="${SIDECAR_SERVICE_VERIFY_SCRIPT:-$repo_root/scripts/verify_webrtc_sidecar_service.py}"
 webrtc_loopback_smoke_script="${WEBRTC_LOOPBACK_SMOKE_SCRIPT:-$repo_root/examples/webrtc-sidecar/full_duplex_loopback_smoke.py}"
 
@@ -78,6 +80,9 @@ Options:
   --require-whatsapp-calling   fail when Cloud Calling credentials/readiness are missing
   --run-whatsapp-inbound-cache-smoke
                                transcribe a bridge-downloaded aud_* file from the audio cache
+  --whatsapp-alpha-profile PROFILE
+                               run categorized alpha readiness profile:
+                               unattended, cached-receive, send, attended-send-receive
   --run-webrtc-loopback-smoke  run one local full-duplex WebRTC media turn
   --webrtc-python PATH         Python used for the WebRTC smoke (default: python3)
   --webrtc-timeout SECONDS     timeout passed to the WebRTC smoke (default: 60)
@@ -92,7 +97,8 @@ Environment aliases:
   WHATSAPP_BRIDGE_URL, WHATSAPP_SESSION_DIR, WHATSAPP_ENV_FILE
   WHATSAPP_AUDIO_CACHE_DIR, WHATSAPP_AGENT_NUMBER, WHATSAPP_AGENT_NAME
   REQUIRE_WHATSAPP_CLOUD=1, REQUIRE_WHATSAPP_CALLING=1
-  RUN_WHATSAPP_INBOUND_CACHE_SMOKE=1, VOICE_WEBRTC_PYTHON, VOICE_WEBRTC_TIMEOUT
+  RUN_WHATSAPP_INBOUND_CACHE_SMOKE=1, WHATSAPP_ALPHA_PROFILE
+  VOICE_WEBRTC_PYTHON, VOICE_WEBRTC_TIMEOUT
 EOF
 }
 
@@ -238,6 +244,11 @@ while [[ $# -gt 0 ]]; do
       run_whatsapp_inbound_cache_smoke=1
       shift
       ;;
+    --whatsapp-alpha-profile)
+      [[ $# -ge 2 ]] || fail "--whatsapp-alpha-profile requires a profile"
+      whatsapp_alpha_profile="$2"
+      shift 2
+      ;;
     --run-webrtc-loopback-smoke)
       run_webrtc_loopback_smoke=1
       shift
@@ -267,6 +278,16 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+if [[ -n "$whatsapp_alpha_profile" ]]; then
+  case "$whatsapp_alpha_profile" in
+    unattended|cached-receive|send|attended-send-receive)
+      ;;
+    *)
+      fail "unknown WhatsApp alpha profile: $whatsapp_alpha_profile"
+      ;;
+  esac
+fi
+
 voice_bin="$(default_voice_bin)"
 if [[ "$voice_bin" == */* ]]; then
   require_executable "$voice_bin" "voice binary"
@@ -280,6 +301,9 @@ if [[ "$skip_whatsapp_bridge" != "1" ]]; then
 fi
 if [[ "$run_whatsapp_inbound_cache_smoke" == "1" ]]; then
   require_executable "$whatsapp_inbound_cache_verify_script" "WhatsApp inbound audio cache verifier"
+fi
+if [[ -n "$whatsapp_alpha_profile" ]]; then
+  require_executable "$whatsapp_alpha_readiness_script" "WhatsApp alpha readiness verifier"
 fi
 if [[ "$skip_hermes_config" != "1" ]]; then
   require_executable "$hermes_config_verify_script" "Hermes voice config verifier"
@@ -441,6 +465,52 @@ else
   webrtc_loopback_status="skipped"
 fi
 
+if [[ -n "$whatsapp_alpha_profile" ]]; then
+  whatsapp_alpha_args=(
+    "$whatsapp_alpha_readiness_script"
+    --voice-bin "$voice_bin"
+    --hermes-home "$hermes_home"
+    --hermes-config "$hermes_config"
+    --bridge-url "$whatsapp_bridge_url"
+    --sidecar-url "$sidecar_url"
+    --profile "$whatsapp_alpha_profile"
+    --text "$text"
+  )
+  if [[ -n "$whatsapp_audio_cache_dir" ]]; then
+    whatsapp_alpha_args+=(--whatsapp-audio-cache-dir "$whatsapp_audio_cache_dir")
+  fi
+  if [[ -n "$expected_whatsapp_agent_number" ]]; then
+    whatsapp_alpha_args+=(--expected-agent-number "$expected_whatsapp_agent_number")
+  fi
+  if [[ -n "$expected_whatsapp_agent_name" ]]; then
+    whatsapp_alpha_args+=(--expected-agent-name "$expected_whatsapp_agent_name")
+  fi
+  if [[ "$skip_systemd" == "1" ]]; then
+    whatsapp_alpha_args+=(--skip-systemd)
+  fi
+  if [[ "$skip_daemon" == "1" ]]; then
+    whatsapp_alpha_args+=(--skip-daemon)
+  elif [[ "$skip_stt_smoke" != "1" ]]; then
+    whatsapp_alpha_args+=(--run-stt-smoke)
+  fi
+  if [[ "$skip_sidecar" == "1" ]]; then
+    whatsapp_alpha_args+=(--skip-sidecar)
+  fi
+  if [[ "$skip_hermes_tts_smoke" == "1" ]]; then
+    whatsapp_alpha_args+=(--skip-hermes-tts-smoke)
+  fi
+  if [[ "$require_whatsapp_cloud" == "1" ]]; then
+    whatsapp_alpha_args+=(--require-whatsapp-cloud)
+  fi
+  if [[ "$require_whatsapp_calling" == "1" ]]; then
+    whatsapp_alpha_args+=(--require-whatsapp-calling)
+  fi
+  run_step "WhatsApp alpha readiness profile ($whatsapp_alpha_profile)" "${whatsapp_alpha_args[@]}"
+  whatsapp_alpha_status="$whatsapp_alpha_profile"
+else
+  whatsapp_alpha_status="skipped"
+fi
+
 echo
 echo "ok: local Hermes voice stack verifier passed"
 echo "voice_bin=$voice_bin"
@@ -450,5 +520,6 @@ echo "cli_mcp=$cli_mcp_status"
 echo "whatsapp_contract=checked"
 echo "whatsapp_bridge=$whatsapp_bridge_status"
 echo "whatsapp_inbound_cache=$whatsapp_inbound_cache_status"
+echo "whatsapp_alpha=$whatsapp_alpha_status"
 echo "sidecar_service=$sidecar_status"
 echo "webrtc_loopback=$webrtc_loopback_status"

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -117,6 +117,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn("cli_mcp=checked", result.stdout)
         self.assertIn("whatsapp_bridge=checked", result.stdout)
         self.assertIn("whatsapp_inbound_cache=skipped", result.stdout)
+        self.assertIn("whatsapp_alpha=skipped", result.stdout)
         self.assertIn("webrtc_loopback=skipped", result.stdout)
         self.assertEqual(
             [entry[0] for entry in entries],
@@ -231,6 +232,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn("hermes_gateway=skipped", result.stdout)
         self.assertIn("whatsapp_bridge=skipped", result.stdout)
         self.assertIn("whatsapp_inbound_cache=skipped", result.stdout)
+        self.assertIn("whatsapp_alpha=skipped", result.stdout)
         self.assertEqual([entry[0] for entry in entries], ["hermes", "cli_mcp", "whatsapp"])
         self.assertIn("--skip-tts-smoke", entries[0])
         self.assertIn("--skip-daemon", entries[1])
@@ -397,6 +399,120 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 "--run-stt",
                 "--audio-cache-dir",
                 str(audio_cache),
+            ],
+        )
+
+    def test_whatsapp_alpha_profile_runs_when_requested(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            hermes = tmp_path / "verify_hermes.py"
+            gateway = tmp_path / "verify_gateway.py"
+            cli_mcp = tmp_path / "verify_cli_mcp.py"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            bridge = tmp_path / "verify_whatsapp_bridge.py"
+            alpha = tmp_path / "verify_alpha.py"
+            sidecar = tmp_path / "verify_sidecar.py"
+            voice = tmp_path / "voice"
+            config = tmp_path / "config.yaml"
+            hermes_home = tmp_path / "hermes"
+            audio_cache = tmp_path / "audio_cache"
+
+            write_helper(hermes, "hermes", log_path)
+            write_helper(gateway, "gateway", log_path)
+            write_helper(cli_mcp, "cli_mcp", log_path)
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_helper(bridge, "bridge", log_path)
+            write_helper(alpha, "alpha", log_path)
+            write_helper(sidecar, "sidecar", log_path)
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+            config.write_text("tts: {}\n", encoding="utf-8")
+            hermes_home.mkdir()
+            audio_cache.mkdir()
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--hermes-config",
+                    str(config),
+                    "--hermes-home",
+                    str(hermes_home),
+                    "--sidecar-url",
+                    "http://127.0.0.1:9999",
+                    "--whatsapp-bridge-url",
+                    "http://127.0.0.1:3001",
+                    "--whatsapp-audio-cache-dir",
+                    str(audio_cache),
+                    "--expected-whatsapp-agent-number",
+                    "13236478455",
+                    "--expected-whatsapp-agent-name",
+                    "Quill",
+                    "--require-whatsapp-cloud",
+                    "--require-whatsapp-calling",
+                    "--skip-hermes-config",
+                    "--skip-hermes-gateway",
+                    "--skip-cli-mcp",
+                    "--skip-sidecar",
+                    "--skip-whatsapp-bridge",
+                    "--skip-systemd",
+                    "--skip-daemon",
+                    "--skip-hermes-tts-smoke",
+                    "--whatsapp-alpha-profile",
+                    "cached-receive",
+                    "--text",
+                    "Alpha stack smoke.",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "HERMES_CONFIG_VERIFY_SCRIPT": str(hermes),
+                    "HERMES_GATEWAY_VERIFY_SCRIPT": str(gateway),
+                    "CLI_MCP_SURFACE_VERIFY_SCRIPT": str(cli_mcp),
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "WHATSAPP_BRIDGE_VERIFY_SCRIPT": str(bridge),
+                    "WHATSAPP_ALPHA_READINESS_SCRIPT": str(alpha),
+                    "SIDECAR_SERVICE_VERIFY_SCRIPT": str(sidecar),
+                },
+            )
+
+            entries = command_log_entries(log_path)
+
+        self.assertIn("whatsapp_alpha=cached-receive", result.stdout)
+        self.assertEqual([entry[0] for entry in entries], ["whatsapp", "alpha"])
+        self.assertEqual(
+            entries[1],
+            [
+                "alpha",
+                "--voice-bin",
+                str(voice),
+                "--hermes-home",
+                str(hermes_home),
+                "--hermes-config",
+                str(config),
+                "--bridge-url",
+                "http://127.0.0.1:3001",
+                "--sidecar-url",
+                "http://127.0.0.1:9999",
+                "--profile",
+                "cached-receive",
+                "--text",
+                "Alpha stack smoke.",
+                "--whatsapp-audio-cache-dir",
+                str(audio_cache),
+                "--expected-agent-number",
+                "13236478455",
+                "--expected-agent-name",
+                "Quill",
+                "--skip-systemd",
+                "--skip-daemon",
+                "--skip-sidecar",
+                "--skip-hermes-tts-smoke",
+                "--require-whatsapp-cloud",
+                "--require-whatsapp-calling",
             ],
         )
 


### PR DESCRIPTION
## Summary
- add `--whatsapp-alpha-profile` to `verify_local_hermes_voice_stack.sh` so the release gate can invoke the categorized WhatsApp alpha readiness profiles
- pass through Hermes, bridge, sidecar, cache, expected identity, daemon, STT, and Meta credential flags to the alpha report
- document the stack-gate alpha profiles and warn which profiles send or drain real WhatsApp messages

## Verification
- `bash -n scripts/verify_local_hermes_voice_stack.sh`
- `python3 -m unittest tests.test_verify_local_hermes_voice_stack`
- `python3 -m unittest tests.test_verify_whatsapp_alpha_readiness`
- `python3 -m unittest discover -s tests`
- `scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --whatsapp-alpha-profile unattended`