### PR TITLE
Add Hermes STT provider smoke check

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,9 @@ stt:
 
 `scripts/verify_hermes_voice_config.py` accepts either these shims or direct
 `voice say --format ogg-opus` / `voice stream-transcribe --quiet` commands, and
-rejects arbitrary wrappers so config drift is caught locally.
+rejects arbitrary wrappers so config drift is caught locally. Add
+`--stt-audio ~/.hermes/audio_cache/aud_...ogg` when you also want to execute the
+configured Hermes STT command against a cached inbound WhatsApp voice note.
 
 Use the local Hermes stack verifier before a release or host update:
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -94,6 +94,9 @@ command: /path/to/voice stream-transcribe --quiet {input_path}
 
 Both forms are accepted by `scripts/verify_hermes_voice_config.py`; arbitrary
 wrappers are rejected so config drift is visible before restarting Hermes.
+Pass `--stt-audio ~/.hermes/audio_cache/aud_...ogg` to execute the configured
+STT command against a cached inbound WhatsApp voice note; the verifier only
+reports transcript size, not transcript text.
 
 Validate the command-provider shape locally before wiring or restarting
 Hermes:

--- a/scripts/verify_hermes_voice_config.py
+++ b/scripts/verify_hermes_voice_config.py
@@ -389,6 +389,65 @@ def run_tts_smoke(
         return probe_ogg_opus(output_path)
 
 
+def substitute_stt_command(
+    args: list[str],
+    *,
+    input_path: Path,
+    voice_bin: str | None,
+    override_first_token: bool,
+) -> list[str]:
+    resolved = []
+    for index, arg in enumerate(args):
+        if index == 0 and voice_bin is not None and override_first_token:
+            resolved.append(voice_bin)
+            continue
+        resolved.append(arg.replace("{input_path}", str(input_path)))
+    return resolved
+
+
+def run_stt_smoke(
+    provider_config: dict[str, Any],
+    command_args: list[str],
+    *,
+    command_kind: str,
+    voice_bin: str | None,
+    audio_path: Path,
+    timeout: float | None,
+) -> dict[str, int]:
+    if not audio_path.is_file():
+        raise ConfigError(f"STT smoke audio not found: {audio_path}")
+
+    command_timeout = timeout
+    if command_timeout is None:
+        command_timeout = float(provider_config.get("timeout") or 180)
+
+    args = substitute_stt_command(
+        command_args,
+        input_path=audio_path,
+        voice_bin=voice_bin,
+        override_first_token=command_kind == "direct_voice",
+    )
+    env = None
+    if voice_bin is not None and command_kind != "direct_voice":
+        env = {**os.environ, "VOICE_BIN": voice_bin}
+    completed = subprocess.run(
+        args,
+        check=True,
+        timeout=command_timeout,
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+    transcript = completed.stdout.strip()
+    if not transcript:
+        raise ConfigError("STT smoke command produced an empty transcript")
+    return {
+        "chars": len(transcript),
+        "lines": len(transcript.splitlines()),
+    }
+
+
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Verify that ~/.hermes/config.yaml uses voice-native TTS/STT.",
@@ -409,6 +468,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="skip STT command-provider validation",
     )
     parser.add_argument(
+        "--stt-audio",
+        type=Path,
+        default=None,
+        help="execute the configured STT command against this audio file",
+    )
+    parser.add_argument(
+        "--stt-timeout",
+        type=float,
+        default=None,
+        help="timeout for --stt-audio execution; defaults to provider timeout",
+    )
+    parser.add_argument(
         "--text",
         default="Hermes voice-native configuration smoke test.",
         help="text to synthesize when running the TTS smoke",
@@ -426,8 +497,12 @@ def main(argv: list[str]) -> int:
     tts_provider, tts_config, tts_args, tts_command_kind = validate_tts(config)
     stt_provider = None
     stt_command_kind = None
+    stt_config = None
+    stt_args = None
+    if args.skip_stt_config and args.stt_audio is not None:
+        raise ConfigError("--stt-audio requires STT config validation")
     if not args.skip_stt_config:
-        stt_provider, _stt_config, _stt_args, stt_command_kind = validate_stt(config)
+        stt_provider, stt_config, stt_args, stt_command_kind = validate_stt(config)
 
     smoke = "skipped"
     probe = None
@@ -440,6 +515,21 @@ def main(argv: list[str]) -> int:
             text=args.text,
         )
         smoke = "checked"
+
+    stt_smoke = "skipped"
+    stt_probe = None
+    if args.stt_audio is not None:
+        if stt_config is None or stt_args is None or stt_command_kind is None:
+            raise ConfigError("--stt-audio requires STT config validation")
+        stt_probe = run_stt_smoke(
+            stt_config,
+            stt_args,
+            command_kind=stt_command_kind,
+            voice_bin=args.voice_bin,
+            audio_path=args.stt_audio.expanduser(),
+            timeout=args.stt_timeout,
+        )
+        stt_smoke = "checked"
 
     print("ok: Hermes voice config verifier passed")
     print(f"config={config_path}")
@@ -462,6 +552,12 @@ def main(argv: list[str]) -> int:
             print("stt.command=voice stream-transcribe --quiet")
         else:
             print("stt.command=hermes-command-stt.sh")
+        print(f"stt_smoke={stt_smoke}")
+        if stt_probe is not None:
+            print(
+                "stt_probe="
+                f"chars={stt_probe['chars']},lines={stt_probe['lines']}"
+            )
     else:
         print("stt_config=skipped")
     return 0

--- a/tests/test_verify_hermes_voice_config.py
+++ b/tests/test_verify_hermes_voice_config.py
@@ -53,6 +53,10 @@ def write_fake_voice(directory: Path) -> Path:
             #!/usr/bin/env bash
             set -euo pipefail
             printf '%s\\n' "$@" > {str(log_path)!r}
+            if [[ "${{1:-}}" == "stream-transcribe" ]]; then
+              echo 'hello from stt'
+              exit 0
+            fi
             out=''
             while [[ $# -gt 0 ]]; do
               if [[ "$1" == "--output" ]]; then
@@ -144,6 +148,41 @@ class HermesVoiceConfigVerifierTests(unittest.TestCase):
         self.assertIn("say\n", voice_args)
         self.assertIn("--format\nogg-opus\n", voice_args)
         self.assertIn("--voice\naf_heart\n", voice_args)
+
+    def test_verifier_executes_configured_stt_command(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            bin_dir = tmp_path / "bin"
+            bin_dir.mkdir()
+            voice_bin = write_fake_voice(bin_dir)
+            config = tmp_path / "config.yaml"
+            audio = tmp_path / "aud_cached.ogg"
+            config.write_text(hermes_config(), encoding="utf-8")
+            audio.write_bytes(b"OggSfake")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--config",
+                    str(config),
+                    "--voice-bin",
+                    str(voice_bin),
+                    "--skip-tts-smoke",
+                    "--stt-audio",
+                    str(audio),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            voice_args = (bin_dir / "voice-args.txt").read_text(encoding="utf-8")
+
+        self.assertIn("stt_smoke=checked", result.stdout)
+        self.assertIn("stt_probe=chars=14,lines=1", result.stdout)
+        self.assertIn("stream-transcribe\n", voice_args)
+        self.assertIn("--quiet\n", voice_args)
+        self.assertIn(f"{audio}\n", voice_args)
 
     def test_verifier_rejects_wav_output_format(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -285,6 +324,77 @@ class HermesVoiceConfigVerifierTests(unittest.TestCase):
         self.assertIn("tts.command=hermes-command-tts.sh", result.stdout)
         self.assertIn("say\n", voice_args)
         self.assertIn("--format\nogg-opus\n", voice_args)
+
+    def test_verifier_executes_stt_command_shim_with_voice_bin_override(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            bin_dir = tmp_path / "bin"
+            bin_dir.mkdir()
+            voice_bin = write_fake_voice(bin_dir)
+            config = tmp_path / "config.yaml"
+            audio = tmp_path / "aud_cached.ogg"
+            config.write_text(
+                hermes_config(
+                    command=(
+                        f"{REPO_ROOT}/examples/hermes-command-tts.sh "
+                        "{input_path} {output_path} {voice} {speed}"
+                    ),
+                    stt_command=f"{REPO_ROOT}/examples/hermes-command-stt.sh {{input_path}}",
+                ),
+                encoding="utf-8",
+            )
+            audio.write_bytes(b"OggSfake")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--config",
+                    str(config),
+                    "--voice-bin",
+                    str(voice_bin),
+                    "--skip-tts-smoke",
+                    "--stt-audio",
+                    str(audio),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={"PATH": f"{bin_dir}:{os_path()}"},
+            )
+
+            voice_args = (bin_dir / "voice-args.txt").read_text(encoding="utf-8")
+
+        self.assertIn("stt.command=hermes-command-stt.sh", result.stdout)
+        self.assertIn("stt_smoke=checked", result.stdout)
+        self.assertIn("stream-transcribe\n", voice_args)
+        self.assertIn("--quiet\n", voice_args)
+        self.assertIn(f"{audio}\n", voice_args)
+
+    def test_stt_audio_requires_stt_config_validation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            config = tmp_path / "config.yaml"
+            audio = tmp_path / "aud_cached.ogg"
+            config.write_text(hermes_config(), encoding="utf-8")
+            audio.write_bytes(b"OggSfake")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--config",
+                    str(config),
+                    "--skip-tts-smoke",
+                    "--skip-stt-config",
+                    "--stt-audio",
+                    str(audio),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--stt-audio requires STT config validation", result.stderr)
 
     def test_verifier_rejects_arbitrary_command_wrapper(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- add optional --stt-audio support to verify_hermes_voice_config.py
- execute the configured Hermes STT provider against a supplied audio file and report transcript size only
- cover direct voice and voice-owned STT shim execution with tests
- document using cached WhatsApp audio for receive-side config drift checks

## Verification
- python3 -m unittest tests.test_verify_hermes_voice_config
- python3 -m unittest discover -s tests
- python3 -m py_compile scripts/verify_hermes_voice_config.py tests/test_verify_hermes_voice_config.py
- git diff --check
- scripts/verify_hermes_voice_config.py --config /home/ubuntu/.hermes/config.yaml --voice-bin /home/ubuntu/.local/bin/voice --skip-tts-smoke --stt-audio /home/ubuntu/.hermes/audio_cache/tts_20260614_182322.ogg