### PR TITLE
Add WhatsApp alpha completion gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - run: cargo build -p voice
 
-      - run: scripts/verify_cli_mcp_surface.py --voice-bin target/debug/voice --skip-daemon
+      - run: scripts/verify_cli_mcp_surface.py --voice-bin target/debug/voice --skip-daemon --timeout 240
 
   sidecar-python:
     runs-on: ubuntu-latest

--- a/scripts/verify_cli_mcp_surface.py
+++ b/scripts/verify_cli_mcp_surface.py
@@ -77,16 +77,37 @@ def run_command(
     input_text: str | None = None,
     timeout: float,
 ) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        command,
-        input=input_text,
-        text=True,
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        timeout=timeout,
-        check=False,
-    )
+    try:
+        return subprocess.run(
+            command,
+            input=input_text,
+            text=True,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = _timeout_text(exc.stdout)
+        stderr = _timeout_text(exc.stderr)
+        if stderr:
+            stderr += "\n"
+        stderr += f"timed out after {exc.timeout}s"
+        return subprocess.CompletedProcess(
+            command,
+            124,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+
+def _timeout_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
 
 
 def hidden_daemon_env() -> dict[str, str]:

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -34,6 +34,7 @@ expected_whatsapp_agent_number="${WHATSAPP_AGENT_NUMBER:-}"
 expected_whatsapp_agent_name="${WHATSAPP_AGENT_NAME:-}"
 require_whatsapp_cloud="${REQUIRE_WHATSAPP_CLOUD:-0}"
 require_whatsapp_calling="${REQUIRE_WHATSAPP_CALLING:-0}"
+require_whatsapp_alpha_complete="${REQUIRE_WHATSAPP_ALPHA_COMPLETE:-0}"
 
 hermes_config_verify_script="${HERMES_CONFIG_VERIFY_SCRIPT:-$repo_root/scripts/verify_hermes_voice_config.py}"
 hermes_gateway_verify_script="${HERMES_GATEWAY_VERIFY_SCRIPT:-$repo_root/scripts/verify_hermes_gateway_service.py}"
@@ -81,6 +82,8 @@ Options:
                                require Baileys creds to expose this profile name
   --require-whatsapp-cloud     fail when WhatsApp Cloud credentials are missing
   --require-whatsapp-calling   fail when Cloud Calling credentials/readiness are missing
+  --require-whatsapp-alpha-complete
+                               fail unless all WhatsApp alpha readiness gates are complete
   --run-whatsapp-inbound-cache-smoke
                                transcribe a bridge-downloaded aud_* file from the audio cache
   --whatsapp-alpha-profile PROFILE
@@ -106,6 +109,7 @@ Environment aliases:
   WHATSAPP_BRIDGE_URL, WHATSAPP_SESSION_DIR, WHATSAPP_ENV_FILE
   WHATSAPP_AUDIO_CACHE_DIR, WHATSAPP_AGENT_NUMBER, WHATSAPP_AGENT_NAME
   REQUIRE_WHATSAPP_CLOUD=1, REQUIRE_WHATSAPP_CALLING=1
+  REQUIRE_WHATSAPP_ALPHA_COMPLETE=1
   RUN_WHATSAPP_INBOUND_CACHE_SMOKE=1, WHATSAPP_ALPHA_PROFILE
   WHATSAPP_ALPHA_VOICE_NOTE_CHAT_ID, WHATSAPP_ALPHA_WAIT_AUDIO_CACHE_SECONDS
   WHATSAPP_ALPHA_WAIT_INBOUND_SECONDS
@@ -251,6 +255,10 @@ while [[ $# -gt 0 ]]; do
       require_whatsapp_calling=1
       shift
       ;;
+    --require-whatsapp-alpha-complete)
+      require_whatsapp_alpha_complete=1
+      shift
+      ;;
     --run-whatsapp-inbound-cache-smoke)
       run_whatsapp_inbound_cache_smoke=1
       shift
@@ -312,6 +320,9 @@ if [[ -n "$whatsapp_alpha_profile" ]]; then
       fail "unknown WhatsApp alpha profile: $whatsapp_alpha_profile"
       ;;
   esac
+fi
+if [[ "$require_whatsapp_alpha_complete" == "1" && -z "$whatsapp_alpha_profile" ]]; then
+  fail "--require-whatsapp-alpha-complete requires --whatsapp-alpha-profile"
 fi
 
 voice_bin="$(default_voice_bin)"
@@ -539,6 +550,9 @@ if [[ -n "$whatsapp_alpha_profile" ]]; then
   fi
   if [[ "$require_whatsapp_calling" == "1" ]]; then
     whatsapp_alpha_args+=(--require-whatsapp-calling)
+  fi
+  if [[ "$require_whatsapp_alpha_complete" == "1" ]]; then
+    whatsapp_alpha_args+=(--require-complete)
   fi
   run_step "WhatsApp alpha readiness profile ($whatsapp_alpha_profile)" "${whatsapp_alpha_args[@]}"
   whatsapp_alpha_status="$whatsapp_alpha_profile"

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -600,6 +600,29 @@ def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
         pending_gates=pending_gates,
         external_meta_setup=external_meta_setup,
     )
+    completion_failures: list[dict[str, Any]] = []
+    if args.require_complete and not readiness_summary["complete"]:
+        success = False
+        next_action_ids = [
+            str(action.get("id"))
+            for action in readiness_summary.get("next_actions") or []
+            if action.get("id")
+        ]
+        failure_messages = [
+            "WhatsApp alpha readiness is not complete: "
+            + str(readiness_summary["status"])
+        ]
+        if next_action_ids:
+            failure_messages.append(
+                "next actions: " + ", ".join(next_action_ids)
+            )
+        completion_failures.append(
+            {
+                "name": "whatsapp_alpha_complete",
+                "category": "readiness_summary",
+                "failures": failure_messages,
+            }
+        )
 
     return {
         "success": success,
@@ -617,7 +640,8 @@ def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
             }
             for item in required_failures
         ]
