### PR TITLE
Summarize failed alpha JSON stack gates

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -172,7 +172,10 @@ status, completion state, next action IDs, attended receive status, and
 Cloud/Calling missing or invalid key groups. When a gate is still pending, the
 same summary also echoes the copyable attended receive command, fallback
 draining command, Cloud verification command, Calling verification command, and
-complete-alpha command if those commands are present in the saved JSON.
+complete-alpha command if those commands are present in the saved JSON. If the
+alpha profile exits non-zero while writing a valid JSON report, such as a
+`--require-complete` run with pending gates, the stack gate still prints this
+summary before returning the alpha failure status.
 
 Use the complete gate only when the local bridge, attended receive, Cloud API,
 and Calling setup are all expected to pass:

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -41,6 +41,7 @@ require_whatsapp_cloud="${REQUIRE_WHATSAPP_CLOUD:-0}"
 require_whatsapp_calling="${REQUIRE_WHATSAPP_CALLING:-0}"
 require_whatsapp_alpha_complete="${REQUIRE_WHATSAPP_ALPHA_COMPLETE:-0}"
 check_whatsapp_cloud_api="${CHECK_WHATSAPP_CLOUD_API:-0}"
+overall_status=0
 
 hermes_config_verify_script="${HERMES_CONFIG_VERIFY_SCRIPT:-$repo_root/scripts/verify_hermes_voice_config.py}"
 hermes_gateway_verify_script="${HERMES_GATEWAY_VERIFY_SCRIPT:-$repo_root/scripts/verify_hermes_gateway_service.py}"
@@ -723,19 +724,33 @@ if [[ -n "$whatsapp_alpha_profile" ]]; then
     whatsapp_alpha_args+=(--json)
     echo
     echo "==> WhatsApp alpha readiness profile ($whatsapp_alpha_profile)"
+    set +e
     "${whatsapp_alpha_args[@]}" >"$whatsapp_alpha_json_output"
+    whatsapp_alpha_exit=$?
+    set -e
     echo "whatsapp_alpha_json=$whatsapp_alpha_json_output"
     print_whatsapp_alpha_json_summary "$whatsapp_alpha_json_output"
+    if [[ "$whatsapp_alpha_exit" != "0" ]]; then
+      echo "error: WhatsApp alpha readiness profile failed with exit $whatsapp_alpha_exit" >&2
+      overall_status="$whatsapp_alpha_exit"
+      whatsapp_alpha_status="$whatsapp_alpha_profile:failed"
+    else
+      whatsapp_alpha_status="$whatsapp_alpha_profile"
+    fi
   else
     run_step "WhatsApp alpha readiness profile ($whatsapp_alpha_profile)" "${whatsapp_alpha_args[@]}"
+    whatsapp_alpha_status="$whatsapp_alpha_profile"
   fi
-  whatsapp_alpha_status="$whatsapp_alpha_profile"
 else
   whatsapp_alpha_status="skipped"
 fi
 
 echo
-echo "ok: local Hermes voice stack verifier passed"
+if [[ "$overall_status" == "0" ]]; then
+  echo "ok: local Hermes voice stack verifier passed"
+else
+  echo "error: local Hermes voice stack verifier failed" >&2
+fi
 echo "voice_bin=$voice_bin"
 echo "hermes_config=$hermes_status"
 echo "hermes_gateway=$hermes_gateway_status"
@@ -749,3 +764,4 @@ if [[ -n "$whatsapp_alpha_json_output" ]]; then
 fi
 echo "sidecar_service=$sidecar_status"
 echo "webrtc_loopback=$webrtc_loopback_status"
+exit "$overall_status"

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -938,6 +938,143 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             result.stdout,
         )
 
