### PR TITLE
Summarize saved WhatsApp alpha JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,10 @@ Cloud/Calling failures can distinguish missing credentials from invalid
 `WHATSAPP_CLOUD_WEBHOOK_*` settings.
 Use `--whatsapp-alpha-json-output` with any alpha profile when another local
 agent should consume the same structured `readiness_summary.next_actions`
-without rerunning the full stack gate.
+without rerunning the full stack gate. The stack verifier also echoes compact
+`whatsapp_alpha_json_*` summary lines after saving the artifact, including
+readiness status, completion state, next actions, attended receive status, and
+Cloud/Calling missing or invalid key groups.
 
 When the WebRTC Python dependencies are installed, add
 `--run-webrtc-loopback-smoke --webrtc-python /tmp/voice-webrtc-venv/bin/python`

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -149,6 +149,12 @@ information with:
 - `whatsapp_calling_verify_command`
 - `whatsapp_calling_complete_command`
 
+When the top-level stack gate is run with `--whatsapp-alpha-json-output`, it
+saves the alpha report and then echoes compact `whatsapp_alpha_json_*` summary
+lines for the saved artifact. Those lines include the alpha profile, readiness
+status, completion state, next action IDs, attended receive status, and
+Cloud/Calling missing or invalid key groups.
+
 Use the complete gate only when the local bridge, attended receive, Cloud API,
 and Calling setup are all expected to pass:
 

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -160,6 +160,70 @@ run_step() {
   "$@"
 }
 
+print_whatsapp_alpha_json_summary() {
+  local json_path="$1"
+  python3 - "$json_path" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+
+def csv(values):
+    return ",".join(str(value) for value in (values or [])) or "none"
+
+
+summary = payload.get("readiness_summary") or {}
+pending = payload.get("pending_gates") or {}
+attended = pending.get("attended_fresh_receive") or {}
+cloud = pending.get("whatsapp_cloud") or {}
+calling = pending.get("whatsapp_cloud_calling") or {}
+cloud_handoff = cloud.get("setup_handoff") or {}
+calling_handoff = calling.get("setup_handoff") or {}
+actions = [
+    str(action.get("id"))
+    for action in (summary.get("next_actions") or [])
+    if action.get("id")
+]
+
+print(f"whatsapp_alpha_json_profile={payload.get('profile')}")
+print(
+    "whatsapp_alpha_json_readiness="
+    f"{summary.get('status')} "
+    f"complete={summary.get('complete')} "
+    f"local_checks_passed={summary.get('local_checks_passed')} "
+    "attended_fresh_receive_verified="
+    f"{summary.get('attended_fresh_receive_verified')} "
+    "external_meta_setup_required="
+    f"{summary.get('external_meta_setup_required')} "
+    f"operator_action_required={summary.get('operator_action_required')}"
+)
+print(f"whatsapp_alpha_json_next_actions={csv(actions)}")
+if attended:
+    print(
+        "whatsapp_alpha_json_attended_fresh_receive="
+        f"{attended.get('status')} "
+        f"cached_receive_verified={attended.get('cached_receive_verified')}"
+    )
+if cloud:
+    print(
+        "whatsapp_alpha_json_cloud="
+        f"{cloud.get('status')} "
+        f"missing={csv(cloud_handoff.get('missing') or cloud.get('missing'))} "
+        f"invalid={csv(cloud_handoff.get('invalid') or cloud.get('invalid'))}"
+    )
+if calling:
+    print(
+        "whatsapp_alpha_json_calling="
+        f"{calling.get('status')} "
+        f"missing={csv(calling_handoff.get('missing') or calling.get('missing'))} "
+        f"invalid={csv(calling_handoff.get('invalid') or calling.get('invalid'))}"
+    )
+PY
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --voice-bin)
@@ -585,6 +649,7 @@ if [[ -n "$whatsapp_alpha_profile" ]]; then
     echo "==> WhatsApp alpha readiness profile ($whatsapp_alpha_profile)"
     "${whatsapp_alpha_args[@]}" >"$whatsapp_alpha_json_output"
     echo "whatsapp_alpha_json=$whatsapp_alpha_json_output"
+    print_whatsapp_alpha_json_summary "$whatsapp_alpha_json_output"
   else
     run_step "WhatsApp alpha readiness profile ($whatsapp_alpha_profile)" "${whatsapp_alpha_args[@]}"
   fi

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -577,7 +577,64 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             json_output = tmp_path / "reports" / "alpha.json"
 
             write_helper(whatsapp, "whatsapp", log_path)
