### PR TITLE
Redact inbound STT transcripts in evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,9 @@ stt:
 `voice say --format ogg-opus` / `voice stream-transcribe --quiet` commands, and
 rejects arbitrary wrappers so config drift is caught locally. Add
 `--stt-audio ~/.hermes/audio_cache/aud_...ogg` when you also want to execute the
-configured Hermes STT command against a cached inbound WhatsApp voice note.
+configured Hermes STT command against a cached inbound WhatsApp voice note. STT
+smoke verifiers report transcript length and audio metrics, not transcript
+text.
 
 Use the local Hermes stack verifier before a release or host update:
 

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -252,8 +252,10 @@ scripts/verify_whatsapp_inbound_audio_cache.py \
 The bridge writes inbound voice/audio media as `aud_*` files under
 `~/.hermes/audio_cache` by default. The cache verifier checks those files look
 like bridge downloads, validates the audio stream with `ffprobe`, and can replay
-one through `voice stream-transcribe --json`. The full stack gate exposes the
-same receive-side smoke behind an explicit opt-in:
+one through `voice stream-transcribe --json`. Saved verifier JSON records audio
+frames, duration, token count, and transcript length, but redacts the transcript
+text. The full stack gate exposes the same receive-side smoke behind an
+explicit opt-in:
 
 ```bash
 scripts/verify_local_hermes_voice_stack.sh \

--- a/scripts/verify_whatsapp_inbound_audio_cache.py
+++ b/scripts/verify_whatsapp_inbound_audio_cache.py
@@ -183,6 +183,21 @@ def probe_audio(path: Path, *, timeout: float, skip_ffprobe: bool) -> tuple[dict
     return probe, failures
 
 
+def redact_stt_event(event: dict[str, Any]) -> dict[str, Any]:
+    redacted = dict(event)
+    data = redacted.get("data")
+    if not isinstance(data, dict):
+        return redacted
+
+    redacted_data = dict(data)
+    text = redacted_data.pop("text", None)
+    if text is not None:
+        redacted_data["text_redacted"] = True
+        redacted_data["text_chars"] = len(str(text))
+    redacted["data"] = redacted_data
+    return redacted
+
+
 def transcribe_audio(
     voice_bin: str,
     path: Path,
@@ -203,6 +218,7 @@ def transcribe_audio(
         failures.append(f"voice stream-transcribe failed for {path}: {completed.stderr.strip()}")
         return result, failures
 
+    terminal_raw: dict[str, Any] | None = None
     for line in completed.stdout.splitlines():
         line = line.strip()
         if not line:
@@ -212,15 +228,16 @@ def transcribe_audio(
         except json.JSONDecodeError as exc:
             failures.append(f"stream-transcribe emitted non-JSON line: {exc}")
             continue
-        result["events"].append(event)
         if event.get("event") in {"stt.transcribed", "stt.error"}:
-            result["terminal_event"] = event
+            terminal_raw = event
+        result["events"].append(redact_stt_event(event))
 
-    terminal = result.get("terminal_event")
+    terminal = terminal_raw
     if not terminal:
         failures.append("stream-transcribe did not emit a terminal STT event")
     elif terminal.get("event") != "stt.transcribed":
         failures.append(f"stream-transcribe terminal event was {terminal.get('event')!r}")
+        result["terminal_event"] = redact_stt_event(terminal)
     else:
         data = terminal.get("data") or {}
         if not str(data.get("text") or "").strip():
@@ -229,6 +246,7 @@ def transcribe_audio(
             failures.append("stream-transcribe reported no audio frames")
         if int(data.get("audio_duration_ms") or 0) <= 0:
             failures.append("stream-transcribe reported no audio duration")
+        result["terminal_event"] = redact_stt_event(terminal)
     return result, failures
 
 
@@ -395,11 +413,10 @@ def human_summary(result: dict[str, Any]) -> None:
         else:
             terminal = stt.get("terminal_event") or {}
             data = terminal.get("data") or {}
-            text = str(data.get("text") or "")
             print(
                 f"stt[{index}]=frames={data.get('frames')} "
                 f"duration_ms={data.get('audio_duration_ms')} "
-                f"text_chars={len(text)}"
+                f"text_chars={data.get('text_chars', 0)}"
             )
     for warning in result["warnings"]:
         print(f"warning: {warning}", file=sys.stderr)

--- a/tests/test_verify_whatsapp_inbound_audio_cache.py
+++ b/tests/test_verify_whatsapp_inbound_audio_cache.py
@@ -2,6 +2,7 @@
 
 import argparse
 import importlib.util
+import json
 from pathlib import Path
 import sys
 import tempfile
@@ -98,7 +99,10 @@ class WhatsAppInboundAudioCacheVerifierTests(unittest.TestCase):
         self.assertTrue(result["success"], result["failures"])
         terminal = result["checks"]["audio"][0]["stt"]["terminal_event"]
         self.assertEqual(terminal["event"], "stt.transcribed")
-        self.assertEqual(terminal["data"]["text"], "hello from whatsapp")
+        self.assertNotIn("text", terminal["data"])
+        self.assertTrue(terminal["data"]["text_redacted"])
+        self.assertEqual(terminal["data"]["text_chars"], len("hello from whatsapp"))
+        self.assertNotIn("hello from whatsapp", json.dumps(result))
 
     def test_explicit_audio_file_must_look_like_bridge_download(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -148,6 +152,8 @@ class WhatsAppInboundAudioCacheVerifierTests(unittest.TestCase):
         self.assertTrue(result["checks"]["selected_files"][0].endswith("aud_fresh.ogg"))
         terminal = result["checks"]["audio"][0]["stt"]["terminal_event"]
         self.assertEqual(terminal["event"], "stt.transcribed")
+        self.assertTrue(terminal["data"]["text_redacted"])
+        self.assertEqual(terminal["data"]["text_chars"], len("hello from whatsapp"))
 
     def test_optional_fresh_watch_falls_back_to_existing_cached_audio(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- redact transcript text from WhatsApp inbound audio cache verifier JSON
- keep proof fields: frames, duration, token count, `text_redacted`, and `text_chars`
- update docs to state saved receive evidence records transcript length and audio metrics, not transcript text

## Verification
- python3 -m unittest tests.test_verify_whatsapp_inbound_audio_cache tests.test_verify_whatsapp_alpha_readiness tests.test_verify_local_hermes_voice_stack
- python3 -m py_compile scripts/verify_whatsapp_inbound_audio_cache.py tests/test_verify_whatsapp_inbound_audio_cache.py
- python3 -m unittest discover -s tests
- git diff --check
- live cached-receive stack smoke with `--whatsapp-alpha-json-output <tmp>`

Live redaction smoke result from the saved alpha JSON:
- `alpha_success=True`
- `contains_text_key=False`
- `contains_text_redacted=True`
- `contains_text_chars=True`

This keeps the attended/cached receive artifact useful as evidence without persisting the content of the user voice note.