-        + external_failures,
+        + external_failures
+        + completion_failures,
     }
 
 
@@ -680,6 +704,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--require-fresh-cache-audio", action="store_true")
     parser.add_argument("--require-whatsapp-cloud", action="store_true")
     parser.add_argument("--require-whatsapp-calling", action="store_true")
+    parser.add_argument(
+        "--require-complete",
+        action="store_true",
+        help=(
+            "fail unless local checks, attended fresh receive, and WhatsApp "
+            "Cloud/Calling gates are all complete"
+        ),
+    )
     parser.add_argument("--json", action="store_true")
     return parser
 
@@ -757,6 +789,16 @@ def human_summary(result: dict[str, Any]) -> None:
         if not item["success"]:
             for failure in item.get("failures") or []:
                 print(f"  - {failure}", file=sys.stderr)
+
+    component_names = {item["name"] for item in result["components"]}
+    for failure in result.get("failures") or []:
+        if failure.get("name") in component_names:
+            continue
+        print(
+            f"{failure.get('name')}=failed category={failure.get('category')}"
+        )
+        for message in failure.get("failures") or []:
+            print(f"  - {message}", file=sys.stderr)
 
     external = result["external_meta_setup"]
     pending = result.get("pending_gates") or {}

--- a/tests/test_verify_cli_mcp_surface.py
+++ b/tests/test_verify_cli_mcp_surface.py
@@ -143,6 +143,19 @@ class CliMcpSurfaceVerifierTests(unittest.TestCase):
         self.assertTrue(checks["daemon_detected"]["detected"])
         self.assertTrue(checks["mcp_with_daemon_detects_daemon"]["ok"])
 
+    def test_run_command_reports_timeout_as_completed_process(self):
+        result = self.script.run_command(
+            [
+                sys.executable,
+                "-c",
+                "import time; time.sleep(1)",
+            ],
+            timeout=0.01,
+        )
+
+        self.assertEqual(result.returncode, 124)
+        self.assertIn("timed out after", result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -451,6 +451,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                     "Quill",
                     "--require-whatsapp-cloud",
                     "--require-whatsapp-calling",
+                    "--require-whatsapp-alpha-complete",
                     "--skip-hermes-config",
                     "--skip-hermes-gateway",
                     "--skip-cli-mcp",
@@ -525,7 +526,25 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 "--skip-hermes-tts-smoke",
                 "--require-whatsapp-cloud",
                 "--require-whatsapp-calling",
+                "--require-complete",
             ],
+        )
+
+    def test_require_whatsapp_alpha_complete_requires_alpha_profile(self):
+        result = subprocess.run(
+            [
+                str(SCRIPT_PATH),
+                "--require-whatsapp-alpha-complete",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "--require-whatsapp-alpha-complete requires --whatsapp-alpha-profile",
+            result.stderr,
         )
 
     def test_skip_hermes_config_does_not_require_config_file(self):

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -96,14 +96,36 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self,
         tmp_path: Path,
         *args: str,
+        cloud_configured: bool = False,
         skip_voice_note_smoke: bool = True,
         voice_note_payload: dict | None = None,
         inbound_cache_payload: dict | None = None,
     ) -> dict:
