### PR TITLE
Document WhatsApp alpha setup handoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,22 @@ the verifier itself should poll and drain the bridge message queue. Add
 attended wait with `--whatsapp-alpha-wait-audio-cache-seconds` /
 `--whatsapp-alpha-wait-inbound-seconds`.
 
+To fail unless every alpha gate is complete, include the strict completion flag:
+
+```bash
+scripts/verify_local_hermes_voice_stack.sh \
+  --hermes-home ~/.hermes \
+  --whatsapp-alpha-profile attended-cache-receive \
+  --require-whatsapp-alpha-complete
+```
+
+That strict gate is expected to fail until the host has a fresh attended inbound
+voice note plus the required Meta WhatsApp Cloud and Calling credentials. The
+alpha output prints `whatsapp_cloud_setup`, `whatsapp_cloud_verify_command`,
+`whatsapp_calling_setup`, `whatsapp_calling_verify_command`, and
+`whatsapp_calling_complete_command` handoff lines so missing external setup is
+separated from local daemon, bridge, and Hermes failures.
+
 When the WebRTC Python dependencies are installed, add
 `--run-webrtc-loopback-smoke --webrtc-python /tmp/voice-webrtc-venv/bin/python`
 to run one full-duplex local media turn through the sidecar spike as well.

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -122,6 +122,33 @@ still report `pending_gates.attended_fresh_receive.status=pending_attended`
 until someone sends a fresh WhatsApp voice note during the guarded receive
 window.
 
+For the external Meta gates, the JSON report includes safe setup handoffs under
+`pending_gates.whatsapp_cloud.setup_handoff` and
+`pending_gates.whatsapp_cloud_calling.setup_handoff`. These handoffs list the
+required key names, which keys are missing, redacted source labels for values
+that were found, and the exact follow-up verifier commands. Secret values are
+never printed. The human output mirrors the same information with:
+
+- `whatsapp_cloud_setup`
+- `whatsapp_cloud_verify_command`
+- `whatsapp_calling_setup`
+- `whatsapp_calling_verify_command`
+- `whatsapp_calling_complete_command`
+
+Use the complete gate only when the local bridge, attended receive, Cloud API,
+and Calling setup are all expected to pass:
+
+```bash
+scripts/verify_whatsapp_alpha_readiness.py \
+  --hermes-home ~/.hermes \
+  --profile attended-cache-receive \
+  --require-complete
+```
+
+Until Meta Cloud/Calling credentials are installed, that command should fail
+with the missing external keys instead of reporting a local Baileys or voice
+runtime regression.
+
 The same alpha report can also drive the real bridge voice-note operation when
 running an attended test. Add `--send-voice-note` to post the generated
 Ogg/Opus note to `WHATSAPP_HOME_CHANNEL`, or pass `--voice-note-chat-id` to


### PR DESCRIPTION
## Summary
- document the strict WhatsApp alpha completion gate from the local stack verifier
- add the Cloud/Calling setup handoff fields and human output lines to the WhatsApp Calling runbook
- clarify that missing Meta credentials remain external setup, not a local Baileys or voice runtime failure

## Verification
- python3 -m unittest tests.test_verify_whatsapp_alpha_readiness tests.test_verify_local_hermes_voice_stack
- git diff --check
- scripts/verify_whatsapp_alpha_readiness.py --hermes-home /home/ubuntu/.hermes --voice-bin /home/ubuntu/.local/bin/voice --profile cached-receive --skip-hermes-tts-smoke --wait-audio-cache-seconds 0.1 --expected-agent-number 13236478455 --expected-agent-name Quill