### PR TITLE
Expose WhatsApp alpha stack overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,10 @@ To include the categorized WhatsApp alpha report in the same command, add
 profiles perform real bridge operations. Prefer `attended-cache-receive` when
 Hermes is already watching the bridge; it waits for a fresh `aud_*` cache
 artifact without draining queued messages. Use `attended-send-receive` only when
-the verifier itself should poll and drain the bridge message queue.
+the verifier itself should poll and drain the bridge message queue. Add
+`--whatsapp-alpha-chat-id` to override `WHATSAPP_HOME_CHANNEL`, or adjust the
+attended wait with `--whatsapp-alpha-wait-audio-cache-seconds` /
+`--whatsapp-alpha-wait-inbound-seconds`.
 
 When the WebRTC Python dependencies are installed, add
 `--run-webrtc-loopback-smoke --webrtc-python /tmp/voice-webrtc-venv/bin/python`

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -88,7 +88,10 @@ voice note through the paired bridge. Prefer
 while Hermes is already running; it watches `~/.hermes/audio_cache` for a fresh
 `aud_*` artifact and does not drain the bridge queue. Use
 `--whatsapp-alpha-profile attended-send-receive` only when the verifier itself
-should poll and drain the bridge `/messages` queue.
+should poll and drain the bridge `/messages` queue. The stack gate also accepts
+`--whatsapp-alpha-chat-id`, `--whatsapp-alpha-wait-audio-cache-seconds`, and
+`--whatsapp-alpha-wait-inbound-seconds` so attended tests do not need to drop
+down to the lower-level alpha script.
 
 For a categorized alpha-readiness report, use:
 

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -19,6 +19,9 @@ skip_daemon="${SKIP_DAEMON:-0}"
 skip_stt_smoke="${SKIP_STT_SMOKE:-0}"
 run_whatsapp_inbound_cache_smoke="${RUN_WHATSAPP_INBOUND_CACHE_SMOKE:-0}"
 whatsapp_alpha_profile="${WHATSAPP_ALPHA_PROFILE:-}"
+whatsapp_alpha_voice_note_chat_id="${WHATSAPP_ALPHA_VOICE_NOTE_CHAT_ID:-}"
+whatsapp_alpha_wait_audio_cache_seconds="${WHATSAPP_ALPHA_WAIT_AUDIO_CACHE_SECONDS:-}"
+whatsapp_alpha_wait_inbound_seconds="${WHATSAPP_ALPHA_WAIT_INBOUND_SECONDS:-}"
 run_webrtc_loopback_smoke="${RUN_WEBRTC_LOOPBACK_SMOKE:-0}"
 webrtc_python="${VOICE_WEBRTC_PYTHON:-python3}"
 webrtc_timeout="${VOICE_WEBRTC_TIMEOUT:-60}"
@@ -84,6 +87,11 @@ Options:
                                run categorized alpha readiness profile:
                                unattended, cached-receive, send,
                                attended-cache-receive, attended-send-receive
+  --whatsapp-alpha-chat-id ID  override WHATSAPP_HOME_CHANNEL for alpha sends
+  --whatsapp-alpha-wait-audio-cache-seconds SECONDS
+                               override attended-cache-receive cache watch time
+  --whatsapp-alpha-wait-inbound-seconds SECONDS
+                               override attended-send-receive bridge poll time
   --run-webrtc-loopback-smoke  run one local full-duplex WebRTC media turn
   --webrtc-python PATH         Python used for the WebRTC smoke (default: python3)
   --webrtc-timeout SECONDS     timeout passed to the WebRTC smoke (default: 60)
@@ -99,6 +107,8 @@ Environment aliases:
   WHATSAPP_AUDIO_CACHE_DIR, WHATSAPP_AGENT_NUMBER, WHATSAPP_AGENT_NAME
   REQUIRE_WHATSAPP_CLOUD=1, REQUIRE_WHATSAPP_CALLING=1
   RUN_WHATSAPP_INBOUND_CACHE_SMOKE=1, WHATSAPP_ALPHA_PROFILE
+  WHATSAPP_ALPHA_VOICE_NOTE_CHAT_ID, WHATSAPP_ALPHA_WAIT_AUDIO_CACHE_SECONDS
+  WHATSAPP_ALPHA_WAIT_INBOUND_SECONDS
   VOICE_WEBRTC_PYTHON, VOICE_WEBRTC_TIMEOUT
 EOF
 }
