### PR TITLE
Save alpha readiness JSON from stack gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ To fail unless every alpha gate is complete, include the strict completion flag:
 scripts/verify_local_hermes_voice_stack.sh \
   --hermes-home ~/.hermes \
   --whatsapp-alpha-profile attended-cache-receive \
+  --whatsapp-alpha-json-output ./whatsapp-alpha.json \
   --require-whatsapp-alpha-complete
 ```
 
@@ -441,6 +442,9 @@ separated from local daemon, bridge, and Hermes failures. It also prints the
 resolved Cloud webhook bind defaults and malformed webhook keys, so strict
 Cloud/Calling failures can distinguish missing credentials from invalid
 `WHATSAPP_CLOUD_WEBHOOK_*` settings.
+Use `--whatsapp-alpha-json-output` with any alpha profile when another local
+agent should consume the same structured `readiness_summary.next_actions`
+without rerunning the full stack gate.
 
 When the WebRTC Python dependencies are installed, add
 `--run-webrtc-loopback-smoke --webrtc-python /tmp/voice-webrtc-venv/bin/python`

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -79,7 +79,8 @@ The same stack gate can run the categorized alpha report as an explicit opt-in:
 ```bash
 scripts/verify_local_hermes_voice_stack.sh \
   --hermes-home ~/.hermes \
