### PR TITLE
Add non-draining WhatsApp receive watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,10 +401,12 @@ daemon and sidecar by default. For narrower checks, run
 `scripts/verify_webrtc_sidecar_service.py` directly.
 
 To include the categorized WhatsApp alpha report in the same command, add
-`--whatsapp-alpha-profile unattended`, `cached-receive`, `send`, or
-`attended-send-receive`. The `send` and `attended-send-receive` profiles perform
-real bridge operations, and `attended-send-receive` drains the bridge message
-queue while waiting for a fresh inbound voice note.
+`--whatsapp-alpha-profile unattended`, `cached-receive`, `send`,
+`attended-cache-receive`, or `attended-send-receive`. The `send` and attended
+profiles perform real bridge operations. Prefer `attended-cache-receive` when
+Hermes is already watching the bridge; it waits for a fresh `aud_*` cache
+artifact without draining queued messages. Use `attended-send-receive` only when
+the verifier itself should poll and drain the bridge message queue.
 
 When the WebRTC Python dependencies are installed, add
 `--run-webrtc-loopback-smoke --webrtc-python /tmp/voice-webrtc-venv/bin/python`

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -83,10 +83,12 @@ scripts/verify_local_hermes_voice_stack.sh \
 ```
 
 Use `--whatsapp-alpha-profile send` only when it is acceptable to post a real
-voice note through the paired bridge. Use
-`--whatsapp-alpha-profile attended-send-receive` only during an attended test;
-that profile waits for fresh inbound audio and drains the bridge `/messages`
-queue.
+voice note through the paired bridge. Prefer
+`--whatsapp-alpha-profile attended-cache-receive` for an attended receive test
+while Hermes is already running; it watches `~/.hermes/audio_cache` for a fresh
+`aud_*` artifact and does not drain the bridge queue. Use
+`--whatsapp-alpha-profile attended-send-receive` only when the verifier itself
+should poll and drain the bridge `/messages` queue.
 
 For a categorized alpha-readiness report, use:
 
@@ -100,9 +102,9 @@ voice-note, live-call local sidecar, or external Meta setup. Use
 `--require-whatsapp-calling` when a host is expected to be ready for real Cloud
 Calling; otherwise missing Meta credentials are reported as external setup
 still required, not as a local Baileys voice-note failure. The named profiles
-are `unattended`, `cached-receive`, `send`, and `attended-send-receive`. Use
-`cached-receive` when the report should also replay a cached inbound WhatsApp
-voice note through `voice stream-transcribe`:
+are `unattended`, `cached-receive`, `send`, `attended-cache-receive`, and
+`attended-send-receive`. Use `cached-receive` when the report should also
+replay a cached inbound WhatsApp voice note through `voice stream-transcribe`:
 
 ```bash
 scripts/verify_whatsapp_alpha_readiness.py \
@@ -128,7 +130,19 @@ scripts/verify_whatsapp_alpha_readiness.py \
   --profile send
 ```
 
-For a full attended send/receive pass, use the guarded receive profile:
+For a full attended send/receive pass while Hermes is already watching the
+bridge, use the cache-watching guarded receive profile:
+
+```bash
+scripts/verify_whatsapp_alpha_readiness.py \
+  --hermes-home ~/.hermes \
+  --profile attended-cache-receive
+```
+
+That profile sends a real voice note, then watches the Hermes audio cache for a
+fresh inbound `aud_*` file without polling the bridge message queue. If Hermes
+is not running and the verifier itself must consume bridge events, use the
+draining profile instead:
 
 ```bash
 scripts/verify_whatsapp_alpha_readiness.py \
@@ -187,6 +201,17 @@ same receive-side smoke behind an explicit opt-in:
 scripts/verify_local_hermes_voice_stack.sh \
   --hermes-home ~/.hermes \
   --run-whatsapp-inbound-cache-smoke
