### PR TITLE
Add attended WhatsApp cache watch launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,19 @@ attended wait with `--whatsapp-alpha-wait-audio-cache-seconds` /
 `--whatsapp-alpha-wait-inbound-seconds`. The generated attended receive
 handoff commands include explicit 60-second wait windows by default.
 
+For a longer unattended receive window, start the non-draining cache watcher as
+a transient user service:
+
+```bash
+scripts/start_whatsapp_attended_cache_watch.py \
+  --voice-bin "$(command -v voice)" \
+  --hermes-home ~/.hermes \
+  --hermes-config ~/.hermes/config.yaml
+```
+
+It prints the unit name plus JSON/log artifact paths, then waits for a fresh
+`aud_*` file without polling the bridge `/messages` queue.
+
 To fail unless every alpha gate is complete, include the strict completion flag:
 
 ```bash

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -301,6 +301,23 @@ baseline/final cache counts, sampled before/after file details, and the fresh
 file descriptors selected for STT. If the window expires, the failure reports
 the latest stale candidate or that the cache stayed empty.
 
+For an unattended operator window, start the same non-draining profile as a
+transient user service and save evidence artifacts under `/tmp`:
+
+```bash
+scripts/start_whatsapp_attended_cache_watch.py \
+  --voice-bin "$(command -v voice)" \
+  --hermes-home ~/.hermes \
+  --hermes-config ~/.hermes/config.yaml \
+  --expected-agent-number 13236478455 \
+  --expected-agent-name Quill
+```
+
+The launcher prints the transient unit name, JSON artifact path, log path, and
+copyable `systemctl --user status ...` / `journalctl --user -u ... -f`
+commands. It runs `attended-cache-receive`, sends the voice-note prompt, then
+watches for a fresh `aud_*` cache file without polling `/messages`.
+
 Cloud/Calling readiness requires these external Meta settings in addition to
 the local sidecar:
 

--- a/scripts/start_whatsapp_attended_cache_watch.py
+++ b/scripts/start_whatsapp_attended_cache_watch.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Start a long non-draining WhatsApp attended receive cache watch."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+
+DEFAULT_WAIT_SECONDS = 6 * 60 * 60
+DEFAULT_UNIT_PREFIX = "voice-whatsapp-attended-cache-watch"
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def default_hermes_home() -> Path:
+    return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+
+
+def default_hermes_config() -> Path:
+    env_value = os.environ.get("HERMES_CONFIG")
+    if env_value:
+        return Path(env_value)
+    return default_hermes_home() / "config.yaml"
+
+
+def default_voice_bin() -> str:
+    env_value = os.environ.get("VOICE_BIN")
+    if env_value:
+        return env_value
+    release_bin = repo_root() / "target" / "release" / "voice"
+    if release_bin.is_file() and os.access(release_bin, os.X_OK):
+        return str(release_bin)
+    found = shutil.which("voice")
+    return found or "voice"
+
+
+def utc_timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def build_alpha_command(args: argparse.Namespace) -> list[str]:
+    command = [
+        str(args.alpha_script),
+        "--voice-bin",
+        str(args.voice_bin),
+        "--hermes-home",
+        str(args.hermes_home),
+        "--hermes-config",
+        str(args.hermes_config),
+        "--profile",
+        "attended-cache-receive",
+        "--wait-audio-cache-seconds",
+        str(float(args.wait_seconds)),
+    ]
+    if args.expected_agent_number:
+        command.extend(["--expected-agent-number", args.expected_agent_number])
+    if args.expected_agent_name:
+        command.extend(["--expected-agent-name", args.expected_agent_name])
+    command.append("--json")
+    return command
+
+
+def build_watch(args: argparse.Namespace) -> dict[str, Any]:
+    timestamp = args.timestamp or utc_timestamp()
+    unit = f"{args.unit_prefix}-{timestamp}"
+    service = unit if unit.endswith(".service") else f"{unit}.service"
+    output_dir = args.output_dir.expanduser().resolve()
+    json_path = output_dir / f"{unit}.json"
+    log_path = output_dir / f"{unit}.log"
+    alpha_command = build_alpha_command(args)
+    inner_command = (
+        f"cd {shlex.quote(str(args.repo_root))} && "
+        f"{shlex.join(alpha_command)} > {shlex.quote(str(json_path))} "
+        f"2> {shlex.quote(str(log_path))}"
+    )
+    systemd_command = [
+        str(args.systemd_run_bin),
+        "--user",
+        f"--unit={unit}",
+        "--collect",
+        "/bin/bash",
+        "-lc",
+        inner_command,
+    ]
+    return {
+        "unit": unit,
+        "service": service,
+        "json_path": str(json_path),
+        "log_path": str(log_path),
+        "alpha_command": alpha_command,
+        "systemd_command": systemd_command,
+        "status_command": ["systemctl", "--user", "status", service],
+        "journal_command": ["journalctl", "--user", "-u", service, "-f"],
+    }
+
+
+def validate_args(args: argparse.Namespace) -> list[str]:
+    failures: list[str] = []
+    if args.wait_seconds <= 0:
+        failures.append("--wait-seconds must be positive")
+    if not args.unit_prefix:
+        failures.append("--unit-prefix must not be empty")
+    if "/" in args.unit_prefix:
+        failures.append("--unit-prefix must not contain '/'")
+    return failures
+
+
+def print_human(result: dict[str, Any]) -> None:
+    if result.get("dry_run"):
+        print("ok: WhatsApp attended cache watch dry run")
+    else:
+        print("ok: WhatsApp attended cache watch started")
+    print(f"unit={result['unit']}")
+    print(f"service={result['service']}")
+    print(f"json={result['json_path']}")
+    print(f"log={result['log_path']}")
+    print(f"wait_seconds={result['wait_seconds']}")
+    print(f"alpha_command={shlex.join(result['alpha_command'])}")
+    print(f"systemd_command={shlex.join(result['systemd_command'])}")
+    print(f"status_command={shlex.join(result['status_command'])}")
+    print(f"journal_command={shlex.join(result['journal_command'])}")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--voice-bin", default=default_voice_bin())
+    parser.add_argument("--hermes-home", type=Path, default=default_hermes_home())
+    parser.add_argument("--hermes-config", type=Path, default=default_hermes_config())
+    parser.add_argument("--wait-seconds", type=float, default=DEFAULT_WAIT_SECONDS)
+    parser.add_argument("--expected-agent-number", default=os.environ.get("WHATSAPP_AGENT_NUMBER"))
+    parser.add_argument("--expected-agent-name", default=os.environ.get("WHATSAPP_AGENT_NAME"))
+    parser.add_argument("--output-dir", type=Path, default=Path("/tmp"))
+    parser.add_argument("--unit-prefix", default=DEFAULT_UNIT_PREFIX)
+    parser.add_argument("--timestamp", default=None)
+    parser.add_argument("--repo-root", type=Path, default=repo_root())
+    parser.add_argument(
+        "--alpha-script",
+        type=Path,
+        default=repo_root() / "scripts" / "verify_whatsapp_alpha_readiness.py",
+    )
+    parser.add_argument("--systemd-run-bin", default=os.environ.get("SYSTEMD_RUN_BIN", "systemd-run"))
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    args.hermes_home = args.hermes_home.expanduser().resolve()
+    args.hermes_config = args.hermes_config.expanduser().resolve()
+    args.output_dir = args.output_dir.expanduser().resolve()
+    args.repo_root = args.repo_root.expanduser().resolve()
+    args.alpha_script = args.alpha_script.expanduser().resolve()
+
+    failures = validate_args(args)
+    if failures:
+        for failure in failures:
+            print(f"error: {failure}", file=sys.stderr)
+        return 2
+
+    watch = build_watch(args)
+    result = {
+        **watch,
+        "dry_run": args.dry_run,
+        "wait_seconds": args.wait_seconds,
+        "returncode": 0,
+    }
+    if not args.dry_run:
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        completed = subprocess.run(
+            watch["systemd_command"],
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        result["returncode"] = completed.returncode
+        result["stdout"] = completed.stdout.strip()
+        result["stderr"] = completed.stderr.strip()
+        if completed.returncode != 0:
+            if args.json:
+                print(json.dumps(result, indent=2, sort_keys=True))
+            else:
+                print_human(result)
+                if completed.stderr.strip():
+                    print(completed.stderr.strip(), file=sys.stderr)
+            return completed.returncode
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print_human(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_start_whatsapp_attended_cache_watch.py
+++ b/tests/test_start_whatsapp_attended_cache_watch.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import json
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "start_whatsapp_attended_cache_watch.py"
+
+
+def write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def command_log_entries(log_path: Path) -> list[list[str]]:
+    entries: list[list[str]] = []
+    for line in log_path.read_bytes().splitlines():
+        if not line:
+            continue
+        entries.append(line.decode("utf-8").split("\0")[:-1])
+    return entries
+
+
+class WhatsAppAttendedCacheWatchLauncherTests(unittest.TestCase):
+    def test_dry_run_reports_repeatable_unit_and_commands(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--dry-run",
+                    "--json",
+                    "--timestamp",
+                    "20260614T225118Z",
+                    "--output-dir",
+                    str(tmp_path),
+                    "--voice-bin",
+                    "/opt/voice/bin/voice",
+                    "--hermes-home",
+                    str(tmp_path / "hermes"),
+                    "--hermes-config",
+                    str(tmp_path / "hermes" / "config.yaml"),
+                    "--wait-seconds",
+                    "120",
+                    "--expected-agent-number",
+                    "13236478455",
+                    "--expected-agent-name",
+                    "Quill",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+        payload = json.loads(result.stdout)
+        self.assertTrue(payload["dry_run"])
+        self.assertEqual(
+            payload["unit"],
+            "voice-whatsapp-attended-cache-watch-20260614T225118Z",
+        )
+        self.assertTrue(payload["json_path"].endswith(".json"))
+        self.assertTrue(payload["log_path"].endswith(".log"))
+        alpha = payload["alpha_command"]
+        self.assertIn("--profile", alpha)
+        self.assertIn("attended-cache-receive", alpha)
+        self.assertIn("--wait-audio-cache-seconds", alpha)
+        self.assertIn("120.0", alpha)
+        self.assertIn("--expected-agent-number", alpha)
+        self.assertIn("13236478455", alpha)
+        systemd = payload["systemd_command"]
+        self.assertIn("--collect", systemd)
+        self.assertIn(
+            "--unit=voice-whatsapp-attended-cache-watch-20260614T225118Z",
+            systemd,
+        )
+        self.assertIn("verify_whatsapp_alpha_readiness.py", systemd[-1])
+        self.assertIn(payload["json_path"], systemd[-1])
+        self.assertIn(payload["log_path"], systemd[-1])
+
+    def test_start_invokes_systemd_run_with_artifact_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "systemd-run.log"
+            fake_systemd_run = tmp_path / "systemd-run"
+            write_executable(
+                fake_systemd_run,
+                textwrap.dedent(
+                    f"""\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    printf 'systemd-run' >> {str(log_path)!r}
+                    printf '\\0' >> {str(log_path)!r}
+                    printf '%s\\0' "$@" >> {str(log_path)!r}
+                    printf '\\n' >> {str(log_path)!r}
+                    echo "Running as unit: $2.service"
+                    """
+                ),
+            )
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--systemd-run-bin",
+                    str(fake_systemd_run),
+                    "--timestamp",
+                    "20260614T225118Z",
+                    "--output-dir",
+                    str(tmp_path),
+                    "--voice-bin",
+                    "/opt/voice/bin/voice",
+                    "--hermes-home",
+                    str(tmp_path / "hermes"),
+                    "--hermes-config",
+                    str(tmp_path / "hermes" / "config.yaml"),
+                    "--wait-seconds",
+                    "30",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            entries = command_log_entries(log_path)
+
+        self.assertIn("ok: WhatsApp attended cache watch started", result.stdout)
+        self.assertIn("wait_seconds=30.0", result.stdout)
+        self.assertEqual(len(entries), 1)
+        entry = entries[0]
+        self.assertEqual(entry[0], "systemd-run")
+        self.assertIn("--user", entry)
+        self.assertIn(
+            "--unit=voice-whatsapp-attended-cache-watch-20260614T225118Z",
+            entry,
+        )
+        self.assertIn("--collect", entry)
+        self.assertEqual(entry[-2], "-lc")
+        self.assertIn("--wait-audio-cache-seconds 30.0", entry[-1])
+        self.assertIn(".json", entry[-1])
+        self.assertIn(".log", entry[-1])
+
+    def test_rejects_non_positive_wait_window(self):
+        result = subprocess.run(
+            [
+                str(SCRIPT_PATH),
+                "--dry-run",
+                "--wait-seconds",
+                "0",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("--wait-seconds must be positive", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a launcher for long non-draining attended WhatsApp cache receive watches as transient systemd user services
- print the unit, JSON/log artifact paths, status command, journal command, and underlying alpha command
- document the launcher in the README and WhatsApp Calling runbook

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_start_whatsapp_attended_cache_watch
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile scripts/start_whatsapp_attended_cache_watch.py tests/test_start_whatsapp_attended_cache_watch.py
- git diff --check
- live dry run against /home/ubuntu/.local/bin/voice and /home/ubuntu/.hermes printed the expected transient unit and artifact paths

## Local runtime note
- Existing watcher remains active: voice-whatsapp-attended-cache-watch-20260614T225118Z.service