### PR TITLE
Report Telegram credential readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ voice stream-transcribe recording.ogg
 VOICE_BIN=/path/to/voice scripts/verify_whatsapp_voice_contract.sh
 VOICE_BIN=/path/to/voice scripts/verify_whatsapp_voice_contract.sh --require-daemon --run-stt-smoke
 VOICE_BIN=/path/to/voice scripts/verify_telegram_voice_contract.sh --skip-hermes-config
+VOICE_BIN=/path/to/voice scripts/verify_telegram_voice_contract.sh --require-telegram-credentials
 
 # Read from a file, strip markdown
 voice say --markdown -f blog-post.mdx
@@ -358,10 +359,13 @@ For WhatsApp or Telegram voice-note delivery through Hermes, prefer
 Opus output directly. `output_format: wav` remains a compatibility fallback,
 with Hermes converting to OGG/Opus when needed.
 
-Telegram voice messages use the same Ogg/Opus file shape as WhatsApp voice
-notes. Run `scripts/verify_telegram_voice_contract.sh` before adding the bot
-token; it does not contact Telegram, but it verifies Voice's Ogg/Opus output
-contract and, unless skipped, the active Hermes command-provider config.
+Telegram voice messages accept the same Ogg/Opus file shape as WhatsApp voice
+notes, even though Telegram also accepts MP3 and M4A uploads. Run
+`scripts/verify_telegram_voice_contract.sh` before adding the bot token; it
+does not contact Telegram, but it verifies Voice's Ogg/Opus output contract
+and, unless skipped, the active Hermes command-provider config. Add
+`--require-telegram-credentials` when you want the preflight to fail unless
+`TELEGRAM_BOT_TOKEN` is present in the Hermes env file.
 
 Hermes can call `voice` directly, or use the voice-owned command-provider
 shims:

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -53,8 +53,9 @@ so the same command still works outside Hermes.
 Set `voice_compatible: true` so Hermes routes the returned `.ogg` file as a
 native voice note. `output_format: wav` remains valid as a compatibility
 fallback; Hermes and the WhatsApp bridge can still convert non-Opus audio when
-needed. Telegram uses the same Ogg/Opus voice-message shape for `sendVoice`, so
-Voice does not need a Telegram-specific encoder.
+needed. Telegram accepts the same Ogg/Opus voice-message shape for `sendVoice`
+alongside MP3 and M4A uploads, so Voice does not need a Telegram-specific
+encoder.
 
 For live WhatsApp Calling, keep Ogg/Opus as the file path and bridge WebRTC
 media through 48 kHz 20 ms PCM frames. See
@@ -167,6 +168,7 @@ For the equivalent Telegram preflight, run:
 
 ```bash
 VOICE_BIN=/path/to/voice scripts/verify_telegram_voice_contract.sh
+VOICE_BIN=/path/to/voice scripts/verify_telegram_voice_contract.sh --require-telegram-credentials
 ```
 
 Those verifiers check `voice stream-contract` against the checked-in sidecar
@@ -175,11 +177,13 @@ write real mono 48 kHz Ogg/Opus, verify misleading `.wav`/`ogg-opus`
 combinations are rejected before writing a file, and, when the daemon is
 running, check both raw 48 kHz 20 ms PCM streaming and streamed Ogg/Opus
 encoding to both named files and stdout. The Telegram verifier also checks the
-active Hermes command-provider config unless `--skip-hermes-config` is passed.
-Pass `--require-daemon` when the daemon stream path must be covered, or
-`--skip-daemon` for a file-only preflight. Pass `--run-stt-smoke` with
-`--require-daemon` when the inbound WebRTC/STT path must also be covered; it
-creates a tiny WAV fixture and requires
+active Hermes command-provider config unless `--skip-hermes-config` is passed,
+and reports whether the Hermes env file contains Telegram credentials without
+printing secret values. Pass `--require-telegram-credentials` when setup should
+fail unless `TELEGRAM_BOT_TOKEN` is present. Pass `--require-daemon` when the
+daemon stream path must be covered, or `--skip-daemon` for a file-only
+preflight. Pass `--run-stt-smoke` with `--require-daemon` when the inbound
+WebRTC/STT path must also be covered; it creates a tiny WAV fixture and requires
 `voice stream-transcribe --json` to return a terminal `stt.transcribed` event.
 This is optional because it may lazily load the Whisper model.
 

