### PR TITLE
Report WhatsApp Cloud setup handoffs

### DIFF
--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -32,6 +32,16 @@ META_SETUP_STEPS = (
     "Enable/approve WhatsApp Calling for the Cloud phone number.",
     "Route Cloud Calling webhooks to the Hermes WhatsApp Cloud adapter.",
 )
+CLOUD_REQUIRED_KEYS = (
+    "WHATSAPP_CLOUD_PHONE_NUMBER_ID",
+    "WHATSAPP_CLOUD_ACCESS_TOKEN",
+    "WHATSAPP_CLOUD_APP_SECRET",
+    "WHATSAPP_CLOUD_VERIFY_TOKEN",
+)
+CALLING_SIDECAR_REQUIRED_KEYS = (
+    "WHATSAPP_CLOUD_CALLING_SIDECAR_URL",
+    "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND",
+)
 
 
 def repo_root() -> Path:
@@ -472,17 +482,158 @@ def attended_receive_gate(
     return gate
 
 
-def external_meta_gate(external_meta_setup: dict[str, Any]) -> dict[str, Any]:
+def presence_sources(
+    presence: dict[str, Any],
+    keys: tuple[str, ...],
+) -> dict[str, list[str]]:
+    sources: dict[str, list[str]] = {}
+    for key in keys:
+        status = presence.get(key) if isinstance(presence, dict) else None
+        if isinstance(status, dict):
+            key_sources = status.get("sources") or []
+            sources[key] = [str(source) for source in key_sources]
+        else:
+            sources[key] = []
+    return sources
+
+
+def source_key_inventory(bridge_checks: dict[str, Any]) -> dict[str, list[str]]:
+    raw = bridge_checks.get("env_key_sources") if isinstance(bridge_checks, dict) else None
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        str(source): [str(key) for key in keys]
+        for source, keys in raw.items()
+        if isinstance(keys, list)
+    }
+
+
+def cloud_setup_handoff(
+    *,
+    external_meta_setup: dict[str, Any],
+    bridge_checks: dict[str, Any],
+    hermes_home: Path,
+) -> dict[str, Any]:
+    cloud = bridge_checks.get("whatsapp_cloud") or {}
+    cloud_required = cloud.get("cloud_required") or {}
+    missing = [str(key) for key in external_meta_setup.get("cloud_missing") or []]
+    configured = bool(external_meta_setup.get("cloud_configured"))
+    verify_command = [
+        "scripts/verify_whatsapp_alpha_readiness.py",
+        "--hermes-home",
+        str(hermes_home),
+        "--require-whatsapp-cloud",
+    ]
+    steps = [] if configured else [
+        "Create or select the Meta app, WABA, and Cloud API phone number for Quill.",
+        "Add the required WHATSAPP_CLOUD_* keys to the Hermes environment without committing secret values.",
+        "Restart hermes-gateway.service so the gateway process sees the new Cloud credentials.",
+        "Rerun the Cloud verification command and confirm whatsapp_cloud=configured.",
+    ]
+    return {
+        "required_keys": list(CLOUD_REQUIRED_KEYS),
+        "missing": missing,
+        "configured": configured,
+        "env_file": bridge_checks.get("env_file"),
+        "credential_sources": presence_sources(cloud_required, CLOUD_REQUIRED_KEYS),
+        "available_source_keys": source_key_inventory(bridge_checks),
+        "verify_command": verify_command,
+        "steps": steps,
+    }
+
+
+def calling_setup_handoff(
+    *,
+    external_meta_setup: dict[str, Any],
+    bridge_checks: dict[str, Any],
+    hermes_home: Path,
+) -> dict[str, Any]:
+    cloud = bridge_checks.get("whatsapp_cloud") or {}
+    calling = cloud.get("calling") or {}
+    cloud_required = cloud.get("cloud_required") or {}
+    missing = [str(key) for key in external_meta_setup.get("calling_missing") or []]
+    sidecar_missing = [
+        key
+        for key in CALLING_SIDECAR_REQUIRED_KEYS
+        if key in missing
+    ]
+    ready = bool(external_meta_setup.get("calling_ready"))
+    verify_command = [
+        "scripts/verify_whatsapp_alpha_readiness.py",
+        "--hermes-home",
+        str(hermes_home),
+        "--require-whatsapp-cloud",
+        "--require-whatsapp-calling",
+    ]
+    complete_command = [
+        "scripts/verify_whatsapp_alpha_readiness.py",
+        "--hermes-home",
+        str(hermes_home),
+        "--profile",
+        "attended-cache-receive",
+        "--require-complete",
+    ]
+    steps = [] if ready else [
+        "Complete WhatsApp Cloud setup first; Calling depends on the same Cloud phone credentials.",
+        "Enable or approve WhatsApp Calling for the configured Cloud phone number in Meta.",
+        "Ensure Hermes has the Calling sidecar URL and TTS stream command environment keys.",
+        "Restart hermes-gateway.service and voice-webrtc-sidecar.service after environment or sidecar changes.",
+        "Rerun the Calling verification command before using the complete alpha gate.",
+    ]
+    return {
+        "required_keys": [*CLOUD_REQUIRED_KEYS, *CALLING_SIDECAR_REQUIRED_KEYS],
+        "missing": missing,
+        "cloud_missing": [
+            key for key in missing if key in CLOUD_REQUIRED_KEYS
+        ],
+        "sidecar_missing": sidecar_missing,
+        "calling_sidecar_configured": bool(
+            external_meta_setup.get("calling_sidecar_configured")
+        ),
+        "calling_ready": ready,
+        "env_file": bridge_checks.get("env_file"),
+        "cloud_credential_sources": presence_sources(
+            cloud_required,
+            CLOUD_REQUIRED_KEYS,
+        ),
+        "sidecar_sources": presence_sources(
+            calling,
+            CALLING_SIDECAR_REQUIRED_KEYS,
+        ),
+        "available_source_keys": source_key_inventory(bridge_checks),
+        "verify_command": verify_command,
+        "complete_verification_command": complete_command,
+        "steps": steps,
+    }
+
+
+def external_meta_gate(
+    external_meta_setup: dict[str, Any],
+    *,
+    bridge_checks: dict[str, Any],
+    hermes_home: Path,
+) -> dict[str, Any]:
     cloud_missing = [str(key) for key in external_meta_setup.get("cloud_missing") or []]
     calling_missing = [
         str(key) for key in external_meta_setup.get("calling_missing") or []
     ]
     cloud_configured = bool(external_meta_setup.get("cloud_configured"))
     calling_ready = bool(external_meta_setup.get("calling_ready"))
