### PR TITLE
Report cached receive evidence during fresh watch

### DIFF
--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -404,6 +404,22 @@ def bridge_runtime_checks(components: list[dict[str, Any]]) -> dict[str, Any]:
     return {}
 
 
+def cached_inbound_audio_verified(components: list[dict[str, Any]]) -> bool:
+    for item in components:
+        if item["name"] not in {
+            "whatsapp_inbound_cache_stt",
+            "whatsapp_inbound_cache_fresh_stt",
+        }:
+            continue
+        if not item.get("success"):
+            continue
+        summary = item.get("summary") or {}
+        checks = summary.get("checks") or {}
+        if checks.get("selected_files") or checks.get("audio"):
+            return True
+    return False
+
+
 def attended_receive_gate(
     components: list[dict[str, Any]],
     *,
@@ -414,10 +430,7 @@ def attended_receive_gate(
     local_config = bridge_checks.get("whatsapp_local_config") or {}
     identity = bridge_checks.get("baileys_identity") or {}
     receive_names = {"whatsapp_voice_note_receive", "whatsapp_voice_note_send_receive"}
-    cached_receive_verified = any(
-        item["name"] == "whatsapp_inbound_cache_stt" and item.get("success")
-        for item in components
-    )
+    cached_receive_verified = cached_inbound_audio_verified(components)
 
     gate: dict[str, Any] = {
         "status": "pending_attended",

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -656,6 +656,8 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         inbound_cache_payload = {
             "success": True,
             "checks": {
+                "selected_files": ["/tmp/aud_fresh.ogg"],
+                "audio": [{"path": "/tmp/aud_fresh.ogg"}],
                 "fresh_watch": {
                     "drains_bridge_messages": False,
                     "fresh_files": ["/tmp/aud_fresh.ogg"],
@@ -693,6 +695,42 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertEqual(
             [action["id"] for action in summary["next_actions"]],
             ["configure_whatsapp_cloud_calling"],
+        )
+
+    def test_cached_receive_verified_survives_optional_fresh_watch_timeout(self):
+        inbound_cache_payload = {
+            "success": True,
+            "checks": {
+                "selected_files": ["/tmp/aud_cached.ogg"],
+                "audio": [{"path": "/tmp/aud_cached.ogg"}],
+                "fresh_watch": {
+                    "drains_bridge_messages": False,
+                    "fresh_files": [],
+                    "fresh_count": 0,
+                },
+            },
+            "failures": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = self.run_readiness(
+                Path(tmp),
+                "--profile",
+                "cached-receive",
+                "--wait-audio-cache-seconds",
+                "0.1",
+                inbound_cache_payload=inbound_cache_payload,
+            )
+
+        gate = payload["pending_gates"]["attended_fresh_receive"]
+        self.assertEqual(gate["component"], "whatsapp_inbound_cache_fresh_stt")
+        self.assertEqual(gate["status"], "not_verified")
+        self.assertTrue(gate["cached_receive_verified"])
+        self.assertTrue(gate["requires_operator"])
+        summary = payload["readiness_summary"]
+        self.assertFalse(summary["attended_fresh_receive_verified"])
+        self.assertIn(
+            "run_attended_fresh_receive",
+            [action["id"] for action in summary["next_actions"]],
         )
 
     def test_verified_attended_receive_gate_requires_audio_event_evidence(self):


### PR DESCRIPTION
## Summary
- Treat both cached receive component names as cached inbound evidence in the WhatsApp alpha pending gate.
- Require actual selected/audio evidence before `cached_receive_verified` is true.
- Add regression coverage for the optional fresh-cache watch timing out while an existing cached `aud_*` file still transcribes successfully.

## Verification
- `python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_alpha_readiness.py`
- `python3 -m unittest tests.test_verify_whatsapp_alpha_readiness`
- `python3 -m unittest discover -s tests`
- `git diff --check`
- Live: `scripts/verify_whatsapp_alpha_readiness.py --hermes-home /home/ubuntu/.hermes --voice-bin /home/ubuntu/.local/bin/voice --profile cached-receive --skip-hermes-tts-smoke --wait-audio-cache-seconds 0.1 --expected-agent-number 13236478455 --expected-agent-name Quill`

Live output now reports:

```text
readiness=local_ready_pending_gates complete=False operator_action_required=True external_meta_setup_required=True
attended_fresh_receive=not_verified cached_receive_verified=True
```
