### PR TITLE
Report local WhatsApp config readiness

### DIFF
--- a/scripts/verify_whatsapp_bridge_runtime.py
+++ b/scripts/verify_whatsapp_bridge_runtime.py
@@ -41,6 +41,15 @@ WHATSAPP_CALLING_ENV = (
     "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND",
     "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT",
 )
+WHATSAPP_LOCAL_CONFIG_ENV = (
+    "WHATSAPP_ENABLED",
+    "WHATSAPP_MODE",
+    "WHATSAPP_HOME_CHANNEL",
+    "WHATSAPP_HOME_CHANNEL_THREAD_ID",
+    "WHATSAPP_ALLOWED_USERS",
+)
+TRUTHY_VALUES = {"1", "true", "yes", "on"}
+FALSY_VALUES = {"0", "false", "no", "off"}
 
 
 def default_hermes_home() -> Path:
@@ -373,6 +382,76 @@ def env_presence(env_sources: dict[str, dict[str, str]], keys: tuple[str, ...]) 
     return key_status
 
 
+def first_env_value(
+    env_sources: dict[str, dict[str, str]],
+    key: str,
+) -> tuple[str | None, list[str]]:
+    sources: list[str] = []
+    first: str | None = None
+    for source, values in env_sources.items():
+        value = values.get(key)
+        if value in (None, ""):
+            continue
+        sources.append(source)
+        if first is None:
+            first = value
+    return first, sources
+
+
+def parse_bool(value: str | None) -> bool | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if normalized in TRUTHY_VALUES:
+        return True
+    if normalized in FALSY_VALUES:
+        return False
+    return None
+
+
+def home_channel_kind(value: str | None) -> str | None:
+    if not value:
+        return None
+    if value.endswith("@lid"):
+        return "lid"
+    if value.endswith("@s.whatsapp.net"):
+        return "jid"
+    if normalize_whatsapp_identifier(value):
+        return "phone"
+    return "other"
+
+
+def count_csv_values(value: str | None) -> int:
+    if not value:
+        return 0
+    return len([item for item in (part.strip() for part in value.split(",")) if item])
+
+
+def build_local_config_summary(env_sources: dict[str, dict[str, str]]) -> dict[str, Any]:
+    enabled_raw, enabled_sources = first_env_value(env_sources, "WHATSAPP_ENABLED")
+    mode, mode_sources = first_env_value(env_sources, "WHATSAPP_MODE")
+    home_channel, home_sources = first_env_value(env_sources, "WHATSAPP_HOME_CHANNEL")
+    thread_id, thread_sources = first_env_value(env_sources, "WHATSAPP_HOME_CHANNEL_THREAD_ID")
+    allowed_users, allowed_sources = first_env_value(env_sources, "WHATSAPP_ALLOWED_USERS")
+    presence = env_presence(env_sources, WHATSAPP_LOCAL_CONFIG_ENV)
+
+    return {
+        "enabled": parse_bool(enabled_raw),
+        "enabled_present": enabled_raw is not None,
+        "enabled_sources": enabled_sources,
+        "mode": mode,
+        "mode_sources": mode_sources,
+        "home_channel": home_channel,
+        "home_channel_kind": home_channel_kind(home_channel),
+        "home_channel_sources": home_sources,
+        "home_channel_thread_id_present": thread_id is not None,
+        "home_channel_thread_id_sources": thread_sources,
+        "allowed_users_count": count_csv_values(allowed_users),
+        "allowed_users_sources": allowed_sources,
+        "key_presence": presence,
+    }
+
+
 def missing_env_keys(env_sources: dict[str, dict[str, str]], keys: tuple[str, ...]) -> list[str]:
     return [
         key
@@ -461,6 +540,13 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
     expected_agent_number = normalize_whatsapp_identifier(args.expected_agent_number)
     expected_agent_name = args.expected_agent_name
     expected_mode = args.expected_mode or env_sources["env_file"].get("WHATSAPP_MODE")
+    local_config = build_local_config_summary(env_sources)
+    if local_config["enabled"] is False:
+        failures.append("WHATSAPP_ENABLED is explicitly disabled")
+    elif local_config["enabled_present"] and local_config["enabled"] is None:
+        warnings.append("WHATSAPP_ENABLED is set but is not a recognized boolean")
+    if not local_config["home_channel"]:
+        warnings.append("WHATSAPP_HOME_CHANNEL is not configured")
 
     if not session_dir.is_dir():
         failures.append(f"WhatsApp session directory not found: {session_dir}")
@@ -576,6 +662,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         "expected_agent_number": expected_agent_number,
         "expected_agent_name": expected_agent_name,
         "expected_mode": expected_mode,
+        "whatsapp_local_config": local_config,
         "baileys_identity": identity,
         "session_artifacts": counts,
         "lid_mapping": lid_mapping,
@@ -621,6 +708,7 @@ def human_summary(result: dict[str, Any]) -> None:
     health = checks.get("bridge_health") or {}
     process = (checks.get("bridge_process") or {}).get("selected") or {}
     cloud = checks.get("whatsapp_cloud") or {}
+    local_config = checks.get("whatsapp_local_config") or {}
 
     if result["success"]:
         print("ok: WhatsApp bridge runtime verifier passed")
@@ -647,6 +735,14 @@ def human_summary(result: dict[str, Any]) -> None:
             f"pid={process.get('pid')} mode={process.get('mode') or '<unknown>'} "
             f"session={process.get('session') or '<unknown>'}"
         )