+    cloud_handoff = cloud_setup_handoff(
+        external_meta_setup=external_meta_setup,
+        bridge_checks=bridge_checks,
+        hermes_home=hermes_home,
+    )
+    calling_handoff = calling_setup_handoff(
+        external_meta_setup=external_meta_setup,
+        bridge_checks=bridge_checks,
+        hermes_home=hermes_home,
+    )
     return {
         "whatsapp_cloud": {
             "status": "configured" if cloud_configured else "external_setup_required",
             "missing": cloud_missing,
+            "setup_handoff": cloud_handoff,
         },
         "whatsapp_cloud_calling": {
             "status": "ready" if calling_ready else "external_setup_required",
@@ -492,6 +643,7 @@ def external_meta_gate(external_meta_setup: dict[str, Any]) -> dict[str, Any]:
                 if calling_ready
                 else list(external_meta_setup.get("setup_steps") or META_SETUP_STEPS)
             ),
+            "setup_handoff": calling_handoff,
         },
     }
 
@@ -576,6 +728,7 @@ def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
         if item.get("required") and not item.get("success"):
             bucket["success"] = False
 
+    bridge_checks = bridge_runtime_checks(components)
     cloud = bridge_cloud_summary(components)
     cloud_missing = [str(key) for key in cloud.get("cloud_missing") or []]
     calling_missing = [str(key) for key in cloud.get("calling_missing") or []]
@@ -625,7 +778,11 @@ def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
                 else args.hermes_home.expanduser().resolve() / "audio_cache"
             ),
         ),
-        **external_meta_gate(external_meta_setup),
+        **external_meta_gate(
+            external_meta_setup,
+            bridge_checks=bridge_checks,
+            hermes_home=args.hermes_home.expanduser().resolve(),
+        ),
     }
     readiness_summary = build_readiness_summary(
         local_checks_passed=not required_failures,
@@ -871,12 +1028,52 @@ def human_summary(result: dict[str, Any]) -> None:
         + " missing="
         + (",".join(external["cloud_missing"]) or "none")
     )
+    cloud_gate = pending.get("whatsapp_cloud") or {}
+    cloud_handoff = cloud_gate.get("setup_handoff") or {}
+    if cloud_gate.get("status") != "configured" and cloud_handoff:
+        print(
+            "whatsapp_cloud_setup="
+            f"env_file={cloud_handoff.get('env_file') or '<unknown>'} "
+            "missing="
+            + (",".join(cloud_handoff.get("missing") or []) or "none")
+        )
+        verify_command = cloud_handoff.get("verify_command") or []
+        if verify_command:
+            print(
+                "whatsapp_cloud_verify_command="
+                f"{shlex.join([str(part) for part in verify_command])}"
+            )
+        for index, step in enumerate(cloud_handoff.get("steps") or [], start=1):
+            print(f"whatsapp_cloud_step[{index}]={step}")
     print(
         "whatsapp_calling="
         + ("ready" if external["calling_ready"] else "not_ready")
         + " missing="
         + (",".join(external["calling_missing"]) or "none")
     )