@@ -248,6 +258,21 @@ while [[ $# -gt 0 ]]; do
     --whatsapp-alpha-profile)
       [[ $# -ge 2 ]] || fail "--whatsapp-alpha-profile requires a profile"
       whatsapp_alpha_profile="$2"
+      shift 2
+      ;;
+    --whatsapp-alpha-chat-id)
+      [[ $# -ge 2 ]] || fail "--whatsapp-alpha-chat-id requires a chat id"
+      whatsapp_alpha_voice_note_chat_id="$2"
+      shift 2
+      ;;
+    --whatsapp-alpha-wait-audio-cache-seconds)
+      [[ $# -ge 2 ]] || fail "--whatsapp-alpha-wait-audio-cache-seconds requires a value"
+      whatsapp_alpha_wait_audio_cache_seconds="$2"
+      shift 2
+      ;;
+    --whatsapp-alpha-wait-inbound-seconds)
+      [[ $# -ge 2 ]] || fail "--whatsapp-alpha-wait-inbound-seconds requires a value"
+      whatsapp_alpha_wait_inbound_seconds="$2"
       shift 2
       ;;
     --run-webrtc-loopback-smoke)
@@ -479,6 +504,15 @@ if [[ -n "$whatsapp_alpha_profile" ]]; then
   )
   if [[ -n "$whatsapp_audio_cache_dir" ]]; then
     whatsapp_alpha_args+=(--whatsapp-audio-cache-dir "$whatsapp_audio_cache_dir")
+  fi
+  if [[ -n "$whatsapp_alpha_voice_note_chat_id" ]]; then
+    whatsapp_alpha_args+=(--voice-note-chat-id "$whatsapp_alpha_voice_note_chat_id")
+  fi
+  if [[ -n "$whatsapp_alpha_wait_audio_cache_seconds" ]]; then
+    whatsapp_alpha_args+=(--wait-audio-cache-seconds "$whatsapp_alpha_wait_audio_cache_seconds")
+  fi
+  if [[ -n "$whatsapp_alpha_wait_inbound_seconds" ]]; then
+    whatsapp_alpha_args+=(--wait-inbound-seconds "$whatsapp_alpha_wait_inbound_seconds")
   fi
   if [[ -n "$expected_whatsapp_agent_number" ]]; then
     whatsapp_alpha_args+=(--expected-agent-number "$expected_whatsapp_agent_number")

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -460,7 +460,13 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                     "--skip-daemon",
                     "--skip-hermes-tts-smoke",
                     "--whatsapp-alpha-profile",
-                    "cached-receive",
+                    "attended-cache-receive",
+                    "--whatsapp-alpha-chat-id",
+                    "20530681934008@lid",
+                    "--whatsapp-alpha-wait-audio-cache-seconds",
+                    "7.5",
+                    "--whatsapp-alpha-wait-inbound-seconds",
+                    "8.5",
                     "--text",
                     "Alpha stack smoke.",
                 ],
@@ -481,7 +487,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
 
             entries = command_log_entries(log_path)
 
-        self.assertIn("whatsapp_alpha=cached-receive", result.stdout)
+        self.assertIn("whatsapp_alpha=attended-cache-receive", result.stdout)
         self.assertEqual([entry[0] for entry in entries], ["whatsapp", "alpha"])
         self.assertEqual(
             entries[1],
@@ -498,11 +504,17 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 "--sidecar-url",
                 "http://127.0.0.1:9999",
                 "--profile",
-                "cached-receive",
+                "attended-cache-receive",
                 "--text",
                 "Alpha stack smoke.",
                 "--whatsapp-audio-cache-dir",
                 str(audio_cache),
+                "--voice-note-chat-id",
+                "20530681934008@lid",
+                "--wait-audio-cache-seconds",
+                "7.5",
+                "--wait-inbound-seconds",
+                "8.5",
                 "--expected-agent-number",
                 "13236478455",
                 "--expected-agent-name",


### PR DESCRIPTION
## Summary
- add stack-gate pass-throughs for alpha voice-note chat id and attended wait windows
- document how to override `WHATSAPP_HOME_CHANNEL` and cache/bridge receive wait durations from the aggregate verifier
- extend the stack verifier unit test to assert the alpha arguments are forwarded

## Verification
- `bash -n scripts/verify_local_hermes_voice_stack.sh`
- `python3 -m unittest tests.test_verify_local_hermes_voice_stack`
- `python3 -m unittest discover -s tests`
- `scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --whatsapp-alpha-profile cached-receive --whatsapp-alpha-wait-audio-cache-seconds 0.1`