### PR TITLE
Clarify attended WhatsApp alpha prompts

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -95,9 +95,13 @@ while Hermes is already running; it watches `~/.hermes/audio_cache` for a fresh
 should poll and drain the bridge `/messages` queue. The stack gate also accepts
 `--whatsapp-alpha-chat-id`, `--whatsapp-alpha-wait-audio-cache-seconds`, and
 `--whatsapp-alpha-wait-inbound-seconds` so attended tests do not need to drop
-down to the lower-level alpha script. When `--whatsapp-alpha-json-output` is
-set, the stack gate runs the alpha profile with `--json` and saves that
-structured report for another agent or runbook step to consume.
+down to the lower-level alpha script. For attended profiles, the default alpha
+voice note asks the recipient to reply with a fresh voice note. Use
+`--whatsapp-alpha-text` when the prompt should be different without changing
+the generic stack smoke text used by the other checks. When
+`--whatsapp-alpha-json-output` is set, the stack gate runs the alpha profile
+with `--json` and saves that structured report for another agent or runbook
+step to consume.
 
 Cached receive profiles also pass the newest cached inbound `aud_*` file to
 the Hermes config verifier, so the configured STT command provider is exercised
@@ -209,7 +213,9 @@ fresh inbound `aud_*` file without polling the bridge message queue. If Hermes
 is not running and the verifier itself must consume bridge events, use the
 draining profile instead. The alpha readiness handoff prints both commands with
 explicit 60-second wait windows so copied commands and saved JSON artifacts are
