### PR TITLE
Add WhatsApp receive operator handoff

### DIFF
--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -351,13 +351,18 @@ def build_components(args: argparse.Namespace) -> list[dict[str, Any]]:
 
 
 def bridge_cloud_summary(components: list[dict[str, Any]]) -> dict[str, Any]:
+    checks = bridge_runtime_checks(components)
+    cloud = checks.get("whatsapp_cloud")
+    return cloud if isinstance(cloud, dict) else {}
+
+
+def bridge_runtime_checks(components: list[dict[str, Any]]) -> dict[str, Any]:
     for item in components:
         if item["name"] != "whatsapp_bridge_runtime":
             continue
         summary = item.get("summary") or {}
         checks = summary.get("checks") or {}
-        cloud = checks.get("whatsapp_cloud")
-        return cloud if isinstance(cloud, dict) else {}
+        return checks if isinstance(checks, dict) else {}
     return {}
 
 
@@ -365,7 +370,11 @@ def attended_receive_gate(
     components: list[dict[str, Any]],
     *,
     hermes_home: Path,
+    audio_cache_dir: Path,
 ) -> dict[str, Any]:
+    bridge_checks = bridge_runtime_checks(components)
+    local_config = bridge_checks.get("whatsapp_local_config") or {}
+    identity = bridge_checks.get("baileys_identity") or {}
     receive_names = {"whatsapp_voice_note_receive", "whatsapp_voice_note_send_receive"}
     cached_receive_verified = any(
         item["name"] == "whatsapp_inbound_cache_stt" and item.get("success")
@@ -392,6 +401,24 @@ def attended_receive_gate(
             str(hermes_home),
             "--profile",
             "attended-send-receive",
+        ],
+    }
+    gate["operator_handoff"] = {
+        "preferred_profile": "attended-cache-receive",
+        "preferred_command": gate["command"],
+        "fallback_profile": "attended-send-receive",
+        "fallback_draining_command": gate["fallback_draining_command"],
+        "drains_bridge_messages": False,
+        "fallback_drains_bridge_messages": True,
+        "audio_cache_dir": str(audio_cache_dir),
+        "home_channel": local_config.get("home_channel"),
+        "home_channel_kind": local_config.get("home_channel_kind"),
+        "agent_number": identity.get("number"),
+        "agent_name": identity.get("name"),
+        "steps": [
+            "Start the preferred command and keep it running for the receive window.",
+            "From an allowed WhatsApp user, send a fresh voice note to the configured agent chat while the command is waiting.",
+            "Use the fallback command only when Hermes is not consuming the bridge queue and it is acceptable to drain GET /messages.",
         ],
     }
 
@@ -592,6 +619,11 @@ def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
         "attended_fresh_receive": attended_receive_gate(
             components,
             hermes_home=args.hermes_home.expanduser().resolve(),
+            audio_cache_dir=(
+                args.whatsapp_audio_cache_dir.expanduser().resolve()
+                if args.whatsapp_audio_cache_dir
+                else args.hermes_home.expanduser().resolve() / "audio_cache"
+            ),
         ),
         **external_meta_gate(external_meta_setup),
     }
@@ -822,6 +854,17 @@ def human_summary(result: dict[str, Any]) -> None:
                     "attended_fresh_receive_fallback_draining_command="
                     f"{shlex.join([str(part) for part in fallback])}"
                 )
