### PR TITLE
Make complete alpha handoff require Cloud checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,10 +469,11 @@ alpha output prints `whatsapp_cloud_setup`, `whatsapp_cloud_verify_command`,
 separated from local daemon, bridge, and Hermes failures. It also prints the
 resolved Cloud webhook bind defaults and malformed webhook keys, so strict
 Cloud/Calling failures can distinguish missing credentials from invalid
-`WHATSAPP_CLOUD_WEBHOOK_*` settings. After real Cloud credentials are present,
-add `--check-whatsapp-cloud-api` to make an authenticated Graph API
-phone-number request and prove the configured phone-number node is reachable
-without printing token or phone-number values.
+`WHATSAPP_CLOUD_WEBHOOK_*` settings. The generated complete-alpha handoff
+includes `--require-whatsapp-cloud`, `--require-whatsapp-calling`, and
+`--check-whatsapp-cloud-api`, so after real Cloud credentials are present it
+also makes an authenticated Graph API phone-number request without printing
+token or phone-number values.
 Use `--whatsapp-alpha-json-output` with any alpha profile when another local
 agent should consume the same structured `readiness_summary.next_actions`
 without rerunning the full stack gate. The stack verifier also echoes compact

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -184,6 +184,9 @@ and Calling setup are all expected to pass:
 scripts/verify_whatsapp_alpha_readiness.py \
   --hermes-home ~/.hermes \
   --profile attended-cache-receive \
+  --require-whatsapp-cloud \
+  --require-whatsapp-calling \
+  --check-whatsapp-cloud-api \
   --require-complete
 ```
 

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -732,6 +732,9 @@ def calling_setup_handoff(
         str(hermes_home),
         "--profile",
         "attended-cache-receive",
+        "--require-whatsapp-cloud",
+        "--require-whatsapp-calling",
+        "--check-whatsapp-cloud-api",
         "--require-complete",
     ]
     steps = [] if ready else [

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -977,6 +977,9 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                               "/home/ubuntu/.hermes",
                               "--profile",
                               "attended-cache-receive",
+                              "--require-whatsapp-cloud",
+                              "--require-whatsapp-calling",
+                              "--check-whatsapp-cloud-api",
                               "--require-complete"
                             ]
                           }}
@@ -1075,6 +1078,8 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             "whatsapp_alpha_json_calling_complete_command="
             "scripts/verify_whatsapp_alpha_readiness.py --hermes-home "
             "/home/ubuntu/.hermes --profile attended-cache-receive "
+            "--require-whatsapp-cloud --require-whatsapp-calling "
+            "--check-whatsapp-cloud-api "
             "--require-complete",
             result.stdout,
         )
@@ -1257,6 +1262,9 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                               "/home/ubuntu/.hermes",
                               "--profile",
                               "attended-cache-receive",
+                              "--require-whatsapp-cloud",
+                              "--require-whatsapp-calling",
+                              "--check-whatsapp-cloud-api",
                               "--require-complete"
                             ]
                           }}

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -356,7 +356,11 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             "--check-whatsapp-cloud-api",
             calling_handoff["verify_command"],
         )
-        self.assertIn("--require-complete", calling_handoff["complete_verification_command"])
+        complete_command = calling_handoff["complete_verification_command"]
+        self.assertIn("--require-whatsapp-cloud", complete_command)
+        self.assertIn("--require-whatsapp-calling", complete_command)
+        self.assertIn("--check-whatsapp-cloud-api", complete_command)
+        self.assertIn("--require-complete", complete_command)
         self.assertEqual(len(calling_handoff["steps"]), 5)
         summary = payload["readiness_summary"]
         self.assertEqual(summary["status"], "local_ready_pending_gates")
@@ -419,6 +423,14 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         )
         self.assertIn(
             "--require-complete",
+            meta_action["complete_verification_command"],
+        )
+        self.assertIn(
+            "--require-whatsapp-calling",
+            meta_action["complete_verification_command"],
+        )
+        self.assertIn(
+            "--check-whatsapp-cloud-api",
             meta_action["complete_verification_command"],
         )
 
@@ -616,6 +628,9 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             "whatsapp_calling_complete_command=scripts/verify_whatsapp_alpha_readiness.py",
             result.stdout,
         )
+        self.assertIn("--require-whatsapp-cloud", result.stdout)
+        self.assertIn("--require-whatsapp-calling", result.stdout)
+        self.assertIn("--check-whatsapp-cloud-api", result.stdout)
         self.assertIn("--require-complete", result.stdout)
         self.assertIn(
             "whatsapp_calling_step[1]=Complete WhatsApp Cloud setup first",


### PR DESCRIPTION
## Summary
- include --require-whatsapp-cloud, --require-whatsapp-calling, and --check-whatsapp-cloud-api in the generated complete-alpha handoff command
- update stack JSON summary fixtures and docs so copied final verification commands are strict by default

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_verify_whatsapp_alpha_readiness
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_verify_local_hermes_voice_stack
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_alpha_readiness.py tests/test_verify_local_hermes_voice_stack.py
- git diff --check

## Live local stack evidence
- Current main cached-receive stack passed against /home/ubuntu/.local/bin/voice and /home/ubuntu/.hermes with daemon streams, stream-transcribe, Hermes gateway, WhatsApp bridge identity, WebRTC sidecar, and Telegram preflight checked.
- Remaining gates are still attended fresh WhatsApp receive and external Meta Cloud/Calling credentials.