--- a/scripts/verify_telegram_voice_contract.sh
+++ b/scripts/verify_telegram_voice_contract.sh
@@ -6,8 +6,10 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 voice_bin="${VOICE_BIN:-}"
 text="${TEXT:-Voice Telegram contract smoke test.}"
 hermes_config="${HERMES_CONFIG:-${HOME:-}/.hermes/config.yaml}"
+hermes_env="${HERMES_ENV:-}"
 skip_hermes_config="${SKIP_HERMES_CONFIG:-0}"
 skip_hermes_tts_smoke="${SKIP_HERMES_TTS_SMOKE:-0}"
+require_telegram_credentials="${REQUIRE_TELEGRAM_CREDENTIALS:-0}"
 require_daemon="${REQUIRE_DAEMON:-0}"
 skip_daemon="${SKIP_DAEMON:-0}"
 run_stt_smoke="${RUN_STT_SMOKE:-0}"
@@ -27,8 +29,11 @@ Options:
   --voice-bin PATH          voice binary to run (default: VOICE_BIN, target/release/voice, then PATH)
   --text TEXT               smoke text to synthesize
   --hermes-config PATH      Hermes config file to validate (default: HERMES_CONFIG or ~/.hermes/config.yaml)
+  --hermes-env PATH         Hermes env file to inspect for Telegram credentials (default: HERMES_ENV or config dir/.env)
   --skip-hermes-config      skip Hermes command-provider config validation
   --skip-hermes-tts-smoke   validate Hermes config without executing TTS
+  --require-telegram-credentials
+                            fail unless TELEGRAM_BOT_TOKEN is present in the Hermes env file
   --require-daemon          fail if voice daemon streaming is unavailable
   --skip-daemon             skip daemon-backed stream checks even if the daemon is running
   --run-stt-smoke           also replay a WAV through daemon stream-transcribe
@@ -36,14 +41,49 @@ Options:
   -h, --help                show this help
 
 Environment aliases:
-  VOICE_BIN, TEXT, HERMES_CONFIG, SKIP_HERMES_CONFIG=1, SKIP_HERMES_TTS_SMOKE=1,
-  REQUIRE_DAEMON=1, SKIP_DAEMON=1, RUN_STT_SMOKE=1, KEEP_OUTPUT=1
+  VOICE_BIN, TEXT, HERMES_CONFIG, HERMES_ENV, SKIP_HERMES_CONFIG=1,
+  SKIP_HERMES_TTS_SMOKE=1, REQUIRE_TELEGRAM_CREDENTIALS=1, REQUIRE_DAEMON=1,
+  SKIP_DAEMON=1, RUN_STT_SMOKE=1, KEEP_OUTPUT=1
 EOF
 }
 
 fail() {
   echo "error: $*" >&2
   exit 1
+}
+
+read_env_key() {
+  local key="$1"
+  local file="$2"
+  [[ -f "$file" ]] || return 1
+  awk -v key="$key" '
+    /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
+    {
+      line = $0
+      sub(/^[[:space:]]*export[[:space:]]+/, "", line)
+      if (line ~ "^[[:space:]]*" key "[[:space:]]*=") {
+        sub("^[[:space:]]*" key "[[:space:]]*=", "", line)
+        sub(/[[:space:]]+#.*$/, "", line)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+        if (line ~ /^".*"$/ || line ~ /^\047.*\047$/) {
+          line = substr(line, 2, length(line) - 2)
+        }
+        print line
+        found = 1
+        exit
+      }
+    }
+    END { if (!found) exit 1 }
+  ' "$file"
+}
+
+credential_status() {
+  local value="$1"
+  if [[ -n "$value" ]]; then
+    echo "configured"
+  else
+    echo "not_configured"
+  fi
 }
 
 while [[ $# -gt 0 ]]; do
@@ -63,12 +103,21 @@ while [[ $# -gt 0 ]]; do
       hermes_config="$2"
       shift 2
       ;;
+    --hermes-env)
+      [[ $# -ge 2 ]] || fail "--hermes-env requires a path"
+      hermes_env="$2"
+      shift 2
+      ;;
     --skip-hermes-config)
       skip_hermes_config=1
       shift
       ;;
     --skip-hermes-tts-smoke)
       skip_hermes_tts_smoke=1
+      shift
+      ;;
+    --require-telegram-credentials)
+      require_telegram_credentials=1
       shift
       ;;
     --require-daemon)
@@ -98,6 +147,35 @@ while [[ $# -gt 0 ]]; do
 done
 
 [[ -x "$voice_contract_script" ]] || fail "voice contract verifier is not executable: $voice_contract_script"
+
+if [[ -z "$hermes_env" ]]; then
+  hermes_config_dir="$(cd "$(dirname "$hermes_config")" 2>/dev/null && pwd || true)"
+  if [[ -z "$hermes_config_dir" ]]; then
+    hermes_config_dir="$(dirname "$hermes_config")"
+  fi
+  hermes_env="$hermes_config_dir/.env"
+fi
+
+telegram_token=""
+telegram_allowed_users=""
+telegram_home_channel=""
+telegram_webhook_url=""
+telegram_env_status="missing"
+if [[ -f "$hermes_env" ]]; then
+  telegram_env_status="found"
+  telegram_token="$(read_env_key "TELEGRAM_BOT_TOKEN" "$hermes_env" || true)"
+  telegram_allowed_users="$(read_env_key "TELEGRAM_ALLOWED_USERS" "$hermes_env" || true)"
+  telegram_home_channel="$(read_env_key "TELEGRAM_HOME_CHANNEL" "$hermes_env" || true)"
+  telegram_webhook_url="$(read_env_key "TELEGRAM_WEBHOOK_URL" "$hermes_env" || true)"
+fi
+telegram_credentials_status="$(credential_status "$telegram_token")"
+telegram_allowed_users_status="$(credential_status "$telegram_allowed_users")"
+telegram_home_channel_status="$(credential_status "$telegram_home_channel")"
+telegram_webhook_status="$(credential_status "$telegram_webhook_url")"
+
+if [[ "$require_telegram_credentials" == "1" && "$telegram_credentials_status" != "configured" ]]; then
+  fail "Telegram credentials are required but TELEGRAM_BOT_TOKEN is missing or empty in $hermes_env"
+fi
 
 voice_contract_cmd=("$voice_contract_script" "--text" "$text")
 if [[ -n "$voice_bin" ]]; then
@@ -142,4 +220,10 @@ echo "ok: voice Telegram contract verifier passed"
 echo "voice_contract=$voice_contract_status"
 echo "hermes_voice_config=$hermes_config_status"
 echo "telegram_send_voice=compatible"
-echo "telegram_credentials=not_required_for_offline_contract"
+echo "telegram_offline_contract_credentials=not_required"
+echo "telegram_env=$hermes_env"
+echo "telegram_env_status=$telegram_env_status"
+echo "telegram_credentials=$telegram_credentials_status"
+echo "telegram_allowed_users=$telegram_allowed_users_status"
+echo "telegram_home_channel=$telegram_home_channel_status"
+echo "telegram_webhook=$telegram_webhook_status"

--- a/tests/test_verify_telegram_voice_contract.py
+++ b/tests/test_verify_telegram_voice_contract.py
@@ -52,11 +52,25 @@ class TelegramVoiceContractVerifierTests(unittest.TestCase):
             hermes_config_verifier = tmp_path / "verify_hermes.py"
             voice = tmp_path / "voice"
             config = tmp_path / "config.yaml"
+            env_file = tmp_path / ".env"
 
             write_helper(voice_contract, "voice_contract", log_path)
             write_helper(hermes_config_verifier, "hermes", log_path)
             write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
             config.write_text("tts: {}\n", encoding="utf-8")
+            env_file.write_text(
+                "\n".join(
+                    [
+                        "# Telegram setup",
+                        "TELEGRAM_BOT_TOKEN=123:abc",
+                        "TELEGRAM_ALLOWED_USERS=42,43",
+                        "TELEGRAM_HOME_CHANNEL=-100123",
+                        "TELEGRAM_WEBHOOK_URL=https://example.invalid/telegram",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
 
             result = subprocess.run(
                 [
@@ -67,6 +81,8 @@ class TelegramVoiceContractVerifierTests(unittest.TestCase):
                     "Telegram smoke.",
                     "--hermes-config",
                     str(config),
+                    "--hermes-env",
+                    str(env_file),
                     "--skip-hermes-tts-smoke",
                     "--skip-daemon",
                 ],
@@ -80,11 +96,17 @@ class TelegramVoiceContractVerifierTests(unittest.TestCase):
                 },
             )
 
-            entries = command_log_entries(log_path)
+            entries = command_log_entries(log_path) if log_path.exists() else []
 
         self.assertIn("ok: voice Telegram contract verifier passed", result.stdout)
         self.assertIn("voice_contract=checked", result.stdout)
         self.assertIn("hermes_voice_config=checked_without_tts_smoke", result.stdout)
+        self.assertIn(f"telegram_env={env_file}", result.stdout)
+        self.assertIn("telegram_env_status=found", result.stdout)
+        self.assertIn("telegram_credentials=configured", result.stdout)
+        self.assertIn("telegram_allowed_users=configured", result.stdout)
+        self.assertIn("telegram_home_channel=configured", result.stdout)
+        self.assertIn("telegram_webhook=configured", result.stdout)
         self.assertEqual([entry[0] for entry in entries], ["voice_contract", "hermes"])
         self.assertEqual(
             entries[0],
@@ -115,6 +137,7 @@ class TelegramVoiceContractVerifierTests(unittest.TestCase):
             log_path = tmp_path / "commands.log"
             voice_contract = tmp_path / "verify_voice_contract.sh"
             missing_config = tmp_path / "missing.yaml"
+            missing_env = tmp_path / "missing.env"
 
             write_helper(voice_contract, "voice_contract", log_path)
 
@@ -123,6 +146,8 @@ class TelegramVoiceContractVerifierTests(unittest.TestCase):
                     str(SCRIPT_PATH),
                     "--hermes-config",
                     str(missing_config),
+                    "--hermes-env",
+                    str(missing_env),
                     "--skip-hermes-config",
                     "--require-daemon",
                     "--run-stt-smoke",
@@ -137,13 +162,51 @@ class TelegramVoiceContractVerifierTests(unittest.TestCase):
                 },
             )
 
-            entries = command_log_entries(log_path)
+            entries = command_log_entries(log_path) if log_path.exists() else []
 
         self.assertIn("hermes_voice_config=skipped", result.stdout)
+        self.assertIn(f"telegram_env={missing_env}", result.stdout)
+        self.assertIn("telegram_env_status=missing", result.stdout)
+        self.assertIn("telegram_credentials=not_configured", result.stdout)
         self.assertEqual([entry[0] for entry in entries], ["voice_contract"])
         self.assertIn("--require-daemon", entries[0])
         self.assertIn("--run-stt-smoke", entries[0])
         self.assertIn("--keep-output", entries[0])
+
+    def test_require_telegram_credentials_fails_without_token(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            voice_contract = tmp_path / "verify_voice_contract.sh"
+            env_file = tmp_path / ".env"
+
+            write_helper(voice_contract, "voice_contract", log_path)
+            env_file.write_text(
+                "# TELEGRAM_BOT_TOKEN=\nTELEGRAM_ALLOWED_USERS=42\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--hermes-env",
+                    str(env_file),
+                    "--skip-hermes-config",
+                    "--require-telegram-credentials",
+                ],
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "VOICE_CONTRACT_VERIFY_SCRIPT": str(voice_contract),
+                },
+            )
+
+            entries = command_log_entries(log_path) if log_path.exists() else []
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("TELEGRAM_BOT_TOKEN is missing or empty", result.stderr)
+        self.assertEqual(entries, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- report local Telegram credential readiness from the Hermes env file without printing secrets
- add `--hermes-env` and `--require-telegram-credentials` to the Telegram verifier
- document Telegram setup preflight and clarify that Voice targets Telegram-compatible Ogg/Opus even though Telegram also accepts MP3/M4A uploads
- add tests for configured, missing, and required-token verifier modes

## Verification
- python3 -m unittest tests.test_verify_telegram_voice_contract
- python3 -m unittest discover -s tests
- bash -n scripts/verify_telegram_voice_contract.sh
- git diff --check
- scripts/verify_telegram_voice_contract.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-config /home/ubuntu/.hermes/config.yaml --hermes-env /home/ubuntu/.hermes/.env --skip-hermes-tts-smoke
- scripts/verify_telegram_voice_contract.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-config /home/ubuntu/.hermes/config.yaml --hermes-env /home/ubuntu/.hermes/.env --skip-hermes-tts-smoke --require-telegram-credentials

Local result: the speech contract is compatible, Hermes is configured for direct Ogg/Opus Voice TTS/STT, and this machine currently reports `telegram_credentials=not_configured`. The required-credentials command fails fast because `TELEGRAM_BOT_TOKEN` is missing or empty in `/home/ubuntu/.hermes/.env`.