### PR TITLE
Enrich WhatsApp alpha next actions

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -127,7 +127,9 @@ For the external Meta gates, the JSON report includes safe setup handoffs under
 `pending_gates.whatsapp_cloud_calling.setup_handoff`. These handoffs list the
 required key names, which keys are missing, redacted source labels for values
 that were found, and the exact follow-up verifier commands. Secret values are
-never printed. The human output mirrors the same information with:
+never printed. `readiness_summary.next_actions` repeats the same non-secret
+commands and missing-key groups so another agent can consume the report without
+scraping human output. The human output mirrors the same information with:
 
 - `whatsapp_cloud_setup`
 - `whatsapp_cloud_verify_command`

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -654,6 +654,9 @@ def build_readiness_summary(
     pending_gates: dict[str, Any],
     external_meta_setup: dict[str, Any],
 ) -> dict[str, Any]:
+    def missing_keys(handoff: dict[str, Any], fallback: Any) -> list[str]:
+        return [str(key) for key in (handoff.get("missing") or fallback or [])]
+
     attended = pending_gates.get("attended_fresh_receive") or {}
     attended_verified = attended.get("status") == "verified"
     external_meta_setup_required = not (
@@ -682,17 +685,62 @@ def build_readiness_summary(
         fallback = attended.get("fallback_draining_command")
         if fallback:
             action["fallback_draining_command"] = fallback
+        handoff = attended.get("operator_handoff")
+        if isinstance(handoff, dict):
+            action["operator_handoff"] = {
+                key: handoff.get(key)
+                for key in (
+                    "preferred_profile",
+                    "fallback_profile",
+                    "drains_bridge_messages",
+                    "fallback_drains_bridge_messages",
+                    "audio_cache_dir",
+                    "home_channel",
+                    "home_channel_kind",
+                    "agent_number",
+                    "agent_name",
+                    "steps",
+                )
+                if key in handoff
+            }
         next_actions.append(action)
     if external_meta_setup_required:
-        next_actions.append(
-            {
-                "id": "configure_whatsapp_cloud_calling",
-                "requires_operator": True,
-                "description": "Complete external Meta WhatsApp Cloud and Calling setup, then rerun with Cloud/Calling requirements.",
-                "missing": external_meta_setup.get("calling_missing") or [],
-                "setup_steps": external_meta_setup.get("setup_steps") or [],
-            }
-        )
+        cloud_gate = pending_gates.get("whatsapp_cloud") or {}
+        calling_gate = pending_gates.get("whatsapp_cloud_calling") or {}
+        cloud_handoff = cloud_gate.get("setup_handoff") or {}
+        calling_handoff = calling_gate.get("setup_handoff") or {}
+        action = {
+            "id": "configure_whatsapp_cloud_calling",
+            "requires_operator": True,
+            "description": "Complete external Meta WhatsApp Cloud and Calling setup, then rerun with Cloud/Calling requirements.",
+            "missing": external_meta_setup.get("calling_missing") or [],
+            "setup_steps": external_meta_setup.get("setup_steps") or [],
+            "gates": [],
+            "missing_by_gate": {},
+            "verify_commands": {},
+        }
+        if cloud_gate.get("status") != "configured":
+            action["gates"].append("whatsapp_cloud")
+            action["missing_by_gate"]["whatsapp_cloud"] = missing_keys(
+                cloud_handoff,
+                external_meta_setup.get("cloud_missing"),
+            )
+            verify_command = cloud_handoff.get("verify_command")
+            if verify_command:
+                action["verify_commands"]["whatsapp_cloud"] = verify_command
+        if calling_gate.get("status") != "ready":
+            action["gates"].append("whatsapp_cloud_calling")
+            action["missing_by_gate"]["whatsapp_cloud_calling"] = missing_keys(
+                calling_handoff,
+                external_meta_setup.get("calling_missing"),
+            )
+            verify_command = calling_handoff.get("verify_command")
+            if verify_command:
+                action["verify_commands"]["whatsapp_cloud_calling"] = verify_command
+            complete_command = calling_handoff.get("complete_verification_command")
+            if complete_command:
+                action["complete_verification_command"] = complete_command
+        next_actions.append(action)
 
     complete = local_checks_passed and attended_verified and not external_meta_setup_required
     if complete:

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -312,6 +312,41 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             "configure_whatsapp_cloud_calling",
             [action["id"] for action in summary["next_actions"]],
         )
+        actions = {action["id"]: action for action in summary["next_actions"]}
+        attended_action = actions["run_attended_fresh_receive"]
+        self.assertEqual(
+            attended_action["operator_handoff"]["preferred_profile"],
+            "attended-cache-receive",
+        )
+        self.assertEqual(
+            attended_action["operator_handoff"]["home_channel"],
+            "20530681934008@lid",
+        )
+        meta_action = actions["configure_whatsapp_cloud_calling"]
+        self.assertEqual(
+            meta_action["gates"],
+            ["whatsapp_cloud", "whatsapp_cloud_calling"],
+        )
+        self.assertIn(
+            "WHATSAPP_CLOUD_ACCESS_TOKEN",
+            meta_action["missing_by_gate"]["whatsapp_cloud"],
+        )
+        self.assertIn(
+            "WHATSAPP_CLOUD_ACCESS_TOKEN",
+            meta_action["missing_by_gate"]["whatsapp_cloud_calling"],
+        )
+        self.assertIn(
+            "--require-whatsapp-cloud",
+            meta_action["verify_commands"]["whatsapp_cloud"],
+        )
+        self.assertIn(
+            "--require-whatsapp-calling",
+            meta_action["verify_commands"]["whatsapp_cloud_calling"],
+        )
+        self.assertIn(
+            "--require-complete",
+            meta_action["complete_verification_command"],
+        )
 
     def test_require_complete_fails_when_alpha_gates_are_pending(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- add attended receive handoff details to readiness_summary.next_actions
- add Cloud/Calling missing-key groups and verifier commands to the machine-readable next action
- document that agents can consume next_actions instead of scraping human output

## Verification
- python3 -m unittest tests.test_verify_whatsapp_alpha_readiness
- python3 -m unittest discover -s tests
- python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_alpha_readiness.py
- git diff --check
- live JSON probe: scripts/verify_whatsapp_alpha_readiness.py --hermes-home /home/ubuntu/.hermes --voice-bin /home/ubuntu/.local/bin/voice --profile cached-receive --skip-hermes-tts-smoke --wait-audio-cache-seconds 0.1 --expected-agent-number 13236478455 --expected-agent-name Quill --json