### PR TITLE
Add WhatsApp Cloud API phone check

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,10 @@ alpha output prints `whatsapp_cloud_setup`, `whatsapp_cloud_verify_command`,
 separated from local daemon, bridge, and Hermes failures. It also prints the
 resolved Cloud webhook bind defaults and malformed webhook keys, so strict
 Cloud/Calling failures can distinguish missing credentials from invalid
-`WHATSAPP_CLOUD_WEBHOOK_*` settings.
+`WHATSAPP_CLOUD_WEBHOOK_*` settings. After real Cloud credentials are present,
+add `--check-whatsapp-cloud-api` to make an authenticated Graph API
+phone-number request and prove the configured phone-number node is reachable
+without printing token or phone-number values.
 Use `--whatsapp-alpha-json-output` with any alpha profile when another local
 agent should consume the same structured `readiness_summary.next_actions`
 without rerunning the full stack gate. The stack verifier also echoes compact

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -72,7 +72,10 @@ That command verifies installed `voice`, daemon-aware CLI/MCP behavior,
 WhatsApp-ready Ogg/Opus output, the Baileys bridge identity, the Hermes gateway
 voice-stream service, and the WebRTC sidecar contract. Add
 `--require-whatsapp-cloud` or `--require-whatsapp-calling` only when the host is
-expected to have real Meta Cloud credentials.
+expected to have real Meta Cloud credentials. Once those credentials are on
+disk, add `--check-whatsapp-cloud-api` to make an authenticated Graph API
+phone-number request and confirm the configured `WHATSAPP_CLOUD_PHONE_NUMBER_ID`
+is reachable without printing token or phone-number values.
 
 The same stack gate can run the categorized alpha report as an explicit opt-in:
 
@@ -112,10 +115,13 @@ and groups failures as voice runtime, Hermes runtime/config, bridge pairing,
 voice-note, live-call local sidecar, or external Meta setup. Use
 `--require-whatsapp-calling` when a host is expected to be ready for real Cloud
 Calling; otherwise missing Meta credentials are reported as external setup
