### PR TITLE
Summarize WhatsApp alpha readiness state

### DIFF
--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -469,6 +469,73 @@ def external_meta_gate(external_meta_setup: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def build_readiness_summary(
+    *,
+    local_checks_passed: bool,
+    pending_gates: dict[str, Any],
+    external_meta_setup: dict[str, Any],
+) -> dict[str, Any]:
+    attended = pending_gates.get("attended_fresh_receive") or {}
+    attended_verified = attended.get("status") == "verified"
+    external_meta_setup_required = not (
+        external_meta_setup.get("cloud_configured")
+        and external_meta_setup.get("calling_ready")
+    )
+    next_actions: list[dict[str, Any]] = []
+
+    if not local_checks_passed:
+        next_actions.append(
+            {
+                "id": "fix_local_runtime",
+                "requires_operator": False,
+                "description": "Fix failed local readiness components before retrying.",
+            }
+        )
+    if not attended_verified:
+        action: dict[str, Any] = {
+            "id": "run_attended_fresh_receive",
+            "requires_operator": True,
+            "description": "Run the non-draining attended receive profile while someone sends a fresh WhatsApp voice note.",
+        }
+        command = attended.get("command")
+        if command:
+            action["command"] = command
+        fallback = attended.get("fallback_draining_command")
+        if fallback:
+            action["fallback_draining_command"] = fallback
+        next_actions.append(action)
+    if external_meta_setup_required:
+        next_actions.append(
+            {
+                "id": "configure_whatsapp_cloud_calling",
+                "requires_operator": True,
+                "description": "Complete external Meta WhatsApp Cloud and Calling setup, then rerun with Cloud/Calling requirements.",
+                "missing": external_meta_setup.get("calling_missing") or [],
+                "setup_steps": external_meta_setup.get("setup_steps") or [],
+            }
+        )
+
+    complete = local_checks_passed and attended_verified and not external_meta_setup_required
+    if complete:
+        status = "complete"
+    elif local_checks_passed:
+        status = "local_ready_pending_gates"
+    else:
+        status = "local_checks_failed"
+
+    return {
+        "status": status,
+        "complete": complete,
+        "local_checks_passed": local_checks_passed,
+        "attended_fresh_receive_verified": attended_verified,
+        "external_meta_setup_required": external_meta_setup_required,
+        "operator_action_required": any(
+            bool(action.get("requires_operator")) for action in next_actions
+        ),
+        "next_actions": next_actions,
+    }
+
+
 def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
     components = build_components(args)
     required_failures = [
@@ -528,6 +595,11 @@ def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
         ),
         **external_meta_gate(external_meta_setup),
     }
