### PR TITLE
Echo alpha JSON handoff commands

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -165,7 +165,10 @@ When the top-level stack gate is run with `--whatsapp-alpha-json-output`, it
 saves the alpha report and then echoes compact `whatsapp_alpha_json_*` summary
 lines for the saved artifact. Those lines include the alpha profile, readiness
 status, completion state, next action IDs, attended receive status, and
-Cloud/Calling missing or invalid key groups.
+Cloud/Calling missing or invalid key groups. When a gate is still pending, the
+same summary also echoes the copyable attended receive command, fallback
+draining command, Cloud verification command, Calling verification command, and
+complete-alpha command if those commands are present in the saved JSON.
 
 Use the complete gate only when the local bridge, attended receive, Cloud API,
 and Calling setup are all expected to pass:

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -167,6 +167,7 @@ print_whatsapp_alpha_json_summary() {
   local json_path="$1"
   python3 - "$json_path" <<'PY'
 import json
+import shlex
 import sys
 
 path = sys.argv[1]
@@ -176,6 +177,12 @@ with open(path, "r", encoding="utf-8") as handle:
 
 def csv(values):
     return ",".join(str(value) for value in (values or [])) or "none"
+
+
+def command_line(parts):
+    if not parts:
+        return ""
+    return shlex.join([str(part) for part in parts])
 
 
 summary = payload.get("readiness_summary") or {}
@@ -224,6 +231,13 @@ if attended:
             f"codec={first_audio.get('codec') or '<unknown>'} "
             f"text_chars={stt.get('text_chars', 0)}"
         )
+    if attended.get("status") != "verified":
+        command = command_line(attended.get("command") or [])
+        fallback = command_line(attended.get("fallback_draining_command") or [])
+        if command:
+            print(f"whatsapp_alpha_json_attended_command={command}")
+        if fallback:
+            print(f"whatsapp_alpha_json_attended_fallback_draining_command={fallback}")
 if cloud:
     print(
         "whatsapp_alpha_json_cloud="
@@ -231,6 +245,10 @@ if cloud:
         f"missing={csv(cloud_handoff.get('missing') or cloud.get('missing'))} "
         f"invalid={csv(cloud_handoff.get('invalid') or cloud.get('invalid'))}"
     )
+    if cloud.get("status") != "configured":
+        command = command_line(cloud_handoff.get("verify_command") or [])
+        if command:
+            print(f"whatsapp_alpha_json_cloud_verify_command={command}")
 if calling:
     print(
         "whatsapp_alpha_json_calling="
@@ -238,6 +256,15 @@ if calling:
         f"missing={csv(calling_handoff.get('missing') or calling.get('missing'))} "
         f"invalid={csv(calling_handoff.get('invalid') or calling.get('invalid'))}"
     )
+    if calling.get("status") != "ready":
+        verify_command = command_line(calling_handoff.get("verify_command") or [])
+        complete_command = command_line(
+            calling_handoff.get("complete_verification_command") or []
+        )
+        if verify_command:
+            print(f"whatsapp_alpha_json_calling_verify_command={verify_command}")
+        if complete_command:
+            print(f"whatsapp_alpha_json_calling_complete_command={complete_command}")
 PY
 }
 

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -633,7 +633,14 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                               "WHATSAPP_CLOUD_PHONE_NUMBER_ID",
                               "WHATSAPP_CLOUD_ACCESS_TOKEN"
                             ],
-                            "invalid": []
+                            "invalid": [],
+                            "verify_command": [
+                              "scripts/verify_whatsapp_alpha_readiness.py",
+                              "--hermes-home",
+                              "/home/ubuntu/.hermes",
+                              "--require-whatsapp-cloud",
+                              "--check-whatsapp-cloud-api"
+                            ]
                           }}
                         }},
                         "whatsapp_cloud_calling": {{
@@ -645,7 +652,23 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                               "WHATSAPP_CLOUD_APP_SECRET",
                               "WHATSAPP_CLOUD_VERIFY_TOKEN"
                             ],
-                            "invalid": []
+                            "invalid": [],
+                            "verify_command": [
+                              "scripts/verify_whatsapp_alpha_readiness.py",
+                              "--hermes-home",
+                              "/home/ubuntu/.hermes",
+                              "--require-whatsapp-cloud",
+                              "--require-whatsapp-calling",
+                              "--check-whatsapp-cloud-api"
+                            ],
+                            "complete_verification_command": [
+                              "scripts/verify_whatsapp_alpha_readiness.py",
+                              "--hermes-home",
+                              "/home/ubuntu/.hermes",
+                              "--profile",
+                              "attended-cache-receive",
+                              "--require-complete"
+                            ]
                           }}
                         }}
                       }}
@@ -720,13 +743,142 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             result.stdout,
         )
         self.assertIn(
+            "whatsapp_alpha_json_cloud_verify_command="
+            "scripts/verify_whatsapp_alpha_readiness.py --hermes-home "
+            "/home/ubuntu/.hermes --require-whatsapp-cloud --check-whatsapp-cloud-api",
+            result.stdout,
+        )
+        self.assertIn(
             "whatsapp_alpha_json_calling=external_setup_required "
             "missing=WHATSAPP_CLOUD_PHONE_NUMBER_ID,WHATSAPP_CLOUD_ACCESS_TOKEN,"
             "WHATSAPP_CLOUD_APP_SECRET,WHATSAPP_CLOUD_VERIFY_TOKEN invalid=none",
             result.stdout,
         )
