### PR TITLE
Summarize attended receive evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,9 @@ agent should consume the same structured `readiness_summary.next_actions`
 without rerunning the full stack gate. The stack verifier also echoes compact
 `whatsapp_alpha_json_*` summary lines after saving the artifact, including
 readiness status, completion state, next actions, attended receive status, and
-Cloud/Calling missing or invalid key groups.
+Cloud/Calling missing or invalid key groups. A verified attended receive also
+stores compact redacted proof under
+`pending_gates.attended_fresh_receive.evidence`.
 
 When the WebRTC Python dependencies are installed, add
 `--run-webrtc-loopback-smoke --webrtc-python /tmp/voice-webrtc-venv/bin/python`

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -134,7 +134,11 @@ part of unattended local readiness: fresh attended inbound receive, WhatsApp
 Cloud API credentials, and WhatsApp Cloud Calling. A default local pass can
 still report `pending_gates.attended_fresh_receive.status=pending_attended`
 until someone sends a fresh WhatsApp voice note during the guarded receive
-window.
+window. When the attended receive gate is verified, the same object includes a
+compact `evidence` summary. The non-draining cache path records fresh-file
+count, codec, sample rate, audio duration, frame count, token count, and
+redacted transcript length. The draining bridge fallback records audio-event
+count, observed media types, and whether `/messages` was drained.
 
 For the external Meta gates, the JSON report includes safe setup handoffs under
 `pending_gates.whatsapp_cloud.setup_handoff` and

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -210,6 +210,20 @@ if attended:
         f"{attended.get('status')} "
         f"cached_receive_verified={attended.get('cached_receive_verified')}"
     )
