### PR TITLE
Inspect gateway process WhatsApp env

### DIFF
--- a/scripts/verify_whatsapp_bridge_runtime.py
+++ b/scripts/verify_whatsapp_bridge_runtime.py
@@ -132,6 +132,61 @@ def get_systemd_service_env(
     return {}, None
 
 
+def get_systemd_main_pid(
+    service_name: str,
+    *,
+    timeout: float,
+) -> tuple[int | None, str | None]:
+    completed = subprocess.run(
+        [
+            "systemctl",
+            "--user",
+            "show",
+            service_name,
+            "-p",
+            "MainPID",
+            "--no-pager",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        stdin=subprocess.DEVNULL,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        return None, detail or f"systemctl show MainPID failed for {service_name}"
+
+    for line in completed.stdout.splitlines():
+        if not line.startswith("MainPID="):
+            continue
+        raw_pid = line.split("=", 1)[1].strip()
+        try:
+            pid = int(raw_pid)
+        except ValueError:
+            return None, f"{service_name} MainPID is not an integer: {raw_pid!r}"
+        return (pid if pid > 0 else None), None
+    return None, None
+
+
+def read_process_environment(pid: int) -> tuple[dict[str, str], str | None]:
+    try:
+        raw = (Path("/proc") / str(pid) / "environ").read_bytes()
+    except OSError as exc:
+        return {}, f"could not read /proc/{pid}/environ: {exc}"
+
+    env: dict[str, str] = {}
+    for item in raw.split(b"\0"):
+        if not item or b"=" not in item:
+            continue
+        key, value = item.split(b"=", 1)
+        decoded_key = key.decode("utf-8", errors="replace")
+        if not decoded_key:
+            continue
+        env[decoded_key] = value.decode("utf-8", errors="replace")
+    return env, None
+
+
 def read_json_file(path: Path) -> tuple[Any | None, str | None]:
     try:
         return json.loads(path.read_text(encoding="utf-8")), None
@@ -386,6 +441,22 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
             warnings.append(
                 f"could not inspect {args.service_name} environment: {service_env_error}"
             )
+        main_pid, main_pid_error = get_systemd_main_pid(
+            args.service_name,
+            timeout=args.timeout,
+        )
+        if main_pid_error:
+            warnings.append(
+                f"could not inspect {args.service_name} MainPID: {main_pid_error}"
+            )
+        elif main_pid:
+            process_env, process_env_error = read_process_environment(main_pid)
+            env_sources["systemd_process"] = process_env
+            if process_env_error:
+                warnings.append(
+                    f"could not inspect {args.service_name} process environment: "
+                    f"{process_env_error}"
+                )
 
     expected_agent_number = normalize_whatsapp_identifier(args.expected_agent_number)
     expected_agent_name = args.expected_agent_name

--- a/tests/test_verify_whatsapp_bridge_runtime.py
+++ b/tests/test_verify_whatsapp_bridge_runtime.py
@@ -151,6 +151,47 @@ class WhatsAppBridgeRuntimeVerifierTests(unittest.TestCase):
         self.assertTrue(summary["calling_ready"])
         self.assertEqual(summary["calling_missing"], [])
 
+    def test_cloud_calling_summary_can_use_running_gateway_process_env(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(tmp_path, skip_systemd=False)
+            write_baileys_session(args.session_dir)
+            args.env_file.parent.mkdir(parents=True, exist_ok=True)
+            args.env_file.write_text("WHATSAPP_MODE=bot\n", encoding="utf-8")
+
+            original_service_env = self.script.get_systemd_service_env
+            original_main_pid = self.script.get_systemd_main_pid
+            original_process_env = self.script.read_process_environment
+            self.script.get_systemd_service_env = lambda *_args, **_kwargs: ({}, None)
+            self.script.get_systemd_main_pid = lambda *_args, **_kwargs: (4242, None)
+            self.script.read_process_environment = lambda _pid: (
+                {
+                    "WHATSAPP_CLOUD_PHONE_NUMBER_ID": "phone-id",
+                    "WHATSAPP_CLOUD_ACCESS_TOKEN": "token",
+                    "WHATSAPP_CLOUD_APP_SECRET": "secret",
+                    "WHATSAPP_CLOUD_VERIFY_TOKEN": "verify",
+                    "WHATSAPP_CLOUD_CALLING_SIDECAR_URL": "http://127.0.0.1:8787",
+                    "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND": "voice stream",
+                },
+                None,
+            )
+            try:
+                result = self.script.verify(args)
+            finally:
+                self.script.get_systemd_service_env = original_service_env
+                self.script.get_systemd_main_pid = original_main_pid
+                self.script.read_process_environment = original_process_env
+
+        self.assertTrue(result["success"], result["failures"])
+        checks = result["checks"]
+        self.assertTrue(checks["whatsapp_cloud"]["cloud_configured"])
+        self.assertTrue(checks["whatsapp_cloud"]["calling_ready"])
+        self.assertIn(
+            "WHATSAPP_CLOUD_ACCESS_TOKEN",
+            checks["env_key_sources"]["systemd_process"],
+        )
+        self.assertNotIn("token", json.dumps(checks["env_key_sources"]))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `systemd_process` as a presence-only env source for WhatsApp Cloud/Calling readiness
- read the running Hermes gateway MainPID environment when systemd checks are enabled
- keep credential values out of verifier output; JSON only reports WHATSAPP key names by source

## Verification
- `python3 -m unittest tests.test_verify_whatsapp_bridge_runtime`
- `python3 -m unittest discover -s tests`
- `python3 -m py_compile scripts/verify_whatsapp_bridge_runtime.py`
- live check: `scripts/verify_whatsapp_bridge_runtime.py --hermes-home /home/ubuntu/.hermes --json` now reports env sources `env_file`, `systemd_service`, and `systemd_process`; Cloud credential keys remain missing