### PR TITLE
Improve WhatsApp inbound cache watch evidence

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -292,6 +292,12 @@ scripts/verify_whatsapp_inbound_audio_cache.py \
   --run-stt
 ```
 
+This mode snapshots the current `aud_*` cache files by path, size, and mtime,
+then waits for a new or updated cache artifact. The JSON report includes
+baseline/final cache counts, sampled before/after file details, and the fresh
+file descriptors selected for STT. If the window expires, the failure reports
+the latest stale candidate or that the cache stayed empty.
+
 Cloud/Calling readiness requires these external Meta settings in addition to
 the local sidecar:
 

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -449,8 +449,12 @@ def cache_audio_evidence(checks: dict[str, Any]) -> dict[str, Any]:
         "kind": "audio_cache",
         "fresh": bool((fresh_watch.get("fresh_files") or [])),
         "fresh_count": fresh_watch.get("fresh_count"),
+        "baseline_count": fresh_watch.get("baseline_count"),
+        "final_count": fresh_watch.get("final_count"),
         "wait_seconds": fresh_watch.get("wait_seconds"),
+        "elapsed_seconds": fresh_watch.get("elapsed_seconds"),
         "drains_bridge_messages": bool(fresh_watch.get("drains_bridge_messages")),
+        "fresh_file_details": fresh_watch.get("fresh_file_details") or [],
         "selected_files_count": len(checks.get("selected_files") or []),
         "audio": [],
     }

--- a/scripts/verify_whatsapp_inbound_audio_cache.py
+++ b/scripts/verify_whatsapp_inbound_audio_cache.py
@@ -14,6 +14,9 @@ import time
 from typing import Any
 
 
+WATCH_FILE_SAMPLE_LIMIT = 5
+
+
 def repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
 
@@ -86,6 +89,40 @@ def audio_file_snapshot(paths: list[Path]) -> dict[Path, tuple[int, int]]:
     return snapshot
 
 
+def describe_audio_file(path: Path, *, now_epoch: float | None = None) -> dict[str, Any]:
+    description: dict[str, Any] = {
+        "path": str(path),
+        "name": path.name,
+        "exists": False,
+    }
+    try:
+        stat = path.stat()
+    except FileNotFoundError:
+        return description
+
+    description.update(
+        {
+            "exists": True,
+            "size_bytes": stat.st_size,
+            "mtime_epoch": stat.st_mtime,
+            "mtime_ns": stat.st_mtime_ns,
+        }
+    )
+    if now_epoch is not None:
+        description["age_seconds"] = round(max(0.0, now_epoch - stat.st_mtime), 3)
+    return description
+
+
+def describe_audio_files(
+    paths: list[Path],
+    *,
+    now_epoch: float | None = None,
+    limit: int | None = WATCH_FILE_SAMPLE_LIMIT,
+) -> list[dict[str, Any]]:
+    sampled = paths if limit is None else paths[:limit]
+    return [describe_audio_file(path, now_epoch=now_epoch) for path in sampled]
+
+
 def fresh_audio_files(
     paths: list[Path],
     *,
@@ -115,6 +152,26 @@ def wait_for_fresh_audio_files(
         discovered = discover_audio_files(audio_cache_dir)
         fresh = fresh_audio_files(discovered, baseline=baseline)
     return fresh, discovered
+
+
+def fresh_watch_failure_detail(fresh_watch: dict[str, Any]) -> str:
+    parts = [
+        f"baseline_count={fresh_watch.get('baseline_count')}",
+        f"final_count={fresh_watch.get('final_count')}",
+    ]
+    final_sample = fresh_watch.get("final_files_sample") or []
+    if final_sample:
+        latest = final_sample[0]
+        parts.append(f"latest_candidate={latest.get('name')}")
+        size = latest.get("size_bytes")
+        if size is not None:
+            parts.append(f"latest_size_bytes={size}")
+        age = latest.get("age_seconds")
+        if age is not None:
+            parts.append(f"latest_age_seconds={age}")
+    else:
+        parts.append("cache_empty=true")
+    return ", ".join(parts)
 
 
 def probe_audio(path: Path, *, timeout: float, skip_ffprobe: bool) -> tuple[dict[str, Any], list[str]]:
@@ -269,6 +326,9 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
     selected_files: list[Path]
     discovered = discover_audio_files(audio_cache_dir)
     baseline = audio_file_snapshot(discovered)
+    watch_started_epoch = time.time()
+    watch_started_monotonic = time.monotonic()
+    baseline_files = describe_audio_files(discovered, now_epoch=watch_started_epoch)
     fresh_files: list[Path] = []
 
     if args.wait_fresh_seconds > 0 and not failures:
@@ -277,6 +337,31 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
             baseline=baseline,
             wait_seconds=args.wait_fresh_seconds,
         )
+    watch_finished_epoch = time.time()
+    watch_elapsed_seconds = time.monotonic() - watch_started_monotonic
+    fresh_watch = {
+        "wait_seconds": args.wait_fresh_seconds,
+        "elapsed_seconds": round(watch_elapsed_seconds, 3),
+        "started_at_epoch": watch_started_epoch,
+        "completed_at_epoch": watch_finished_epoch,
+        "drains_bridge_messages": False,
+        "baseline_count": len(baseline),
+        "final_count": len(discovered),
+        "fresh_count": len(fresh_files),
+        "fresh_files": [str(path) for path in fresh_files],
+        "fresh_file_details": describe_audio_files(
+            fresh_files,
+            now_epoch=watch_finished_epoch,
+            limit=None,
+        ),
+        "baseline_files_sample": baseline_files,
+        "final_files_sample": describe_audio_files(
+            discovered,
+            now_epoch=watch_finished_epoch,
+        ),
+        "sample_limit": WATCH_FILE_SAMPLE_LIMIT,
+        "skipped": args.wait_fresh_seconds <= 0,
+    }
 
     if args.audio_file:
         selected_files = [path.expanduser().resolve() for path in args.audio_file]
@@ -292,7 +377,8 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         if args.wait_fresh_seconds > 0 and args.require_fresh_audio:
             message = (
                 "no fresh bridge-downloaded inbound audio files found in "
-                f"{audio_cache_dir} during {args.wait_fresh_seconds}s watch"
+                f"{audio_cache_dir} during {args.wait_fresh_seconds}s watch "
+                f"({fresh_watch_failure_detail(fresh_watch)})"
             )
         else:
             message = f"no bridge-downloaded inbound audio files found in {audio_cache_dir}"
@@ -307,14 +393,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         "voice_bin": voice_bin,
         "discovered_count": len(discovered),
         "selected_files": [str(path) for path in selected_files],
-        "fresh_watch": {
-            "wait_seconds": args.wait_fresh_seconds,
-            "drains_bridge_messages": False,
-            "baseline_count": len(baseline),
-            "fresh_count": len(fresh_files),
-            "fresh_files": [str(path) for path in fresh_files],
-            "skipped": args.wait_fresh_seconds <= 0,
-        },
+        "fresh_watch": fresh_watch,
         "audio": [],
     }
 
@@ -394,9 +473,18 @@ def human_summary(result: dict[str, Any]) -> None:
         print(
             "fresh_watch="
             f"fresh_count={fresh.get('fresh_count')} "
+            f"baseline_count={fresh.get('baseline_count')} "
+            f"final_count={fresh.get('final_count')} "
             f"wait_seconds={fresh.get('wait_seconds')} "
+            f"elapsed_seconds={fresh.get('elapsed_seconds')} "
             f"drains_messages={fresh.get('drains_bridge_messages')}"
         )
+        for index, item in enumerate(fresh.get("fresh_file_details") or [], start=1):
+            print(
+                f"fresh_file[{index}]={item.get('path')} "
+                f"size={item.get('size_bytes')} "
+                f"age_seconds={item.get('age_seconds')}"
+            )
     for index, audio in enumerate(checks["audio"], start=1):
         probe = audio.get("probe") or {}
         stream = ((probe.get("ffprobe") or {}).get("stream") or {})

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -822,7 +822,18 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
                 "fresh_watch": {
                     "drains_bridge_messages": False,
                     "fresh_files": ["/tmp/aud_fresh.ogg"],
+                    "fresh_file_details": [
+                        {
+                            "path": "/tmp/aud_fresh.ogg",
+                            "name": "aud_fresh.ogg",
+                            "size_bytes": 12345,
+                            "age_seconds": 0.1,
+                        }
+                    ],
                     "fresh_count": 1,
+                    "baseline_count": 0,
+                    "final_count": 1,
+                    "elapsed_seconds": 0.2,
                 }
             },
             "failures": [],
@@ -859,6 +870,10 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertTrue(evidence["fresh"])
         self.assertFalse(evidence["drains_bridge_messages"])
         self.assertEqual(evidence["fresh_count"], 1)
+        self.assertEqual(evidence["baseline_count"], 0)
+        self.assertEqual(evidence["final_count"], 1)
+        self.assertEqual(evidence["elapsed_seconds"], 0.2)
+        self.assertEqual(evidence["fresh_file_details"][0]["name"], "aud_fresh.ogg")
         self.assertEqual(evidence["audio"][0]["name"], "aud_fresh.ogg")
         self.assertEqual(evidence["audio"][0]["codec"], "opus")
         self.assertEqual(evidence["audio"][0]["stt"]["frames"], 210)

--- a/tests/test_verify_whatsapp_inbound_audio_cache.py
+++ b/tests/test_verify_whatsapp_inbound_audio_cache.py
@@ -148,7 +148,11 @@ class WhatsAppInboundAudioCacheVerifierTests(unittest.TestCase):
         self.assertTrue(result["success"], result["failures"])
         fresh = result["checks"]["fresh_watch"]
         self.assertEqual(fresh["fresh_count"], 1)
+        self.assertEqual(fresh["baseline_count"], 0)
+        self.assertEqual(fresh["final_count"], 1)
         self.assertFalse(fresh["drains_bridge_messages"])
+        self.assertEqual(fresh["fresh_file_details"][0]["name"], "aud_fresh.ogg")
+        self.assertEqual(fresh["final_files_sample"][0]["name"], "aud_fresh.ogg")
         self.assertTrue(result["checks"]["selected_files"][0].endswith("aud_fresh.ogg"))
         terminal = result["checks"]["audio"][0]["stt"]["terminal_event"]
         self.assertEqual(terminal["event"], "stt.transcribed")
@@ -170,8 +174,35 @@ class WhatsAppInboundAudioCacheVerifierTests(unittest.TestCase):
         self.assertTrue(result["success"], result["failures"])
         fresh = result["checks"]["fresh_watch"]
         self.assertEqual(fresh["fresh_count"], 0)
+        self.assertEqual(fresh["baseline_count"], 1)
+        self.assertEqual(fresh["final_count"], 1)
+        self.assertEqual(fresh["baseline_files_sample"][0]["name"], "aud_existing.ogg")
+        self.assertEqual(fresh["final_files_sample"][0]["name"], "aud_existing.ogg")
         self.assertFalse(fresh["drains_bridge_messages"])
         self.assertTrue(result["checks"]["selected_files"][0].endswith("aud_existing.ogg"))
+
+    def test_require_fresh_audio_failure_reports_stale_cache_context(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(
+                tmp_path,
+                wait_fresh_seconds=0.01,
+                require_fresh_audio=True,
+            )
+            write_audio(args.hermes_home / "audio_cache" / "aud_stale.ogg")
+
+            result = self.script.verify(args)
+
+        self.assertFalse(result["success"])
+        message = "\n".join(result["failures"])
+        self.assertIn("no fresh bridge-downloaded inbound audio files", message)
+        self.assertIn("baseline_count=1", message)
+        self.assertIn("final_count=1", message)
+        self.assertIn("latest_candidate=aud_stale.ogg", message)
+        fresh = result["checks"]["fresh_watch"]
+        self.assertEqual(fresh["fresh_count"], 0)
+        self.assertEqual(fresh["baseline_files_sample"][0]["name"], "aud_stale.ogg")
+        self.assertEqual(fresh["final_files_sample"][0]["name"], "aud_stale.ogg")
 
     def test_require_fresh_audio_requires_wait_window(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- add before/after cache watch metadata to the WhatsApp inbound audio cache verifier
- improve require-fresh failures with baseline/final counts and the latest stale candidate
- expose fresh cache evidence in alpha readiness reports and document the attended cache watch behavior

Refs #183

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_verify_whatsapp_inbound_audio_cache
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_verify_whatsapp_alpha_readiness
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile scripts/verify_whatsapp_inbound_audio_cache.py scripts/verify_whatsapp_alpha_readiness.py
- git diff --check