+```
+
+For attended fresh receive without draining bridge messages, use the cache
+watch mode:
+
+```bash
+scripts/verify_whatsapp_inbound_audio_cache.py \
+  --hermes-home ~/.hermes \
+  --wait-fresh-seconds 60 \
+  --require-fresh-audio \
+  --run-stt
 ```
 
 Cloud/Calling readiness requires these external Meta settings in addition to

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -82,7 +82,8 @@ Options:
                                transcribe a bridge-downloaded aud_* file from the audio cache
   --whatsapp-alpha-profile PROFILE
                                run categorized alpha readiness profile:
-                               unattended, cached-receive, send, attended-send-receive
+                               unattended, cached-receive, send,
+                               attended-cache-receive, attended-send-receive
   --run-webrtc-loopback-smoke  run one local full-duplex WebRTC media turn
   --webrtc-python PATH         Python used for the WebRTC smoke (default: python3)
   --webrtc-timeout SECONDS     timeout passed to the WebRTC smoke (default: 60)
@@ -280,7 +281,7 @@ done
 
 if [[ -n "$whatsapp_alpha_profile" ]]; then
   case "$whatsapp_alpha_profile" in
-    unattended|cached-receive|send|attended-send-receive)
+    unattended|cached-receive|send|attended-cache-receive|attended-send-receive)
       ;;
     *)
       fail "unknown WhatsApp alpha profile: $whatsapp_alpha_profile"

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -19,6 +19,7 @@ PROFILE_CHOICES = (
     "unattended",
     "cached-receive",
     "send",
+    "attended-cache-receive",
     "attended-send-receive",
 )
 
@@ -294,6 +295,7 @@ def build_components(args: argparse.Namespace) -> list[dict[str, Any]]:
         )
 
     if args.run_inbound_cache_smoke:
+        inbound_name = "whatsapp_inbound_cache_stt"
         inbound_cmd = [
             script_path("verify_whatsapp_inbound_audio_cache.py"),
             "--voice-bin",
@@ -306,12 +308,17 @@ def build_components(args: argparse.Namespace) -> list[dict[str, Any]]:
         ]
         if args.whatsapp_audio_cache_dir:
             inbound_cmd.extend(["--audio-cache-dir", str(args.whatsapp_audio_cache_dir)])
+        if args.wait_audio_cache_seconds > 0:
+            inbound_name = "whatsapp_inbound_cache_fresh_stt"
+            inbound_cmd.extend(["--wait-fresh-seconds", str(args.wait_audio_cache_seconds)])
+            if args.require_fresh_cache_audio:
+                inbound_cmd.append("--require-fresh-audio")
         components.append(
             component(
-                name="whatsapp_inbound_cache_stt",
+                name=inbound_name,
                 category="voice_note",
                 command=inbound_cmd,
-                timeout=args.stt_timeout,
+                timeout=args.stt_timeout + args.wait_audio_cache_seconds + args.timeout,
                 parse_json=True,
             )
         )
@@ -404,6 +411,30 @@ def attended_receive_gate(
             gate["reason"] = "fresh receive verifier failed"
             gate["failures"] = item.get("failures") or []
         break
+    else:
+        for item in components:
+            if item["name"] != "whatsapp_inbound_cache_fresh_stt":
+                continue
+            summary = item.get("summary") or {}
+            checks = summary.get("checks") or {}
+            fresh_watch = checks.get("fresh_watch") or {}
+            fresh_files = fresh_watch.get("fresh_files") or []
+            gate["component"] = item["name"]
+            gate["drains_bridge_messages"] = False
+            if item.get("success") and fresh_files:
+                gate["status"] = "verified"
+                gate["requires_operator"] = False
+                gate["reason"] = "fresh WhatsApp inbound audio cache artifact observed"
+                gate["fresh_files"] = len(fresh_files)
+            elif item.get("success"):
+                gate["status"] = "not_verified"
+                gate["reason"] = "audio cache watch completed without fresh audio evidence"
+                gate["fresh_files"] = len(fresh_files)
+            else:
+                gate["status"] = "failed"
+                gate["reason"] = "fresh audio cache receive verifier failed"
+                gate["failures"] = item.get("failures") or []
+            break
     return gate
 
 
@@ -518,7 +549,8 @@ def build_parser() -> argparse.ArgumentParser:
         default="unattended",
         help=(
             "named readiness profile: unattended dry run, cached receive STT, "
-            "real send, or attended send/receive"
+            "real send, non-draining attended cache receive, or attended "
+            "bridge send/receive"
         ),
     )
     parser.add_argument("--voice-bin", default=default_voice_bin())
@@ -564,6 +596,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--run-stt-smoke", action="store_true")
     parser.add_argument("--run-inbound-cache-smoke", action="store_true")
+    parser.add_argument("--wait-audio-cache-seconds", type=float, default=0.0)
+    parser.add_argument("--require-fresh-cache-audio", action="store_true")
     parser.add_argument("--require-whatsapp-cloud", action="store_true")
     parser.add_argument("--require-whatsapp-calling", action="store_true")
     parser.add_argument("--json", action="store_true")
@@ -575,6 +609,12 @@ def apply_profile(args: argparse.Namespace) -> None:
         args.run_inbound_cache_smoke = True
     elif args.profile == "send":
         args.send_voice_note = True
+    elif args.profile == "attended-cache-receive":
+        args.send_voice_note = True
+        args.run_inbound_cache_smoke = True
+        if args.wait_audio_cache_seconds == 0:
+            args.wait_audio_cache_seconds = 60.0
+        args.require_fresh_cache_audio = True
     elif args.profile == "attended-send-receive":
         args.send_voice_note = True
         if args.wait_inbound_seconds == 0:
@@ -597,10 +637,16 @@ def validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> 
         )
     if args.wait_inbound_seconds < 0:
         parser.error("--wait-inbound-seconds must be non-negative")
+    if args.wait_audio_cache_seconds < 0:
+        parser.error("--wait-audio-cache-seconds must be non-negative")
     if args.voice_note_chat_id and not args.send_voice_note:
         parser.error("--voice-note-chat-id requires --send-voice-note")
     if args.require_inbound_audio and args.wait_inbound_seconds <= 0:
         parser.error("--require-inbound-audio requires --wait-inbound-seconds")
+    if args.require_fresh_cache_audio and args.wait_audio_cache_seconds <= 0:
+        parser.error(
+            "--require-fresh-cache-audio requires --wait-audio-cache-seconds"
+        )
     if args.drain_bridge_messages and args.wait_inbound_seconds <= 0:
         parser.error("--drain-bridge-messages requires --wait-inbound-seconds")
     if args.wait_inbound_seconds > 0 and not args.drain_bridge_messages:

--- a/scripts/verify_whatsapp_inbound_audio_cache.py
+++ b/scripts/verify_whatsapp_inbound_audio_cache.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import shutil
 import subprocess
 import sys
+import time
 from typing import Any
 
 
@@ -66,6 +67,54 @@ def discover_audio_files(audio_cache_dir: Path) -> list[Path]:
         and path.suffix.lower() in {".ogg", ".opus", ".m4a"}
     ]
     return sorted(files, key=lambda path: path.stat().st_mtime, reverse=True)
+
+
+def audio_file_signature(path: Path) -> tuple[int, int] | None:
+    try:
+        stat = path.stat()
+    except FileNotFoundError:
+        return None
+    return (stat.st_size, stat.st_mtime_ns)
+
+
+def audio_file_snapshot(paths: list[Path]) -> dict[Path, tuple[int, int]]:
+    snapshot: dict[Path, tuple[int, int]] = {}
+    for path in paths:
+        signature = audio_file_signature(path)
+        if signature is not None:
+            snapshot[path.resolve()] = signature
+    return snapshot
+
+
+def fresh_audio_files(
+    paths: list[Path],
+    *,
+    baseline: dict[Path, tuple[int, int]],
+) -> list[Path]:
+    fresh: list[Path] = []
+    for path in paths:
+        signature = audio_file_signature(path)
+        if signature is None:
+            continue
+        if baseline.get(path.resolve()) != signature:
+            fresh.append(path)
+    return fresh
+
+
+def wait_for_fresh_audio_files(
+    audio_cache_dir: Path,
+    *,
+    baseline: dict[Path, tuple[int, int]],
+    wait_seconds: float,
+) -> tuple[list[Path], list[Path]]:
+    deadline = time.monotonic() + wait_seconds
+    discovered = discover_audio_files(audio_cache_dir)
+    fresh = fresh_audio_files(discovered, baseline=baseline)
+    while not fresh and time.monotonic() < deadline:
+        time.sleep(min(1.0, max(0.1, deadline - time.monotonic())))
+        discovered = discover_audio_files(audio_cache_dir)
+        fresh = fresh_audio_files(discovered, baseline=baseline)
+    return fresh, discovered
 
 
 def probe_audio(path: Path, *, timeout: float, skip_ffprobe: bool) -> tuple[dict[str, Any], list[str]]:
@@ -194,16 +243,42 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
 
     failures: list[str] = []
     warnings: list[str] = []
+    if args.wait_fresh_seconds < 0:
+        failures.append("--wait-fresh-seconds must be non-negative")
+    if args.require_fresh_audio and args.wait_fresh_seconds <= 0:
+        failures.append("--require-fresh-audio requires --wait-fresh-seconds")
+
     selected_files: list[Path]
     discovered = discover_audio_files(audio_cache_dir)
+    baseline = audio_file_snapshot(discovered)
+    fresh_files: list[Path] = []
+
+    if args.wait_fresh_seconds > 0 and not failures:
+        fresh_files, discovered = wait_for_fresh_audio_files(
+            audio_cache_dir,
+            baseline=baseline,
+            wait_seconds=args.wait_fresh_seconds,
+        )
+
     if args.audio_file:
         selected_files = [path.expanduser().resolve() for path in args.audio_file]
+    elif args.wait_fresh_seconds > 0:
+        if fresh_files or args.require_fresh_audio:
+            selected_files = fresh_files[: args.max_files]
+        else:
+            selected_files = discovered[: args.max_files]
     else:
         selected_files = discovered[: args.max_files]
 
     if not selected_files:
-        message = f"no bridge-downloaded inbound audio files found in {audio_cache_dir}"
-        if args.require_cache:
+        if args.wait_fresh_seconds > 0 and args.require_fresh_audio:
+            message = (
+                "no fresh bridge-downloaded inbound audio files found in "
+                f"{audio_cache_dir} during {args.wait_fresh_seconds}s watch"
+            )
+        else:
+            message = f"no bridge-downloaded inbound audio files found in {audio_cache_dir}"
+        if args.require_cache or args.require_fresh_audio:
             failures.append(message)
         else:
             warnings.append(message)
@@ -214,6 +289,14 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         "voice_bin": voice_bin,
         "discovered_count": len(discovered),
         "selected_files": [str(path) for path in selected_files],
+        "fresh_watch": {
+            "wait_seconds": args.wait_fresh_seconds,
+            "drains_bridge_messages": False,
+            "baseline_count": len(baseline),
+            "fresh_count": len(fresh_files),
+            "fresh_files": [str(path) for path in fresh_files],
+            "skipped": args.wait_fresh_seconds <= 0,
+        },
         "audio": [],
     }
 
@@ -258,6 +341,17 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--audio-file", type=Path, action="append", default=None)
     parser.add_argument("--max-files", type=int, default=1)
     parser.add_argument("--require-cache", action="store_true")
+    parser.add_argument(
+        "--wait-fresh-seconds",
+        type=float,
+        default=0.0,
+        help="watch the audio cache for a new or updated aud_* file without polling the bridge",
+    )
+    parser.add_argument(
+        "--require-fresh-audio",
+        action="store_true",
+        help="fail unless --wait-fresh-seconds observes a fresh inbound audio artifact",
+    )
     parser.add_argument("--run-stt", action="store_true")
     parser.add_argument("--skip-ffprobe", action="store_true")
     parser.add_argument("--timeout", type=float, default=15.0)
@@ -277,6 +371,14 @@ def human_summary(result: dict[str, Any]) -> None:
 
     print(f"audio_cache_dir={checks['audio_cache_dir']}")
     print(f"discovered_count={checks['discovered_count']}")
+    fresh = checks.get("fresh_watch") or {}
+    if not fresh.get("skipped"):
+        print(
+            "fresh_watch="
+            f"fresh_count={fresh.get('fresh_count')} "
+            f"wait_seconds={fresh.get('wait_seconds')} "
+            f"drains_messages={fresh.get('drains_bridge_messages')}"
+        )
     for index, audio in enumerate(checks["audio"], start=1):
         probe = audio.get("probe") or {}
         stream = ((probe.get("ffprobe") or {}).get("stream") or {})

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -44,6 +44,7 @@ def write_fake_helpers(
     *,
     cloud_configured: bool = False,
     voice_note_payload: dict | None = None,
+    inbound_cache_payload: dict | None = None,
 ) -> None:
     ok_shell(directory / "verify_hermes_voice_config.py")
     ok_shell(directory / "verify_whatsapp_voice_contract.sh")
@@ -55,7 +56,10 @@ def write_fake_helpers(
         directory / "verify_whatsapp_voice_note_bridge.py",
         voice_note_payload or success_payload,
     )
-    json_script(directory / "verify_whatsapp_inbound_audio_cache.py", success_payload)
+    json_script(
+        directory / "verify_whatsapp_inbound_audio_cache.py",
+        inbound_cache_payload or success_payload,
+    )
 
     cloud_missing = [] if cloud_configured else [
         "WHATSAPP_CLOUD_PHONE_NUMBER_ID",
@@ -94,10 +98,15 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         *args: str,
         skip_voice_note_smoke: bool = True,
         voice_note_payload: dict | None = None,
+        inbound_cache_payload: dict | None = None,
     ) -> dict:
         helpers = tmp_path / "helpers"
         helpers.mkdir()
-        write_fake_helpers(helpers, voice_note_payload=voice_note_payload)
+        write_fake_helpers(
+            helpers,
+            voice_note_payload=voice_note_payload,
+            inbound_cache_payload=inbound_cache_payload,
+        )
         voice = tmp_path / "voice"
         write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
         config = tmp_path / "config.yaml"
@@ -260,6 +269,41 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertIn("--require-inbound-audio", command)
         self.assertIn("--drain-bridge-messages", command)
 
+    def test_attended_cache_receive_profile_watches_cache_without_draining_bridge(self):
+        inbound_cache_payload = {
+            "success": True,
+            "checks": {
+                "fresh_watch": {
+                    "drains_bridge_messages": False,
+                    "fresh_files": ["/tmp/aud_fresh.ogg"],
+                    "fresh_count": 1,
+                }
+            },
+            "failures": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = self.run_readiness(
+                Path(tmp),
+                "--profile",
+                "attended-cache-receive",
+                skip_voice_note_smoke=False,
+                inbound_cache_payload=inbound_cache_payload,
+            )
+
+        self.assertEqual(payload["profile"], "attended-cache-receive")
+        components = {item["name"]: item for item in payload["components"]}
+        self.assertIn("whatsapp_voice_note_send", components)
+        self.assertIn("whatsapp_inbound_cache_fresh_stt", components)
+        command = components["whatsapp_inbound_cache_fresh_stt"]["command"]
+        self.assertIn("--wait-fresh-seconds", command)
+        self.assertIn("60.0", command)
+        self.assertIn("--require-fresh-audio", command)
+        gate = payload["pending_gates"]["attended_fresh_receive"]
+        self.assertEqual(gate["status"], "verified")
+        self.assertEqual(gate["component"], "whatsapp_inbound_cache_fresh_stt")
+        self.assertFalse(gate["drains_bridge_messages"])
+        self.assertFalse(gate["requires_operator"])
+
     def test_verified_attended_receive_gate_requires_audio_event_evidence(self):
         voice_note_payload = {
             "success": True,
@@ -317,6 +361,15 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertEqual(result.returncode, 2)
         self.assertIn(
             "--require-inbound-audio requires --wait-inbound-seconds",
+            result.stderr,
+        )
+
+    def test_require_fresh_cache_audio_requires_wait_window(self):
+        result = self.run_invalid("--require-fresh-cache-audio")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn(
+            "--require-fresh-cache-audio requires --wait-audio-cache-seconds",
             result.stderr,
         )
 

--- a/tests/test_verify_whatsapp_inbound_audio_cache.py
+++ b/tests/test_verify_whatsapp_inbound_audio_cache.py
@@ -5,7 +5,9 @@ import importlib.util
 from pathlib import Path
 import sys
 import tempfile
+import threading
 import textwrap
+import time
 import unittest
 
 
@@ -55,6 +57,8 @@ def make_args(tmp_path: Path, **overrides):
         "audio_file": None,
         "max_files": 1,
         "require_cache": False,
+        "wait_fresh_seconds": 0.0,
+        "require_fresh_audio": False,
         "run_stt": False,
         "skip_ffprobe": True,
         "timeout": 1.0,
@@ -114,6 +118,66 @@ class WhatsAppInboundAudioCacheVerifierTests(unittest.TestCase):
 
         self.assertFalse(result["success"])
         self.assertIn("no bridge-downloaded inbound audio", "\n".join(result["failures"]))
+
+    def test_wait_fresh_audio_selects_new_cache_artifact_without_draining_bridge(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(
+                tmp_path,
+                wait_fresh_seconds=1.0,
+                require_fresh_audio=True,
+                run_stt=True,
+            )
+            audio = args.hermes_home / "audio_cache" / "aud_fresh.ogg"
+
+            def create_audio() -> None:
+                time.sleep(0.05)
+                write_audio(audio)
+
+            thread = threading.Thread(target=create_audio)
+            thread.start()
+            try:
+                result = self.script.verify(args)
+            finally:
+                thread.join()
+
+        self.assertTrue(result["success"], result["failures"])
+        fresh = result["checks"]["fresh_watch"]
+        self.assertEqual(fresh["fresh_count"], 1)
+        self.assertFalse(fresh["drains_bridge_messages"])
+        self.assertTrue(result["checks"]["selected_files"][0].endswith("aud_fresh.ogg"))
+        terminal = result["checks"]["audio"][0]["stt"]["terminal_event"]
+        self.assertEqual(terminal["event"], "stt.transcribed")
+
+    def test_optional_fresh_watch_falls_back_to_existing_cached_audio(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(
+                tmp_path,
+                wait_fresh_seconds=0.01,
+                require_cache=True,
+            )
+            write_audio(args.hermes_home / "audio_cache" / "aud_existing.ogg")
+
+            result = self.script.verify(args)
+
+        self.assertTrue(result["success"], result["failures"])
+        fresh = result["checks"]["fresh_watch"]
+        self.assertEqual(fresh["fresh_count"], 0)
+        self.assertFalse(fresh["drains_bridge_messages"])
+        self.assertTrue(result["checks"]["selected_files"][0].endswith("aud_existing.ogg"))
+
+    def test_require_fresh_audio_requires_wait_window(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self.script.verify(
+                make_args(Path(tmp), require_fresh_audio=True)
+            )
+
+        self.assertFalse(result["success"])
+        self.assertIn(
+            "--require-fresh-audio requires --wait-fresh-seconds",
+            "\n".join(result["failures"]),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a fresh audio-cache watch to `verify_whatsapp_inbound_audio_cache.py` so attended receive can observe new `aud_*` artifacts without polling `/messages`
- add `attended-cache-receive` to WhatsApp alpha readiness and stack-gate profile choices
- mark attended receive verified only when the cache watch reports fresh file evidence; keep the existing queue-draining profile available for diagnostics
- document when to use cache watching versus bridge queue draining

## Verification
- `python3 -m unittest tests.test_verify_whatsapp_inbound_audio_cache tests.test_verify_whatsapp_alpha_readiness`
- `python3 -m unittest discover -s tests`
- `python3 -m py_compile scripts/verify_whatsapp_inbound_audio_cache.py scripts/verify_whatsapp_alpha_readiness.py`
- `bash -n scripts/verify_local_hermes_voice_stack.sh`
- `scripts/verify_whatsapp_inbound_audio_cache.py --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --wait-fresh-seconds 0.1 --run-stt --json`
- `scripts/verify_whatsapp_alpha_readiness.py --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --skip-voice-note-smoke --run-inbound-cache-smoke --wait-audio-cache-seconds 0.1`