+    def test_whatsapp_alpha_json_output_summarizes_nonzero_alpha(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            alpha = tmp_path / "verify_alpha.py"
+            voice = tmp_path / "voice"
+            json_output = tmp_path / "alpha.json"
+
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_executable(
+                alpha,
+                textwrap.dedent(
+                    f"""\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    printf 'alpha' >> {str(log_path)!r}
+                    printf '\\0' >> {str(log_path)!r}
+                    printf '%s\\0' "$@" >> {str(log_path)!r}
+                    printf '\\n' >> {str(log_path)!r}
+                    cat <<'JSON'
+                    {{
+                      "profile": "attended-cache-receive",
+                      "readiness_summary": {{
+                        "status": "local_ready_pending_gates",
+                        "complete": false,
+                        "local_checks_passed": true,
+                        "attended_fresh_receive_verified": false,
+                        "external_meta_setup_required": true,
+                        "operator_action_required": true,
+                        "next_actions": [
+                          {{"id": "run_attended_fresh_receive"}},
+                          {{"id": "configure_whatsapp_cloud_calling"}}
+                        ]
+                      }},
+                      "pending_gates": {{
+                        "attended_fresh_receive": {{
+                          "status": "not_verified",
+                          "cached_receive_verified": true,
+                          "command": [
+                            "scripts/verify_whatsapp_alpha_readiness.py",
+                            "--hermes-home",
+                            "/home/ubuntu/.hermes",
+                            "--profile",
+                            "attended-cache-receive",
+                            "--wait-audio-cache-seconds",
+                            "60.0"
+                          ]
+                        }},
+                        "whatsapp_cloud": {{
+                          "status": "external_setup_required",
+                          "setup_handoff": {{
+                            "missing": ["WHATSAPP_CLOUD_PHONE_NUMBER_ID"],
+                            "invalid": []
+                          }}
+                        }},
+                        "whatsapp_cloud_calling": {{
+                          "status": "external_setup_required",
+                          "setup_handoff": {{
+                            "missing": ["WHATSAPP_CLOUD_PHONE_NUMBER_ID"],
+                            "invalid": [],
+                            "complete_verification_command": [
+                              "scripts/verify_whatsapp_alpha_readiness.py",
+                              "--hermes-home",
+                              "/home/ubuntu/.hermes",
+                              "--profile",
+                              "attended-cache-receive",
+                              "--require-complete"
+                            ]
+                          }}
+                        }}
+                      }}
+                    }}
+                    JSON
+                    exit 3
+                    """
+                ),
+            )
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--skip-hermes-config",
+                    "--skip-hermes-gateway",
+                    "--skip-cli-mcp",
+                    "--skip-sidecar",
+                    "--skip-whatsapp-bridge",
+                    "--skip-systemd",
+                    "--skip-daemon",
+                    "--whatsapp-alpha-profile",
+                    "attended-cache-receive",
+                    "--require-whatsapp-alpha-complete",
+                    "--whatsapp-alpha-json-output",
+                    str(json_output),
+                ],
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "WHATSAPP_ALPHA_READINESS_SCRIPT": str(alpha),
+                },
+            )
+
+        self.assertEqual(result.returncode, 3)
+        self.assertIn(f"whatsapp_alpha_json={json_output}", result.stdout)
+        self.assertIn("whatsapp_alpha_json_profile=attended-cache-receive", result.stdout)
+        self.assertIn(
+            "whatsapp_alpha_json_readiness=local_ready_pending_gates complete=False",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_alpha_json_next_actions=run_attended_fresh_receive,"
+            "configure_whatsapp_cloud_calling",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_alpha_json_attended_command="
+            "scripts/verify_whatsapp_alpha_readiness.py --hermes-home "
+            "/home/ubuntu/.hermes --profile attended-cache-receive "
+            "--wait-audio-cache-seconds 60.0",
+            result.stdout,
+        )
+        self.assertIn("whatsapp_alpha=attended-cache-receive:failed", result.stdout)
+        self.assertNotIn("ok: local Hermes voice stack verifier passed", result.stdout)
+        self.assertIn(
+            "error: WhatsApp alpha readiness profile failed with exit 3",
+            result.stderr,
+        )
+        self.assertIn(
+            "error: local Hermes voice stack verifier failed",
+            result.stderr,
+        )
+
     def test_skip_hermes_config_does_not_require_config_file(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)


### PR DESCRIPTION
## Summary

- keep printing saved WhatsApp alpha JSON summaries when the alpha profile exits non-zero
- preserve the alpha exit status for the top-level stack gate while marking `whatsapp_alpha=<profile>:failed`
- report the final stack verifier as failed instead of printing the success banner on expected complete-gate failures
- document the behavior for `--require-complete` runs with pending gates

## Verification

- `python3 -m unittest tests.test_verify_local_hermes_voice_stack`
- `bash -n scripts/verify_local_hermes_voice_stack.sh`
- `python3 -m py_compile tests/test_verify_local_hermes_voice_stack.py`
- `git diff --check`
- `python3 -m unittest discover -s tests`
- live local `--require-whatsapp-alpha-complete --whatsapp-alpha-json-output` stack run against `/home/ubuntu/.local/bin/voice` and `/home/ubuntu/.hermes`; it returned status 1 after printing the alpha next-action summary and `whatsapp_alpha=cached-receive:failed`