-still required, not as a local Baileys voice-note failure. The named profiles
-are `unattended`, `cached-receive`, `send`, `attended-cache-receive`, and
-`attended-send-receive`. Use `cached-receive` when the report should also
-replay a cached inbound WhatsApp voice note through `voice stream-transcribe`:
+still required, not as a local Baileys voice-note failure. Add
+`--check-whatsapp-cloud-api` when credentials are expected to work and the
+report should prove the configured Cloud phone-number node is reachable. The
+named profiles are `unattended`, `cached-receive`, `send`,
+`attended-cache-receive`, and `attended-send-receive`. Use `cached-receive`
+when the report should also replay a cached inbound WhatsApp voice note through
+`voice stream-transcribe`:
 
 ```bash
 scripts/verify_whatsapp_alpha_readiness.py \

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -37,6 +37,7 @@ expected_whatsapp_agent_name="${WHATSAPP_AGENT_NAME:-}"
 require_whatsapp_cloud="${REQUIRE_WHATSAPP_CLOUD:-0}"
 require_whatsapp_calling="${REQUIRE_WHATSAPP_CALLING:-0}"
 require_whatsapp_alpha_complete="${REQUIRE_WHATSAPP_ALPHA_COMPLETE:-0}"
+check_whatsapp_cloud_api="${CHECK_WHATSAPP_CLOUD_API:-0}"
 
 hermes_config_verify_script="${HERMES_CONFIG_VERIFY_SCRIPT:-$repo_root/scripts/verify_hermes_voice_config.py}"
 hermes_gateway_verify_script="${HERMES_GATEWAY_VERIFY_SCRIPT:-$repo_root/scripts/verify_hermes_gateway_service.py}"
@@ -87,6 +88,8 @@ Options:
   --require-whatsapp-calling   fail when Cloud Calling credentials/readiness are missing
   --require-whatsapp-alpha-complete
                                fail unless all WhatsApp alpha readiness gates are complete
+  --check-whatsapp-cloud-api   call the Meta Graph API phone-number endpoint when Cloud
+                               credentials are configured
   --run-whatsapp-inbound-cache-smoke
                                transcribe a bridge-downloaded aud_* file from the audio cache
   --whatsapp-alpha-profile PROFILE
@@ -115,7 +118,7 @@ Environment aliases:
   WHATSAPP_BRIDGE_URL, WHATSAPP_SESSION_DIR, WHATSAPP_ENV_FILE
   WHATSAPP_AUDIO_CACHE_DIR, WHATSAPP_AGENT_NUMBER, WHATSAPP_AGENT_NAME
   REQUIRE_WHATSAPP_CLOUD=1, REQUIRE_WHATSAPP_CALLING=1
-  REQUIRE_WHATSAPP_ALPHA_COMPLETE=1
+  REQUIRE_WHATSAPP_ALPHA_COMPLETE=1, CHECK_WHATSAPP_CLOUD_API=1
   RUN_WHATSAPP_INBOUND_CACHE_SMOKE=1, WHATSAPP_ALPHA_PROFILE
   WHATSAPP_ALPHA_VOICE_NOTE_CHAT_ID, WHATSAPP_ALPHA_WAIT_AUDIO_CACHE_SECONDS
   WHATSAPP_ALPHA_WAIT_INBOUND_SECONDS, WHATSAPP_ALPHA_JSON_OUTPUT
@@ -333,6 +336,10 @@ while [[ $# -gt 0 ]]; do
       require_whatsapp_alpha_complete=1
       shift
       ;;
+    --check-whatsapp-cloud-api)
+      check_whatsapp_cloud_api=1
+      shift
+      ;;
     --run-whatsapp-inbound-cache-smoke)
       run_whatsapp_inbound_cache_smoke=1
       shift
@@ -533,6 +540,9 @@ if [[ "$skip_whatsapp_bridge" != "1" ]]; then
   if [[ "$require_whatsapp_calling" == "1" ]]; then
     whatsapp_bridge_args+=(--require-whatsapp-calling)
   fi
+  if [[ "$check_whatsapp_cloud_api" == "1" ]]; then
+    whatsapp_bridge_args+=(--check-whatsapp-cloud-api)
+  fi
   run_step "WhatsApp bridge identity and credential readiness" "${whatsapp_bridge_args[@]}"
   whatsapp_bridge_status="checked"
 else
@@ -635,6 +645,9 @@ if [[ -n "$whatsapp_alpha_profile" ]]; then
   fi
   if [[ "$require_whatsapp_calling" == "1" ]]; then
     whatsapp_alpha_args+=(--require-whatsapp-calling)
+  fi
+  if [[ "$check_whatsapp_cloud_api" == "1" ]]; then
+    whatsapp_alpha_args+=(--check-whatsapp-cloud-api)
   fi
   if [[ "$require_whatsapp_alpha_complete" == "1" ]]; then
     whatsapp_alpha_args+=(--require-complete)

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -283,6 +283,8 @@ def build_components(args: argparse.Namespace) -> list[dict[str, Any]]:
         bridge_cmd.extend(["--expected-agent-number", args.expected_agent_number])
     if args.expected_agent_name:
         bridge_cmd.extend(["--expected-agent-name", args.expected_agent_name])
+    if args.check_whatsapp_cloud_api:
+        bridge_cmd.append("--check-whatsapp-cloud-api")
     if args.skip_systemd:
         bridge_cmd.append("--skip-systemd")
     components.append(
@@ -576,6 +578,7 @@ def cloud_setup_handoff(
         "--hermes-home",
         str(hermes_home),
         "--require-whatsapp-cloud",
+        "--check-whatsapp-cloud-api",
     ]
     steps = [] if configured else [
         "Create or select the Meta app, WABA, and Cloud API phone number for Quill.",
@@ -630,6 +633,7 @@ def calling_setup_handoff(
         str(hermes_home),
         "--require-whatsapp-cloud",
         "--require-whatsapp-calling",
+        "--check-whatsapp-cloud-api",
     ]
     complete_command = [
         "scripts/verify_whatsapp_alpha_readiness.py",
@@ -1057,6 +1061,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--require-fresh-cache-audio", action="store_true")
     parser.add_argument("--require-whatsapp-cloud", action="store_true")
     parser.add_argument("--require-whatsapp-calling", action="store_true")
+    parser.add_argument(
+        "--check-whatsapp-cloud-api",
+        action="store_true",
+        help=(
+            "when Cloud credentials are configured, call the Meta Graph API "
+            "phone-number endpoint without printing credential values"
+        ),
+    )
     parser.add_argument(
         "--require-complete",
         action="store_true",

--- a/scripts/verify_whatsapp_bridge_runtime.py
+++ b/scripts/verify_whatsapp_bridge_runtime.py
@@ -13,15 +13,26 @@ import subprocess
 import sys
 from typing import Any
 from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlencode
 from urllib.request import Request, urlopen
 
 
 DEFAULT_BRIDGE_URL = "http://127.0.0.1:3000"
 DEFAULT_SERVICE_NAME = "hermes-gateway.service"
+DEFAULT_GRAPH_API_BASE_URL = "https://graph.facebook.com"
 DEFAULT_WHATSAPP_CLOUD_WEBHOOK_HOST = "0.0.0.0"
 DEFAULT_WHATSAPP_CLOUD_WEBHOOK_PORT = 8090
 DEFAULT_WHATSAPP_CLOUD_WEBHOOK_PATH = "/whatsapp/webhook"
 DEFAULT_WHATSAPP_CLOUD_API_VERSION = "v20.0"
+WHATSAPP_CLOUD_PHONE_NUMBER_FIELDS = (
+    "id",
+    "display_phone_number",
+    "verified_name",
+    "code_verification_status",
+    "quality_rating",
+    "platform_type",
+    "throughput",
+)
 
 WHATSAPP_CLOUD_REQUIRED_ENV = (
     "WHATSAPP_CLOUD_PHONE_NUMBER_ID",
@@ -554,6 +565,158 @@ def build_cloud_summary(env_sources: dict[str, dict[str, str]]) -> dict[str, Any
     }
 
 
+def graph_error_summary(body: bytes) -> dict[str, Any]:
+    try:
+        payload = json.loads(body.decode("utf-8", errors="replace"))
+    except json.JSONDecodeError:
+        return {"message": "Graph API returned a non-JSON error body"}
+    if not isinstance(payload, dict):
+        return {"message": "Graph API returned a non-object error body"}
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return {"message": "Graph API error body did not include an error object"}
+    summary: dict[str, Any] = {}
+    for key in ("message", "type", "code", "error_subcode", "fbtrace_id"):
+        value = error.get(key)
+        if value not in (None, ""):
+            summary[key] = value
+    return summary or {"message": "Graph API returned an empty error object"}
+
+
+def cloud_phone_number_url(
+    graph_api_base_url: str,
+    *,
+    api_version: str,
+    phone_number_id: str,
+) -> str:
+    base = graph_api_base_url.rstrip("/")
+    path = f"{quote(api_version.strip('/'), safe='')}/{quote(phone_number_id, safe='')}"
+    query = urlencode({"fields": ",".join(WHATSAPP_CLOUD_PHONE_NUMBER_FIELDS)})
+    return f"{base}/{path}?{query}"
+
+
+def fetch_cloud_phone_number(
+    *,
+    graph_api_base_url: str,
+    api_version: str,
+    phone_number_id: str,
+    access_token: str,
+    timeout: float,
+) -> tuple[dict[str, Any] | None, int | None, dict[str, Any] | None]:
+    url = cloud_phone_number_url(
+        graph_api_base_url,
+        api_version=api_version,
+        phone_number_id=phone_number_id,
+    )
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {access_token}",
+        },
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            body = response.read()
+            status = getattr(response, "status", None)
+    except HTTPError as exc:
+        return None, exc.code, graph_error_summary(exc.read())
+    except URLError as exc:
+        return None, None, {"message": f"Graph API request failed: {exc.reason}"}
+    except OSError as exc:
+        return None, None, {"message": f"Graph API request failed: {exc}"}
+
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        return None, status, {"message": f"Graph API did not return JSON: {exc}"}
+    if not isinstance(payload, dict):
+        return None, status, {"message": "Graph API response must be an object"}
+    return payload, status, None
+
+
+def build_cloud_api_check(
+    env_sources: dict[str, dict[str, str]],
+    *,
+    graph_api_base_url: str,
+    timeout: float,
+) -> dict[str, Any]:
+    phone_number_id, phone_sources = first_env_value(
+        env_sources,
+        "WHATSAPP_CLOUD_PHONE_NUMBER_ID",
+    )
+    access_token, token_sources = first_env_value(
+        env_sources,
+        "WHATSAPP_CLOUD_ACCESS_TOKEN",
+    )
+    api_version, api_sources = first_env_value(
+        env_sources,
+        "WHATSAPP_CLOUD_API_VERSION",
+    )
+    api_version = api_version or DEFAULT_WHATSAPP_CLOUD_API_VERSION
+    check: dict[str, Any] = {
+        "checked": True,
+        "ok": False,
+        "graph_api_base_url": graph_api_base_url.rstrip("/"),
+        "api_version": api_version,
+        "phone_number_id_present": phone_number_id is not None,
+        "phone_number_id_sources": phone_sources,
+        "access_token_present": access_token is not None,
+        "access_token_sources": token_sources,
+        "api_version_sources": api_sources,
+        "fields": list(WHATSAPP_CLOUD_PHONE_NUMBER_FIELDS),
+        "missing": [],
+        "invalid": [],
+    }
+    if not phone_number_id:
+        check["missing"].append("WHATSAPP_CLOUD_PHONE_NUMBER_ID")
+    if not access_token:
+        check["missing"].append("WHATSAPP_CLOUD_ACCESS_TOKEN")
+    if not re.match(r"^v\d+\.\d+$", api_version):
+        check["invalid"].append("WHATSAPP_CLOUD_API_VERSION")
+    if check["missing"] or check["invalid"]:
+        check["error"] = {
+            "message": "Cloud API check requires a phone number ID, access token, and valid API version"
+        }
+        return check
+
+    payload, status, error = fetch_cloud_phone_number(
+        graph_api_base_url=graph_api_base_url,
+        api_version=api_version,
+        phone_number_id=phone_number_id,
+        access_token=access_token,
+        timeout=timeout,
+    )
+    check["http_status"] = status
+    if error:
+        check["error"] = error
+        return check
+
+    payload = payload or {}
+    phone = {
+        "id_matches_config": str(payload.get("id")) == phone_number_id,
+        "display_phone_number_present": bool(payload.get("display_phone_number")),
+        "verified_name_present": bool(payload.get("verified_name")),
+        "code_verification_status": payload.get("code_verification_status"),
+        "quality_rating": payload.get("quality_rating"),
+        "platform_type": payload.get("platform_type"),
+        "throughput_level": (
+            payload.get("throughput", {}).get("level")
+            if isinstance(payload.get("throughput"), dict)
+            else None
+        ),
+    }
+    check["phone_number"] = phone
+    if not phone["id_matches_config"]:
+        check["error"] = {
+            "message": "Graph API phone number id did not match WHATSAPP_CLOUD_PHONE_NUMBER_ID"
+        }
+        return check
+
+    check["ok"] = True
+    return check
+
+
 def port_from_url(url: str) -> int | None:
     match = re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*://[^/:]+:(\d+)(?:/|$)", url)
     if not match:
@@ -709,6 +872,20 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
                 )
 
     cloud = build_cloud_summary(env_sources)
+    if args.check_whatsapp_cloud_api:
+        cloud_api = build_cloud_api_check(
+            env_sources,
+            graph_api_base_url=args.graph_api_base_url,
+            timeout=args.timeout,
+        )
+        cloud["cloud_api"] = cloud_api
+        if not cloud_api.get("ok"):
+            failures.append(
+                "WhatsApp Cloud API phone number check failed: "
+                + str((cloud_api.get("error") or {}).get("message") or "unknown error")
+            )
+    else:
+        cloud["cloud_api"] = {"checked": False}
     if args.require_whatsapp_cloud and cloud["cloud_missing"]:
         failures.append(
             "WhatsApp Cloud credentials missing: "
@@ -774,6 +951,19 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--skip-systemd", action="store_true")
     parser.add_argument("--require-whatsapp-cloud", action="store_true")
     parser.add_argument("--require-whatsapp-calling", action="store_true")
+    parser.add_argument(
+        "--check-whatsapp-cloud-api",
+        action="store_true",
+        help=(
+            "call the Meta Graph API phone-number endpoint with the configured "
+            "Cloud phone number ID and access token"
+        ),
+    )
+    parser.add_argument(
+        "--graph-api-base-url",
+        default=os.environ.get("GRAPH_API_BASE_URL", DEFAULT_GRAPH_API_BASE_URL),
+        help=argparse.SUPPRESS,
+    )
     parser.add_argument("--json", action="store_true", help="print JSON output")
     return parser
 
@@ -785,6 +975,7 @@ def human_summary(result: dict[str, Any]) -> None:
     process = (checks.get("bridge_process") or {}).get("selected") or {}
     cloud = checks.get("whatsapp_cloud") or {}
     webhook = cloud.get("webhook") or {}
+    cloud_api = cloud.get("cloud_api") or {}
     local_config = checks.get("whatsapp_local_config") or {}
 
     if result["success"]:
@@ -846,6 +1037,25 @@ def human_summary(result: dict[str, Any]) -> None:
         + " invalid="
         + (",".join(webhook.get("invalid") or []) or "none")
     )
+    if cloud_api.get("checked"):
+        phone = cloud_api.get("phone_number") or {}
+        error = cloud_api.get("error") or {}
+        print(
+            "whatsapp_cloud_api="
+            + ("ok" if cloud_api.get("ok") else "failed")
+            + f" api_version={cloud_api.get('api_version') or '<unknown>'}"
+            + f" http_status={cloud_api.get('http_status') or '<none>'}"
+            + " id_matches_config="
+            + str(phone.get("id_matches_config"))
+            + " display_phone_number_present="
+            + str(phone.get("display_phone_number_present"))
+            + " verified_name_present="
+            + str(phone.get("verified_name_present"))
+            + f" platform_type={phone.get('platform_type') or '<unknown>'}"
+            + f" quality_rating={phone.get('quality_rating') or '<unknown>'}"
+            + " error="
+            + str(error.get("message") or "none")
+        )
     print(
         "calling_sidecar="
         + ("configured" if cloud.get("calling_sidecar_configured") else "not_configured")

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -452,6 +452,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                     "--require-whatsapp-cloud",
                     "--require-whatsapp-calling",
                     "--require-whatsapp-alpha-complete",
+                    "--check-whatsapp-cloud-api",
                     "--skip-hermes-config",
                     "--skip-hermes-gateway",
                     "--skip-cli-mcp",
@@ -528,6 +529,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 "--skip-hermes-stt-smoke",
                 "--require-whatsapp-cloud",
                 "--require-whatsapp-calling",
+                "--check-whatsapp-cloud-api",
                 "--require-complete",
             ],
         )

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -319,6 +319,10 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             cloud_handoff["available_source_keys"]["systemd_service"],
         )
         self.assertIn("--require-whatsapp-cloud", cloud_handoff["verify_command"])
+        self.assertIn(
+            "--check-whatsapp-cloud-api",
+            cloud_handoff["verify_command"],
+        )
         self.assertEqual(len(cloud_handoff["steps"]), 4)
         self.assertNotIn("phone-id", json.dumps(cloud_handoff))
         self.assertEqual(cloud_handoff["invalid"], [])
@@ -348,6 +352,10 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertTrue(calling_handoff["calling_sidecar_configured"])
         self.assertFalse(calling_handoff["calling_ready"])
         self.assertIn("--require-whatsapp-calling", calling_handoff["verify_command"])
+        self.assertIn(
+            "--check-whatsapp-cloud-api",
+            calling_handoff["verify_command"],
+        )
         self.assertIn("--require-complete", calling_handoff["complete_verification_command"])
         self.assertEqual(len(calling_handoff["steps"]), 5)
         summary = payload["readiness_summary"]
@@ -614,6 +622,18 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             result.stdout,
         )
         self.assertIn("readiness=local_ready_pending_gates", result.stdout)
+
+    def test_cloud_api_check_is_forwarded_to_bridge_verifier(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = self.run_readiness(
+                Path(tmp),
+                "--check-whatsapp-cloud-api",
+            )
+
+        bridge = {
+            component["name"]: component for component in payload["components"]
+        }["whatsapp_bridge_runtime"]
+        self.assertIn("--check-whatsapp-cloud-api", bridge["command"])
 
     def test_inbound_cache_smoke_adds_receive_component(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_verify_whatsapp_bridge_runtime.py
+++ b/tests/test_verify_whatsapp_bridge_runtime.py
@@ -69,6 +69,8 @@ def make_args(tmp_path: Path, **overrides):
         "skip_systemd": True,
         "require_whatsapp_cloud": False,
         "require_whatsapp_calling": False,
+        "check_whatsapp_cloud_api": False,
+        "graph_api_base_url": "https://graph.facebook.com",
     }
     values.update(overrides)
     return argparse.Namespace(**values)
@@ -274,6 +276,141 @@ class WhatsAppBridgeRuntimeVerifierTests(unittest.TestCase):
             checks["env_key_sources"]["systemd_process"],
         )
         self.assertNotIn("token", json.dumps(checks["env_key_sources"]))
+
+    def test_cloud_api_phone_number_check_uses_safe_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(tmp_path, check_whatsapp_cloud_api=True)
+            write_baileys_session(args.session_dir)
+            args.env_file.parent.mkdir(parents=True, exist_ok=True)
+            args.env_file.write_text(
+                "\n".join(
+                    [
+                        "WHATSAPP_MODE=bot",
+                        "WHATSAPP_CLOUD_PHONE_NUMBER_ID=7794189252778687",
+                        "WHATSAPP_CLOUD_ACCESS_TOKEN=secret-token",
+                        "WHATSAPP_CLOUD_APP_SECRET=secret-app",
+                        "WHATSAPP_CLOUD_VERIFY_TOKEN=secret-verify",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            original_fetch = self.script.fetch_cloud_phone_number
+            calls = []
+
+            def fake_fetch(**kwargs):
+                calls.append(kwargs)
+                return (
+                    {
+                        "id": "7794189252778687",
+                        "display_phone_number": "+1 555 0100",
+                        "verified_name": "Quill",
+                        "quality_rating": "GREEN",
+                        "platform_type": "CLOUD_API",
+                        "throughput": {"level": "STANDARD"},
+                    },
+                    200,
+                    None,
+                )
+
+            self.script.fetch_cloud_phone_number = fake_fetch
+            try:
+                result = self.script.verify(args)
+            finally:
+                self.script.fetch_cloud_phone_number = original_fetch
+
+        self.assertTrue(result["success"], result["failures"])
+        self.assertEqual(calls[0]["phone_number_id"], "7794189252778687")
+        self.assertEqual(calls[0]["access_token"], "secret-token")
+        cloud_api = result["checks"]["whatsapp_cloud"]["cloud_api"]
+        self.assertTrue(cloud_api["checked"])
+        self.assertTrue(cloud_api["ok"])
+        self.assertEqual(cloud_api["http_status"], 200)
+        phone = cloud_api["phone_number"]
+        self.assertTrue(phone["id_matches_config"])
+        self.assertTrue(phone["display_phone_number_present"])
+        self.assertTrue(phone["verified_name_present"])
+        self.assertEqual(phone["quality_rating"], "GREEN")
+        self.assertEqual(phone["platform_type"], "CLOUD_API")
+        self.assertEqual(phone["throughput_level"], "STANDARD")
+        serialized = json.dumps(result)
+        self.assertNotIn("secret-token", serialized)
+        self.assertNotIn("+1 555 0100", serialized)
+        self.assertNotIn('"Quill"', json.dumps(cloud_api))
+
+    def test_cloud_api_check_fails_without_required_values(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(tmp_path, check_whatsapp_cloud_api=True)
+            write_baileys_session(args.session_dir)
+            args.env_file.parent.mkdir(parents=True, exist_ok=True)
+            args.env_file.write_text("WHATSAPP_MODE=bot\n", encoding="utf-8")
+
+            result = self.script.verify(args)
+
+        self.assertFalse(result["success"])
+        cloud_api = result["checks"]["whatsapp_cloud"]["cloud_api"]
+        self.assertTrue(cloud_api["checked"])
+        self.assertFalse(cloud_api["ok"])
+        self.assertEqual(
+            cloud_api["missing"],
+            [
+                "WHATSAPP_CLOUD_PHONE_NUMBER_ID",
+                "WHATSAPP_CLOUD_ACCESS_TOKEN",
+            ],
+        )
+        self.assertIn(
+            "WhatsApp Cloud API phone number check failed",
+            "\n".join(result["failures"]),
+        )
+
+    def test_cloud_api_http_error_is_sanitized(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(tmp_path, check_whatsapp_cloud_api=True)
+            write_baileys_session(args.session_dir)
+            args.env_file.parent.mkdir(parents=True, exist_ok=True)
+            args.env_file.write_text(
+                "\n".join(
+                    [
+                        "WHATSAPP_MODE=bot",
+                        "WHATSAPP_CLOUD_PHONE_NUMBER_ID=7794189252778687",
+                        "WHATSAPP_CLOUD_ACCESS_TOKEN=secret-token",
+                        "WHATSAPP_CLOUD_APP_SECRET=secret-app",
+                        "WHATSAPP_CLOUD_VERIFY_TOKEN=secret-verify",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            original_fetch = self.script.fetch_cloud_phone_number
+
+            def fake_fetch(**_kwargs):
+                return (
+                    None,
+                    403,
+                    {
+                        "message": "Unsupported get request",
+                        "type": "GraphMethodException",
+                        "code": 100,
+                    },
+                )
+
+            self.script.fetch_cloud_phone_number = fake_fetch
+            try:
+                result = self.script.verify(args)
+            finally:
+                self.script.fetch_cloud_phone_number = original_fetch
+
+        self.assertFalse(result["success"])
+        cloud_api = result["checks"]["whatsapp_cloud"]["cloud_api"]
+        self.assertFalse(cloud_api["ok"])
+        self.assertEqual(cloud_api["http_status"], 403)
+        self.assertEqual(cloud_api["error"]["code"], 100)
+        self.assertNotIn("secret-token", json.dumps(result))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add opt-in `--check-whatsapp-cloud-api` to verify the configured WhatsApp Cloud phone-number node via the Meta Graph API
- keep the probe secret-safe: no access token, display phone number, or verified-name values are emitted
- thread the option through alpha readiness and the top-level local stack gate
- strengthen Cloud/Calling setup handoff commands so copied verification commands include the API probe
- document when to use the online check after real Cloud credentials are configured

## Verification
- python3 -m unittest tests.test_verify_whatsapp_bridge_runtime tests.test_verify_whatsapp_alpha_readiness tests.test_verify_local_hermes_voice_stack
- python3 -m py_compile scripts/verify_whatsapp_bridge_runtime.py scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_bridge_runtime.py tests/test_verify_whatsapp_alpha_readiness.py
- bash -n scripts/verify_local_hermes_voice_stack.sh
- python3 -m unittest discover -s tests
- git diff --check
- live default stack: `scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --skip-hermes-tts-smoke --whatsapp-alpha-profile cached-receive --whatsapp-alpha-wait-audio-cache-seconds 0.1 --whatsapp-alpha-json-output <tmp> --expected-whatsapp-agent-number 13236478455 --expected-whatsapp-agent-name Quill`
- expected local failure: `scripts/verify_whatsapp_bridge_runtime.py --hermes-home /home/ubuntu/.hermes --bridge-url http://127.0.0.1:3000 --expected-agent-number 13236478455 --expected-agent-name Quill --check-whatsapp-cloud-api`

The live default stack remains green. The opt-in API probe fails as expected on this host because `WHATSAPP_CLOUD_PHONE_NUMBER_ID` and `WHATSAPP_CLOUD_ACCESS_TOKEN` are not configured yet.