+    calling_gate = pending.get("whatsapp_cloud_calling") or {}
+    calling_handoff = calling_gate.get("setup_handoff") or {}
+    if calling_gate.get("status") != "ready" and calling_handoff:
+        print(
+            "whatsapp_calling_setup="
+            f"sidecar_configured={calling_handoff.get('calling_sidecar_configured')} "
+            "missing="
+            + (",".join(calling_handoff.get("missing") or []) or "none")
+        )
+        verify_command = calling_handoff.get("verify_command") or []
+        complete_command = calling_handoff.get("complete_verification_command") or []
+        if verify_command:
+            print(
+                "whatsapp_calling_verify_command="
+                f"{shlex.join([str(part) for part in verify_command])}"
+            )
+        if complete_command:
+            print(
+                "whatsapp_calling_complete_command="
+                f"{shlex.join([str(part) for part in complete_command])}"
+            )
+        for index, step in enumerate(calling_handoff.get("steps") or [], start=1):
+            print(f"whatsapp_calling_step[{index}]={step}")
     if external["setup_steps"]:
         print("external_meta_setup=required")
         for step in external["setup_steps"]:

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -67,9 +67,46 @@ def write_fake_helpers(
         "WHATSAPP_CLOUD_APP_SECRET",
         "WHATSAPP_CLOUD_VERIFY_TOKEN",
     ]
+    cloud_required = {
+        key: {
+            "present": key not in cloud_missing,
+            "sources": ["env_file"] if key not in cloud_missing else [],
+        }
+        for key in [
+            "WHATSAPP_CLOUD_PHONE_NUMBER_ID",
+            "WHATSAPP_CLOUD_ACCESS_TOKEN",
+            "WHATSAPP_CLOUD_APP_SECRET",
+            "WHATSAPP_CLOUD_VERIFY_TOKEN",
+        ]
+    }
+    calling = {
+        "WHATSAPP_CLOUD_CALLING_SIDECAR_URL": {
+            "present": True,
+            "sources": ["systemd_service"],
+        },
+        "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND": {
+            "present": True,
+            "sources": ["systemd_service"],
+        },
+        "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT": {
+            "present": True,
+            "sources": ["systemd_service"],
+        },
+    }
+    env_key_sources = {
+        "env_file": [
+            "WHATSAPP_ENABLED",
+            "WHATSAPP_HOME_CHANNEL",
+            "WHATSAPP_MODE",
+            *([] if not cloud_configured else list(cloud_required)),
+        ],
+        "systemd_service": list(calling),
+    }
     bridge_payload = {
         "success": True,
         "checks": {
+            "env_file": str(directory.parent / "hermes" / ".env"),
+            "env_key_sources": env_key_sources,
             "baileys_identity": {
                 "name": "Quill",
                 "number": "13236478455",
@@ -87,6 +124,8 @@ def write_fake_helpers(
                 "calling_ready": cloud_configured,
                 "cloud_missing": cloud_missing,
                 "calling_missing": cloud_missing,
+                "cloud_required": cloud_required,
+                "calling": calling,
             }
         },
         "failures": [],
@@ -212,10 +251,52 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             gates["whatsapp_cloud_calling"]["status"],
             "external_setup_required",
         )
+        cloud_gate = gates["whatsapp_cloud"]
+        self.assertEqual(cloud_gate["status"], "external_setup_required")
+        cloud_handoff = cloud_gate["setup_handoff"]
+        self.assertEqual(
+            cloud_handoff["required_keys"],
+            [
+                "WHATSAPP_CLOUD_PHONE_NUMBER_ID",
+                "WHATSAPP_CLOUD_ACCESS_TOKEN",
+                "WHATSAPP_CLOUD_APP_SECRET",
+                "WHATSAPP_CLOUD_VERIFY_TOKEN",
+            ],
+        )
+        self.assertIn("WHATSAPP_CLOUD_ACCESS_TOKEN", cloud_handoff["missing"])
+        self.assertIn("hermes/.env", cloud_handoff["env_file"])
+        self.assertEqual(
+            cloud_handoff["credential_sources"]["WHATSAPP_CLOUD_ACCESS_TOKEN"],
+            [],
+        )
+        self.assertIn(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_URL",
+            cloud_handoff["available_source_keys"]["systemd_service"],
+        )
+        self.assertIn("--require-whatsapp-cloud", cloud_handoff["verify_command"])
+        self.assertEqual(len(cloud_handoff["steps"]), 4)
+        self.assertNotIn("phone-id", json.dumps(cloud_handoff))
         self.assertIn(
             "WHATSAPP_CLOUD_ACCESS_TOKEN",
             gates["whatsapp_cloud_calling"]["missing"],
         )
+        calling_handoff = gates["whatsapp_cloud_calling"]["setup_handoff"]
+        self.assertIn(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND",
+            calling_handoff["required_keys"],
+        )
+        self.assertEqual(
+            calling_handoff["sidecar_sources"][
+                "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND"
+            ],
+            ["systemd_service"],
+        )
+        self.assertEqual(calling_handoff["sidecar_missing"], [])
+        self.assertTrue(calling_handoff["calling_sidecar_configured"])
+        self.assertFalse(calling_handoff["calling_ready"])
+        self.assertIn("--require-whatsapp-calling", calling_handoff["verify_command"])
+        self.assertIn("--require-complete", calling_handoff["complete_verification_command"])
+        self.assertEqual(len(calling_handoff["steps"]), 5)
         summary = payload["readiness_summary"]
         self.assertEqual(summary["status"], "local_ready_pending_gates")
         self.assertFalse(summary["complete"])
@@ -361,6 +442,41 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         )
         self.assertIn(
             "attended_fresh_receive_step[1]=Start the preferred command",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_cloud_setup=env_file=",
+            result.stdout,
+        )
+        self.assertIn(
+            "missing=WHATSAPP_CLOUD_PHONE_NUMBER_ID,WHATSAPP_CLOUD_ACCESS_TOKEN",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_cloud_verify_command=scripts/verify_whatsapp_alpha_readiness.py",
+            result.stdout,
+        )
+        self.assertIn("--require-whatsapp-cloud", result.stdout)
+        self.assertIn(
+            "whatsapp_cloud_step[1]=Create or select the Meta app",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_calling_setup=sidecar_configured=True",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_calling_verify_command=scripts/verify_whatsapp_alpha_readiness.py",
+            result.stdout,
+        )
+        self.assertIn("--require-whatsapp-calling", result.stdout)
+        self.assertIn(
+            "whatsapp_calling_complete_command=scripts/verify_whatsapp_alpha_readiness.py",
+            result.stdout,
+        )
+        self.assertIn("--require-complete", result.stdout)
+        self.assertIn(
+            "whatsapp_calling_step[1]=Complete WhatsApp Cloud setup first",
             result.stdout,
         )
         self.assertIn("readiness=local_ready_pending_gates", result.stdout)