-            write_helper(alpha, "alpha", log_path)
+            write_executable(
+                alpha,
+                textwrap.dedent(
+                    f"""\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    printf 'alpha' >> {str(log_path)!r}
+                    printf '\\0' >> {str(log_path)!r}
+                    printf '%s\\0' "$@" >> {str(log_path)!r}
+                    printf '\\n' >> {str(log_path)!r}
+                    cat <<'JSON'
+                    {{
+                      "profile": "cached-receive",
+                      "readiness_summary": {{
+                        "status": "local_ready_pending_gates",
+                        "complete": false,
+                        "local_checks_passed": true,
+                        "attended_fresh_receive_verified": false,
+                        "external_meta_setup_required": true,
+                        "operator_action_required": true,
+                        "next_actions": [
+                          {{"id": "run_attended_fresh_receive"}},
+                          {{"id": "configure_whatsapp_cloud_calling"}}
+                        ]
+                      }},
+                      "pending_gates": {{
+                        "attended_fresh_receive": {{
+                          "status": "not_verified",
+                          "cached_receive_verified": true
+                        }},
+                        "whatsapp_cloud": {{
+                          "status": "external_setup_required",
+                          "setup_handoff": {{
+                            "missing": [
+                              "WHATSAPP_CLOUD_PHONE_NUMBER_ID",
+                              "WHATSAPP_CLOUD_ACCESS_TOKEN"
+                            ],
+                            "invalid": []
+                          }}
+                        }},
+                        "whatsapp_cloud_calling": {{
+                          "status": "external_setup_required",
+                          "setup_handoff": {{
+                            "missing": [
+                              "WHATSAPP_CLOUD_PHONE_NUMBER_ID",
+                              "WHATSAPP_CLOUD_ACCESS_TOKEN",
+                              "WHATSAPP_CLOUD_APP_SECRET",
+                              "WHATSAPP_CLOUD_VERIFY_TOKEN"
+                            ],
+                            "invalid": []
+                          }}
+                        }}
+                      }}
+                    }}
+                    JSON
+                    """
+                ),
+            )
             write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
 
             result = subprocess.run(
@@ -614,8 +671,37 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             json_output_exists = json_output.is_file()
 
         self.assertTrue(json_output_exists)
-        self.assertEqual(saved_output, "ok: alpha")
+        self.assertIn('"profile": "cached-receive"', saved_output)
         self.assertIn(f"whatsapp_alpha_json={json_output}", result.stdout)
+        self.assertIn("whatsapp_alpha_json_profile=cached-receive", result.stdout)
+        self.assertIn(
+            "whatsapp_alpha_json_readiness=local_ready_pending_gates complete=False "
+            "local_checks_passed=True attended_fresh_receive_verified=False "
+            "external_meta_setup_required=True operator_action_required=True",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_alpha_json_next_actions=run_attended_fresh_receive,"
+            "configure_whatsapp_cloud_calling",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_alpha_json_attended_fresh_receive=not_verified "
+            "cached_receive_verified=True",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_alpha_json_cloud=external_setup_required "
+            "missing=WHATSAPP_CLOUD_PHONE_NUMBER_ID,WHATSAPP_CLOUD_ACCESS_TOKEN "
+            "invalid=none",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_alpha_json_calling=external_setup_required "
+            "missing=WHATSAPP_CLOUD_PHONE_NUMBER_ID,WHATSAPP_CLOUD_ACCESS_TOKEN,"
+            "WHATSAPP_CLOUD_APP_SECRET,WHATSAPP_CLOUD_VERIFY_TOKEN invalid=none",
+            result.stdout,
+        )
         self.assertEqual([entry[0] for entry in entries], ["whatsapp", "alpha"])
         self.assertIn("--json", entries[1])
 


### PR DESCRIPTION
## Summary
- print compact `whatsapp_alpha_json_*` summary lines after the stack gate saves an alpha readiness JSON artifact
- include readiness status, completion state, next actions, attended receive state, and Cloud/Calling missing or invalid key groups
- update stack wrapper tests and docs for the saved-artifact summary

## Verification
- python3 -m unittest tests.test_verify_local_hermes_voice_stack
- python3 -m unittest tests.test_verify_local_hermes_voice_stack tests.test_verify_whatsapp_alpha_readiness
- python3 -m unittest discover -s tests
- bash -n scripts/verify_local_hermes_voice_stack.sh
- git diff --check
- scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --skip-hermes-tts-smoke --whatsapp-alpha-profile cached-receive --whatsapp-alpha-wait-audio-cache-seconds 0.1 --whatsapp-alpha-json-output <tmp> --expected-whatsapp-agent-number 13236478455 --expected-whatsapp-agent-name Quill

Live local stack result passed and printed:
- `whatsapp_alpha_json_readiness=local_ready_pending_gates complete=False local_checks_passed=True attended_fresh_receive_verified=False external_meta_setup_required=True operator_action_required=True`
- `whatsapp_alpha_json_next_actions=run_attended_fresh_receive,configure_whatsapp_cloud_calling`
- Cloud/Calling missing keys remain `WHATSAPP_CLOUD_PHONE_NUMBER_ID`, `WHATSAPP_CLOUD_ACCESS_TOKEN`, `WHATSAPP_CLOUD_APP_SECRET`, and `WHATSAPP_CLOUD_VERIFY_TOKEN`.