### PR TITLE
Run Hermes config installer in stack verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,9 +420,9 @@ scripts/verify_local_hermes_voice_stack.sh \
 ```
 
 That single gate checks plain CLI/MCP daemon behavior, Hermes' active command
-provider, direct Ogg/Opus voice note output, daemon-backed streaming,
-`stream-transcribe`, and the local WebRTC sidecar service. It requires the
-daemon and sidecar by default. For narrower checks, run
+provider, the voice-owned config installer dry-run, direct Ogg/Opus voice note
+output, daemon-backed streaming, `stream-transcribe`, and the local WebRTC
+sidecar service. It requires the daemon and sidecar by default. For narrower checks, run
 `scripts/verify_cli_mcp_surface.py`, `scripts/verify_hermes_voice_config.py`,
 `scripts/verify_whatsapp_voice_contract.sh`,
 `scripts/verify_telegram_voice_contract.sh`, or

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -152,6 +152,9 @@ VOICE_BIN=/path/to/voice scripts/verify_local_hermes_voice_stack.sh
 The gateway verifier confirms `hermes-gateway.service` is active, points at the
 expected Hermes home, exports `WHATSAPP_CLOUD_CALLING_SIDECAR_URL`, and uses a
 `voice stream --raw-output -` command for the WhatsApp Calling sidecar path.
+The aggregate stack verifier also dry-runs `install_hermes_voice_config.py`
+against the active config, so one command now checks both config drift
+detection and the voice-owned repair path.
 
 ## CLI Smoke Test
 

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -11,6 +11,7 @@ text="${TEXT:-Local Hermes voice stack smoke test.}"
 default_stack_text="Local Hermes voice stack smoke test."
 default_attended_alpha_text="Please reply with a fresh WhatsApp voice note so I can verify the voice runtime."
 skip_hermes_config="${SKIP_HERMES_CONFIG:-0}"
+skip_hermes_install_dry_run="${SKIP_HERMES_INSTALL_DRY_RUN:-0}"
 skip_hermes_tts_smoke="${SKIP_HERMES_TTS_SMOKE:-0}"
 skip_hermes_stt_smoke="${SKIP_HERMES_STT_SMOKE:-0}"
 skip_hermes_gateway="${SKIP_HERMES_GATEWAY:-0}"
@@ -44,6 +45,7 @@ check_whatsapp_cloud_api="${CHECK_WHATSAPP_CLOUD_API:-0}"
 overall_status=0
 
 hermes_config_verify_script="${HERMES_CONFIG_VERIFY_SCRIPT:-$repo_root/scripts/verify_hermes_voice_config.py}"
+hermes_config_install_script="${HERMES_CONFIG_INSTALL_SCRIPT:-$repo_root/scripts/install_hermes_voice_config.py}"
 hermes_gateway_verify_script="${HERMES_GATEWAY_VERIFY_SCRIPT:-$repo_root/scripts/verify_hermes_gateway_service.py}"
 cli_mcp_surface_verify_script="${CLI_MCP_SURFACE_VERIFY_SCRIPT:-$repo_root/scripts/verify_cli_mcp_surface.py}"
 whatsapp_contract_verify_script="${WHATSAPP_CONTRACT_VERIFY_SCRIPT:-$repo_root/scripts/verify_whatsapp_voice_contract.sh}"
@@ -70,6 +72,8 @@ Options:
   --sidecar-url URL            sidecar base URL (default: http://127.0.0.1:8787)
   --text TEXT                  smoke text used by TTS checks
   --skip-hermes-config         skip Hermes config validation and TTS command smoke
+  --skip-hermes-install-dry-run
+                               skip dry-run validation of the config repair installer
   --skip-hermes-tts-smoke      validate Hermes config without executing TTS
   --skip-hermes-stt-smoke      keep alpha cached-receive Hermes STT validation shape-only
   --skip-hermes-gateway        skip running Hermes gateway service verification
@@ -118,7 +122,8 @@ Options:
 
 Environment aliases:
   VOICE_BIN, HERMES_CONFIG, SIDECAR_URL, TEXT
-  SKIP_HERMES_CONFIG=1, SKIP_HERMES_TTS_SMOKE=1, SKIP_HERMES_STT_SMOKE=1
+  SKIP_HERMES_CONFIG=1, SKIP_HERMES_INSTALL_DRY_RUN=1
+  SKIP_HERMES_TTS_SMOKE=1, SKIP_HERMES_STT_SMOKE=1
   SKIP_SIDECAR=1, SKIP_HERMES_GATEWAY=1, SKIP_WHATSAPP_BRIDGE=1
   SKIP_SYSTEMD=1, SKIP_CLI_MCP=1, SKIP_DAEMON=1, SKIP_STT_SMOKE=1
   RUN_WEBRTC_LOOPBACK_SMOKE=1
@@ -307,6 +312,10 @@ while [[ $# -gt 0 ]]; do
       skip_hermes_config=1
       shift
       ;;
+    --skip-hermes-install-dry-run)
+      skip_hermes_install_dry_run=1
+      shift
+      ;;
     --skip-hermes-tts-smoke)
       skip_hermes_tts_smoke=1
       shift
@@ -487,6 +496,9 @@ if [[ -n "$whatsapp_alpha_profile" ]]; then
 fi
 if [[ "$skip_hermes_config" != "1" ]]; then
   require_executable "$hermes_config_verify_script" "Hermes voice config verifier"
+  if [[ "$skip_hermes_install_dry_run" != "1" ]]; then
+    require_executable "$hermes_config_install_script" "Hermes voice config installer"
+  fi
   require_file "$hermes_config" "Hermes config"
 fi
 if [[ "$skip_cli_mcp" != "1" ]]; then
@@ -519,8 +531,20 @@ if [[ "$skip_hermes_config" != "1" ]]; then
   fi
   run_step "Hermes voice-native config" "${hermes_args[@]}"
   hermes_status="checked"
+  if [[ "$skip_hermes_install_dry_run" != "1" ]]; then
+    hermes_install_args=(
+      "$hermes_config_install_script"
+      --config "$hermes_config"
+      --voice-bin "$voice_bin"
+    )
+    run_step "Hermes voice config installer dry run" "${hermes_install_args[@]}"
+    hermes_install_status="dry_run"
+  else
+    hermes_install_status="skipped"
+  fi
 else
   hermes_status="skipped"
+  hermes_install_status="skipped"
 fi
 
 if [[ "$skip_hermes_gateway" != "1" && "$skip_systemd" != "1" ]]; then
@@ -753,6 +777,7 @@ else
 fi
 echo "voice_bin=$voice_bin"
 echo "hermes_config=$hermes_status"
+echo "hermes_config_install=$hermes_install_status"
 echo "hermes_gateway=$hermes_gateway_status"
 echo "cli_mcp=$cli_mcp_status"
 echo "whatsapp_contract=checked"

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -66,6 +66,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             tmp_path = Path(tmp)
             log_path = tmp_path / "commands.log"
             hermes = tmp_path / "verify_hermes.py"
+            install = tmp_path / "install_hermes.py"
             gateway = tmp_path / "verify_gateway.py"
             cli_mcp = tmp_path / "verify_cli_mcp.py"
             whatsapp = tmp_path / "verify_whatsapp.sh"
@@ -75,6 +76,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             config = tmp_path / "config.yaml"
 
             write_helper(hermes, "hermes", log_path)
+            write_helper(install, "install", log_path)
             write_helper(gateway, "gateway", log_path)
             write_helper(cli_mcp, "cli_mcp", log_path)
             write_helper(whatsapp, "whatsapp", log_path)
@@ -102,6 +104,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 env={
                     **os.environ,
                     "HERMES_CONFIG_VERIFY_SCRIPT": str(hermes),
+                    "HERMES_CONFIG_INSTALL_SCRIPT": str(install),
                     "HERMES_GATEWAY_VERIFY_SCRIPT": str(gateway),
                     "CLI_MCP_SURFACE_VERIFY_SCRIPT": str(cli_mcp),
                     "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
@@ -113,6 +116,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             entries = command_log_entries(log_path)
 
         self.assertIn("ok: local Hermes voice stack verifier passed", result.stdout)
+        self.assertIn("hermes_config_install=dry_run", result.stdout)
         self.assertIn("hermes_gateway=skipped", result.stdout)
         self.assertIn("cli_mcp=checked", result.stdout)
         self.assertIn("whatsapp_bridge=checked", result.stdout)
@@ -121,7 +125,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn("webrtc_loopback=skipped", result.stdout)
         self.assertEqual(
             [entry[0] for entry in entries],
-            ["hermes", "cli_mcp", "whatsapp", "bridge", "sidecar"],
+            ["hermes", "install", "cli_mcp", "whatsapp", "bridge", "sidecar"],
         )
         self.assertEqual(
             entries[0],
@@ -138,6 +142,16 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertEqual(
             entries[1],
             [
+                "install",
+                "--config",
+                str(config),
+                "--voice-bin",
+                str(voice),
+            ],
+        )
+        self.assertEqual(
+            entries[2],
+            [
                 "cli_mcp",
                 "--voice-bin",
                 str(voice),
@@ -145,7 +159,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             ],
         )
         self.assertEqual(
-            entries[2],
+            entries[3],
             [
                 "whatsapp",
                 "--voice-bin",
@@ -157,7 +171,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             ],
         )
         self.assertEqual(
-            entries[3],
+            entries[4],
             [
                 "bridge",
                 "--hermes-home",
@@ -168,7 +182,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             ],
         )
         self.assertEqual(
-            entries[4],
+            entries[5],
             [
                 "sidecar",
                 "--voice-bin",
@@ -207,6 +221,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                     "--hermes-config",
                     str(config),
                     "--skip-hermes-tts-smoke",
+                    "--skip-hermes-install-dry-run",
                     "--skip-hermes-gateway",
                     "--skip-sidecar",
                     "--skip-whatsapp-bridge",
@@ -229,6 +244,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             entries = command_log_entries(log_path)
 
         self.assertIn("sidecar_service=skipped", result.stdout)
+        self.assertIn("hermes_config_install=skipped", result.stdout)
         self.assertIn("hermes_gateway=skipped", result.stdout)
         self.assertIn("whatsapp_bridge=skipped", result.stdout)
         self.assertIn("whatsapp_inbound_cache=skipped", result.stdout)
@@ -273,6 +289,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                     "--hermes-config",
                     str(config),
                     "--skip-hermes-tts-smoke",
+                    "--skip-hermes-install-dry-run",
                     "--skip-sidecar",
                     "--skip-daemon",
                     "--run-webrtc-loopback-smoke",
@@ -560,6 +577,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                     "--hermes-config",
                     str(config),
                     "--skip-hermes-gateway",
+                    "--skip-hermes-install-dry-run",
                     "--skip-whatsapp-bridge",
                     "--skip-sidecar",
                     "--skip-systemd",
@@ -1165,6 +1183,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                     "--sidecar-url",
                     "http://127.0.0.1:9999",
                     "--skip-daemon",
+                    "--skip-hermes-install-dry-run",
                     "--text",
                     "Stack smoke.",
                 ],


### PR DESCRIPTION
## Summary
- run `install_hermes_voice_config.py` as a default dry-run step in the aggregate Hermes stack verifier
- add `--skip-hermes-install-dry-run` / `SKIP_HERMES_INSTALL_DRY_RUN=1` for focused checks
- report `hermes_config_install=dry_run|skipped` in the final stack summary
- update docs to mention the one-command repair-path check

## Verification
- `python3 -m unittest tests.test_verify_local_hermes_voice_stack`
- `python3 -m unittest discover -s tests`
- `python3 -m py_compile scripts/install_hermes_voice_config.py scripts/macos_release_compare.py scripts/verify_cli_mcp_surface.py scripts/verify_hermes_voice_config.py scripts/verify_webrtc_sidecar_service.py tests/test_install_hermes_voice_config.py tests/test_install_webrtc_sidecar_service.py tests/test_macos_release_compare.py tests/test_verify_cli_mcp_surface.py tests/test_verify_hermes_voice_config.py tests/test_verify_local_hermes_voice_stack.py tests/test_verify_telegram_voice_contract.py tests/test_verify_webrtc_sidecar_service.py`
- `bash -n scripts/verify_local_hermes_voice_stack.sh scripts/verify_telegram_voice_contract.sh scripts/verify_whatsapp_voice_contract.sh scripts/verify_hermes_command_tts.sh scripts/install_webrtc_sidecar_service.sh`
- `git diff --check`
- live stack smoke against `/home/ubuntu/.local/bin/voice` and `/home/ubuntu/.hermes` passed with `hermes_config_install=dry_run` and `stack_status=0`