@@ -610,6 +726,19 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertFalse(summary["external_meta_setup_required"])
         self.assertFalse(summary["operator_action_required"])
         self.assertEqual(summary["next_actions"], [])
+        gates = payload["pending_gates"]
+        self.assertEqual(gates["whatsapp_cloud"]["status"], "configured")
+        self.assertEqual(gates["whatsapp_cloud"]["setup_handoff"]["steps"], [])
+        self.assertEqual(gates["whatsapp_cloud"]["setup_handoff"]["missing"], [])
+        self.assertEqual(gates["whatsapp_cloud_calling"]["status"], "ready")
+        self.assertEqual(
+            gates["whatsapp_cloud_calling"]["setup_handoff"]["steps"],
+            [],
+        )
+        self.assertEqual(
+            gates["whatsapp_cloud_calling"]["setup_handoff"]["missing"],
+            [],
+        )
 
     def test_voice_note_flags_cannot_be_used_when_voice_note_smoke_is_skipped(self):
         result = self.run_invalid("--skip-voice-note-smoke", "--send-voice-note")


### PR DESCRIPTION
## Summary
- add machine-readable Cloud and Calling setup handoff fields to the WhatsApp alpha readiness gates
- print human-readable Cloud/Calling setup commands and steps in the readiness summary
- cover missing-credential and fully-configured gate behavior in the alpha readiness tests

## Verification
- python3 -m unittest tests.test_verify_whatsapp_alpha_readiness
- python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_alpha_readiness.py
- git diff --check
- python3 -m unittest discover -s tests
- live: scripts/verify_whatsapp_alpha_readiness.py --hermes-home /home/ubuntu/.hermes --voice-bin /home/ubuntu/.local/bin/voice --profile cached-receive --skip-hermes-tts-smoke --wait-audio-cache-seconds 0.1 --expected-agent-number 13236478455 --expected-agent-name Quill
- live JSON probe confirmed Cloud credentials missing, sidecar configured, readiness local_ready_pending_gates