+    print(
+        "whatsapp_local="
+        f"enabled={local_config.get('enabled')} "
+        f"mode={local_config.get('mode') or '<unknown>'} "
+        f"home_channel={local_config.get('home_channel') or '<missing>'} "
+        f"home_channel_kind={local_config.get('home_channel_kind') or '<unknown>'} "
+        f"allowed_users={local_config.get('allowed_users_count', 0)}"
+    )
     print(
         "session_artifacts="
         + ",".join(

--- a/tests/test_verify_whatsapp_bridge_runtime.py
+++ b/tests/test_verify_whatsapp_bridge_runtime.py
@@ -86,7 +86,15 @@ class WhatsAppBridgeRuntimeVerifierTests(unittest.TestCase):
             write_baileys_session(args.session_dir)
             args.env_file.parent.mkdir(parents=True, exist_ok=True)
             args.env_file.write_text(
-                "WHATSAPP_ENABLED=true\nWHATSAPP_MODE=bot\n",
+                "\n".join(
+                    [
+                        "WHATSAPP_ENABLED=true",
+                        "WHATSAPP_MODE=bot",
+                        "WHATSAPP_HOME_CHANNEL=20530681934008@lid",
+                        "WHATSAPP_ALLOWED_USERS=18316653748,17202993514",
+                        "",
+                    ]
+                ),
                 encoding="utf-8",
             )
 
@@ -98,6 +106,13 @@ class WhatsAppBridgeRuntimeVerifierTests(unittest.TestCase):
         self.assertEqual(checks["baileys_identity"]["number"], "13236478455")
         self.assertEqual(checks["baileys_identity"]["lid_number"], "186999436771390")
         self.assertTrue(checks["lid_mapping"]["ok"])
+        local = checks["whatsapp_local_config"]
+        self.assertTrue(local["enabled"])
+        self.assertEqual(local["mode"], "bot")
+        self.assertEqual(local["home_channel"], "20530681934008@lid")
+        self.assertEqual(local["home_channel_kind"], "lid")
+        self.assertEqual(local["allowed_users_count"], 2)
+        self.assertNotIn("18316653748", json.dumps(local))
         self.assertFalse(checks["whatsapp_cloud"]["cloud_configured"])
         self.assertIn(
             "WHATSAPP_CLOUD_ACCESS_TOKEN",
@@ -129,6 +144,22 @@ class WhatsAppBridgeRuntimeVerifierTests(unittest.TestCase):
 
         self.assertFalse(result["success"])
         self.assertIn("WhatsApp Cloud credentials missing", "\n".join(result["failures"]))
+
+    def test_disabled_local_whatsapp_config_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(tmp_path)
+            write_baileys_session(args.session_dir)
+            args.env_file.parent.mkdir(parents=True, exist_ok=True)
+            args.env_file.write_text(
+                "WHATSAPP_ENABLED=false\nWHATSAPP_MODE=bot\n",
+                encoding="utf-8",
+            )
+
+            result = self.script.verify(args)
+
+        self.assertFalse(result["success"])
+        self.assertIn("WHATSAPP_ENABLED is explicitly disabled", result["failures"])
 
     def test_cloud_calling_summary_merges_env_file_and_systemd_sources(self):
         summary = self.script.build_cloud_summary(


### PR DESCRIPTION
## Summary
- add a safe `whatsapp_local_config` summary to the bridge runtime verifier
- report WhatsApp enabled/mode/home-channel kind and allowed-user count without printing allowed-user values
- fail when `WHATSAPP_ENABLED=false` and warn when home-channel config is missing

## Why
The bridge verifier already proved Baileys pairing and Cloud/Calling key presence, but the local WhatsApp config surface was only visible as key names. This makes the one-command stack gate more useful for confirming the current Quill setup on disk without exposing credential values.

## Live evidence
Current host reports:
- `WHATSAPP_ENABLED=true`
- mode `bot`
- home channel `20530681934008@lid` with kind `lid`
- allowed user count `2`
- paired Baileys identity `Quill`, number `13236478455`, LID `186999436771390`
- Cloud/Calling keys still missing: `WHATSAPP_CLOUD_PHONE_NUMBER_ID`, `WHATSAPP_CLOUD_ACCESS_TOKEN`, `WHATSAPP_CLOUD_APP_SECRET`, `WHATSAPP_CLOUD_VERIFY_TOKEN`

## Verification
- `python3 -m unittest tests.test_verify_whatsapp_bridge_runtime`
- `python3 -m py_compile scripts/verify_whatsapp_bridge_runtime.py tests/test_verify_whatsapp_bridge_runtime.py && git diff --check`
- `scripts/verify_whatsapp_bridge_runtime.py --hermes-home /home/ubuntu/.hermes --json`
- `python3 -m unittest discover -s tests`
- `scripts/verify_local_hermes_voice_stack.sh --hermes-home /home/ubuntu/.hermes --skip-hermes-tts-smoke --whatsapp-alpha-profile cached-receive --whatsapp-alpha-wait-audio-cache-seconds 0.1`