-self-contained:
+self-contained. By default, attended profiles synthesize a clear reply prompt;
+pass `--text` to the lower-level alpha script when you want different spoken
+prompt text:
 
 ```bash
 scripts/verify_whatsapp_alpha_readiness.py \

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -8,6 +8,8 @@ hermes_config="${HERMES_CONFIG:-${HOME:-}/.hermes/config.yaml}"
 hermes_home="${HERMES_HOME:-${HOME:-}/.hermes}"
 sidecar_url="${SIDECAR_URL:-http://127.0.0.1:8787}"
 text="${TEXT:-Local Hermes voice stack smoke test.}"
+default_stack_text="Local Hermes voice stack smoke test."
+default_attended_alpha_text="Please reply with a fresh WhatsApp voice note so I can verify the voice runtime."
 skip_hermes_config="${SKIP_HERMES_CONFIG:-0}"
 skip_hermes_tts_smoke="${SKIP_HERMES_TTS_SMOKE:-0}"
 skip_hermes_stt_smoke="${SKIP_HERMES_STT_SMOKE:-0}"
@@ -20,6 +22,7 @@ skip_daemon="${SKIP_DAEMON:-0}"
 skip_stt_smoke="${SKIP_STT_SMOKE:-0}"
 run_whatsapp_inbound_cache_smoke="${RUN_WHATSAPP_INBOUND_CACHE_SMOKE:-0}"
 whatsapp_alpha_profile="${WHATSAPP_ALPHA_PROFILE:-}"
+whatsapp_alpha_text="${WHATSAPP_ALPHA_TEXT:-}"
 whatsapp_alpha_voice_note_chat_id="${WHATSAPP_ALPHA_VOICE_NOTE_CHAT_ID:-}"
 whatsapp_alpha_wait_audio_cache_seconds="${WHATSAPP_ALPHA_WAIT_AUDIO_CACHE_SECONDS:-}"
 whatsapp_alpha_wait_inbound_seconds="${WHATSAPP_ALPHA_WAIT_INBOUND_SECONDS:-}"
@@ -96,6 +99,9 @@ Options:
                                run categorized alpha readiness profile:
                                unattended, cached-receive, send,
                                attended-cache-receive, attended-send-receive
+  --whatsapp-alpha-text TEXT   override only the alpha profile TTS text; useful
+                               for attended prompts without changing generic
+                               stack smoke text
   --whatsapp-alpha-chat-id ID  override WHATSAPP_HOME_CHANNEL for alpha sends
   --whatsapp-alpha-wait-audio-cache-seconds SECONDS
                                override attended-cache-receive cache watch time
@@ -120,8 +126,9 @@ Environment aliases:
   REQUIRE_WHATSAPP_CLOUD=1, REQUIRE_WHATSAPP_CALLING=1
   REQUIRE_WHATSAPP_ALPHA_COMPLETE=1, CHECK_WHATSAPP_CLOUD_API=1
   RUN_WHATSAPP_INBOUND_CACHE_SMOKE=1, WHATSAPP_ALPHA_PROFILE
-  WHATSAPP_ALPHA_VOICE_NOTE_CHAT_ID, WHATSAPP_ALPHA_WAIT_AUDIO_CACHE_SECONDS
-  WHATSAPP_ALPHA_WAIT_INBOUND_SECONDS, WHATSAPP_ALPHA_JSON_OUTPUT
+  WHATSAPP_ALPHA_TEXT, WHATSAPP_ALPHA_VOICE_NOTE_CHAT_ID
+  WHATSAPP_ALPHA_WAIT_AUDIO_CACHE_SECONDS, WHATSAPP_ALPHA_WAIT_INBOUND_SECONDS
+  WHATSAPP_ALPHA_JSON_OUTPUT
   VOICE_WEBRTC_PYTHON, VOICE_WEBRTC_TIMEOUT
 EOF
 }
@@ -390,6 +397,11 @@ while [[ $# -gt 0 ]]; do
       whatsapp_alpha_profile="$2"
       shift 2
       ;;
+    --whatsapp-alpha-text)
+      [[ $# -ge 2 ]] || fail "--whatsapp-alpha-text requires a value"
+      whatsapp_alpha_text="$2"
+      shift 2
+      ;;
     --whatsapp-alpha-chat-id)
       [[ $# -ge 2 ]] || fail "--whatsapp-alpha-chat-id requires a chat id"
       whatsapp_alpha_voice_note_chat_id="$2"
@@ -636,6 +648,16 @@ else
 fi
 
 if [[ -n "$whatsapp_alpha_profile" ]]; then
+  alpha_text="$text"
+  if [[ -n "$whatsapp_alpha_text" ]]; then
+    alpha_text="$whatsapp_alpha_text"
+  elif [[ "$text" == "$default_stack_text" ]]; then
+    case "$whatsapp_alpha_profile" in
+      attended-cache-receive|attended-send-receive)
+        alpha_text="$default_attended_alpha_text"
+        ;;
+    esac
+  fi
   whatsapp_alpha_args=(
     "$whatsapp_alpha_readiness_script"
     --voice-bin "$voice_bin"
@@ -644,7 +666,7 @@ if [[ -n "$whatsapp_alpha_profile" ]]; then
     --bridge-url "$whatsapp_bridge_url"
     --sidecar-url "$sidecar_url"
     --profile "$whatsapp_alpha_profile"
-    --text "$text"
+    --text "$alpha_text"
   )
   if [[ -n "$whatsapp_audio_cache_dir" ]]; then
     whatsapp_alpha_args+=(--whatsapp-audio-cache-dir "$whatsapp_audio_cache_dir")

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -16,6 +16,10 @@ from typing import Any
 
 DEFAULT_BRIDGE_URL = "http://127.0.0.1:3000"
 DEFAULT_SIDECAR_URL = "http://127.0.0.1:8787"
+DEFAULT_TEXT = "WhatsApp alpha readiness smoke."
+DEFAULT_ATTENDED_PROMPT_TEXT = (
+    "Please reply with a fresh WhatsApp voice note so I can verify the voice runtime."
+)
 PROFILE_CHOICES = (
     "unattended",
     "cached-receive",
@@ -1101,7 +1105,15 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--whatsapp-audio-cache-dir", type=Path, default=None)
     parser.add_argument("--expected-agent-number", default=os.environ.get("WHATSAPP_AGENT_NUMBER"))
     parser.add_argument("--expected-agent-name", default=os.environ.get("WHATSAPP_AGENT_NAME"))
-    parser.add_argument("--text", default="WhatsApp alpha readiness smoke.")
+    parser.add_argument("--text", default=DEFAULT_TEXT)
+    parser.add_argument(
+        "--attended-prompt-text",
+        default=DEFAULT_ATTENDED_PROMPT_TEXT,
+        help=(
+            "voice-note text to synthesize for attended receive profiles when "
+            "--text is left at the default"
+        ),
+    )
     parser.add_argument("--timeout", type=float, default=30.0)
     parser.add_argument("--voice-timeout", type=float, default=180.0)
     parser.add_argument("--stt-timeout", type=float, default=180.0)
@@ -1172,11 +1184,15 @@ def apply_profile(args: argparse.Namespace) -> None:
     elif args.profile == "attended-cache-receive":
         args.send_voice_note = True
         args.run_inbound_cache_smoke = True
+        if args.text == DEFAULT_TEXT:
+            args.text = args.attended_prompt_text
         if args.wait_audio_cache_seconds == 0:
             args.wait_audio_cache_seconds = DEFAULT_ATTENDED_CACHE_RECEIVE_SECONDS
         args.require_fresh_cache_audio = True
     elif args.profile == "attended-send-receive":
         args.send_voice_note = True
+        if args.text == DEFAULT_TEXT:
+            args.text = args.attended_prompt_text
         if args.wait_inbound_seconds == 0:
             args.wait_inbound_seconds = DEFAULT_ATTENDED_DRAIN_RECEIVE_SECONDS
         args.require_inbound_audio = True

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -534,6 +534,64 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             ],
         )
 
+    def test_whatsapp_alpha_text_overrides_only_alpha_prompt(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            hermes = tmp_path / "verify_hermes.py"
+            cli_mcp = tmp_path / "verify_cli_mcp.py"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            alpha = tmp_path / "verify_alpha.py"
+            voice = tmp_path / "voice"
+            config = tmp_path / "config.yaml"
+
+            write_helper(hermes, "hermes", log_path)
+            write_helper(cli_mcp, "cli_mcp", log_path)
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_helper(alpha, "alpha", log_path)
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+            config.write_text("tts: {}\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--hermes-config",
+                    str(config),
+                    "--skip-hermes-gateway",
+                    "--skip-whatsapp-bridge",
+                    "--skip-sidecar",
+                    "--skip-systemd",
+                    "--skip-daemon",
+                    "--whatsapp-alpha-profile",
+                    "attended-cache-receive",
+                    "--whatsapp-alpha-text",
+                    "Please send a short test voice note back to Quill.",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "HERMES_CONFIG_VERIFY_SCRIPT": str(hermes),
+                    "CLI_MCP_SURFACE_VERIFY_SCRIPT": str(cli_mcp),
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "WHATSAPP_ALPHA_READINESS_SCRIPT": str(alpha),
+                },
+            )
+
+            entries = command_log_entries(log_path)
+
+        self.assertIn("whatsapp_alpha=attended-cache-receive", result.stdout)
+        self.assertEqual([entry[0] for entry in entries], ["hermes", "cli_mcp", "whatsapp", "alpha"])
+        self.assertIn("--text", entries[0])
+        self.assertIn("Local Hermes voice stack smoke test.", entries[0])
+        alpha_entry = entries[3]
+        self.assertIn("--text", alpha_entry)
+        self.assertIn("Please send a short test voice note back to Quill.", alpha_entry)
+        self.assertNotIn("Local Hermes voice stack smoke test.", alpha_entry)
+
     def test_require_whatsapp_alpha_complete_requires_alpha_profile(self):
         result = subprocess.run(
             [

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -774,6 +774,10 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         components = {item["name"]: item for item in payload["components"]}
         command = components["whatsapp_voice_note_send_receive"]["command"]
         self.assertIn("--send", command)
+        self.assertIn(
+            "Please reply with a fresh WhatsApp voice note so I can verify the voice runtime.",
+            command,
+        )
         self.assertIn("--wait-inbound-seconds", command)
         self.assertIn("60.0", command)
         self.assertIn("--require-inbound-audio", command)
@@ -836,6 +840,11 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         components = {item["name"]: item for item in payload["components"]}
         self.assertIn("whatsapp_voice_note_send", components)
         self.assertIn("whatsapp_inbound_cache_fresh_stt", components)
+        send_command = components["whatsapp_voice_note_send"]["command"]
+        self.assertIn(
+            "Please reply with a fresh WhatsApp voice note so I can verify the voice runtime.",
+            send_command,
+        )
         command = components["whatsapp_inbound_cache_fresh_stt"]["command"]
         self.assertIn("--wait-fresh-seconds", command)
         self.assertIn("60.0", command)
@@ -863,6 +872,39 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertEqual(
             [action["id"] for action in summary["next_actions"]],
             ["configure_whatsapp_cloud_calling"],
+        )
+
+    def test_attended_profile_keeps_explicit_text(self):
+        inbound_cache_payload = {
+            "success": True,
+            "checks": {
+                "selected_files": [],
+                "audio": [],
+                "fresh_watch": {
+                    "drains_bridge_messages": False,
+                    "fresh_files": [],
+                    "fresh_count": 0,
+                },
+            },
+            "failures": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = self.run_readiness(
+                Path(tmp),
+                "--profile",
+                "attended-cache-receive",
+                "--text",
+                "Custom attended prompt.",
+                skip_voice_note_smoke=False,
+                inbound_cache_payload=inbound_cache_payload,
+            )
+
+        components = {item["name"]: item for item in payload["components"]}
+        send_command = components["whatsapp_voice_note_send"]["command"]
+        self.assertIn("Custom attended prompt.", send_command)
+        self.assertNotIn(
+            "Please reply with a fresh WhatsApp voice note so I can verify the voice runtime.",
+            send_command,
         )
 
     def test_cached_receive_verified_survives_optional_fresh_watch_timeout(self):


### PR DESCRIPTION
## Summary

- give attended WhatsApp alpha profiles a clear default voice-note prompt asking for a fresh reply
- add `--whatsapp-alpha-text` to the top-level stack gate so alpha prompt text can differ from generic smoke text
- document the attended prompt behavior and cover direct/top-level command generation

## Verification

- `python3 -m unittest tests.test_verify_whatsapp_alpha_readiness tests.test_verify_local_hermes_voice_stack`
- `python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_alpha_readiness.py tests/test_verify_local_hermes_voice_stack.py`
- `bash -n scripts/verify_local_hermes_voice_stack.sh`
- `git diff --check`
- `python3 -m unittest discover -s tests`
- live cached-receive stack smoke with installed `/home/ubuntu/.local/bin/voice`, Hermes home `/home/ubuntu/.hermes`, and Quill identity checks
