### PR TITLE
Add Telegram voice contract verifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
             tests/test_verify_cli_mcp_surface.py \
             tests/test_verify_hermes_voice_config.py \
             tests/test_verify_local_hermes_voice_stack.py \
+            tests/test_verify_telegram_voice_contract.py \
             tests/test_verify_webrtc_sidecar_service.py
 
       - run: python -m unittest discover -s tests
@@ -90,4 +91,5 @@ jobs:
             scripts/install_webrtc_sidecar_service.sh \
             scripts/verify_hermes_command_tts.sh \
             scripts/verify_local_hermes_voice_stack.sh \
+            scripts/verify_telegram_voice_contract.sh \
             scripts/verify_whatsapp_voice_contract.sh

--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ voice stream --sample-rate 48000 --frame-ms 20 --output streamed.ogg --format og
 # Replay audio through daemon streaming STT
 voice stream-transcribe recording.ogg
 
-# Verify WhatsApp-ready file output and stream contract from an installed binary
+# Verify messaging voice-note output and stream contract from an installed binary
 VOICE_BIN=/path/to/voice scripts/verify_whatsapp_voice_contract.sh
 VOICE_BIN=/path/to/voice scripts/verify_whatsapp_voice_contract.sh --require-daemon --run-stt-smoke
+VOICE_BIN=/path/to/voice scripts/verify_telegram_voice_contract.sh --skip-hermes-config
 
 # Read from a file, strip markdown
 voice say --markdown -f blog-post.mdx
@@ -357,6 +358,11 @@ For WhatsApp or Telegram voice-note delivery through Hermes, prefer
 Opus output directly. `output_format: wav` remains a compatibility fallback,
 with Hermes converting to OGG/Opus when needed.
 
+Telegram voice messages use the same Ogg/Opus file shape as WhatsApp voice
+notes. Run `scripts/verify_telegram_voice_contract.sh` before adding the bot
+token; it does not contact Telegram, but it verifies Voice's Ogg/Opus output
+contract and, unless skipped, the active Hermes command-provider config.
+
 Hermes can call `voice` directly, or use the voice-owned command-provider
 shims:
 
@@ -397,7 +403,8 @@ provider, direct Ogg/Opus voice note output, daemon-backed streaming,
 `stream-transcribe`, and the local WebRTC sidecar service. It requires the
 daemon and sidecar by default. For narrower checks, run
 `scripts/verify_cli_mcp_surface.py`, `scripts/verify_hermes_voice_config.py`,
-`scripts/verify_whatsapp_voice_contract.sh`, or
+`scripts/verify_whatsapp_voice_contract.sh`,
+`scripts/verify_telegram_voice_contract.sh`, or
 `scripts/verify_webrtc_sidecar_service.py` directly.
 
 To include the categorized WhatsApp alpha report in the same command, add

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -53,7 +53,8 @@ so the same command still works outside Hermes.
 Set `voice_compatible: true` so Hermes routes the returned `.ogg` file as a
 native voice note. `output_format: wav` remains valid as a compatibility
 fallback; Hermes and the WhatsApp bridge can still convert non-Opus audio when
-needed.
+needed. Telegram uses the same Ogg/Opus voice-message shape for `sendVoice`, so
+Voice does not need a Telegram-specific encoder.
 
 For live WhatsApp Calling, keep Ogg/Opus as the file path and bridge WebRTC
 media through 48 kHz 20 ms PCM frames. See
