### PR TITLE
Add Hermes voice config installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,12 @@ jobs:
 
       - run: |
           python -m py_compile \
+            scripts/install_hermes_voice_config.py \
             scripts/macos_release_compare.py \
             scripts/verify_cli_mcp_surface.py \
             scripts/verify_hermes_voice_config.py \
             scripts/verify_webrtc_sidecar_service.py \
+            tests/test_install_hermes_voice_config.py \
             tests/test_install_webrtc_sidecar_service.py \
             tests/test_macos_release_compare.py \
             tests/test_verify_cli_mcp_surface.py \

--- a/README.md
+++ b/README.md
@@ -390,6 +390,19 @@ stt:
       format: txt
 ```
 
+To avoid hand-editing `~/.hermes/config.yaml`, generate or install the same
+voice-native provider blocks with:
+
+```bash
+scripts/install_hermes_voice_config.py --print-snippet --voice-bin "$(command -v voice)"
+scripts/install_hermes_voice_config.py --config ~/.hermes/config.yaml --voice-bin "$(command -v voice)"
+scripts/install_hermes_voice_config.py --config ~/.hermes/config.yaml --voice-bin "$(command -v voice)" --apply
+```
+
+Without `--apply`, the installer performs a dry run and verifies the patched
+config in a temporary file. With `--apply`, it keeps a timestamped backup and
+runs `scripts/verify_hermes_voice_config.py` on the result.
+
 `scripts/verify_hermes_voice_config.py` accepts either these shims or direct
 `voice say --format ogg-opus` / `voice stream-transcribe --quiet` commands, and
 rejects arbitrary wrappers so config drift is caught locally. Add

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -99,6 +99,18 @@ Pass `--stt-audio ~/.hermes/audio_cache/aud_...ogg` to execute the configured
 STT command against a cached inbound WhatsApp voice note; the verifier only
 reports transcript size, not transcript text.
 
+To generate or install the voice-owned provider blocks, run:
+
+```bash
+scripts/install_hermes_voice_config.py --print-snippet --voice-bin "$(command -v voice)"
+scripts/install_hermes_voice_config.py --config ~/.hermes/config.yaml --voice-bin "$(command -v voice)"
+scripts/install_hermes_voice_config.py --config ~/.hermes/config.yaml --voice-bin "$(command -v voice)" --apply
+```
+
+The default run is a dry run: it patches a temporary copy and verifies the
+resulting shape. `--apply` writes the config, keeps a timestamped backup unless
+`--no-backup` is passed, and reruns the Hermes config verifier.
+
 Validate the command-provider shape locally before wiring or restarting
 Hermes:
 

--- a/scripts/install_hermes_voice_config.py
+++ b/scripts/install_hermes_voice_config.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Install voice-native Hermes TTS/STT command-provider config."""
+
+from __future__ import annotations
+
+import argparse
+from copy import deepcopy
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+
+DEFAULT_CONFIG = Path.home() / ".hermes" / "config.yaml"
+DEFAULT_TTS_PROVIDER = "kokoro"
+DEFAULT_STT_PROVIDER = "voice"
+DEFAULT_VOICE = "af_heart"
+DEFAULT_SPEED = "1.0"
+DEFAULT_TTS_TIMEOUT = 180
+DEFAULT_STT_TIMEOUT = 300
+DEFAULT_MAX_TEXT_LENGTH = 2000
+
+
+class InstallError(Exception):
+    """Hermes voice config installation failure."""
+
+
+def import_yaml():
+    try:
+        import yaml  # type: ignore[import-not-found]
+    except Exception as exc:  # pragma: no cover - depends on host environment
+        raise InstallError(
+            "PyYAML is required to read/write Hermes config. Install it with "
+            "`python -m pip install PyYAML`, or run this script with "
+            "`--print-snippet` and copy the YAML manually."
+        ) from exc
+    return yaml
+
+
+def resolve_voice_bin(value: str | None) -> str:
+    if value:
+        return value
+    found = shutil.which("voice")
+    return found or "voice"
+
+
+def quote_command(parts: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in parts)
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def build_tts_command(args: argparse.Namespace, voice_bin: str) -> str:
+    if args.mode == "shim":
+        shim = args.tts_shim or repo_root() / "examples" / "hermes-command-tts.sh"
+        return quote_command(
+            [
+                str(shim),
+                "{input_path}",
+                "{output_path}",
+                "{voice}",
+                "{speed}",
+            ]
+        )
+
+    return quote_command(
+        [
+            voice_bin,
+            "say",
+            "--format",
+            "ogg-opus",
+            "--input-file",
+            "{input_path}",
+            "--output",
+            "{output_path}",
+            "--voice",
+            "{voice}",
+            "--speed",
+            "{speed}",
+        ]
+    )
+
+
+def build_stt_command(args: argparse.Namespace, voice_bin: str) -> str:
+    if args.mode == "shim":
+        shim = args.stt_shim or repo_root() / "examples" / "hermes-command-stt.sh"
+        return quote_command([str(shim), "{input_path}"])
+    return quote_command([voice_bin, "stream-transcribe", "--quiet", "{input_path}"])
+
+
+def provider_blocks(args: argparse.Namespace, voice_bin: str) -> dict[str, Any]:
+    return {
+        "tts": {
+            "provider": args.tts_provider,
+            "providers": {
+                args.tts_provider: {
+                    "type": "command",
+                    "command": build_tts_command(args, voice_bin),
+                    "output_format": "ogg",
+                    "voice_compatible": True,
+                    "voice": args.voice,
+                    "speed": str(args.speed),
+                    "timeout": int(args.tts_timeout),
+                    "max_text_length": int(args.max_text_length),
+                }
+            },
+        },
+        "stt": {
+            "enabled": True,
+            "provider": args.stt_provider,
+            "providers": {
+                args.stt_provider: {
+                    "type": "command",
+                    "command": build_stt_command(args, voice_bin),
+                    "format": "txt",
+                    "timeout": int(args.stt_timeout),
+                }
+            },
+        },
+    }
+
+
+def render_snippet(blocks: dict[str, Any]) -> str:
+    lines: list[str] = []
+    tts_provider = next(iter(blocks["tts"]["providers"]))
+    tts = blocks["tts"]["providers"][tts_provider]
+    stt_provider = next(iter(blocks["stt"]["providers"]))
+    stt = blocks["stt"]["providers"][stt_provider]
+    lines.extend(
+        [
+            "tts:",
+            f"  provider: {blocks['tts']['provider']}",
+            "  providers:",
+            f"    {tts_provider}:",
+            "      type: command",
+            f"      command: {tts['command']}",
+            "      output_format: ogg",
+            "      voice_compatible: true",
+            f"      voice: {tts['voice']}",
+            f"      speed: {tts['speed']}",
+            f"      timeout: {tts['timeout']}",
+            f"      max_text_length: {tts['max_text_length']}",
+            "",
+            "stt:",
+            "  enabled: true",
+            f"  provider: {blocks['stt']['provider']}",
+            "  providers:",
+            f"    {stt_provider}:",
+            "      type: command",
+            f"      command: {stt['command']}",
+            "      format: txt",
+            f"      timeout: {stt['timeout']}",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def load_config(path: Path, *, create: bool) -> dict[str, Any]:
+    yaml = import_yaml()
+    if not path.exists():
+        if create:
+            return {}
+        raise InstallError(f"Hermes config not found: {path}; pass --create to create it")
+    try:
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise InstallError(f"failed to parse YAML in {path}: {exc}") from exc
+    if loaded is None:
+        return {}
+    if not isinstance(loaded, dict):
+        raise InstallError(f"{path} must contain a YAML mapping")
+    return loaded
+
+
+def ensure_mapping(parent: dict[str, Any], key: str) -> dict[str, Any]:
+    value = parent.get(key)
+    if value is None:
+        value = {}
+        parent[key] = value
+    if not isinstance(value, dict):
+        raise InstallError(f"config key {key!r} must be a mapping")
+    return value
+
+
+def merge_provider_config(config: dict[str, Any], blocks: dict[str, Any]) -> dict[str, Any]:
+    updated = deepcopy(config)
+
+    tts = ensure_mapping(updated, "tts")
+    tts["provider"] = blocks["tts"]["provider"]
+    tts_providers = ensure_mapping(tts, "providers")
+    for provider, provider_config in blocks["tts"]["providers"].items():
+        existing = tts_providers.get(provider)
+        merged = existing.copy() if isinstance(existing, dict) else {}
+        merged.update(provider_config)
+        tts_providers[provider] = merged
+
+    stt = ensure_mapping(updated, "stt")
+    stt["enabled"] = True
+    stt["provider"] = blocks["stt"]["provider"]
+    stt_providers = ensure_mapping(stt, "providers")
+    for provider, provider_config in blocks["stt"]["providers"].items():
+        existing = stt_providers.get(provider)
+        merged = existing.copy() if isinstance(existing, dict) else {}
+        merged.update(provider_config)
+        stt_providers[provider] = merged
+
+    return updated
+
+
+def write_yaml_atomic(path: Path, config: dict[str, Any]) -> None:
+    yaml = import_yaml()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rendered = yaml.safe_dump(
+        config,
+        sort_keys=False,
+        default_flow_style=False,
+        allow_unicode=True,
+    )
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        dir=str(path.parent),
+        prefix=f".{path.name}.",
+        delete=False,
+    ) as handle:
+        handle.write(rendered)
+        temp_path = Path(handle.name)
+    os.replace(temp_path, path)
+
+
+def backup_config(path: Path) -> Path | None:
+    if not path.exists():
+        return None
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S%f")
+    backup = path.with_name(f"{path.name}.bak.{timestamp}")
+    shutil.copy2(path, backup)
+    return backup
+
+
+def run_verifier(path: Path, voice_bin: str, *, run_tts_smoke: bool) -> str:
+    verifier = Path(__file__).resolve().with_name("verify_hermes_voice_config.py")
+    command = [
+        sys.executable,
+        str(verifier),
+        "--config",
+        str(path),
+        "--voice-bin",
+        voice_bin,
+    ]
+    if not run_tts_smoke:
+        command.append("--skip-tts-smoke")
+    completed = subprocess.run(command, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        raise InstallError(f"post-install verifier failed: {detail}")
+    return completed.stdout
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Install voice-native Hermes TTS/STT command-provider config.",
+    )
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--voice-bin", default=None)
+    parser.add_argument(
+        "--mode",
+        choices=["direct", "shim"],
+        default="direct",
+        help="install direct voice commands or repo-owned command shims",
+    )
+    parser.add_argument("--tts-provider", default=DEFAULT_TTS_PROVIDER)
+    parser.add_argument("--stt-provider", default=DEFAULT_STT_PROVIDER)
+    parser.add_argument("--voice", default=DEFAULT_VOICE)
+    parser.add_argument("--speed", default=DEFAULT_SPEED)
+    parser.add_argument("--tts-timeout", type=int, default=DEFAULT_TTS_TIMEOUT)
+    parser.add_argument("--stt-timeout", type=int, default=DEFAULT_STT_TIMEOUT)
+    parser.add_argument("--max-text-length", type=int, default=DEFAULT_MAX_TEXT_LENGTH)
+    parser.add_argument("--tts-shim", type=Path, default=None)
+    parser.add_argument("--stt-shim", type=Path, default=None)
+    parser.add_argument("--apply", action="store_true", help="write the config")
+    parser.add_argument("--create", action="store_true", help="create the config if missing")
+    parser.add_argument("--no-backup", action="store_true", help="do not keep a .bak copy")
+    parser.add_argument(
+        "--skip-verify",
+        action="store_true",
+        help="do not run verify_hermes_voice_config.py on the resulting config",
+    )
+    parser.add_argument(
+        "--run-tts-smoke",
+        action="store_true",
+        help="let post-install verification execute the configured TTS command",
+    )
+    parser.add_argument(
+        "--print-snippet",
+        action="store_true",
+        help="print only the YAML snippet; does not require PyYAML",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    voice_bin = resolve_voice_bin(args.voice_bin)
+    blocks = provider_blocks(args, voice_bin)
+
+    if args.print_snippet:
+        print(render_snippet(blocks), end="")
+        return 0
+
+    config_path = args.config.expanduser()
+    config = load_config(config_path, create=args.create)
+    updated = merge_provider_config(config, blocks)
+
+    if not args.apply:
+        print("dry_run=true")
+        print(f"config={config_path}")
+        print("applied=false")
+        print(f"mode={args.mode}")
+        print(f"tts.provider={args.tts_provider}")
+        print(f"stt.provider={args.stt_provider}")
+        print("snippet:")
+        print(render_snippet(blocks), end="")
+        if not args.skip_verify:
+            with tempfile.TemporaryDirectory(prefix="voice-hermes-install.") as tmp:
+                temp_config = Path(tmp) / "config.yaml"
+                write_yaml_atomic(temp_config, updated)
+                run_verifier(temp_config, voice_bin, run_tts_smoke=args.run_tts_smoke)
+            print("verify=passed")
+        return 0
+
+    backup = None
+    if not args.no_backup:
+        backup = backup_config(config_path)
+    write_yaml_atomic(config_path, updated)
+    if not args.skip_verify:
+        run_verifier(config_path, voice_bin, run_tts_smoke=args.run_tts_smoke)
+
+    print("ok: Hermes voice config installed")
+    print(f"config={config_path}")
+    print("applied=true")
+    print(f"mode={args.mode}")
+    print(f"tts.provider={args.tts_provider}")
+    print(f"stt.provider={args.stt_provider}")
+    print(f"backup={backup or 'none'}")
+    print(f"verify={'skipped' if args.skip_verify else 'passed'}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except (InstallError, subprocess.SubprocessError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/tests/test_install_hermes_voice_config.py
+++ b/tests/test_install_hermes_voice_config.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "install_hermes_voice_config.py"
+VERIFY_PATH = REPO_ROOT / "scripts" / "verify_hermes_voice_config.py"
+
+
+def has_yaml() -> bool:
+    try:
+        import yaml  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def base_config() -> str:
+    return """\
+model:
+  default: gpt-5.5
+tts:
+  provider: edge
+  edge:
+    voice: en-US-AriaNeural
+  providers:
+    legacy:
+      type: command
+      command: old-tts {input_path} {output_path}
+      output_format: wav
+stt:
+  enabled: false
+  provider: local
+  providers:
+    local:
+      type: command
+      command: old-stt {input_path}
+      format: txt
+"""
+
+
+class HermesVoiceConfigInstallerTests(unittest.TestCase):
+    def test_print_snippet_does_not_require_config_file(self):
+        result = subprocess.run(
+            [
+                str(SCRIPT_PATH),
+                "--config",
+                "/tmp/does-not-exist-hermes-config.yaml",
+                "--voice-bin",
+                "/opt/voice/bin/voice",
+                "--print-snippet",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertIn("tts:", result.stdout)
+        self.assertIn("provider: kokoro", result.stdout)
+        self.assertIn("/opt/voice/bin/voice say --format ogg-opus", result.stdout)
+        self.assertIn("voice_compatible: true", result.stdout)
+        self.assertIn("stt:", result.stdout)
+        self.assertIn("/opt/voice/bin/voice stream-transcribe --quiet", result.stdout)
+
+    @unittest.skipUnless(has_yaml(), "PyYAML is required for write-mode config tests")
+    def test_dry_run_does_not_modify_config_and_verifies_temp_result(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp) / "config.yaml"
+            config.write_text(base_config(), encoding="utf-8")
+            before = config.read_text(encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--config",
+                    str(config),
+                    "--voice-bin",
+                    "/opt/voice/bin/voice",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            after = config.read_text(encoding="utf-8")
+
+        self.assertEqual(after, before)
+        self.assertIn("dry_run=true", result.stdout)
+        self.assertIn("applied=false", result.stdout)
+        self.assertIn("tts.provider=kokoro", result.stdout)
+        self.assertIn("stt.provider=voice", result.stdout)
+        self.assertIn("verify=passed", result.stdout)
+
+    @unittest.skipUnless(has_yaml(), "PyYAML is required for write-mode config tests")
+    def test_apply_patches_only_voice_provider_blocks_and_keeps_backup(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp) / "config.yaml"
+            config.write_text(base_config(), encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--config",
+                    str(config),
+                    "--voice-bin",
+                    "/opt/voice/bin/voice",
+                    "--apply",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            verify = subprocess.run(
+                [
+                    str(VERIFY_PATH),
+                    "--config",
+                    str(config),
+                    "--voice-bin",
+                    "/opt/voice/bin/voice",
+                    "--skip-tts-smoke",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            backups = list(Path(tmp).glob("config.yaml.bak.*"))
+            rendered = config.read_text(encoding="utf-8")
+            backup_text = backups[0].read_text(encoding="utf-8") if backups else ""
+
+        self.assertIn("ok: Hermes voice config installed", result.stdout)
+        self.assertIn("applied=true", result.stdout)
+        self.assertIn("verify=passed", result.stdout)
+        self.assertEqual(len(backups), 1)
+        self.assertIn("provider: edge", backup_text)
+        self.assertIn("default: gpt-5.5", rendered)
+        self.assertIn("provider: kokoro", rendered)
+        self.assertIn("/opt/voice/bin/voice say --format ogg-opus", rendered)
+        self.assertIn("voice_compatible: true", rendered)
+        self.assertIn("provider: voice", rendered)
+        self.assertIn("/opt/voice/bin/voice stream-transcribe --quiet", rendered)
+        self.assertIn("ok: Hermes voice config verifier passed", verify.stdout)
+
+    @unittest.skipUnless(has_yaml(), "PyYAML is required for write-mode config tests")
+    def test_apply_can_create_missing_config_when_requested(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp) / "config.yaml"
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--config",
+                    str(config),
+                    "--voice-bin",
+                    "voice",
+                    "--apply",
+                    "--create",
+                    "--no-backup",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={**os.environ, "PATH": os.environ.get("PATH", "")},
+            )
+
+            rendered = config.read_text(encoding="utf-8")
+
+        self.assertIn("backup=none", result.stdout)
+        self.assertIn("provider: kokoro", rendered)
+        self.assertIn("provider: voice", rendered)
+
+    @unittest.skipUnless(has_yaml(), "PyYAML is required for write-mode config tests")
+    def test_dry_run_can_create_missing_config_shape_when_requested(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp) / "config.yaml"
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--config",
+                    str(config),
+                    "--voice-bin",
+                    "voice",
+                    "--create",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertFalse(config.exists())
+        self.assertIn("dry_run=true", result.stdout)
+        self.assertIn("applied=false", result.stdout)
+        self.assertIn("verify=passed", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a voice-owned Hermes config installer for TTS/STT command-provider blocks
- support snippet-only, dry-run verification, apply with backup, and create-missing modes
- document the installer and add it to Python helper compile coverage

## Verification
- python3 -m unittest tests.test_install_hermes_voice_config tests.test_verify_hermes_voice_config
- python3 -m unittest discover -s tests
- python3 -m py_compile scripts/install_hermes_voice_config.py scripts/macos_release_compare.py scripts/verify_cli_mcp_surface.py scripts/verify_hermes_voice_config.py scripts/verify_webrtc_sidecar_service.py tests/test_install_hermes_voice_config.py tests/test_install_webrtc_sidecar_service.py tests/test_macos_release_compare.py tests/test_verify_cli_mcp_surface.py tests/test_verify_hermes_voice_config.py tests/test_verify_local_hermes_voice_stack.py tests/test_verify_telegram_voice_contract.py tests/test_verify_webrtc_sidecar_service.py
- git diff --check
- scripts/install_hermes_voice_config.py --config /home/ubuntu/.hermes/config.yaml --voice-bin /home/ubuntu/.local/bin/voice
