### PR TITLE
Classify local stack verifier failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,9 @@ sidecar service. It requires the daemon and sidecar by default. For narrower che
 `scripts/verify_whatsapp_voice_contract.sh`,
 `scripts/verify_telegram_voice_contract.sh`, or
 `scripts/verify_webrtc_sidecar_service.py` directly.
+When a step fails, the aggregate verifier prints `failure_category=...` with
+values such as `voice_runtime`, `hermes_config`, `upstream_hermes`,
+`whatsapp_bridge_or_credentials`, or `webrtc_sidecar`.
 
 To include the categorized WhatsApp alpha report in the same command, add
 `--whatsapp-alpha-profile unattended`, `cached-receive`, `send`,

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -155,6 +155,9 @@ expected Hermes home, exports `WHATSAPP_CLOUD_CALLING_SIDECAR_URL`, and uses a
 The aggregate stack verifier also dry-runs `install_hermes_voice_config.py`
 against the active config, so one command now checks both config drift
 detection and the voice-owned repair path.
+If any step fails, it emits `failure_category=...` so automation can distinguish
+voice runtime, Hermes config/service, WhatsApp bridge or credential, inbound
+audio, and WebRTC sidecar failures.
 
 ## CLI Smoke Test
 

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -173,7 +173,47 @@ run_step() {
   shift
   echo
   echo "==> $label"
+  set +e
   "$@"
+  local status=$?
+  set -e
+  if [[ "$status" != "0" ]]; then
+    echo "error: local Hermes voice stack step failed: $label" >&2
+    echo "failure_category=$(step_failure_category "$label")" >&2
+    echo "failure_step=$label" >&2
+    echo "failure_status=$status" >&2
+    return "$status"
+  fi
+}
+
+step_failure_category() {
+  local label="$1"
+  case "$label" in
+    "Hermes voice-native config"|"Hermes voice config installer dry run")
+      echo "hermes_config"
+      ;;
+    "Hermes gateway voice stream service")
+      echo "upstream_hermes"
+      ;;
+    "Voice CLI and MCP daemon surfaces"|"Voice WhatsApp and streaming contract")
+      echo "voice_runtime"
+      ;;
+    "WhatsApp bridge identity and credential readiness")
+      echo "whatsapp_bridge_or_credentials"
+      ;;
+    "WhatsApp inbound cached audio STT smoke")
+      echo "whatsapp_inbound_audio"
+      ;;
+    "Voice WebRTC sidecar service"|"Full-duplex WebRTC media smoke")
+      echo "webrtc_sidecar"
+      ;;
+    "WhatsApp alpha readiness profile"*)
+      echo "whatsapp_alpha"
+      ;;
+    *)
+      echo "unknown"
+      ;;
+  esac
 }
 
 print_whatsapp_alpha_json_summary() {

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -34,6 +34,24 @@ def write_helper(path: Path, label: str, log_path: Path) -> None:
     )
 
 
+def write_failing_helper(path: Path, label: str, log_path: Path, status: int = 17) -> None:
+    write_executable(
+        path,
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            printf '{label}' >> {str(log_path)!r}
+            printf '\\0' >> {str(log_path)!r}
+            printf '%s\\0' "$@" >> {str(log_path)!r}
+            printf '\\n' >> {str(log_path)!r}
+            echo "failing {label}" >&2
+            exit {status}
+            """
+        ),
+    )
+
+
 def write_fake_python(path: Path, label: str, log_path: Path) -> None:
     write_executable(
         path,
@@ -192,6 +210,103 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 "--skip-systemd",
             ],
         )
+
+    def test_step_failure_reports_hermes_config_category(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            hermes = tmp_path / "verify_hermes.py"
+            install = tmp_path / "install_hermes.py"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            voice = tmp_path / "voice"
+            config = tmp_path / "config.yaml"
+
+            write_failing_helper(hermes, "hermes", log_path, status=17)
+            write_helper(install, "install", log_path)
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+            config.write_text("tts: {}\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--hermes-config",
+                    str(config),
+                    "--skip-hermes-gateway",
+                    "--skip-cli-mcp",
+                    "--skip-sidecar",
+                    "--skip-whatsapp-bridge",
+                    "--skip-daemon",
+                ],
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "HERMES_CONFIG_VERIFY_SCRIPT": str(hermes),
+                    "HERMES_CONFIG_INSTALL_SCRIPT": str(install),
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                },
+            )
+
+            entries = command_log_entries(log_path)
+
+        self.assertEqual(result.returncode, 17)
+        self.assertEqual([entry[0] for entry in entries], ["hermes"])
+        self.assertIn("error: local Hermes voice stack step failed: Hermes voice-native config", result.stderr)
+        self.assertIn("failure_category=hermes_config", result.stderr)
+        self.assertIn("failure_step=Hermes voice-native config", result.stderr)
+        self.assertIn("failure_status=17", result.stderr)
+        self.assertNotIn("ok: local Hermes voice stack verifier passed", result.stdout)
+
+    def test_step_failure_reports_bridge_or_credentials_category(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            bridge = tmp_path / "verify_whatsapp_bridge.py"
+            voice = tmp_path / "voice"
+
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_failing_helper(bridge, "bridge", log_path, status=23)
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--hermes-config",
+                    str(tmp_path / "missing.yaml"),
+                    "--skip-hermes-config",
+                    "--skip-hermes-gateway",
+                    "--skip-cli-mcp",
+                    "--skip-sidecar",
+                    "--skip-daemon",
+                ],
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "WHATSAPP_BRIDGE_VERIFY_SCRIPT": str(bridge),
+                },
+            )
+
+            entries = command_log_entries(log_path)
+
+        self.assertEqual(result.returncode, 23)
+        self.assertEqual([entry[0] for entry in entries], ["whatsapp", "bridge"])
+        self.assertIn(
+            "error: local Hermes voice stack step failed: "
+            "WhatsApp bridge identity and credential readiness",
+            result.stderr,
+        )
+        self.assertIn("failure_category=whatsapp_bridge_or_credentials", result.stderr)
+        self.assertIn("failure_step=WhatsApp bridge identity and credential readiness", result.stderr)
+        self.assertIn("failure_status=23", result.stderr)
+        self.assertNotIn("ok: local Hermes voice stack verifier passed", result.stdout)
 
     def test_skip_flags_disable_optional_release_checks(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- classify aggregate local stack verifier failures by subsystem
- print `failure_category`, `failure_step`, and `failure_status` when a verifier step fails
- document the new failure category output for automation and operator triage

## Verification
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_verify_local_hermes_voice_stack`
- `bash -n scripts/verify_local_hermes_voice_stack.sh`
- `git diff --check`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests`
- live stack smoke: `scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --skip-hermes-tts-smoke --whatsapp-alpha-profile cached-receive --whatsapp-alpha-wait-audio-cache-seconds 0.1 --expected-whatsapp-agent-number 13236478455 --expected-whatsapp-agent-name Quill`

Live stack result: `stack_status=0`. Remaining goal gates are unchanged: attended fresh WhatsApp voice-note receive is not verified, and WhatsApp Cloud/Calling credentials are still missing (`WHATSAPP_CLOUD_PHONE_NUMBER_ID`, `WHATSAPP_CLOUD_ACCESS_TOKEN`, `WHATSAPP_CLOUD_APP_SECRET`, `WHATSAPP_CLOUD_VERIFY_TOKEN`).

Refs #183