+            handoff = attended.get("operator_handoff") or {}
+            if handoff:
+                print(
+                    "attended_fresh_receive_operator="
+                    f"agent={handoff.get('agent_name') or '<unknown>'} "
+                    f"number={handoff.get('agent_number') or '<unknown>'} "
+                    f"home_channel={handoff.get('home_channel') or '<unknown>'} "
+                    f"audio_cache_dir={handoff.get('audio_cache_dir')}"
+                )
+                for index, step in enumerate(handoff.get("steps") or [], start=1):
+                    print(f"attended_fresh_receive_step[{index}]={step}")
     print(
         "whatsapp_cloud="
         + ("configured" if external["cloud_configured"] else "not_configured")

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -70,6 +70,17 @@ def write_fake_helpers(
     bridge_payload = {
         "success": True,
         "checks": {
+            "baileys_identity": {
+                "name": "Quill",
+                "number": "13236478455",
+                "lid_number": "186999436771390",
+            },
+            "whatsapp_local_config": {
+                "home_channel": "20530681934008@lid",
+                "home_channel_kind": "lid",
+                "mode": "bot",
+                "allowed_users_count": 2,
+            },
             "whatsapp_cloud": {
                 "cloud_configured": cloud_configured,
                 "calling_sidecar_configured": True,
@@ -186,6 +197,17 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             "attended-send-receive",
             gates["attended_fresh_receive"]["fallback_draining_command"],
         )
+        handoff = gates["attended_fresh_receive"]["operator_handoff"]
+        self.assertEqual(handoff["preferred_profile"], "attended-cache-receive")
+        self.assertEqual(handoff["fallback_profile"], "attended-send-receive")
+        self.assertEqual(handoff["home_channel"], "20530681934008@lid")
+        self.assertEqual(handoff["home_channel_kind"], "lid")
+        self.assertEqual(handoff["agent_name"], "Quill")
+        self.assertEqual(handoff["agent_number"], "13236478455")
+        self.assertFalse(handoff["drains_bridge_messages"])
+        self.assertTrue(handoff["fallback_drains_bridge_messages"])
+        self.assertIn("audio_cache", handoff["audio_cache_dir"])
+        self.assertEqual(len(handoff["steps"]), 3)
         self.assertEqual(
             gates["whatsapp_cloud_calling"]["status"],
             "external_setup_required",
@@ -329,15 +351,28 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             result.stdout,
         )
         self.assertIn("--profile attended-send-receive", result.stdout)
+        self.assertIn(
+            "attended_fresh_receive_operator=agent=Quill number=13236478455",
+            result.stdout,
+        )
+        self.assertIn(
+            "home_channel=20530681934008@lid",
+            result.stdout,
+        )
+        self.assertIn(
+            "attended_fresh_receive_step[1]=Start the preferred command",
+            result.stdout,
+        )
         self.assertIn("readiness=local_ready_pending_gates", result.stdout)
 
     def test_inbound_cache_smoke_adds_receive_component(self):
         with tempfile.TemporaryDirectory() as tmp:
+            audio_cache = Path(tmp) / "audio_cache"
             payload = self.run_readiness(
                 Path(tmp),
                 "--run-inbound-cache-smoke",
                 "--whatsapp-audio-cache-dir",
-                str(Path(tmp) / "audio_cache"),
+                str(audio_cache),
             )
 
         self.assertTrue(payload["success"])
@@ -350,6 +385,12 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertIn(
             "whatsapp_inbound_cache_stt",
             payload["by_category"]["voice_note"]["components"],
+        )
+        self.assertEqual(
+            payload["pending_gates"]["attended_fresh_receive"]["operator_handoff"][
+                "audio_cache_dir"
+            ],
+            str(audio_cache.resolve()),
         )
 
     def test_cached_receive_profile_adds_receive_component(self):


### PR DESCRIPTION
## Summary
- add an `operator_handoff` block to the pending attended fresh receive gate
- include the preferred non-draining receive command, fallback draining command, bridge destination context, agent identity, audio cache path, and operator steps
- print the same handoff fields in the human alpha readiness summary

## Verification
- `python3 -m unittest tests.test_verify_whatsapp_alpha_readiness`
- `python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_alpha_readiness.py && git diff --check`
- `python3 -m unittest discover -s tests`
- live: `scripts/verify_whatsapp_alpha_readiness.py --hermes-home /home/ubuntu/.hermes --profile cached-receive --skip-hermes-tts-smoke --wait-audio-cache-seconds 0.1` now prints Quill's number, home channel, audio cache dir, and the non-draining/fallback attended receive instructions

## Context
This does not mark the alpha complete. It makes the remaining attended receive gate self-contained so an operator can run the preferred receive window and send the fresh WhatsApp voice note without reconstructing the process from docs.
