### PR TITLE
Prefer non-draining WhatsApp receive gate

### DIFF
--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -374,17 +374,21 @@ def attended_receive_gate(
         "component": None,
         "cached_receive_verified": cached_receive_verified,
         "requires_operator": True,
-        "drains_bridge_messages": True,
+        "drains_bridge_messages": False,
         "reason": "fresh WhatsApp inbound voice-note receive has not been run",
         "command": [
             "scripts/verify_whatsapp_alpha_readiness.py",
             "--hermes-home",
             str(hermes_home),
-            "--send-voice-note",
-            "--wait-inbound-seconds",
-            "60",
-            "--require-inbound-audio",
-            "--drain-bridge-messages",
+            "--profile",
+            "attended-cache-receive",
+        ],
+        "fallback_draining_command": [
+            "scripts/verify_whatsapp_alpha_readiness.py",
+            "--hermes-home",
+            str(hermes_home),
+            "--profile",
+            "attended-send-receive",
         ],
     }
 

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -156,6 +156,15 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             gates["attended_fresh_receive"]["status"],
             "pending_attended",
         )
+        self.assertFalse(gates["attended_fresh_receive"]["drains_bridge_messages"])
+        self.assertIn(
+            "attended-cache-receive",
+            gates["attended_fresh_receive"]["command"],
+        )
+        self.assertIn(
+            "attended-send-receive",
+            gates["attended_fresh_receive"]["fallback_draining_command"],
+        )
         self.assertEqual(
             gates["whatsapp_cloud_calling"]["status"],
             "external_setup_required",


### PR DESCRIPTION
## Summary
- update the default attended receive pending gate to recommend `--profile attended-cache-receive`
- keep the queue-draining `attended-send-receive` command as an explicit fallback diagnostic
- add a regression assertion so the pending gate does not regress to draining by default

## Verification
- `python3 -m unittest tests.test_verify_whatsapp_alpha_readiness`
- `python3 -m unittest discover -s tests`
- `python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py`
- live JSON check confirmed `pending_gates.attended_fresh_receive.command` uses `attended-cache-receive` and `drains_bridge_messages=false`