### PR TITLE
Report WhatsApp Cloud webhook readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,10 @@ voice note plus the required Meta WhatsApp Cloud and Calling credentials. The
 alpha output prints `whatsapp_cloud_setup`, `whatsapp_cloud_verify_command`,
 `whatsapp_calling_setup`, `whatsapp_calling_verify_command`, and
 `whatsapp_calling_complete_command` handoff lines so missing external setup is
-separated from local daemon, bridge, and Hermes failures.
+separated from local daemon, bridge, and Hermes failures. It also prints the
+resolved Cloud webhook bind defaults and malformed webhook keys, so strict
+Cloud/Calling failures can distinguish missing credentials from invalid
+`WHATSAPP_CLOUD_WEBHOOK_*` settings.
 
 When the WebRTC Python dependencies are installed, add
 `--run-webrtc-loopback-smoke --webrtc-python /tmp/voice-webrtc-venv/bin/python`

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -132,9 +132,13 @@ For the external Meta gates, the JSON report includes safe setup handoffs under
 `pending_gates.whatsapp_cloud_calling.setup_handoff`. These handoffs list the
 required key names, which keys are missing, redacted source labels for values
 that were found, and the exact follow-up verifier commands. Secret values are
-never printed. `readiness_summary.next_actions` repeats the same non-secret
-commands and missing-key groups so another agent can consume the report without
-scraping human output. The human output mirrors the same information with:
+never printed. The Cloud handoff also reports the resolved local webhook
+binding (`host`, `port`, `path`, and `api_version`), which values came from env
+sources versus Hermes defaults, and malformed webhook keys under `invalid`.
+`readiness_summary.next_actions` repeats the same non-secret commands,
+missing-key groups, and invalid-key groups so another agent can consume the
+report without scraping human output. The human output mirrors the same
+information with:
 
 - `whatsapp_cloud_setup`
 - `whatsapp_cloud_verify_command`
@@ -260,6 +264,12 @@ the local sidecar:
 - `WHATSAPP_CLOUD_VERIFY_TOKEN`
 - `WHATSAPP_CLOUD_CALLING_SIDECAR_URL`
 - `WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND`
+
+Hermes defaults the local Cloud webhook bind to `0.0.0.0:8090` at
+`/whatsapp/webhook` with Graph API version `v20.0` when the matching optional
+`WHATSAPP_CLOUD_WEBHOOK_*` keys are not set. The voice verifier reports those
+resolved defaults and fails strict Cloud/Calling gates if the configured
+webhook port, path, or API version is malformed.
 
 The external Meta setup behind those keys is:
 

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -557,7 +557,9 @@ def cloud_setup_handoff(
 ) -> dict[str, Any]:
     cloud = bridge_checks.get("whatsapp_cloud") or {}
     cloud_required = cloud.get("cloud_required") or {}
+    webhook = cloud.get("webhook") or {}
     missing = [str(key) for key in external_meta_setup.get("cloud_missing") or []]