+        self.assertIn(
+            "whatsapp_alpha_json_calling_verify_command="
+            "scripts/verify_whatsapp_alpha_readiness.py --hermes-home "
+            "/home/ubuntu/.hermes --require-whatsapp-cloud "
+            "--require-whatsapp-calling --check-whatsapp-cloud-api",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_alpha_json_calling_complete_command="
+            "scripts/verify_whatsapp_alpha_readiness.py --hermes-home "
+            "/home/ubuntu/.hermes --profile attended-cache-receive "
+            "--require-complete",
+            result.stdout,
+        )
         self.assertEqual([entry[0] for entry in entries], ["whatsapp", "alpha"])
         self.assertIn("--json", entries[1])
+
+    def test_whatsapp_alpha_json_summary_prints_attended_commands(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            alpha = tmp_path / "verify_alpha.py"
+            voice = tmp_path / "voice"
+            json_output = tmp_path / "alpha.json"
+
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_executable(
+                alpha,
+                textwrap.dedent(
+                    f"""\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    printf 'alpha' >> {str(log_path)!r}
+                    printf '\\0' >> {str(log_path)!r}
+                    printf '%s\\0' "$@" >> {str(log_path)!r}
+                    printf '\\n' >> {str(log_path)!r}
+                    cat <<'JSON'
+                    {{
+                      "profile": "cached-receive",
+                      "readiness_summary": {{
+                        "status": "local_ready_pending_gates",
+                        "complete": false,
+                        "local_checks_passed": true,
+                        "attended_fresh_receive_verified": false,
+                        "external_meta_setup_required": false,
+                        "operator_action_required": true,
+                        "next_actions": [
+                          {{"id": "run_attended_fresh_receive"}}
+                        ]
+                      }},
+                      "pending_gates": {{
+                        "attended_fresh_receive": {{
+                          "status": "not_verified",
+                          "cached_receive_verified": true,
+                          "command": [
+                            "scripts/verify_whatsapp_alpha_readiness.py",
+                            "--hermes-home",
+                            "/home/ubuntu/.hermes",
+                            "--profile",
+                            "attended-cache-receive",
+                            "--wait-audio-cache-seconds",
+                            "60.0"
+                          ],
+                          "fallback_draining_command": [
+                            "scripts/verify_whatsapp_alpha_readiness.py",
+                            "--hermes-home",
+                            "/home/ubuntu/.hermes",
+                            "--profile",
+                            "attended-send-receive",
+                            "--wait-inbound-seconds",
+                            "60.0"
+                          ]
+                        }},
+                        "whatsapp_cloud": {{"status": "configured"}},
+                        "whatsapp_cloud_calling": {{"status": "ready"}}
+                      }}
+                    }}
+                    JSON
+                    """
+                ),
+            )
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--skip-hermes-config",
+                    "--skip-hermes-gateway",
+                    "--skip-cli-mcp",
+                    "--skip-sidecar",
+                    "--skip-whatsapp-bridge",
+                    "--skip-systemd",
+                    "--skip-daemon",
+                    "--whatsapp-alpha-profile",
+                    "cached-receive",
+                    "--whatsapp-alpha-json-output",
+                    str(json_output),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "WHATSAPP_ALPHA_READINESS_SCRIPT": str(alpha),
+                },
+            )
+
+        self.assertIn(
+            "whatsapp_alpha_json_attended_command="
+            "scripts/verify_whatsapp_alpha_readiness.py --hermes-home "
+            "/home/ubuntu/.hermes --profile attended-cache-receive "
+            "--wait-audio-cache-seconds 60.0",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_alpha_json_attended_fallback_draining_command="
+            "scripts/verify_whatsapp_alpha_readiness.py --hermes-home "
+            "/home/ubuntu/.hermes --profile attended-send-receive "
+            "--wait-inbound-seconds 60.0",
+            result.stdout,
+        )
 
     def test_skip_hermes_config_does_not_require_config_file(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- Echo copyable attended receive and Cloud/Calling verification commands from saved WhatsApp alpha JSON summaries.
- Keep the full alpha JSON artifact unchanged; this only makes the top-level stack verifier logs more actionable.
- Document the new `whatsapp_alpha_json_*_command` summary lines.

## Verification
- `python3 -m unittest tests.test_verify_local_hermes_voice_stack`
- `python3 -m py_compile tests/test_verify_local_hermes_voice_stack.py`
- `bash -n scripts/verify_local_hermes_voice_stack.sh`
- `git diff --check`
- `python3 -m unittest discover -s tests`
- `tmp_json="$(mktemp)"; scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --skip-hermes-tts-smoke --whatsapp-alpha-profile cached-receive --whatsapp-alpha-wait-audio-cache-seconds 0.1 --whatsapp-alpha-json-output "$tmp_json" --expected-whatsapp-agent-number 13236478455 --expected-whatsapp-agent-name Quill; status=$?; rm -f "$tmp_json"; exit $status`

## Live result
The live stack smoke remains `local_ready_pending_gates` and now prints:
- `whatsapp_alpha_json_attended_command=... attended-cache-receive ...`
- `whatsapp_alpha_json_attended_fallback_draining_command=... attended-send-receive ...`
- `whatsapp_alpha_json_cloud_verify_command=... --require-whatsapp-cloud --check-whatsapp-cloud-api`
- `whatsapp_alpha_json_calling_verify_command=... --require-whatsapp-cloud --require-whatsapp-calling --check-whatsapp-cloud-api`
- `whatsapp_alpha_json_calling_complete_command=... --profile attended-cache-receive --require-complete`
