### PR TITLE
Prefer installed voice in WhatsApp alpha readiness

### DIFF
--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -42,11 +42,13 @@ def default_voice_bin() -> str:
     env_value = os.environ.get("VOICE_BIN")
     if env_value:
         return env_value
+    found = shutil.which("voice")
+    if found:
+        return found
     release_bin = repo_root() / "target" / "release" / "voice"
     if release_bin.is_file() and os.access(release_bin, os.X_OK):
         return str(release_bin)
-    found = shutil.which("voice")
-    return found or "voice"
+    return "voice"
 
 
 def default_hermes_home() -> Path:

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -174,6 +174,52 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             gates["whatsapp_cloud_calling"]["missing"],
         )
 
+    def test_default_voice_bin_prefers_installed_voice_on_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            helpers = tmp_path / "helpers"
+            bin_dir = tmp_path / "bin"
+            helpers.mkdir()
+            bin_dir.mkdir()
+            write_fake_helpers(helpers)
+            voice = bin_dir / "voice"
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+            config = tmp_path / "config.yaml"
+            config.write_text("tts: {}\n", encoding="utf-8")
+
+            env = {**os.environ}
+            env.pop("VOICE_BIN", None)
+            env["PATH"] = f"{bin_dir}:{env['PATH']}"
+            env["VOICE_READINESS_SCRIPT_DIR"] = str(helpers)
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--hermes-home",
+                    str(tmp_path / "hermes"),
+                    "--hermes-config",
+                    str(config),
+                    "--skip-systemd",
+                    "--skip-daemon",
+                    "--skip-sidecar",
+                    "--skip-voice-note-smoke",
+                    "--json",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=env,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        expected = str(voice.resolve())
+        for component in payload["components"]:
+            command = component["command"]
+            if "--voice-bin" in command:
+                index = command.index("--voice-bin")
+                self.assertEqual(command[index + 1], expected)
+
     def test_human_summary_prints_non_draining_attended_next_step(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)


### PR DESCRIPTION
## Summary
- make `verify_whatsapp_alpha_readiness.py` prefer the installed `voice` on `PATH` before falling back to `target/release/voice`
- add regression coverage for the case where an installed `voice` exists while a repo release build is also present

## Why
The top-level local stack verifier already prefers `command -v voice`, but the alpha readiness script defaulted to `target/release/voice` first. On this host that caused direct alpha runs from the repo to compare Hermes/sidecar services configured for `/home/ubuntu/.local/bin/voice` against the repo build path and fail, even though the operational runtime is the installed binary.

## Verification
- `python3 -m unittest tests.test_verify_whatsapp_alpha_readiness`
- `python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_alpha_readiness.py && git diff --check`
- `python3 -m unittest discover -s tests`
- `scripts/verify_whatsapp_alpha_readiness.py --hermes-home /home/ubuntu/.hermes --profile cached-receive --skip-hermes-tts-smoke --wait-audio-cache-seconds 0.1 --json`
- `scripts/verify_local_hermes_voice_stack.sh --hermes-home /home/ubuntu/.hermes --skip-hermes-tts-smoke --whatsapp-alpha-profile cached-receive --whatsapp-alpha-wait-audio-cache-seconds 0.1`