+        result = self.run_readiness_process(
+            tmp_path,
+            *args,
+            cloud_configured=cloud_configured,
+            skip_voice_note_smoke=skip_voice_note_smoke,
+            voice_note_payload=voice_note_payload,
+            inbound_cache_payload=inbound_cache_payload,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return json.loads(result.stdout)
+
+    def run_readiness_process(
+        self,
+        tmp_path: Path,
+        *args: str,
+        cloud_configured: bool = False,
+        skip_voice_note_smoke: bool = True,
+        voice_note_payload: dict | None = None,
+        inbound_cache_payload: dict | None = None,
+    ) -> subprocess.CompletedProcess[str]:
         helpers = tmp_path / "helpers"
         helpers.mkdir()
         write_fake_helpers(
             helpers,
+            cloud_configured=cloud_configured,
             voice_note_payload=voice_note_payload,
             inbound_cache_payload=inbound_cache_payload,
         )
@@ -137,8 +159,7 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
                 "VOICE_READINESS_SCRIPT_DIR": str(helpers),
             },
         )
-        self.assertEqual(result.returncode, 0, result.stderr)
-        return json.loads(result.stdout)
+        return result
 
     def test_readiness_succeeds_for_baileys_alpha_when_cloud_is_missing(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -187,6 +208,34 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertIn(
             "configure_whatsapp_cloud_calling",
             [action["id"] for action in summary["next_actions"]],
+        )
+
+    def test_require_complete_fails_when_alpha_gates_are_pending(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self.run_readiness_process(
+                Path(tmp),
+                "--require-complete",
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        payload = json.loads(result.stdout)
+        self.assertFalse(payload["success"])
+        self.assertEqual(
+            payload["readiness_summary"]["status"],
+            "local_ready_pending_gates",
+        )
+        failures = {
+            item["name"]: item
+            for item in payload["failures"]
+        }
+        self.assertIn("whatsapp_alpha_complete", failures)
+        self.assertEqual(
+            failures["whatsapp_alpha_complete"]["category"],
+            "readiness_summary",
+        )
+        self.assertIn(
+            "run_attended_fresh_receive",
+            failures["whatsapp_alpha_complete"]["failures"][1],
         )
 
     def test_default_voice_bin_prefers_installed_voice_on_path(self):
@@ -498,6 +547,7 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
                     "--skip-sidecar",
                     "--profile",
                     "attended-cache-receive",
+                    "--require-complete",
                     "--json",
                 ],
                 capture_output=True,


### PR DESCRIPTION
## Summary
- add `--require-complete` to `verify_whatsapp_alpha_readiness.py` so alpha readiness can fail until local checks, attended fresh receive, and Cloud/Calling setup are all complete
- add `--require-whatsapp-alpha-complete` / `REQUIRE_WHATSAPP_ALPHA_COMPLETE=1` to the local Hermes voice stack verifier
- print non-component readiness failures in the human alpha summary
- cover pending-gate failure, all-gates-complete success, and stack wrapper pass-through behavior in tests

## Verification
- `python3 -m unittest tests.test_verify_whatsapp_alpha_readiness tests.test_verify_local_hermes_voice_stack`
- `python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_alpha_readiness.py tests/test_verify_local_hermes_voice_stack.py && bash -n scripts/verify_local_hermes_voice_stack.sh && git diff --check`
- `python3 -m unittest discover -s tests`
- `scripts/verify_whatsapp_alpha_readiness.py --hermes-home /home/ubuntu/.hermes --profile cached-receive --skip-hermes-tts-smoke --wait-audio-cache-seconds 0.1 --json` passed with `readiness_summary.status=local_ready_pending_gates`
- `scripts/verify_whatsapp_alpha_readiness.py --hermes-home /home/ubuntu/.hermes --profile cached-receive --skip-hermes-tts-smoke --wait-audio-cache-seconds 0.1 --require-complete --json` failed as expected with `whatsapp_alpha_complete` and next actions `run_attended_fresh_receive, configure_whatsapp_cloud_calling`

## Live state noted
The local voice runtime, Hermes gateway, Baileys bridge, and WebRTC sidecar checks pass. Full alpha completion is still blocked by attended fresh receive evidence and external WhatsApp Cloud/Calling credentials.
