### PR TITLE
Redact bridge inbound receive events

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -138,7 +138,9 @@ window. When the attended receive gate is verified, the same object includes a
 compact `evidence` summary. The non-draining cache path records fresh-file
 count, codec, sample rate, audio duration, frame count, token count, and
 redacted transcript length. The draining bridge fallback records audio-event
-count, observed media types, and whether `/messages` was drained.
+count, observed media types, media URL count, and whether `/messages` was
+drained; chat IDs, sender IDs, and media URL paths are reduced to presence or
+count fields.
 
 For the external Meta gates, the JSON report includes safe setup handoffs under
 `pending_gates.whatsapp_cloud.setup_handoff` and

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -488,6 +488,11 @@ def bridge_audio_event_evidence(inbound: dict[str, Any]) -> dict[str, Any]:
         media_urls = event.get("mediaUrls")
         if isinstance(media_urls, list):
             media_url_count += len(media_urls)
+        else:
+            try:
+                media_url_count += int(event.get("media_url_count") or 0)
+            except (TypeError, ValueError):
+                pass
     return {
         "kind": "bridge_messages",
         "fresh": bool(audio_events),

--- a/scripts/verify_whatsapp_voice_note_bridge.py
+++ b/scripts/verify_whatsapp_voice_note_bridge.py
@@ -302,6 +302,17 @@ def get_json(url: str, *, timeout: float) -> Any:
     return json.loads(response_body.decode("utf-8"))
 
 
+def summarize_inbound_event(event: dict[str, Any]) -> dict[str, Any]:
+    media_urls = event.get("mediaUrls")
+    return {
+        "chat_id_present": bool(event.get("chatId")),
+        "sender_id_present": bool(event.get("senderId")),
+        "hasMedia": event.get("hasMedia"),
+        "mediaType": event.get("mediaType"),
+        "media_url_count": len(media_urls) if isinstance(media_urls, list) else 0,
+    }
+
+
 def poll_inbound_audio(
     bridge_url: str,
     *,
@@ -319,15 +330,7 @@ def poll_inbound_audio(
             for event in payload:
                 if not isinstance(event, dict):
                     continue
-                seen.append(
-                    {
-                        "chatId": event.get("chatId"),
-                        "senderId": event.get("senderId"),
-                        "hasMedia": event.get("hasMedia"),
-                        "mediaType": event.get("mediaType"),
-                        "mediaUrls": event.get("mediaUrls"),
-                    }
-                )
+                seen.append(summarize_inbound_event(event))
                 if event.get("hasMedia") and event.get("mediaType") in {"audio", "ptt"}:
                     audio_events.append(seen[-1])
         if audio_events:

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -748,7 +748,15 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             "checks": {
                 "inbound_audio": {
                     "drains_bridge_messages": True,
-                    "audio_events": [{"mediaType": "ptt"}],
+                    "audio_events": [
+                        {
+                            "chat_id_present": True,
+                            "sender_id_present": True,
+                            "hasMedia": True,
+                            "mediaType": "ptt",
+                            "media_url_count": 1,
+                        }
+                    ],
                 }
             },
             "failures": [],
@@ -899,7 +907,15 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             "checks": {
                 "inbound_audio": {
                     "drains_bridge_messages": True,
-                    "audio_events": [{"mediaType": "ptt"}],
+                    "audio_events": [
+                        {
+                            "chat_id_present": True,
+                            "sender_id_present": True,
+                            "hasMedia": True,
+                            "mediaType": "ptt",
+                            "media_url_count": 1,
+                        }
+                    ],
                 }
             },
             "failures": [],
@@ -927,6 +943,7 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertTrue(evidence["drains_bridge_messages"])
         self.assertEqual(evidence["audio_event_count"], 1)
         self.assertEqual(evidence["media_types"], ["ptt"])
+        self.assertEqual(evidence["media_url_count"], 1)
 
     def test_readiness_summary_is_complete_when_all_gates_are_verified(self):
         inbound_cache_payload = {

--- a/tests/test_verify_whatsapp_voice_note_bridge.py
+++ b/tests/test_verify_whatsapp_voice_note_bridge.py
@@ -2,6 +2,7 @@
 
 import argparse
 import importlib.util
+import json
 import os
 from pathlib import Path
 import sys
@@ -186,6 +187,15 @@ class WhatsAppVoiceNoteBridgeSmokeTests(unittest.TestCase):
         self.assertTrue(inbound["drains_bridge_messages"])
         self.assertEqual(len(inbound["seen_events"]), 1)
         self.assertEqual(len(inbound["audio_events"]), 1)
+        event = inbound["audio_events"][0]
+        self.assertTrue(event["chat_id_present"])
+        self.assertTrue(event["sender_id_present"])
+        self.assertEqual(event["mediaType"], "ptt")
+        self.assertEqual(event["media_url_count"], 1)
+        serialized = json.dumps(inbound)
+        self.assertNotIn("20530681934008@lid", serialized)
+        self.assertNotIn("13236478455@s.whatsapp.net", serialized)
+        self.assertNotIn("aud_test.ogg", serialized)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Redact `/messages` inbound receive summaries to presence/count fields instead of raw chat IDs, sender IDs, and media URL paths.
- Keep alpha readiness evidence useful by preserving audio event count, media types, media URL count, and drain status.
- Update WhatsApp Calling docs to describe the redacted bridge fallback evidence shape.

## Verification
- `python3 -m unittest tests.test_verify_whatsapp_voice_note_bridge tests.test_verify_whatsapp_alpha_readiness`
- `python3 -m py_compile scripts/verify_whatsapp_voice_note_bridge.py scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_voice_note_bridge.py tests/test_verify_whatsapp_alpha_readiness.py`
- `git diff --check`
- `python3 -m unittest discover -s tests`
- `tmp_json="$(mktemp)"; scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --skip-hermes-tts-smoke --whatsapp-alpha-profile cached-receive --whatsapp-alpha-wait-audio-cache-seconds 0.1 --whatsapp-alpha-json-output "$tmp_json" --expected-whatsapp-agent-number 13236478455 --expected-whatsapp-agent-name Quill; status=$?; rm -f "$tmp_json"; exit $status`

## Notes
- Local stack smoke remains `local_ready_pending_gates`: cached receive is verified, but attended fresh receive and WhatsApp Cloud/Calling credentials remain pending external/operator gates.