+    evidence = attended.get("evidence") or {}
+    if evidence:
+        first_audio = (evidence.get("audio") or [{}])[0]
+        stt = first_audio.get("stt") or {}
+        print(
+            "whatsapp_alpha_json_attended_evidence="
+            f"kind={evidence.get('kind')} "
+            f"fresh={evidence.get('fresh')} "
+            f"drains_messages={evidence.get('drains_bridge_messages')} "
+            "audio_events="
+            f"{evidence.get('audio_event_count', evidence.get('fresh_count'))} "
+            f"codec={first_audio.get('codec') or '<unknown>'} "
+            f"text_chars={stt.get('text_chars', 0)}"
+        )
 if cloud:
     print(
         "whatsapp_alpha_json_cloud="

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -424,6 +424,82 @@ def cached_inbound_audio_verified(components: list[dict[str, Any]]) -> bool:
     return False
 
 
+def stt_evidence(stt: dict[str, Any]) -> dict[str, Any]:
+    terminal = stt.get("terminal_event") if isinstance(stt, dict) else None
+    terminal = terminal if isinstance(terminal, dict) else {}
+    data = terminal.get("data") if isinstance(terminal.get("data"), dict) else {}
+    return {
+        "terminal_event": terminal.get("event"),
+        "frames": data.get("frames"),
+        "audio_duration_ms": data.get("audio_duration_ms"),
+        "tokens": data.get("tokens"),
+        "text_redacted": bool(data.get("text_redacted")),
+        "text_chars": data.get("text_chars"),
+    }
+
+
+def cache_audio_evidence(checks: dict[str, Any]) -> dict[str, Any]:
+    fresh_watch = checks.get("fresh_watch") if isinstance(checks, dict) else {}
+    fresh_watch = fresh_watch if isinstance(fresh_watch, dict) else {}
+    evidence: dict[str, Any] = {
+        "kind": "audio_cache",
+        "fresh": bool((fresh_watch.get("fresh_files") or [])),
+        "fresh_count": fresh_watch.get("fresh_count"),
+        "wait_seconds": fresh_watch.get("wait_seconds"),
+        "drains_bridge_messages": bool(fresh_watch.get("drains_bridge_messages")),
+        "selected_files_count": len(checks.get("selected_files") or []),
+        "audio": [],
+    }
+    for item in checks.get("audio") or []:
+        if not isinstance(item, dict):
+            continue
+        probe = item.get("probe") if isinstance(item.get("probe"), dict) else {}
+        ffprobe = probe.get("ffprobe") if isinstance(probe.get("ffprobe"), dict) else {}
+        stream = ffprobe.get("stream") if isinstance(ffprobe.get("stream"), dict) else {}
+        evidence["audio"].append(
+            {
+                "path": probe.get("path") or item.get("path"),
+                "name": probe.get("name"),
+                "size_bytes": probe.get("size_bytes"),
+                "magic": probe.get("magic"),
+                "codec": stream.get("codec_name"),
+                "sample_rate": stream.get("sample_rate"),
+                "channels": stream.get("channels"),
+                "duration": stream.get("duration"),
+                "stt": stt_evidence(item.get("stt") or {}),
+            }
+        )
+    return evidence
+
+
+def bridge_audio_event_evidence(inbound: dict[str, Any]) -> dict[str, Any]:
+    audio_events = [
+        event for event in (inbound.get("audio_events") or []) if isinstance(event, dict)
+    ]
+    media_types = sorted(
+        {
+            str(event.get("mediaType"))
+            for event in audio_events
+            if event.get("mediaType")
+        }
+    )
+    media_url_count = 0
+    for event in audio_events:
+        media_urls = event.get("mediaUrls")
+        if isinstance(media_urls, list):
+            media_url_count += len(media_urls)
+    return {
+        "kind": "bridge_messages",
+        "fresh": bool(audio_events),
+        "audio_event_count": len(audio_events),
+        "seen_event_count": len(inbound.get("seen_events") or []),
+        "wait_seconds": inbound.get("wait_seconds"),
+        "drains_bridge_messages": bool(inbound.get("drains_bridge_messages")),
+        "media_types": media_types,
+        "media_url_count": media_url_count,
+    }
+
+
 def attended_receive_gate(
     components: list[dict[str, Any]],
     *,
@@ -499,6 +575,7 @@ def attended_receive_gate(
             gate["requires_operator"] = False
             gate["reason"] = "fresh WhatsApp inbound audio event observed"
             gate["audio_events"] = len(audio_events)
+            gate["evidence"] = bridge_audio_event_evidence(inbound)
         elif item.get("success"):
             gate["status"] = "not_verified"
             gate["reason"] = "receive polling completed without fresh audio-event evidence"
@@ -523,6 +600,7 @@ def attended_receive_gate(
                 gate["requires_operator"] = False
                 gate["reason"] = "fresh WhatsApp inbound audio cache artifact observed"
                 gate["fresh_files"] = len(fresh_files)
+                gate["evidence"] = cache_audio_evidence(checks)
             elif item.get("success"):
                 gate["status"] = "not_verified"
                 gate["reason"] = "audio cache watch completed without fresh audio evidence"
@@ -1174,6 +1252,20 @@ def human_summary(result: dict[str, Any]) -> None:
             f"{attended.get('status')} cached_receive_verified="
             f"{attended.get('cached_receive_verified')}"
         )
+        evidence = attended.get("evidence") or {}
+        if evidence:
+            first_audio = (evidence.get("audio") or [{}])[0]
+            stt = first_audio.get("stt") or {}
+            print(
+                "attended_fresh_receive_evidence="
+                f"kind={evidence.get('kind')} "
+                f"fresh={evidence.get('fresh')} "
+                f"drains_messages={evidence.get('drains_bridge_messages')} "
+                "audio_events="
+                f"{evidence.get('audio_event_count', evidence.get('fresh_count'))} "
+                f"codec={first_audio.get('codec') or '<unknown>'} "
+                f"text_chars={stt.get('text_chars', 0)}"
+            )
         if attended.get("status") != "verified":
             command = attended.get("command") or []
             fallback = attended.get("fallback_draining_command") or []

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -596,18 +596,35 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                         "status": "local_ready_pending_gates",
                         "complete": false,
                         "local_checks_passed": true,
-                        "attended_fresh_receive_verified": false,
+                        "attended_fresh_receive_verified": true,
                         "external_meta_setup_required": true,
                         "operator_action_required": true,
                         "next_actions": [
-                          {{"id": "run_attended_fresh_receive"}},
                           {{"id": "configure_whatsapp_cloud_calling"}}
                         ]
                       }},
                       "pending_gates": {{
                         "attended_fresh_receive": {{
-                          "status": "not_verified",
-                          "cached_receive_verified": true
+                          "status": "verified",
+                          "cached_receive_verified": true,
+                          "evidence": {{
+                            "kind": "audio_cache",
+                            "fresh": true,
+                            "fresh_count": 1,
+                            "drains_bridge_messages": false,
+                            "audio": [
+                              {{
+                                "codec": "opus",
+                                "stt": {{
+                                  "frames": 210,
+                                  "audio_duration_ms": 4200,
+                                  "tokens": 6,
+                                  "text_redacted": true,
+                                  "text_chars": 42
+                                }}
+                              }}
+                            ]
+                          }}
                         }},
                         "whatsapp_cloud": {{
                           "status": "external_setup_required",
@@ -678,18 +695,22 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn("whatsapp_alpha_json_profile=cached-receive", result.stdout)
         self.assertIn(
             "whatsapp_alpha_json_readiness=local_ready_pending_gates complete=False "
-            "local_checks_passed=True attended_fresh_receive_verified=False "
+            "local_checks_passed=True attended_fresh_receive_verified=True "
             "external_meta_setup_required=True operator_action_required=True",
             result.stdout,
         )
         self.assertIn(
-            "whatsapp_alpha_json_next_actions=run_attended_fresh_receive,"
-            "configure_whatsapp_cloud_calling",
+            "whatsapp_alpha_json_next_actions=configure_whatsapp_cloud_calling",
             result.stdout,
         )
         self.assertIn(
-            "whatsapp_alpha_json_attended_fresh_receive=not_verified "
+            "whatsapp_alpha_json_attended_fresh_receive=verified "
             "cached_receive_verified=True",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_alpha_json_attended_evidence=kind=audio_cache fresh=True "
+            "drains_messages=False audio_events=1 codec=opus text_chars=42",
             result.stdout,
         )
         self.assertIn(

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -776,7 +776,37 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             "success": True,
             "checks": {
                 "selected_files": ["/tmp/aud_fresh.ogg"],
-                "audio": [{"path": "/tmp/aud_fresh.ogg"}],
+                "audio": [
+                    {
+                        "path": "/tmp/aud_fresh.ogg",
+                        "probe": {
+                            "path": "/tmp/aud_fresh.ogg",
+                            "name": "aud_fresh.ogg",
+                            "size_bytes": 12345,
+                            "magic": "OggS",
+                            "ffprobe": {
+                                "stream": {
+                                    "codec_name": "opus",
+                                    "sample_rate": "48000",
+                                    "channels": 1,
+                                    "duration": "4.2",
+                                },
+                            },
+                        },
+                        "stt": {
+                            "terminal_event": {
+                                "event": "stt.transcribed",
+                                "data": {
+                                    "frames": 210,
+                                    "audio_duration_ms": 4200,
+                                    "tokens": 6,
+                                    "text_redacted": True,
+                                    "text_chars": 42,
+                                },
+                            },
+                        },
+                    },
+                ],
                 "fresh_watch": {
                     "drains_bridge_messages": False,
                     "fresh_files": ["/tmp/aud_fresh.ogg"],
@@ -807,6 +837,17 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertEqual(gate["component"], "whatsapp_inbound_cache_fresh_stt")
         self.assertFalse(gate["drains_bridge_messages"])
         self.assertFalse(gate["requires_operator"])
+        evidence = gate["evidence"]
+        self.assertEqual(evidence["kind"], "audio_cache")
+        self.assertTrue(evidence["fresh"])
+        self.assertFalse(evidence["drains_bridge_messages"])
+        self.assertEqual(evidence["fresh_count"], 1)
+        self.assertEqual(evidence["audio"][0]["name"], "aud_fresh.ogg")
+        self.assertEqual(evidence["audio"][0]["codec"], "opus")
+        self.assertEqual(evidence["audio"][0]["stt"]["frames"], 210)
+        self.assertEqual(evidence["audio"][0]["stt"]["text_chars"], 42)
+        self.assertTrue(evidence["audio"][0]["stt"]["text_redacted"])
+        self.assertNotIn("hello from whatsapp", json.dumps(evidence))
         summary = payload["readiness_summary"]
         self.assertFalse(summary["complete"])
         self.assertTrue(summary["attended_fresh_receive_verified"])
@@ -880,6 +921,12 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertEqual(gate["component"], "whatsapp_voice_note_send_receive")
         self.assertEqual(gate["audio_events"], 1)
         self.assertFalse(gate["requires_operator"])
+        evidence = gate["evidence"]
+        self.assertEqual(evidence["kind"], "bridge_messages")
+        self.assertTrue(evidence["fresh"])
+        self.assertTrue(evidence["drains_bridge_messages"])
+        self.assertEqual(evidence["audio_event_count"], 1)
+        self.assertEqual(evidence["media_types"], ["ptt"])
 
     def test_readiness_summary_is_complete_when_all_gates_are_verified(self):
         inbound_cache_payload = {


### PR DESCRIPTION
## Summary
- add compact redacted evidence to `pending_gates.attended_fresh_receive` when fresh receive is verified
- summarize non-draining audio-cache proof with fresh count, codec, sample rate, duration, STT frames/tokens, and redacted transcript length
- summarize draining bridge fallback proof with audio event count, media types, and drain status
- echo attended evidence in the alpha human output and saved stack JSON summary output
- document where the evidence is stored

## Verification
- python3 -m unittest tests.test_verify_whatsapp_alpha_readiness
- python3 -m unittest tests.test_verify_whatsapp_alpha_readiness tests.test_verify_local_hermes_voice_stack
- python3 -m unittest discover -s tests
- python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_alpha_readiness.py
- bash -n scripts/verify_local_hermes_voice_stack.sh
- git diff --check
- live cached-receive stack smoke with installed `/home/ubuntu/.local/bin/voice`, saved alpha JSON, and expected Quill identity

The live stack remains `local_ready_pending_gates` because no fresh attended voice note was sent during the short watch. Unit coverage exercises the verified cache receive and draining bridge receive evidence shapes.