@@ -159,15 +160,23 @@ For a single voice-side WhatsApp preflight, run:
 VOICE_BIN=/path/to/voice scripts/verify_whatsapp_voice_contract.sh
 ```
 
-That verifier checks `voice stream-contract` against the checked-in sidecar
-contract, proves `voice say --format ogg-opus` and `.ogg` extension inference
-write real mono 48 kHz Ogg/Opus, verifies misleading `.wav`/`ogg-opus`
+For the equivalent Telegram preflight, run:
+
+```bash
+VOICE_BIN=/path/to/voice scripts/verify_telegram_voice_contract.sh
+```
+
+Those verifiers check `voice stream-contract` against the checked-in sidecar
+contract, prove `voice say --format ogg-opus` and `.ogg` extension inference
+write real mono 48 kHz Ogg/Opus, verify misleading `.wav`/`ogg-opus`
 combinations are rejected before writing a file, and, when the daemon is
-running, checks both raw 48 kHz 20 ms PCM streaming and streamed Ogg/Opus
-encoding to both named files and stdout. Pass `--require-daemon` when the daemon
-stream path must be covered, or `--skip-daemon` for a file-only preflight. Pass
-`--run-stt-smoke` with `--require-daemon` when the inbound WebRTC/STT path must
-also be covered; it creates a tiny WAV fixture and requires
+running, check both raw 48 kHz 20 ms PCM streaming and streamed Ogg/Opus
+encoding to both named files and stdout. The Telegram verifier also checks the
+active Hermes command-provider config unless `--skip-hermes-config` is passed.
+Pass `--require-daemon` when the daemon stream path must be covered, or
+`--skip-daemon` for a file-only preflight. Pass `--run-stt-smoke` with
+`--require-daemon` when the inbound WebRTC/STT path must also be covered; it
+creates a tiny WAV fixture and requires
 `voice stream-transcribe --json` to return a terminal `stt.transcribed` event.
 This is optional because it may lazily load the Whisper model.
 

--- a/scripts/verify_telegram_voice_contract.sh
+++ b/scripts/verify_telegram_voice_contract.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+voice_bin="${VOICE_BIN:-}"
+text="${TEXT:-Voice Telegram contract smoke test.}"
+hermes_config="${HERMES_CONFIG:-${HOME:-}/.hermes/config.yaml}"
+skip_hermes_config="${SKIP_HERMES_CONFIG:-0}"
+skip_hermes_tts_smoke="${SKIP_HERMES_TTS_SMOKE:-0}"
+require_daemon="${REQUIRE_DAEMON:-0}"
+skip_daemon="${SKIP_DAEMON:-0}"
+run_stt_smoke="${RUN_STT_SMOKE:-0}"
+keep_output="${KEEP_OUTPUT:-0}"
+
+voice_contract_script="${VOICE_CONTRACT_VERIFY_SCRIPT:-$repo_root/scripts/verify_whatsapp_voice_contract.sh}"
+hermes_config_verify_script="${HERMES_CONFIG_VERIFY_SCRIPT:-$repo_root/scripts/verify_hermes_voice_config.py}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/verify_telegram_voice_contract.sh [OPTIONS]
+
+Validate an installed voice binary against Telegram voice-message requirements.
+This is an offline preflight; it does not require a Telegram bot token.
+
+Options:
+  --voice-bin PATH          voice binary to run (default: VOICE_BIN, target/release/voice, then PATH)
+  --text TEXT               smoke text to synthesize
+  --hermes-config PATH      Hermes config file to validate (default: HERMES_CONFIG or ~/.hermes/config.yaml)
+  --skip-hermes-config      skip Hermes command-provider config validation
+  --skip-hermes-tts-smoke   validate Hermes config without executing TTS
+  --require-daemon          fail if voice daemon streaming is unavailable
+  --skip-daemon             skip daemon-backed stream checks even if the daemon is running
+  --run-stt-smoke           also replay a WAV through daemon stream-transcribe
+  --keep-output             retain generated files from the underlying voice contract check
+  -h, --help                show this help
+
+Environment aliases:
+  VOICE_BIN, TEXT, HERMES_CONFIG, SKIP_HERMES_CONFIG=1, SKIP_HERMES_TTS_SMOKE=1,
+  REQUIRE_DAEMON=1, SKIP_DAEMON=1, RUN_STT_SMOKE=1, KEEP_OUTPUT=1
+EOF
+}
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --voice-bin)
+      [[ $# -ge 2 ]] || fail "--voice-bin requires a path"
+      voice_bin="$2"
+      shift 2
+      ;;
+    --text)
+      [[ $# -ge 2 ]] || fail "--text requires a value"
+      text="$2"
+      shift 2
+      ;;
+    --hermes-config)
+      [[ $# -ge 2 ]] || fail "--hermes-config requires a path"
+      hermes_config="$2"
+      shift 2
+      ;;
+    --skip-hermes-config)
+      skip_hermes_config=1
+      shift
+      ;;
+    --skip-hermes-tts-smoke)
+      skip_hermes_tts_smoke=1
+      shift
+      ;;
+    --require-daemon)
+      require_daemon=1
+      shift
+      ;;
+    --skip-daemon)
+      skip_daemon=1
+      shift
+      ;;
+    --run-stt-smoke)
+      run_stt_smoke=1
+      shift
+      ;;
+    --keep-output)
+      keep_output=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option: $1"
+      ;;
+  esac
+done
+
+[[ -x "$voice_contract_script" ]] || fail "voice contract verifier is not executable: $voice_contract_script"
+
+voice_contract_cmd=("$voice_contract_script" "--text" "$text")
+if [[ -n "$voice_bin" ]]; then
+  voice_contract_cmd+=("--voice-bin" "$voice_bin")
+fi
+if [[ "$require_daemon" == "1" ]]; then
+  voice_contract_cmd+=("--require-daemon")
+fi
+if [[ "$skip_daemon" == "1" ]]; then
+  voice_contract_cmd+=("--skip-daemon")
+fi
+if [[ "$run_stt_smoke" == "1" ]]; then
+  voice_contract_cmd+=("--run-stt-smoke")
+fi
+if [[ "$keep_output" == "1" ]]; then
+  voice_contract_cmd+=("--keep-output")
+fi
+
+"${voice_contract_cmd[@]}"
+voice_contract_status="checked"
+
+hermes_config_status="skipped"
+if [[ "$skip_hermes_config" != "1" ]]; then
+  [[ -x "$hermes_config_verify_script" ]] || fail "Hermes config verifier is not executable: $hermes_config_verify_script"
+  [[ -f "$hermes_config" ]] || fail "Hermes config not found: $hermes_config"
+
+  hermes_cmd=("$hermes_config_verify_script" "--config" "$hermes_config")
+  if [[ -n "$voice_bin" ]]; then
+    hermes_cmd+=("--voice-bin" "$voice_bin")
+  fi
+  if [[ "$skip_hermes_tts_smoke" == "1" ]]; then
+    hermes_cmd+=("--skip-tts-smoke")
+    hermes_config_status="checked_without_tts_smoke"
+  else
+    hermes_config_status="checked"
+  fi
+
+  "${hermes_cmd[@]}"
+fi
+
+echo "ok: voice Telegram contract verifier passed"
+echo "voice_contract=$voice_contract_status"
+echo "hermes_voice_config=$hermes_config_status"
+echo "telegram_send_voice=compatible"
+echo "telegram_credentials=not_required_for_offline_contract"

--- a/tests/test_verify_telegram_voice_contract.py
+++ b/tests/test_verify_telegram_voice_contract.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "verify_telegram_voice_contract.sh"
+
+
+def write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def write_helper(path: Path, label: str, log_path: Path) -> None:
+    write_executable(
+        path,
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            printf '{label}' >> {str(log_path)!r}
+            printf '\\0' >> {str(log_path)!r}
+            printf '%s\\0' "$@" >> {str(log_path)!r}
+            printf '\\n' >> {str(log_path)!r}
+            echo "ok: {label}"
+            """
+        ),
+    )
+
+
+def command_log_entries(log_path: Path) -> list[list[str]]:
+    entries: list[list[str]] = []
+    for line in log_path.read_bytes().splitlines():
+        if not line:
+            continue
+        entries.append(line.decode("utf-8").split("\0")[:-1])
+    return entries
+
+
+class TelegramVoiceContractVerifierTests(unittest.TestCase):
+    def test_runs_voice_contract_and_hermes_config(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            voice_contract = tmp_path / "verify_voice_contract.sh"
+            hermes_config_verifier = tmp_path / "verify_hermes.py"
+            voice = tmp_path / "voice"
+            config = tmp_path / "config.yaml"
+
+            write_helper(voice_contract, "voice_contract", log_path)
+            write_helper(hermes_config_verifier, "hermes", log_path)
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+            config.write_text("tts: {}\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--text",
+                    "Telegram smoke.",
+                    "--hermes-config",
+                    str(config),
+                    "--skip-hermes-tts-smoke",
+                    "--skip-daemon",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "VOICE_CONTRACT_VERIFY_SCRIPT": str(voice_contract),
+                    "HERMES_CONFIG_VERIFY_SCRIPT": str(hermes_config_verifier),
+                },
+            )
+
+            entries = command_log_entries(log_path)
+
+        self.assertIn("ok: voice Telegram contract verifier passed", result.stdout)
+        self.assertIn("voice_contract=checked", result.stdout)
+        self.assertIn("hermes_voice_config=checked_without_tts_smoke", result.stdout)
+        self.assertEqual([entry[0] for entry in entries], ["voice_contract", "hermes"])
+        self.assertEqual(
+            entries[0],
+            [
+                "voice_contract",
+                "--text",
+                "Telegram smoke.",
+                "--voice-bin",
+                str(voice),
+                "--skip-daemon",
+            ],
+        )
+        self.assertEqual(
+            entries[1],
+            [
+                "hermes",
+                "--config",
+                str(config),
+                "--voice-bin",
+                str(voice),
+                "--skip-tts-smoke",
+            ],
+        )
+
+    def test_skip_hermes_config_only_runs_voice_contract(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            voice_contract = tmp_path / "verify_voice_contract.sh"
+            missing_config = tmp_path / "missing.yaml"
+
+            write_helper(voice_contract, "voice_contract", log_path)
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--hermes-config",
+                    str(missing_config),
+                    "--skip-hermes-config",
+                    "--require-daemon",
+                    "--run-stt-smoke",
+                    "--keep-output",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "VOICE_CONTRACT_VERIFY_SCRIPT": str(voice_contract),
+                },
+            )
+
+            entries = command_log_entries(log_path)
+
+        self.assertIn("hermes_voice_config=skipped", result.stdout)
+        self.assertEqual([entry[0] for entry in entries], ["voice_contract"])
+        self.assertIn("--require-daemon", entries[0])
+        self.assertIn("--run-stt-smoke", entries[0])
+        self.assertIn("--keep-output", entries[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an offline Telegram voice contract verifier that reuses the existing Ogg/Opus voice-note contract and optionally validates the active Hermes voice config
- document Telegram as compatible with the same Ogg/Opus voice-message shape used for WhatsApp voice notes
- add unit coverage for verifier wiring and include it in helper CI checks

## Compatibility note
Telegram Bot API `sendVoice` accepts voice messages as uploaded files, and Hermes locally routes `.ogg` / `.opus` through the Telegram adapter's `send_voice` path. The current local Hermes config already uses `/home/ubuntu/.local/bin/voice say --format ogg-opus`, `output_format: ogg`, and `voice_compatible: true`.

This PR does not require or validate a Telegram bot token; it verifies the offline file/config contract before BotFather setup.

## Verification
- `python3 -m unittest tests.test_verify_telegram_voice_contract`
- `python3 -m unittest discover -s tests`
- `bash -n scripts/verify_telegram_voice_contract.sh scripts/verify_whatsapp_voice_contract.sh scripts/verify_local_hermes_voice_stack.sh scripts/verify_hermes_command_tts.sh scripts/install_webrtc_sidecar_service.sh`
- `scripts/verify_telegram_voice_contract.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-config /home/ubuntu/.hermes/config.yaml --skip-hermes-tts-smoke --skip-daemon`