### PR TITLE
Add Telegram option to local stack verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,9 +429,12 @@ sidecar service. It requires the daemon and sidecar by default. For narrower che
 `scripts/verify_whatsapp_voice_contract.sh`,
 `scripts/verify_telegram_voice_contract.sh`, or
 `scripts/verify_webrtc_sidecar_service.py` directly.
+Add `--run-telegram-voice-contract` to include Telegram bot voice-message
+preflight output in the aggregate gate; add `--require-telegram-credentials`
+when the local Telegram bot token should already be configured.
 When a step fails, the aggregate verifier prints `failure_category=...` with
 values such as `voice_runtime`, `hermes_config`, `upstream_hermes`,
-`whatsapp_bridge_or_credentials`, or `webrtc_sidecar`.
+`whatsapp_bridge_or_credentials`, `telegram_setup`, or `webrtc_sidecar`.
 
 To include the categorized WhatsApp alpha report in the same command, add
 `--whatsapp-alpha-profile unattended`, `cached-receive`, `send`,

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -190,6 +190,10 @@ VOICE_BIN=/path/to/voice scripts/verify_telegram_voice_contract.sh
 VOICE_BIN=/path/to/voice scripts/verify_telegram_voice_contract.sh --require-telegram-credentials
 ```
 
+The aggregate local stack gate can include the same check with
+`--run-telegram-voice-contract`; add `--require-telegram-credentials` when the
+configured Hermes env file should already contain `TELEGRAM_BOT_TOKEN`.
+
 Those verifiers check `voice stream-contract` against the checked-in sidecar
 contract, prove `voice say --format ogg-opus` and `.ogg` extension inference
 write real mono 48 kHz Ogg/Opus, verify misleading `.wav`/`ogg-opus`

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -22,6 +22,9 @@ skip_cli_mcp="${SKIP_CLI_MCP:-0}"
 skip_daemon="${SKIP_DAEMON:-0}"
 skip_stt_smoke="${SKIP_STT_SMOKE:-0}"
 run_whatsapp_inbound_cache_smoke="${RUN_WHATSAPP_INBOUND_CACHE_SMOKE:-0}"
+run_telegram_voice_contract="${RUN_TELEGRAM_VOICE_CONTRACT:-0}"
+telegram_env_file="${TELEGRAM_ENV_FILE:-${HERMES_ENV:-}}"
+require_telegram_credentials="${REQUIRE_TELEGRAM_CREDENTIALS:-0}"
 whatsapp_alpha_profile="${WHATSAPP_ALPHA_PROFILE:-}"
 whatsapp_alpha_text="${WHATSAPP_ALPHA_TEXT:-}"
 whatsapp_alpha_voice_note_chat_id="${WHATSAPP_ALPHA_VOICE_NOTE_CHAT_ID:-}"
@@ -52,6 +55,7 @@ whatsapp_contract_verify_script="${WHATSAPP_CONTRACT_VERIFY_SCRIPT:-$repo_root/s
 whatsapp_bridge_verify_script="${WHATSAPP_BRIDGE_VERIFY_SCRIPT:-$repo_root/scripts/verify_whatsapp_bridge_runtime.py}"
 whatsapp_inbound_cache_verify_script="${WHATSAPP_INBOUND_CACHE_VERIFY_SCRIPT:-$repo_root/scripts/verify_whatsapp_inbound_audio_cache.py}"
 whatsapp_alpha_readiness_script="${WHATSAPP_ALPHA_READINESS_SCRIPT:-$repo_root/scripts/verify_whatsapp_alpha_readiness.py}"
+telegram_contract_verify_script="${TELEGRAM_CONTRACT_VERIFY_SCRIPT:-$repo_root/scripts/verify_telegram_voice_contract.sh}"
 sidecar_service_verify_script="${SIDECAR_SERVICE_VERIFY_SCRIPT:-$repo_root/scripts/verify_webrtc_sidecar_service.py}"
 webrtc_loopback_smoke_script="${WEBRTC_LOOPBACK_SMOKE_SCRIPT:-$repo_root/examples/webrtc-sidecar/full_duplex_loopback_smoke.py}"
 
@@ -100,6 +104,11 @@ Options:
                                credentials are configured
   --run-whatsapp-inbound-cache-smoke
                                transcribe a bridge-downloaded aud_* file from the audio cache
+  --run-telegram-voice-contract
+                               run the Telegram bot voice-message preflight
+  --telegram-env-file PATH     Hermes env file with Telegram settings
+  --require-telegram-credentials
+                               fail when TELEGRAM_BOT_TOKEN is missing from the Telegram env file
   --whatsapp-alpha-profile PROFILE
                                run categorized alpha readiness profile:
                                unattended, cached-receive, send,
@@ -135,6 +144,8 @@ Environment aliases:
   WHATSAPP_ALPHA_TEXT, WHATSAPP_ALPHA_VOICE_NOTE_CHAT_ID
   WHATSAPP_ALPHA_WAIT_AUDIO_CACHE_SECONDS, WHATSAPP_ALPHA_WAIT_INBOUND_SECONDS
   WHATSAPP_ALPHA_JSON_OUTPUT
+  RUN_TELEGRAM_VOICE_CONTRACT=1, TELEGRAM_ENV_FILE, HERMES_ENV
+  REQUIRE_TELEGRAM_CREDENTIALS=1
   VOICE_WEBRTC_PYTHON, VOICE_WEBRTC_TIMEOUT
 EOF
 }
@@ -203,6 +214,9 @@ step_failure_category() {
       ;;
     "WhatsApp inbound cached audio STT smoke")
       echo "whatsapp_inbound_audio"
+      ;;
+    "Telegram voice contract")
+      echo "telegram_setup"
       ;;
     "Voice WebRTC sidecar service"|"Full-duplex WebRTC media smoke")
       echo "webrtc_sidecar"
@@ -442,6 +456,19 @@ while [[ $# -gt 0 ]]; do
       run_whatsapp_inbound_cache_smoke=1
       shift
       ;;
+    --run-telegram-voice-contract)
+      run_telegram_voice_contract=1
+      shift
+      ;;
+    --telegram-env-file)
+      [[ $# -ge 2 ]] || fail "--telegram-env-file requires a path"
+      telegram_env_file="$2"
+      shift 2
+      ;;
+    --require-telegram-credentials)
+      require_telegram_credentials=1
+      shift
+      ;;
     --whatsapp-alpha-profile)
       [[ $# -ge 2 ]] || fail "--whatsapp-alpha-profile requires a profile"
       whatsapp_alpha_profile="$2"
@@ -530,6 +557,9 @@ if [[ "$skip_whatsapp_bridge" != "1" ]]; then
 fi
 if [[ "$run_whatsapp_inbound_cache_smoke" == "1" ]]; then
   require_executable "$whatsapp_inbound_cache_verify_script" "WhatsApp inbound audio cache verifier"
+fi
+if [[ "$run_telegram_voice_contract" == "1" ]]; then
+  require_executable "$telegram_contract_verify_script" "Telegram voice contract verifier"
 fi
 if [[ -n "$whatsapp_alpha_profile" ]]; then
   require_executable "$whatsapp_alpha_readiness_script" "WhatsApp alpha readiness verifier"
@@ -630,6 +660,38 @@ else
   fi
 fi
 run_step "Voice WhatsApp and streaming contract" "${whatsapp_args[@]}"
+
+if [[ "$run_telegram_voice_contract" == "1" ]]; then
+  telegram_args=(
+    "$telegram_contract_verify_script"
+    --voice-bin "$voice_bin"
+    --text "$text"
+    --hermes-config "$hermes_config"
+  )
+  if [[ -n "$telegram_env_file" ]]; then
+    telegram_args+=(--hermes-env "$telegram_env_file")
+  fi
+  if [[ "$skip_hermes_config" == "1" ]]; then
+    telegram_args+=(--skip-hermes-config)
+  elif [[ "$skip_hermes_tts_smoke" == "1" ]]; then
+    telegram_args+=(--skip-hermes-tts-smoke)
+  fi
+  if [[ "$require_telegram_credentials" == "1" ]]; then
+    telegram_args+=(--require-telegram-credentials)
+  fi
+  if [[ "$skip_daemon" == "1" ]]; then
+    telegram_args+=(--skip-daemon)
+  else
+    telegram_args+=(--require-daemon)
+    if [[ "$skip_stt_smoke" != "1" ]]; then
+      telegram_args+=(--run-stt-smoke)
+    fi
+  fi
+  run_step "Telegram voice contract" "${telegram_args[@]}"
+  telegram_voice_contract_status="checked"
+else
+  telegram_voice_contract_status="skipped"
+fi
 
 if [[ "$skip_whatsapp_bridge" != "1" ]]; then
   whatsapp_bridge_args=(
@@ -821,6 +883,7 @@ echo "hermes_config_install=$hermes_install_status"
 echo "hermes_gateway=$hermes_gateway_status"
 echo "cli_mcp=$cli_mcp_status"
 echo "whatsapp_contract=checked"
+echo "telegram_voice_contract=$telegram_voice_contract_status"
 echo "whatsapp_bridge=$whatsapp_bridge_status"
 echo "whatsapp_inbound_cache=$whatsapp_inbound_cache_status"
 echo "whatsapp_alpha=$whatsapp_alpha_status"

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -138,6 +138,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn("hermes_gateway=skipped", result.stdout)
         self.assertIn("cli_mcp=checked", result.stdout)
         self.assertIn("whatsapp_bridge=checked", result.stdout)
+        self.assertIn("telegram_voice_contract=skipped", result.stdout)
         self.assertIn("whatsapp_inbound_cache=skipped", result.stdout)
         self.assertIn("whatsapp_alpha=skipped", result.stdout)
         self.assertIn("webrtc_loopback=skipped", result.stdout)
@@ -362,6 +363,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn("hermes_config_install=skipped", result.stdout)
         self.assertIn("hermes_gateway=skipped", result.stdout)
         self.assertIn("whatsapp_bridge=skipped", result.stdout)
+        self.assertIn("telegram_voice_contract=skipped", result.stdout)
         self.assertIn("whatsapp_inbound_cache=skipped", result.stdout)
         self.assertIn("whatsapp_alpha=skipped", result.stdout)
         self.assertEqual([entry[0] for entry in entries], ["hermes", "cli_mcp", "whatsapp"])
@@ -533,6 +535,123 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 str(audio_cache),
             ],
         )
+
+    def test_telegram_voice_contract_runs_when_requested(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            telegram = tmp_path / "verify_telegram.sh"
+            voice = tmp_path / "voice"
+            config = tmp_path / "config.yaml"
+            env_file = tmp_path / ".env"
+
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_helper(telegram, "telegram", log_path)
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+            config.write_text("tts: {}\n", encoding="utf-8")
+            env_file.write_text("TELEGRAM_BOT_TOKEN=123:abc\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--hermes-config",
+                    str(config),
+                    "--skip-hermes-config",
+                    "--skip-hermes-gateway",
+                    "--skip-cli-mcp",
+                    "--skip-sidecar",
+                    "--skip-daemon",
+                    "--skip-whatsapp-bridge",
+                    "--run-telegram-voice-contract",
+                    "--telegram-env-file",
+                    str(env_file),
+                    "--require-telegram-credentials",
+                    "--text",
+                    "Telegram stack smoke.",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "TELEGRAM_CONTRACT_VERIFY_SCRIPT": str(telegram),
+                },
+            )
+
+            entries = command_log_entries(log_path)
+
+        self.assertIn("telegram_voice_contract=checked", result.stdout)
+        self.assertEqual([entry[0] for entry in entries], ["whatsapp", "telegram"])
+        self.assertEqual(
+            entries[1],
+            [
+                "telegram",
+                "--voice-bin",
+                str(voice),
+                "--text",
+                "Telegram stack smoke.",
+                "--hermes-config",
+                str(config),
+                "--hermes-env",
+                str(env_file),
+                "--skip-hermes-config",
+                "--require-telegram-credentials",
+                "--skip-daemon",
+            ],
+        )
+
+    def test_step_failure_reports_telegram_setup_category(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            telegram = tmp_path / "verify_telegram.sh"
+            voice = tmp_path / "voice"
+
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_failing_helper(telegram, "telegram", log_path, status=31)
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--hermes-config",
+                    str(tmp_path / "missing.yaml"),
+                    "--skip-hermes-config",
+                    "--skip-hermes-gateway",
+                    "--skip-cli-mcp",
+                    "--skip-sidecar",
+                    "--skip-daemon",
+                    "--skip-whatsapp-bridge",
+                    "--run-telegram-voice-contract",
+                ],
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "TELEGRAM_CONTRACT_VERIFY_SCRIPT": str(telegram),
+                },
+            )
+
+            entries = command_log_entries(log_path)
+
+        self.assertEqual(result.returncode, 31)
+        self.assertEqual([entry[0] for entry in entries], ["whatsapp", "telegram"])
+        self.assertIn(
+            "error: local Hermes voice stack step failed: Telegram voice contract",
+            result.stderr,
+        )
+        self.assertIn("failure_category=telegram_setup", result.stderr)
+        self.assertIn("failure_step=Telegram voice contract", result.stderr)
+        self.assertIn("failure_status=31", result.stderr)
+        self.assertNotIn("ok: local Hermes voice stack verifier passed", result.stdout)
 
     def test_whatsapp_alpha_profile_runs_when_requested(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- add an opt-in Telegram bot voice-message preflight to the aggregate local Hermes voice stack verifier
- support Telegram env-file and required-credentials flags in the stack gate
- report Telegram failures as failure_category=telegram_setup and document the aggregate flag

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_verify_local_hermes_voice_stack
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests
- bash -n scripts/verify_local_hermes_voice_stack.sh scripts/verify_telegram_voice_contract.sh
- git diff --check