+    invalid = [str(key) for key in external_meta_setup.get("cloud_invalid") or []]
     configured = bool(external_meta_setup.get("cloud_configured"))
     verify_command = [
         "scripts/verify_whatsapp_alpha_readiness.py",
@@ -574,10 +576,22 @@ def cloud_setup_handoff(
     return {
         "required_keys": list(CLOUD_REQUIRED_KEYS),
         "missing": missing,
+        "invalid": invalid,
         "configured": configured,
         "env_file": bridge_checks.get("env_file"),
         "credential_sources": presence_sources(cloud_required, CLOUD_REQUIRED_KEYS),
         "available_source_keys": source_key_inventory(bridge_checks),
+        "webhook": {
+            "host": webhook.get("host"),
+            "port": webhook.get("port"),
+            "path": webhook.get("path"),
+            "api_version": webhook.get("api_version"),
+            "defaulted": webhook.get("defaulted") or [],
+            "sources": webhook.get("sources") or {},
+            "invalid": webhook.get("invalid") or [],
+            "public_route_required": bool(webhook.get("public_route_required")),
+            "public_route_note": webhook.get("public_route_note"),
+        },
         "verify_command": verify_command,
         "steps": steps,
     }
@@ -593,6 +607,7 @@ def calling_setup_handoff(
     calling = cloud.get("calling") or {}
     cloud_required = cloud.get("cloud_required") or {}
     missing = [str(key) for key in external_meta_setup.get("calling_missing") or []]
+    invalid = [str(key) for key in external_meta_setup.get("calling_invalid") or []]
     sidecar_missing = [
         key
         for key in CALLING_SIDECAR_REQUIRED_KEYS
@@ -624,6 +639,7 @@ def calling_setup_handoff(
     return {
         "required_keys": [*CLOUD_REQUIRED_KEYS, *CALLING_SIDECAR_REQUIRED_KEYS],
         "missing": missing,
+        "invalid": invalid,
         "cloud_missing": [
             key for key in missing if key in CLOUD_REQUIRED_KEYS
         ],
@@ -655,8 +671,12 @@ def external_meta_gate(
     hermes_home: Path,
 ) -> dict[str, Any]:
     cloud_missing = [str(key) for key in external_meta_setup.get("cloud_missing") or []]
+    cloud_invalid = [str(key) for key in external_meta_setup.get("cloud_invalid") or []]
     calling_missing = [
         str(key) for key in external_meta_setup.get("calling_missing") or []
+    ]
+    calling_invalid = [
+        str(key) for key in external_meta_setup.get("calling_invalid") or []
     ]
     cloud_configured = bool(external_meta_setup.get("cloud_configured"))
     calling_ready = bool(external_meta_setup.get("calling_ready"))
@@ -674,11 +694,13 @@ def external_meta_gate(
         "whatsapp_cloud": {
             "status": "configured" if cloud_configured else "external_setup_required",
             "missing": cloud_missing,
+            "invalid": cloud_invalid,
             "setup_handoff": cloud_handoff,
         },
         "whatsapp_cloud_calling": {
             "status": "ready" if calling_ready else "external_setup_required",
             "missing": calling_missing,
+            "invalid": calling_invalid,
             "setup_steps": (
                 []
                 if calling_ready
@@ -697,6 +719,9 @@ def build_readiness_summary(
 ) -> dict[str, Any]:
     def missing_keys(handoff: dict[str, Any], fallback: Any) -> list[str]:
         return [str(key) for key in (handoff.get("missing") or fallback or [])]
+
+    def invalid_keys(handoff: dict[str, Any], fallback: Any) -> list[str]:
+        return [str(key) for key in (handoff.get("invalid") or fallback or [])]
 
     attended = pending_gates.get("attended_fresh_receive") or {}
     attended_verified = attended.get("status") == "verified"
@@ -755,9 +780,11 @@ def build_readiness_summary(
             "requires_operator": True,
             "description": "Complete external Meta WhatsApp Cloud and Calling setup, then rerun with Cloud/Calling requirements.",
             "missing": external_meta_setup.get("calling_missing") or [],
+            "invalid": external_meta_setup.get("calling_invalid") or [],
             "setup_steps": external_meta_setup.get("setup_steps") or [],
             "gates": [],
             "missing_by_gate": {},
+            "invalid_by_gate": {},
             "verify_commands": {},
         }
         if cloud_gate.get("status") != "configured":
@@ -765,6 +792,10 @@ def build_readiness_summary(
             action["missing_by_gate"]["whatsapp_cloud"] = missing_keys(
                 cloud_handoff,
                 external_meta_setup.get("cloud_missing"),
+            )
+            action["invalid_by_gate"]["whatsapp_cloud"] = invalid_keys(
+                cloud_handoff,
+                external_meta_setup.get("cloud_invalid"),
             )
             verify_command = cloud_handoff.get("verify_command")
             if verify_command:
@@ -774,6 +805,10 @@ def build_readiness_summary(
             action["missing_by_gate"]["whatsapp_cloud_calling"] = missing_keys(
                 calling_handoff,
                 external_meta_setup.get("calling_missing"),
+            )
+            action["invalid_by_gate"]["whatsapp_cloud_calling"] = invalid_keys(
+                calling_handoff,
+                external_meta_setup.get("calling_invalid"),
             )
             verify_command = calling_handoff.get("verify_command")
             if verify_command:
@@ -820,39 +855,49 @@ def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
     bridge_checks = bridge_runtime_checks(components)
     cloud = bridge_cloud_summary(components)
     cloud_missing = [str(key) for key in cloud.get("cloud_missing") or []]
+    cloud_invalid = [str(key) for key in cloud.get("cloud_invalid") or []]
     calling_missing = [str(key) for key in cloud.get("calling_missing") or []]
+    calling_invalid = [str(key) for key in cloud.get("calling_invalid") or []]
     external_meta_setup = {
         "cloud_configured": bool(cloud.get("cloud_configured")),
         "calling_sidecar_configured": bool(cloud.get("calling_sidecar_configured")),
         "calling_ready": bool(cloud.get("calling_ready")),
         "cloud_missing": cloud_missing,
+        "cloud_invalid": cloud_invalid,
         "calling_missing": calling_missing,
-        "setup_steps": list(META_SETUP_STEPS) if cloud_missing or calling_missing else [],
+        "calling_invalid": calling_invalid,
+        "setup_steps": (
+            list(META_SETUP_STEPS)
+            if cloud_missing or calling_missing or cloud_invalid or calling_invalid
+            else []
+        ),
     }
 
     external_failures: list[dict[str, Any]] = []
     success = not required_failures
     if args.require_whatsapp_calling and not external_meta_setup["calling_ready"]:
         success = False
+        calling_detail = ", ".join(calling_missing + calling_invalid)
         external_failures.append(
             {
                 "name": "whatsapp_cloud_calling",
                 "category": "external_meta_setup",
                 "failures": [
-                    "WhatsApp Cloud Calling not ready; missing: "
-                    + (", ".join(calling_missing) or "external Meta calling approval")
+                    "WhatsApp Cloud Calling not ready; missing/invalid: "
+                    + (calling_detail or "external Meta calling approval")
                 ],
             }
         )
     if args.require_whatsapp_cloud and not external_meta_setup["cloud_configured"]:
         success = False
+        cloud_detail = ", ".join(cloud_missing + cloud_invalid)
         external_failures.append(
             {
                 "name": "whatsapp_cloud",
                 "category": "external_meta_setup",
                 "failures": [
-                    "WhatsApp Cloud credentials missing: "
-                    + (", ".join(cloud_missing) or "external Meta Cloud setup")
+                    "WhatsApp Cloud config missing/invalid: "
+                    + (cloud_detail or "external Meta Cloud setup")
                 ],
             }
         )
@@ -1124,15 +1169,32 @@ def human_summary(result: dict[str, Any]) -> None:
         + ("configured" if external["cloud_configured"] else "not_configured")
         + " missing="
         + (",".join(external["cloud_missing"]) or "none")
+        + " invalid="
+        + (",".join(external.get("cloud_invalid") or []) or "none")
     )
     cloud_gate = pending.get("whatsapp_cloud") or {}
     cloud_handoff = cloud_gate.get("setup_handoff") or {}
+    cloud_webhook = cloud_handoff.get("webhook") or {}
+    if cloud_webhook:
+        print(
+            "whatsapp_cloud_webhook="
+            f"host={cloud_webhook.get('host') or '<unknown>'} "
+            f"port={cloud_webhook.get('port') or '<invalid>'} "
+            f"path={cloud_webhook.get('path') or '<unknown>'} "
+            f"api_version={cloud_webhook.get('api_version') or '<unknown>'} "
+            "defaulted="
+            + (",".join(cloud_webhook.get("defaulted") or []) or "none")
+            + " invalid="
+            + (",".join(cloud_webhook.get("invalid") or []) or "none")
+        )
     if cloud_gate.get("status") != "configured" and cloud_handoff:
         print(
             "whatsapp_cloud_setup="
             f"env_file={cloud_handoff.get('env_file') or '<unknown>'} "
             "missing="
             + (",".join(cloud_handoff.get("missing") or []) or "none")
+            + " invalid="
+            + (",".join(cloud_handoff.get("invalid") or []) or "none")
         )
         verify_command = cloud_handoff.get("verify_command") or []
         if verify_command:
@@ -1147,6 +1209,8 @@ def human_summary(result: dict[str, Any]) -> None:
         + ("ready" if external["calling_ready"] else "not_ready")
         + " missing="
         + (",".join(external["calling_missing"]) or "none")
+        + " invalid="
+        + (",".join(external.get("calling_invalid") or []) or "none")
     )
     calling_gate = pending.get("whatsapp_cloud_calling") or {}
     calling_handoff = calling_gate.get("setup_handoff") or {}
@@ -1156,6 +1220,8 @@ def human_summary(result: dict[str, Any]) -> None:
             f"sidecar_configured={calling_handoff.get('calling_sidecar_configured')} "
             "missing="
             + (",".join(calling_handoff.get("missing") or []) or "none")
+            + " invalid="
+            + (",".join(calling_handoff.get("invalid") or []) or "none")
         )
         verify_command = calling_handoff.get("verify_command") or []
         complete_command = calling_handoff.get("complete_verification_command") or []

--- a/scripts/verify_whatsapp_bridge_runtime.py
+++ b/scripts/verify_whatsapp_bridge_runtime.py
@@ -18,6 +18,10 @@ from urllib.request import Request, urlopen
 
 DEFAULT_BRIDGE_URL = "http://127.0.0.1:3000"
 DEFAULT_SERVICE_NAME = "hermes-gateway.service"
+DEFAULT_WHATSAPP_CLOUD_WEBHOOK_HOST = "0.0.0.0"
+DEFAULT_WHATSAPP_CLOUD_WEBHOOK_PORT = 8090
+DEFAULT_WHATSAPP_CLOUD_WEBHOOK_PATH = "/whatsapp/webhook"
+DEFAULT_WHATSAPP_CLOUD_API_VERSION = "v20.0"
 
 WHATSAPP_CLOUD_REQUIRED_ENV = (
     "WHATSAPP_CLOUD_PHONE_NUMBER_ID",
@@ -460,10 +464,68 @@ def missing_env_keys(env_sources: dict[str, dict[str, str]], keys: tuple[str, ..
     ]
 
 
+def build_cloud_webhook_summary(env_sources: dict[str, dict[str, str]]) -> dict[str, Any]:
+    host, host_sources = first_env_value(env_sources, "WHATSAPP_CLOUD_WEBHOOK_HOST")
+    raw_port, port_sources = first_env_value(env_sources, "WHATSAPP_CLOUD_WEBHOOK_PORT")
+    path, path_sources = first_env_value(env_sources, "WHATSAPP_CLOUD_WEBHOOK_PATH")
+    api_version, api_sources = first_env_value(env_sources, "WHATSAPP_CLOUD_API_VERSION")
+
+    invalid: list[str] = []
+    port: int | None = DEFAULT_WHATSAPP_CLOUD_WEBHOOK_PORT
+    if raw_port is not None:
+        try:
+            port = int(raw_port)
+        except ValueError:
+            port = None
+            invalid.append("WHATSAPP_CLOUD_WEBHOOK_PORT")
+        else:
+            if port < 1 or port > 65535:
+                invalid.append("WHATSAPP_CLOUD_WEBHOOK_PORT")
+
+    resolved_path = path or DEFAULT_WHATSAPP_CLOUD_WEBHOOK_PATH
+    if path is not None and not path.startswith("/"):
+        invalid.append("WHATSAPP_CLOUD_WEBHOOK_PATH")
+
+    resolved_api_version = api_version or DEFAULT_WHATSAPP_CLOUD_API_VERSION
+    if api_version is not None and not re.match(r"^v\d+\.\d+$", api_version):
+        invalid.append("WHATSAPP_CLOUD_API_VERSION")
+
+    return {
+        "host": host or DEFAULT_WHATSAPP_CLOUD_WEBHOOK_HOST,
+        "port": port,
+        "path": resolved_path,
+        "api_version": resolved_api_version,
+        "raw_port": raw_port,
+        "defaulted": [
+            key
+            for key, value in (
+                ("WHATSAPP_CLOUD_WEBHOOK_HOST", host),
+                ("WHATSAPP_CLOUD_WEBHOOK_PORT", raw_port),
+                ("WHATSAPP_CLOUD_WEBHOOK_PATH", path),
+                ("WHATSAPP_CLOUD_API_VERSION", api_version),
+            )
+            if value is None
+        ],
+        "sources": {
+            "WHATSAPP_CLOUD_WEBHOOK_HOST": host_sources,
+            "WHATSAPP_CLOUD_WEBHOOK_PORT": port_sources,
+            "WHATSAPP_CLOUD_WEBHOOK_PATH": path_sources,
+            "WHATSAPP_CLOUD_API_VERSION": api_sources,
+        },
+        "invalid": invalid,
+        "public_route_required": True,
+        "public_route_note": (
+            "Meta must be configured with a public HTTPS URL that forwards to "
+            "this local webhook path."
+        ),
+    }
+
+
 def build_cloud_summary(env_sources: dict[str, dict[str, str]]) -> dict[str, Any]:
     required_presence = env_presence(env_sources, WHATSAPP_CLOUD_REQUIRED_ENV)
     optional_presence = env_presence(env_sources, WHATSAPP_CLOUD_OPTIONAL_ENV)
     calling_presence = env_presence(env_sources, WHATSAPP_CALLING_ENV)
+    webhook = build_cloud_webhook_summary(env_sources)
     cloud_missing = [
         key for key, status in required_presence.items() if not status["present"]
     ]
@@ -476,14 +538,18 @@ def build_cloud_summary(env_sources: dict[str, dict[str, str]]) -> dict[str, Any
         if not calling_presence[key]["present"]
     ]
     calling_missing = cloud_missing + sidecar_missing
+    cloud_invalid = [str(key) for key in webhook["invalid"]]
     return {
-        "cloud_configured": not cloud_missing,
+        "cloud_configured": not cloud_missing and not cloud_invalid,
         "cloud_missing": cloud_missing,
+        "cloud_invalid": cloud_invalid,
         "cloud_required": required_presence,
         "cloud_optional": optional_presence,
+        "webhook": webhook,
         "calling_sidecar_configured": not sidecar_missing,
-        "calling_ready": not calling_missing,
+        "calling_ready": not calling_missing and not cloud_invalid,
         "calling_missing": calling_missing,
+        "calling_invalid": cloud_invalid,
         "calling": calling_presence,
     }
 
@@ -643,15 +709,25 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
                 )
 
     cloud = build_cloud_summary(env_sources)
-    if args.require_whatsapp_cloud and not cloud["cloud_configured"]:
+    if args.require_whatsapp_cloud and cloud["cloud_missing"]:
         failures.append(
             "WhatsApp Cloud credentials missing: "
             + ", ".join(cloud["cloud_missing"])
         )
-    if args.require_whatsapp_calling and not cloud["calling_ready"]:
+    if args.require_whatsapp_cloud and cloud["cloud_invalid"]:
+        failures.append(
+            "WhatsApp Cloud config invalid: "
+            + ", ".join(cloud["cloud_invalid"])
+        )
+    if args.require_whatsapp_calling and cloud["calling_missing"]:
         failures.append(
             "WhatsApp Cloud Calling not ready; missing: "
             + ", ".join(cloud["calling_missing"])
+        )
+    if args.require_whatsapp_calling and cloud["calling_invalid"]:
+        failures.append(
+            "WhatsApp Cloud Calling config invalid: "
+            + ", ".join(cloud["calling_invalid"])
         )
 
     checks: dict[str, Any] = {
@@ -708,6 +784,7 @@ def human_summary(result: dict[str, Any]) -> None:
     health = checks.get("bridge_health") or {}
     process = (checks.get("bridge_process") or {}).get("selected") or {}
     cloud = checks.get("whatsapp_cloud") or {}
+    webhook = cloud.get("webhook") or {}
     local_config = checks.get("whatsapp_local_config") or {}
 
     if result["success"]:
@@ -755,6 +832,19 @@ def human_summary(result: dict[str, Any]) -> None:
         + ("configured" if cloud.get("cloud_configured") else "not_configured")
         + " missing="
         + (",".join(cloud.get("cloud_missing") or []) or "none")
+        + " invalid="
+        + (",".join(cloud.get("cloud_invalid") or []) or "none")
+    )
+    print(
+        "whatsapp_cloud_webhook="
+        f"host={webhook.get('host') or '<unknown>'} "
+        f"port={webhook.get('port') or '<invalid>'} "
+        f"path={webhook.get('path') or '<unknown>'} "
+        f"api_version={webhook.get('api_version') or '<unknown>'} "
+        "defaulted="
+        + (",".join(webhook.get("defaulted") or []) or "none")
+        + " invalid="
+        + (",".join(webhook.get("invalid") or []) or "none")
     )
     print(
         "calling_sidecar="
@@ -763,6 +853,8 @@ def human_summary(result: dict[str, Any]) -> None:
         + ("yes" if cloud.get("calling_ready") else "no")
         + " missing="
         + (",".join(cloud.get("calling_missing") or []) or "none")
+        + " invalid="
+        + (",".join(cloud.get("calling_invalid") or []) or "none")
     )
     for warning in result["warnings"]:
         print(f"warning: {warning}", file=sys.stderr)

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -43,6 +43,7 @@ def write_fake_helpers(
     directory: Path,
     *,
     cloud_configured: bool = False,
+    cloud_invalid: list[str] | None = None,
     voice_note_payload: dict | None = None,
     inbound_cache_payload: dict | None = None,
 ) -> None:
@@ -102,6 +103,28 @@ def write_fake_helpers(
         ],
         "systemd_service": list(calling),
     }
+    webhook = {
+        "host": "0.0.0.0",
+        "port": 8090,
+        "path": "/whatsapp/webhook",
+        "api_version": "v20.0",
+        "defaulted": [
+            "WHATSAPP_CLOUD_WEBHOOK_HOST",
+            "WHATSAPP_CLOUD_WEBHOOK_PORT",
+            "WHATSAPP_CLOUD_WEBHOOK_PATH",
+            "WHATSAPP_CLOUD_API_VERSION",
+        ],
+        "sources": {
+            "WHATSAPP_CLOUD_WEBHOOK_HOST": [],
+            "WHATSAPP_CLOUD_WEBHOOK_PORT": [],
+            "WHATSAPP_CLOUD_WEBHOOK_PATH": [],
+            "WHATSAPP_CLOUD_API_VERSION": [],
+        },
+        "invalid": cloud_invalid or [],
+        "public_route_required": True,
+        "public_route_note": "Meta must reach the configured webhook path.",
+    }
+    cloud_is_configured = cloud_configured and not cloud_invalid
     bridge_payload = {
         "success": True,
         "checks": {
@@ -119,13 +142,16 @@ def write_fake_helpers(
                 "allowed_users_count": 2,
             },
             "whatsapp_cloud": {
-                "cloud_configured": cloud_configured,
+                "cloud_configured": cloud_is_configured,
                 "calling_sidecar_configured": True,
-                "calling_ready": cloud_configured,
+                "calling_ready": cloud_is_configured,
                 "cloud_missing": cloud_missing,
+                "cloud_invalid": cloud_invalid or [],
                 "calling_missing": cloud_missing,
+                "calling_invalid": cloud_invalid or [],
                 "cloud_required": cloud_required,
                 "calling": calling,
+                "webhook": webhook,
             }
         },
         "failures": [],
@@ -147,6 +173,7 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         tmp_path: Path,
         *args: str,
         cloud_configured: bool = False,
+        cloud_invalid: list[str] | None = None,
         skip_voice_note_smoke: bool = True,
         voice_note_payload: dict | None = None,
         inbound_cache_payload: dict | None = None,
@@ -155,6 +182,7 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             tmp_path,
             *args,
             cloud_configured=cloud_configured,
+            cloud_invalid=cloud_invalid,
             skip_voice_note_smoke=skip_voice_note_smoke,
             voice_note_payload=voice_note_payload,
             inbound_cache_payload=inbound_cache_payload,
@@ -167,6 +195,7 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         tmp_path: Path,
         *args: str,
         cloud_configured: bool = False,
+        cloud_invalid: list[str] | None = None,
         skip_voice_note_smoke: bool = True,
         voice_note_payload: dict | None = None,
         inbound_cache_payload: dict | None = None,
@@ -176,6 +205,7 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         write_fake_helpers(
             helpers,
             cloud_configured=cloud_configured,
+            cloud_invalid=cloud_invalid,
             voice_note_payload=voice_note_payload,
             inbound_cache_payload=inbound_cache_payload,
         )
@@ -276,6 +306,14 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertIn("--require-whatsapp-cloud", cloud_handoff["verify_command"])
         self.assertEqual(len(cloud_handoff["steps"]), 4)
         self.assertNotIn("phone-id", json.dumps(cloud_handoff))
+        self.assertEqual(cloud_handoff["invalid"], [])
+        self.assertEqual(cloud_handoff["webhook"]["host"], "0.0.0.0")
+        self.assertEqual(cloud_handoff["webhook"]["port"], 8090)
+        self.assertEqual(cloud_handoff["webhook"]["path"], "/whatsapp/webhook")
+        self.assertIn(
+            "WHATSAPP_CLOUD_WEBHOOK_PORT",
+            cloud_handoff["webhook"]["defaulted"],
+        )
         self.assertIn(
             "WHATSAPP_CLOUD_ACCESS_TOKEN",
             gates["whatsapp_cloud_calling"]["missing"],
@@ -335,6 +373,11 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             "WHATSAPP_CLOUD_ACCESS_TOKEN",
             meta_action["missing_by_gate"]["whatsapp_cloud_calling"],
         )
+        self.assertEqual(meta_action["invalid_by_gate"]["whatsapp_cloud"], [])
+        self.assertEqual(
+            meta_action["invalid_by_gate"]["whatsapp_cloud_calling"],
+            [],
+        )
         self.assertIn(
             "--require-whatsapp-cloud",
             meta_action["verify_commands"]["whatsapp_cloud"],
@@ -347,6 +390,30 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             "--require-complete",
             meta_action["complete_verification_command"],
         )
+
+    def test_invalid_cloud_webhook_config_is_reported_in_alpha_handoff(self):
+        invalid = ["WHATSAPP_CLOUD_WEBHOOK_PORT", "WHATSAPP_CLOUD_WEBHOOK_PATH"]
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = self.run_readiness(
+                Path(tmp),
+                cloud_configured=True,
+                cloud_invalid=invalid,
+            )
+
+        self.assertFalse(payload["external_meta_setup"]["cloud_configured"])
+        self.assertEqual(payload["external_meta_setup"]["cloud_missing"], [])
+        self.assertEqual(payload["external_meta_setup"]["cloud_invalid"], invalid)
+        cloud_gate = payload["pending_gates"]["whatsapp_cloud"]
+        self.assertEqual(cloud_gate["invalid"], invalid)
+        cloud_handoff = cloud_gate["setup_handoff"]
+        self.assertEqual(cloud_handoff["invalid"], invalid)
+        self.assertEqual(cloud_handoff["webhook"]["invalid"], invalid)
+        action = {
+            item["id"]: item
+            for item in payload["readiness_summary"]["next_actions"]
+        }["configure_whatsapp_cloud_calling"]
+        self.assertEqual(action["missing_by_gate"]["whatsapp_cloud"], [])
+        self.assertEqual(action["invalid_by_gate"]["whatsapp_cloud"], invalid)
 
     def test_require_complete_fails_when_alpha_gates_are_pending(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -483,6 +550,11 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             "whatsapp_cloud_setup=env_file=",
             result.stdout,
         )
+        self.assertIn(
+            "whatsapp_cloud_webhook=host=0.0.0.0 port=8090 path=/whatsapp/webhook",
+            result.stdout,
+        )
+        self.assertIn("invalid=none", result.stdout)
         self.assertIn(
             "missing=WHATSAPP_CLOUD_PHONE_NUMBER_ID,WHATSAPP_CLOUD_ACCESS_TOKEN",
             result.stdout,

--- a/tests/test_verify_whatsapp_bridge_runtime.py
+++ b/tests/test_verify_whatsapp_bridge_runtime.py
@@ -181,6 +181,58 @@ class WhatsAppBridgeRuntimeVerifierTests(unittest.TestCase):
         self.assertTrue(summary["calling_sidecar_configured"])
         self.assertTrue(summary["calling_ready"])
         self.assertEqual(summary["calling_missing"], [])
+        self.assertEqual(summary["cloud_invalid"], [])
+        self.assertEqual(summary["webhook"]["host"], "0.0.0.0")
+        self.assertEqual(summary["webhook"]["port"], 8090)
+        self.assertEqual(summary["webhook"]["path"], "/whatsapp/webhook")
+        self.assertEqual(summary["webhook"]["api_version"], "v20.0")
+        self.assertIn(
+            "WHATSAPP_CLOUD_WEBHOOK_PORT",
+            summary["webhook"]["defaulted"],
+        )
+
+    def test_invalid_cloud_webhook_config_fails_strict_cloud_readiness(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(tmp_path, require_whatsapp_cloud=True)
+            write_baileys_session(args.session_dir)
+            args.env_file.parent.mkdir(parents=True, exist_ok=True)
+            args.env_file.write_text(
+                "\n".join(
+                    [
+                        "WHATSAPP_MODE=bot",
+                        "WHATSAPP_CLOUD_PHONE_NUMBER_ID=7794189252778687",
+                        "WHATSAPP_CLOUD_ACCESS_TOKEN=secret-token",
+                        "WHATSAPP_CLOUD_APP_SECRET=secret-app",
+                        "WHATSAPP_CLOUD_VERIFY_TOKEN=secret-verify",
+                        "WHATSAPP_CLOUD_WEBHOOK_PORT=not-a-port",
+                        "WHATSAPP_CLOUD_WEBHOOK_PATH=whatsapp/webhook",
+                        "WHATSAPP_CLOUD_API_VERSION=20",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.script.verify(args)
+
+        self.assertFalse(result["success"])
+        failures = "\n".join(result["failures"])
+        self.assertIn("WhatsApp Cloud config invalid", failures)
+        self.assertIn("WHATSAPP_CLOUD_WEBHOOK_PORT", failures)
+        self.assertIn("WHATSAPP_CLOUD_WEBHOOK_PATH", failures)
+        self.assertIn("WHATSAPP_CLOUD_API_VERSION", failures)
+        self.assertNotIn("secret-token", json.dumps(result))
+        webhook = result["checks"]["whatsapp_cloud"]["webhook"]
+        self.assertEqual(webhook["port"], None)
+        self.assertEqual(
+            webhook["invalid"],
+            [
+                "WHATSAPP_CLOUD_WEBHOOK_PORT",
+                "WHATSAPP_CLOUD_WEBHOOK_PATH",
+                "WHATSAPP_CLOUD_API_VERSION",
+            ],
+        )
 
     def test_cloud_calling_summary_can_use_running_gateway_process_env(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- Resolve and report Hermes WhatsApp Cloud webhook defaults (`host`, `port`, `path`, `api_version`) in the bridge runtime verifier.
- Mark malformed Cloud webhook env (`WHATSAPP_CLOUD_WEBHOOK_PORT`, `WHATSAPP_CLOUD_WEBHOOK_PATH`, `WHATSAPP_CLOUD_API_VERSION`) as invalid so strict Cloud/Calling gates distinguish invalid config from missing credentials.
- Thread the safe webhook summary and invalid-key groups into alpha readiness handoffs, next actions, human output, and docs.

## Verification
- `python3 -m py_compile scripts/verify_whatsapp_bridge_runtime.py scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_bridge_runtime.py tests/test_verify_whatsapp_alpha_readiness.py`
- `python3 -m unittest tests.test_verify_whatsapp_bridge_runtime tests.test_verify_whatsapp_alpha_readiness`
- `python3 -m unittest discover -s tests`
- `git diff --check`
- Live bridge runtime summary on this host reports `whatsapp_cloud_webhook=host=0.0.0.0 port=8090 path=/whatsapp/webhook api_version=v20.0 ... invalid=none`.
- Live alpha cached-receive summary still reports `readiness=local_ready_pending_gates`, missing Cloud credentials, and `invalid=none` for Cloud/Calling config.
