### PR TITLE
Make attended receive handoff wait windows explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,8 @@ draining queued messages. Use `attended-send-receive` only when the verifier
 itself should poll and drain the bridge message queue. Add
 `--whatsapp-alpha-chat-id` to override `WHATSAPP_HOME_CHANNEL`, or adjust the
 attended wait with `--whatsapp-alpha-wait-audio-cache-seconds` /
-`--whatsapp-alpha-wait-inbound-seconds`.
+`--whatsapp-alpha-wait-inbound-seconds`. The generated attended receive
+handoff commands include explicit 60-second wait windows by default.
 
 To fail unless every alpha gate is complete, include the strict completion flag:
 

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -186,7 +186,9 @@ scripts/verify_whatsapp_alpha_readiness.py \
 That profile sends a real voice note, then watches the Hermes audio cache for a
 fresh inbound `aud_*` file without polling the bridge message queue. If Hermes
 is not running and the verifier itself must consume bridge events, use the
-draining profile instead:
+draining profile instead. The alpha readiness handoff prints both commands with
+explicit 60-second wait windows so copied commands and saved JSON artifacts are
+self-contained:
 
 ```bash
 scripts/verify_whatsapp_alpha_readiness.py \

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -23,6 +23,8 @@ PROFILE_CHOICES = (
     "attended-cache-receive",
     "attended-send-receive",
 )
+DEFAULT_ATTENDED_CACHE_RECEIVE_SECONDS = 60.0
+DEFAULT_ATTENDED_DRAIN_RECEIVE_SECONDS = 60.0
 
 META_SETUP_STEPS = (
     "Create or select a WhatsApp Business Platform app and WABA.",
@@ -425,6 +427,8 @@ def attended_receive_gate(
     *,
     hermes_home: Path,
     audio_cache_dir: Path,
+    preferred_wait_audio_cache_seconds: float = DEFAULT_ATTENDED_CACHE_RECEIVE_SECONDS,
+    fallback_wait_inbound_seconds: float = DEFAULT_ATTENDED_DRAIN_RECEIVE_SECONDS,
 ) -> dict[str, Any]:
     bridge_checks = bridge_runtime_checks(components)
     local_config = bridge_checks.get("whatsapp_local_config") or {}
@@ -445,6 +449,8 @@ def attended_receive_gate(
             str(hermes_home),
             "--profile",
             "attended-cache-receive",
+            "--wait-audio-cache-seconds",
+            str(preferred_wait_audio_cache_seconds),
         ],
         "fallback_draining_command": [
             "scripts/verify_whatsapp_alpha_readiness.py",
@@ -452,6 +458,8 @@ def attended_receive_gate(
             str(hermes_home),
             "--profile",
             "attended-send-receive",
+            "--wait-inbound-seconds",
+            str(fallback_wait_inbound_seconds),
         ],
     }
     gate["operator_handoff"] = {
@@ -461,6 +469,8 @@ def attended_receive_gate(
         "fallback_draining_command": gate["fallback_draining_command"],
         "drains_bridge_messages": False,
         "fallback_drains_bridge_messages": True,
+        "wait_audio_cache_seconds": preferred_wait_audio_cache_seconds,
+        "fallback_wait_inbound_seconds": fallback_wait_inbound_seconds,
         "audio_cache_dir": str(audio_cache_dir),
         "home_channel": local_config.get("home_channel"),
         "home_channel_kind": local_config.get("home_channel_kind"),
@@ -760,6 +770,8 @@ def build_readiness_summary(
                     "fallback_profile",
                     "drains_bridge_messages",
                     "fallback_drains_bridge_messages",
+                    "wait_audio_cache_seconds",
+                    "fallback_wait_inbound_seconds",
                     "audio_cache_dir",
                     "home_channel",
                     "home_channel_kind",
@@ -911,6 +923,16 @@ def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
                 if args.whatsapp_audio_cache_dir
                 else args.hermes_home.expanduser().resolve() / "audio_cache"
             ),
+            preferred_wait_audio_cache_seconds=(
+                args.wait_audio_cache_seconds
+                if args.profile == "attended-cache-receive"
+                else DEFAULT_ATTENDED_CACHE_RECEIVE_SECONDS
+            ),
+            fallback_wait_inbound_seconds=(
+                args.wait_inbound_seconds
+                if args.profile == "attended-send-receive"
+                else DEFAULT_ATTENDED_DRAIN_RECEIVE_SECONDS
+            ),
         ),
         **external_meta_gate(
             external_meta_setup,
@@ -1056,12 +1078,12 @@ def apply_profile(args: argparse.Namespace) -> None:
         args.send_voice_note = True
         args.run_inbound_cache_smoke = True
         if args.wait_audio_cache_seconds == 0:
-            args.wait_audio_cache_seconds = 60.0
+            args.wait_audio_cache_seconds = DEFAULT_ATTENDED_CACHE_RECEIVE_SECONDS
         args.require_fresh_cache_audio = True
     elif args.profile == "attended-send-receive":
         args.send_voice_note = True
         if args.wait_inbound_seconds == 0:
-            args.wait_inbound_seconds = 60.0
+            args.wait_inbound_seconds = DEFAULT_ATTENDED_DRAIN_RECEIVE_SECONDS
         args.require_inbound_audio = True
         args.drain_bridge_messages = True
 
@@ -1160,7 +1182,11 @@ def human_summary(result: dict[str, Any]) -> None:
                     f"agent={handoff.get('agent_name') or '<unknown>'} "
                     f"number={handoff.get('agent_number') or '<unknown>'} "
                     f"home_channel={handoff.get('home_channel') or '<unknown>'} "
-                    f"audio_cache_dir={handoff.get('audio_cache_dir')}"
+                    f"audio_cache_dir={handoff.get('audio_cache_dir')} "
+                    "wait_audio_cache_seconds="
+                    f"{handoff.get('wait_audio_cache_seconds')} "
+                    "fallback_wait_inbound_seconds="
+                    f"{handoff.get('fallback_wait_inbound_seconds')}"
                 )
                 for index, step in enumerate(handoff.get("steps") or [], start=1):
                     print(f"attended_fresh_receive_step[{index}]={step}")

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -263,12 +263,27 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             gates["attended_fresh_receive"]["command"],
         )
         self.assertIn(
+            "--wait-audio-cache-seconds",
+            gates["attended_fresh_receive"]["command"],
+        )
+        self.assertIn("60.0", gates["attended_fresh_receive"]["command"])
+        self.assertIn(
             "attended-send-receive",
+            gates["attended_fresh_receive"]["fallback_draining_command"],
+        )
+        self.assertIn(
+            "--wait-inbound-seconds",
+            gates["attended_fresh_receive"]["fallback_draining_command"],
+        )
+        self.assertIn(
+            "60.0",
             gates["attended_fresh_receive"]["fallback_draining_command"],
         )
         handoff = gates["attended_fresh_receive"]["operator_handoff"]
         self.assertEqual(handoff["preferred_profile"], "attended-cache-receive")
         self.assertEqual(handoff["fallback_profile"], "attended-send-receive")
+        self.assertEqual(handoff["wait_audio_cache_seconds"], 60.0)
+        self.assertEqual(handoff["fallback_wait_inbound_seconds"], 60.0)
         self.assertEqual(handoff["home_channel"], "20530681934008@lid")
         self.assertEqual(handoff["home_channel_kind"], "lid")
         self.assertEqual(handoff["agent_name"], "Quill")
@@ -359,6 +374,14 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertEqual(
             attended_action["operator_handoff"]["home_channel"],
             "20530681934008@lid",
+        )
+        self.assertEqual(
+            attended_action["operator_handoff"]["wait_audio_cache_seconds"],
+            60.0,
+        )
+        self.assertEqual(
+            attended_action["operator_handoff"]["fallback_wait_inbound_seconds"],
+            60.0,
         )
         meta_action = actions["configure_whatsapp_cloud_calling"]
         self.assertEqual(
@@ -529,15 +552,19 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             result.stdout,
         )
         self.assertIn("--profile attended-cache-receive", result.stdout)
+        self.assertIn("--wait-audio-cache-seconds 60.0", result.stdout)
         self.assertIn(
             "attended_fresh_receive_fallback_draining_command=",
             result.stdout,
         )
         self.assertIn("--profile attended-send-receive", result.stdout)
+        self.assertIn("--wait-inbound-seconds 60.0", result.stdout)
         self.assertIn(
             "attended_fresh_receive_operator=agent=Quill number=13236478455",
             result.stdout,
         )
+        self.assertIn("wait_audio_cache_seconds=60.0", result.stdout)
+        self.assertIn("fallback_wait_inbound_seconds=60.0", result.stdout)
         self.assertIn(
             "home_channel=20530681934008@lid",
             result.stdout,


### PR DESCRIPTION
## Summary
- add named defaults for attended receive wait windows
- include explicit wait flags in preferred and fallback handoff commands
- surface those values in operator handoff JSON, readiness next actions, and human output
- update docs and tests for the copied-command behavior

## Verification
- python3 -m unittest tests.test_verify_whatsapp_alpha_readiness
- python3 -m unittest discover -s tests
- python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_alpha_readiness.py
- git diff --check
- scripts/verify_whatsapp_alpha_readiness.py --hermes-home /home/ubuntu/.hermes --voice-bin /home/ubuntu/.local/bin/voice --profile cached-receive --skip-hermes-tts-smoke --wait-audio-cache-seconds 0.1 --expected-agent-number 13236478455 --expected-agent-name Quill

The local smoke reports `attended_fresh_receive_command` with `--wait-audio-cache-seconds 60.0`, fallback with `--wait-inbound-seconds 60.0`, and matching operator handoff fields.