+    readiness_summary = build_readiness_summary(
+        local_checks_passed=not required_failures,
+        pending_gates=pending_gates,
+        external_meta_setup=external_meta_setup,
+    )
 
     return {
         "success": success,
@@ -536,6 +608,7 @@ def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
         "by_category": by_category,
         "external_meta_setup": external_meta_setup,
         "pending_gates": pending_gates,
+        "readiness_summary": readiness_summary,
         "failures": [
             {
                 "name": item["name"],
@@ -669,6 +742,14 @@ def human_summary(result: dict[str, Any]) -> None:
     else:
         print("error: WhatsApp alpha readiness failed", file=sys.stderr)
     print(f"profile={result.get('profile')}")
+    summary = result.get("readiness_summary") or {}
+    if summary:
+        print(
+            "readiness="
+            f"{summary.get('status')} complete={summary.get('complete')} "
+            f"operator_action_required={summary.get('operator_action_required')} "
+            f"external_meta_setup_required={summary.get('external_meta_setup_required')}"
+        )
 
     for item in result["components"]:
         status = "ok" if item["success"] else "failed"

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -173,6 +173,21 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             "WHATSAPP_CLOUD_ACCESS_TOKEN",
             gates["whatsapp_cloud_calling"]["missing"],
         )
+        summary = payload["readiness_summary"]
+        self.assertEqual(summary["status"], "local_ready_pending_gates")
+        self.assertFalse(summary["complete"])
+        self.assertTrue(summary["local_checks_passed"])
+        self.assertFalse(summary["attended_fresh_receive_verified"])
+        self.assertTrue(summary["external_meta_setup_required"])
+        self.assertTrue(summary["operator_action_required"])
+        self.assertIn(
+            "run_attended_fresh_receive",
+            [action["id"] for action in summary["next_actions"]],
+        )
+        self.assertIn(
+            "configure_whatsapp_cloud_calling",
+            [action["id"] for action in summary["next_actions"]],
+        )
 
     def test_default_voice_bin_prefers_installed_voice_on_path(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -265,6 +280,7 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             result.stdout,
         )
         self.assertIn("--profile attended-send-receive", result.stdout)
+        self.assertIn("readiness=local_ready_pending_gates", result.stdout)
 
     def test_inbound_cache_smoke_adds_receive_component(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -404,6 +420,14 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertEqual(gate["component"], "whatsapp_inbound_cache_fresh_stt")
         self.assertFalse(gate["drains_bridge_messages"])
         self.assertFalse(gate["requires_operator"])
+        summary = payload["readiness_summary"]
+        self.assertFalse(summary["complete"])
+        self.assertTrue(summary["attended_fresh_receive_verified"])
+        self.assertTrue(summary["external_meta_setup_required"])
+        self.assertEqual(
+            [action["id"] for action in summary["next_actions"]],
+            ["configure_whatsapp_cloud_calling"],
+        )
 
     def test_verified_attended_receive_gate_requires_audio_event_evidence(self):
         voice_note_payload = {
@@ -433,6 +457,68 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertEqual(gate["component"], "whatsapp_voice_note_send_receive")
         self.assertEqual(gate["audio_events"], 1)
         self.assertFalse(gate["requires_operator"])
+
+    def test_readiness_summary_is_complete_when_all_gates_are_verified(self):
+        inbound_cache_payload = {
+            "success": True,
+            "checks": {
+                "fresh_watch": {
+                    "drains_bridge_messages": False,
+                    "fresh_files": ["/tmp/aud_fresh.ogg"],
+                    "fresh_count": 1,
+                }
+            },
+            "failures": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            helpers = tmp_path / "helpers"
+            helpers.mkdir()
+            write_fake_helpers(
+                helpers,
+                cloud_configured=True,
+                inbound_cache_payload=inbound_cache_payload,
+            )
+            voice = tmp_path / "voice"
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+            config = tmp_path / "config.yaml"
+            config.write_text("tts: {}\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--hermes-home",
+                    str(tmp_path / "hermes"),
+                    "--hermes-config",
+                    str(config),
+                    "--skip-systemd",
+                    "--skip-daemon",
+                    "--skip-sidecar",
+                    "--profile",
+                    "attended-cache-receive",
+                    "--json",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                env={
+                    **os.environ,
+                    "VOICE_READINESS_SCRIPT_DIR": str(helpers),
+                },
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        summary = payload["readiness_summary"]
+        self.assertEqual(summary["status"], "complete")
+        self.assertTrue(summary["complete"])
+        self.assertTrue(summary["local_checks_passed"])
+        self.assertTrue(summary["attended_fresh_receive_verified"])
+        self.assertFalse(summary["external_meta_setup_required"])
+        self.assertFalse(summary["operator_action_required"])
+        self.assertEqual(summary["next_actions"], [])
 
     def test_voice_note_flags_cannot_be_used_when_voice_note_smoke_is_skipped(self):
         result = self.run_invalid("--skip-voice-note-smoke", "--send-voice-note")


### PR DESCRIPTION
## Summary
- add a derived `readiness_summary` object to the WhatsApp alpha JSON report
- expose whether local checks passed, whether attended fresh receive is verified, whether external Meta setup is still required, and the remaining next actions
- print a compact `readiness=...` line in the human report for automation and operator scans

## Why
The alpha report already had all the raw pieces, but callers had to infer whether a green local run meant the full alpha was complete. The new summary preserves existing pass/fail behavior while making the state explicit: local runtime can be ready while attended receive and Meta Cloud/Calling gates remain pending.

## Live evidence
Current host now reports:

```text
readiness=local_ready_pending_gates complete=False operator_action_required=True external_meta_setup_required=True
```

The JSON `next_actions` list contains `run_attended_fresh_receive` and `configure_whatsapp_cloud_calling`.

## Verification
- `python3 -m unittest tests.test_verify_whatsapp_alpha_readiness`
- `python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_alpha_readiness.py && git diff --check`
- `scripts/verify_whatsapp_alpha_readiness.py --hermes-home /home/ubuntu/.hermes --profile cached-receive --skip-hermes-tts-smoke --wait-audio-cache-seconds 0.1 --json`
- `python3 -m unittest discover -s tests`
- `scripts/verify_local_hermes_voice_stack.sh --hermes-home /home/ubuntu/.hermes --skip-hermes-tts-smoke --whatsapp-alpha-profile cached-receive --whatsapp-alpha-wait-audio-cache-seconds 0.1`