-  --whatsapp-alpha-profile cached-receive
+  --whatsapp-alpha-profile cached-receive \
+  --whatsapp-alpha-json-output ./whatsapp-alpha.json
 ```
 
 Use `--whatsapp-alpha-profile send` only when it is acceptable to post a real
@@ -91,7 +92,9 @@ while Hermes is already running; it watches `~/.hermes/audio_cache` for a fresh
 should poll and drain the bridge `/messages` queue. The stack gate also accepts
 `--whatsapp-alpha-chat-id`, `--whatsapp-alpha-wait-audio-cache-seconds`, and
 `--whatsapp-alpha-wait-inbound-seconds` so attended tests do not need to drop
-down to the lower-level alpha script.
+down to the lower-level alpha script. When `--whatsapp-alpha-json-output` is
+set, the stack gate runs the alpha profile with `--json` and saves that
+structured report for another agent or runbook step to consume.
 
 Cached receive profiles also pass the newest cached inbound `aud_*` file to
 the Hermes config verifier, so the configured STT command provider is exercised

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -23,6 +23,7 @@ whatsapp_alpha_profile="${WHATSAPP_ALPHA_PROFILE:-}"
 whatsapp_alpha_voice_note_chat_id="${WHATSAPP_ALPHA_VOICE_NOTE_CHAT_ID:-}"
 whatsapp_alpha_wait_audio_cache_seconds="${WHATSAPP_ALPHA_WAIT_AUDIO_CACHE_SECONDS:-}"
 whatsapp_alpha_wait_inbound_seconds="${WHATSAPP_ALPHA_WAIT_INBOUND_SECONDS:-}"
+whatsapp_alpha_json_output="${WHATSAPP_ALPHA_JSON_OUTPUT:-}"
 run_webrtc_loopback_smoke="${RUN_WEBRTC_LOOPBACK_SMOKE:-0}"
 webrtc_python="${VOICE_WEBRTC_PYTHON:-python3}"
 webrtc_timeout="${VOICE_WEBRTC_TIMEOUT:-60}"
@@ -97,6 +98,8 @@ Options:
                                override attended-cache-receive cache watch time
   --whatsapp-alpha-wait-inbound-seconds SECONDS
                                override attended-send-receive bridge poll time
+  --whatsapp-alpha-json-output PATH
+                               save the categorized alpha readiness JSON report
   --run-webrtc-loopback-smoke  run one local full-duplex WebRTC media turn
   --webrtc-python PATH         Python used for the WebRTC smoke (default: python3)
   --webrtc-timeout SECONDS     timeout passed to the WebRTC smoke (default: 60)
@@ -115,7 +118,7 @@ Environment aliases:
   REQUIRE_WHATSAPP_ALPHA_COMPLETE=1
   RUN_WHATSAPP_INBOUND_CACHE_SMOKE=1, WHATSAPP_ALPHA_PROFILE
   WHATSAPP_ALPHA_VOICE_NOTE_CHAT_ID, WHATSAPP_ALPHA_WAIT_AUDIO_CACHE_SECONDS
-  WHATSAPP_ALPHA_WAIT_INBOUND_SECONDS
+  WHATSAPP_ALPHA_WAIT_INBOUND_SECONDS, WHATSAPP_ALPHA_JSON_OUTPUT
   VOICE_WEBRTC_PYTHON, VOICE_WEBRTC_TIMEOUT
 EOF
 }
@@ -290,6 +293,11 @@ while [[ $# -gt 0 ]]; do
       whatsapp_alpha_wait_inbound_seconds="$2"
       shift 2
       ;;
+    --whatsapp-alpha-json-output)
+      [[ $# -ge 2 ]] || fail "--whatsapp-alpha-json-output requires a path"
+      whatsapp_alpha_json_output="$2"
+      shift 2
+      ;;
     --run-webrtc-loopback-smoke)
       run_webrtc_loopback_smoke=1
       shift
@@ -330,6 +338,9 @@ if [[ -n "$whatsapp_alpha_profile" ]]; then
 fi
 if [[ "$require_whatsapp_alpha_complete" == "1" && -z "$whatsapp_alpha_profile" ]]; then
   fail "--require-whatsapp-alpha-complete requires --whatsapp-alpha-profile"
+fi
+if [[ -n "$whatsapp_alpha_json_output" && -z "$whatsapp_alpha_profile" ]]; then
+  fail "--whatsapp-alpha-json-output requires --whatsapp-alpha-profile"
 fi
 
 voice_bin="$(default_voice_bin)"
@@ -564,7 +575,19 @@ if [[ -n "$whatsapp_alpha_profile" ]]; then
   if [[ "$require_whatsapp_alpha_complete" == "1" ]]; then
     whatsapp_alpha_args+=(--require-complete)
   fi
-  run_step "WhatsApp alpha readiness profile ($whatsapp_alpha_profile)" "${whatsapp_alpha_args[@]}"
+  if [[ -n "$whatsapp_alpha_json_output" ]]; then
+    output_dir="$(dirname -- "$whatsapp_alpha_json_output")"
+    if [[ "$output_dir" != "." ]]; then
+      mkdir -p "$output_dir"
+    fi
+    whatsapp_alpha_args+=(--json)
+    echo
+    echo "==> WhatsApp alpha readiness profile ($whatsapp_alpha_profile)"
+    "${whatsapp_alpha_args[@]}" >"$whatsapp_alpha_json_output"
+    echo "whatsapp_alpha_json=$whatsapp_alpha_json_output"
+  else
+    run_step "WhatsApp alpha readiness profile ($whatsapp_alpha_profile)" "${whatsapp_alpha_args[@]}"
+  fi
   whatsapp_alpha_status="$whatsapp_alpha_profile"
 else
   whatsapp_alpha_status="skipped"
@@ -580,5 +603,8 @@ echo "whatsapp_contract=checked"
 echo "whatsapp_bridge=$whatsapp_bridge_status"
 echo "whatsapp_inbound_cache=$whatsapp_inbound_cache_status"
 echo "whatsapp_alpha=$whatsapp_alpha_status"
+if [[ -n "$whatsapp_alpha_json_output" ]]; then
+  echo "whatsapp_alpha_json=$whatsapp_alpha_json_output"
+fi
 echo "sidecar_service=$sidecar_status"
 echo "webrtc_loopback=$webrtc_loopback_status"

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -549,6 +549,76 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             result.stderr,
         )
 
+    def test_whatsapp_alpha_json_output_requires_alpha_profile(self):
+        result = subprocess.run(
+            [
+                str(SCRIPT_PATH),
+                "--whatsapp-alpha-json-output",
+                "alpha.json",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "--whatsapp-alpha-json-output requires --whatsapp-alpha-profile",
+            result.stderr,
+        )
+
+    def test_whatsapp_alpha_json_output_saves_alpha_stdout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            alpha = tmp_path / "verify_alpha.py"
+            voice = tmp_path / "voice"
+            json_output = tmp_path / "reports" / "alpha.json"
+
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_helper(alpha, "alpha", log_path)
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--hermes-config",
+                    str(tmp_path / "missing.yaml"),
+                    "--skip-hermes-config",
+                    "--skip-hermes-gateway",
+                    "--skip-cli-mcp",
+                    "--skip-sidecar",
+                    "--skip-whatsapp-bridge",
+                    "--skip-systemd",
+                    "--skip-daemon",
+                    "--whatsapp-alpha-profile",
+                    "cached-receive",
+                    "--whatsapp-alpha-json-output",
+                    str(json_output),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "WHATSAPP_ALPHA_READINESS_SCRIPT": str(alpha),
+                },
+            )
+
+            entries = command_log_entries(log_path)
+            saved_output = json_output.read_text(encoding="utf-8").strip()
+            json_output_exists = json_output.is_file()
+
+        self.assertTrue(json_output_exists)
+        self.assertEqual(saved_output, "ok: alpha")
+        self.assertIn(f"whatsapp_alpha_json={json_output}", result.stdout)
+        self.assertEqual([entry[0] for entry in entries], ["whatsapp", "alpha"])
+        self.assertIn("--json", entries[1])
+
     def test_skip_hermes_config_does_not_require_config_file(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)


### PR DESCRIPTION
## Summary
- Add `--whatsapp-alpha-json-output PATH` / `WHATSAPP_ALPHA_JSON_OUTPUT` to `verify_local_hermes_voice_stack.sh`.
- When set with an alpha profile, the top-level stack gate runs alpha readiness with `--json` and saves the structured report for another agent/runbook step.
- Document the option in the README and WhatsApp Calling runbook.

## Verification
- `bash -n scripts/verify_local_hermes_voice_stack.sh`
- `python3 -m py_compile tests/test_verify_local_hermes_voice_stack.py`
- `python3 -m unittest tests.test_verify_local_hermes_voice_stack`
- `python3 -m unittest discover -s tests`
- `git diff --check`
- Live stack gate with `--whatsapp-alpha-json-output` saved a valid cached-receive alpha report showing:
  - `profile=cached-receive`
  - `readiness_summary.status=local_ready_pending_gates`
  - `readiness_summary.complete=False`
  - `pending_gates.attended_fresh_receive.cached_receive_verified=True`
  - `next_actions=run_attended_fresh_receive,configure_whatsapp_cloud_calling`
