### PR TITLE
Show WhatsApp alpha next-step commands

### DIFF
--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 from pathlib import Path
+import shlex
 import shutil
 import subprocess
 import sys
@@ -683,6 +684,19 @@ def human_summary(result: dict[str, Any]) -> None:
             f"{attended.get('status')} cached_receive_verified="
             f"{attended.get('cached_receive_verified')}"
         )
+        if attended.get("status") != "verified":
+            command = attended.get("command") or []
+            fallback = attended.get("fallback_draining_command") or []
+            if command:
+                print(
+                    "attended_fresh_receive_command="
+                    f"{shlex.join([str(part) for part in command])}"
+                )
+            if fallback:
+                print(
+                    "attended_fresh_receive_fallback_draining_command="
+                    f"{shlex.join([str(part) for part in fallback])}"
+                )
     print(
         "whatsapp_cloud="
         + ("configured" if external["cloud_configured"] else "not_configured")

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -174,6 +174,52 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             gates["whatsapp_cloud_calling"]["missing"],
         )
 
+    def test_human_summary_prints_non_draining_attended_next_step(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            helpers = tmp_path / "helpers"
+            helpers.mkdir()
+            write_fake_helpers(helpers)
+            voice = tmp_path / "voice"
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+            config = tmp_path / "config.yaml"
+            config.write_text("tts: {}\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--hermes-home",
+                    str(tmp_path / "hermes"),
+                    "--hermes-config",
+                    str(config),
+                    "--skip-systemd",
+                    "--skip-daemon",
+                    "--skip-sidecar",
+                    "--skip-voice-note-smoke",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                env={
+                    **os.environ,
+                    "VOICE_READINESS_SCRIPT_DIR": str(helpers),
+                },
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            "attended_fresh_receive_command=scripts/verify_whatsapp_alpha_readiness.py",
+            result.stdout,
+        )
+        self.assertIn("--profile attended-cache-receive", result.stdout)
+        self.assertIn(
+            "attended_fresh_receive_fallback_draining_command=",
+            result.stdout,
+        )
+        self.assertIn("--profile attended-send-receive", result.stdout)
+
     def test_inbound_cache_smoke_adds_receive_component(self):
         with tempfile.TemporaryDirectory() as tmp:
             payload = self.run_readiness(


### PR DESCRIPTION
## Summary
- print the recommended attended fresh-receive command in the human alpha readiness report
- include the explicit queue-draining fallback command when fresh receive remains pending
- cover the human output so the operator-facing next step stays visible

## Verification
- `python3 -m unittest tests.test_verify_whatsapp_alpha_readiness`
- `python3 -m unittest discover -s tests`
- `python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py`
- `scripts/verify_whatsapp_alpha_readiness.py --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --skip-voice-note-smoke --skip-sidecar | sed -n '/attended_fresh_receive/,+4p'`