### PR TITLE
Add attended watch status reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,9 @@ scripts/start_whatsapp_attended_cache_watch.py \
 
 It prints the unit name plus JSON/log artifact paths, then waits for a fresh
 `aud_*` file without polling the bridge `/messages` queue.
+Use `--status <unit-or-service>` with the printed unit name to summarize
+whether the watch is still waiting, failed, completed, or verified fresh
+receive evidence.
 
 To fail unless every alpha gate is complete, include the strict completion flag:
 

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -317,6 +317,16 @@ The launcher prints the transient unit name, JSON artifact path, log path, and
 copyable `systemctl --user status ...` / `journalctl --user -u ... -f`
 commands. It runs `attended-cache-receive`, sends the voice-note prompt, then
 watches for a fresh `aud_*` cache file without polling `/messages`.
+To inspect a launched watch without hand-parsing systemd or the saved JSON,
+run:
+
+```bash
+scripts/start_whatsapp_attended_cache_watch.py \
+  --status voice-whatsapp-attended-cache-watch-20260614T225118Z.service
+```
+
+Status output reports whether the watch is still waiting, has no artifact yet,
+failed, completed, or verified fresh receive evidence.
 
 Cloud/Calling readiness requires these external Meta settings in addition to
 the local sidecar:

--- a/scripts/start_whatsapp_attended_cache_watch.py
+++ b/scripts/start_whatsapp_attended_cache_watch.py
@@ -72,9 +72,8 @@ def build_alpha_command(args: argparse.Namespace) -> list[str]:
 
 
 def build_watch(args: argparse.Namespace) -> dict[str, Any]:
-    timestamp = args.timestamp or utc_timestamp()
-    unit = f"{args.unit_prefix}-{timestamp}"
-    service = unit if unit.endswith(".service") else f"{unit}.service"
+    unit = watch_unit_name(args)
+    service = service_name(unit)
     output_dir = args.output_dir.expanduser().resolve()
     json_path = output_dir / f"{unit}.json"
     log_path = output_dir / f"{unit}.log"
@@ -105,9 +104,155 @@ def build_watch(args: argparse.Namespace) -> dict[str, Any]:
     }
 
 
+def service_name(unit: str) -> str:
+    return unit if unit.endswith(".service") else f"{unit}.service"
+
+
+def watch_unit_name(args: argparse.Namespace) -> str:
+    timestamp = args.timestamp or utc_timestamp()
+    return f"{args.unit_prefix}-{timestamp}"
+
+
+def normalize_status_unit(value: str) -> tuple[str, str]:
+    service = service_name(value)
+    unit = service.removesuffix(".service")
+    return unit, service
+
+
+def parse_systemctl_show(output: str) -> dict[str, str]:
+    state: dict[str, str] = {}
+    for line in output.splitlines():
+        if not line or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        state[key] = value
+    return state
+
+
+def artifact_status(path: Path) -> dict[str, Any]:
+    status: dict[str, Any] = {
+        "path": str(path),
+        "exists": path.exists(),
+        "size_bytes": 0,
+        "parsed": False,
+        "parse_error": None,
+        "payload": None,
+    }
+    if not path.exists():
+        return status
+    status["size_bytes"] = path.stat().st_size
+    if status["size_bytes"] <= 0:
+        return status
+    try:
+        status["payload"] = json.loads(path.read_text(encoding="utf-8"))
+        status["parsed"] = True
+    except (OSError, json.JSONDecodeError) as exc:
+        status["parse_error"] = str(exc)
+    return status
+
+
+def summarize_alpha_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {}
+    summary = payload.get("readiness_summary")
+    summary = summary if isinstance(summary, dict) else {}
+    pending = payload.get("pending_gates")
+    pending = pending if isinstance(pending, dict) else {}
+    attended = pending.get("attended_fresh_receive")
+    attended = attended if isinstance(attended, dict) else {}
+    evidence = attended.get("evidence")
+    evidence = evidence if isinstance(evidence, dict) else {}
+    return {
+        "profile": payload.get("profile"),
+        "success": bool(payload.get("success")),
+        "readiness_status": summary.get("status"),
+        "complete": summary.get("complete"),
+        "attended_fresh_receive_verified": summary.get(
+            "attended_fresh_receive_verified"
+        ),
+        "external_meta_setup_required": summary.get("external_meta_setup_required"),
+        "attended_status": attended.get("status"),
+        "cached_receive_verified": attended.get("cached_receive_verified"),
+        "evidence_kind": evidence.get("kind"),
+        "fresh_count": evidence.get("fresh_count"),
+    }
+
+
+def classify_watch_status(
+    *,
+    systemd_state: dict[str, str],
+    json_artifact: dict[str, Any],
+    alpha_summary: dict[str, Any],
+) -> str:
+    active_state = systemd_state.get("ActiveState")
+    if active_state == "active":
+        if json_artifact.get("parsed"):
+            return "completed_running"
+        return "waiting_for_fresh_audio"
+    if json_artifact.get("parsed"):
+        if alpha_summary.get("attended_status") == "verified":
+            return "verified"
+        if alpha_summary.get("success"):
+            return "completed"
+        return "failed"
+    if json_artifact.get("exists"):
+        return "empty_artifact"
+    return "no_artifact"
+
+
+def inspect_status(args: argparse.Namespace) -> dict[str, Any]:
+    unit, service = normalize_status_unit(args.status)
+    output_dir = args.output_dir.expanduser().resolve()
+    json_path = output_dir / f"{unit}.json"
+    log_path = output_dir / f"{unit}.log"
+    systemctl_command = [
+        str(args.systemctl_bin),
+        "--user",
+        "show",
+        service,
+        "-p",
+        "ActiveState",
+        "-p",
+        "SubState",
+        "-p",
+        "MainPID",
+    ]
+    completed = subprocess.run(
+        systemctl_command,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    systemd_state = parse_systemctl_show(completed.stdout)
+    json_artifact = artifact_status(json_path)
+    log_artifact = artifact_status(log_path)
+    log_artifact.pop("payload", None)
+    alpha_summary = summarize_alpha_payload(json_artifact.get("payload"))
+    watch_status = classify_watch_status(
+        systemd_state=systemd_state,
+        json_artifact=json_artifact,
+        alpha_summary=alpha_summary,
+    )
+    json_artifact.pop("payload", None)
+    return {
+        "unit": unit,
+        "service": service,
+        "watch_status": watch_status,
+        "systemctl_command": systemctl_command,
+        "systemctl_returncode": completed.returncode,
+        "systemctl_stderr": completed.stderr.strip(),
+        "systemd": systemd_state,
+        "json": json_artifact,
+        "log": log_artifact,
+        "alpha": alpha_summary,
+        "status_command": ["systemctl", "--user", "status", service],
+        "journal_command": ["journalctl", "--user", "-u", service, "-f"],
+    }
+
+
 def validate_args(args: argparse.Namespace) -> list[str]:
     failures: list[str] = []
-    if args.wait_seconds <= 0:
+    if not args.status and args.wait_seconds <= 0:
         failures.append("--wait-seconds must be positive")
     if not args.unit_prefix:
         failures.append("--unit-prefix must not be empty")
@@ -132,8 +277,43 @@ def print_human(result: dict[str, Any]) -> None:
     print(f"journal_command={shlex.join(result['journal_command'])}")
 
 
+def print_status_human(result: dict[str, Any]) -> None:
+    print("ok: WhatsApp attended cache watch status")
+    print(f"unit={result['unit']}")
+    print(f"service={result['service']}")
+    print(f"watch_status={result['watch_status']}")
+    print(f"active_state={result.get('systemd', {}).get('ActiveState')}")
+    print(f"sub_state={result.get('systemd', {}).get('SubState')}")
+    print(f"main_pid={result.get('systemd', {}).get('MainPID')}")
+    json_artifact = result.get("json") or {}
+    log_artifact = result.get("log") or {}
+    print(f"json={json_artifact.get('path')} size={json_artifact.get('size_bytes')}")
+    print(f"log={log_artifact.get('path')} size={log_artifact.get('size_bytes')}")
+    alpha = result.get("alpha") or {}
+    if alpha:
+        print(
+            "alpha="
+            f"profile={alpha.get('profile')} "
+            f"success={alpha.get('success')} "
+            f"readiness={alpha.get('readiness_status')} "
+            f"attended_status={alpha.get('attended_status')} "
+            "attended_fresh_receive_verified="
+            f"{alpha.get('attended_fresh_receive_verified')} "
+            "external_meta_setup_required="
+            f"{alpha.get('external_meta_setup_required')}"
+        )
+    print(f"status_command={shlex.join(result['status_command'])}")
+    print(f"journal_command={shlex.join(result['journal_command'])}")
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--status",
+        metavar="UNIT",
+        default=None,
+        help="inspect a started attended watch unit instead of starting a new one",
+    )
     parser.add_argument("--voice-bin", default=default_voice_bin())
     parser.add_argument("--hermes-home", type=Path, default=default_hermes_home())
     parser.add_argument("--hermes-config", type=Path, default=default_hermes_config())
@@ -150,6 +330,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=repo_root() / "scripts" / "verify_whatsapp_alpha_readiness.py",
     )
     parser.add_argument("--systemd-run-bin", default=os.environ.get("SYSTEMD_RUN_BIN", "systemd-run"))
+    parser.add_argument("--systemctl-bin", default=os.environ.get("SYSTEMCTL_BIN", "systemctl"))
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--json", action="store_true")
     return parser.parse_args(argv)
@@ -168,6 +349,14 @@ def main(argv: list[str] | None = None) -> int:
         for failure in failures:
             print(f"error: {failure}", file=sys.stderr)
         return 2
+
+    if args.status:
+        result = inspect_status(args)
+        if args.json:
+            print(json.dumps(result, indent=2, sort_keys=True))
+        else:
+            print_status_human(result)
+        return 0
 
     watch = build_watch(args)
     result = {

--- a/tests/test_start_whatsapp_attended_cache_watch.py
+++ b/tests/test_start_whatsapp_attended_cache_watch.py
@@ -158,6 +158,120 @@ class WhatsAppAttendedCacheWatchLauncherTests(unittest.TestCase):
         self.assertEqual(result.returncode, 2)
         self.assertIn("--wait-seconds must be positive", result.stderr)
 
+    def test_status_reports_active_empty_artifact_as_waiting(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            fake_systemctl = tmp_path / "systemctl"
+            write_executable(
+                fake_systemctl,
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    cat <<'EOF'
+                    ActiveState=active
+                    SubState=running
+                    MainPID=12345
+                    EOF
+                    """
+                ),
+            )
+            (tmp_path / "watch.json").write_text("", encoding="utf-8")
+            (tmp_path / "watch.log").write_text("", encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--status",
+                    "watch.service",
+                    "--output-dir",
+                    str(tmp_path),
+                    "--systemctl-bin",
+                    str(fake_systemctl),
+                    "--json",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["watch_status"], "waiting_for_fresh_audio")
+        self.assertEqual(payload["systemd"]["ActiveState"], "active")
+        self.assertEqual(payload["systemd"]["MainPID"], "12345")
+        self.assertTrue(payload["json"]["exists"])
+        self.assertEqual(payload["json"]["size_bytes"], 0)
+        self.assertEqual(payload["service"], "watch.service")
+
+    def test_status_summarizes_verified_artifact(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            fake_systemctl = tmp_path / "systemctl"
+            write_executable(
+                fake_systemctl,
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    cat <<'EOF'
+                    ActiveState=inactive
+                    SubState=dead
+                    MainPID=0
+                    EOF
+                    """
+                ),
+            )
+            (tmp_path / "watch.json").write_text(
+                json.dumps(
+                    {
+                        "success": True,
+                        "profile": "attended-cache-receive",
+                        "readiness_summary": {
+                            "status": "local_ready_pending_gates",
+                            "complete": False,
+                            "attended_fresh_receive_verified": True,
+                            "external_meta_setup_required": True,
+                        },
+                        "pending_gates": {
+                            "attended_fresh_receive": {
+                                "status": "verified",
+                                "cached_receive_verified": True,
+                                "evidence": {
+                                    "kind": "audio_cache",
+                                    "fresh_count": 1,
+                                },
+                            },
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (tmp_path / "watch.log").write_text("done\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--status",
+                    "watch",
+                    "--output-dir",
+                    str(tmp_path),
+                    "--systemctl-bin",
+                    str(fake_systemctl),
+                    "--json",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["watch_status"], "verified")
+        self.assertTrue(payload["json"]["parsed"])
+        self.assertEqual(payload["alpha"]["profile"], "attended-cache-receive")
+        self.assertEqual(payload["alpha"]["attended_status"], "verified")
+        self.assertTrue(payload["alpha"]["attended_fresh_receive_verified"])
+        self.assertEqual(payload["alpha"]["fresh_count"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add --status UNIT to the attended WhatsApp cache watch launcher
- report active systemd state, JSON/log artifact sizes, and summarized alpha readiness when an artifact exists
- document the status command in README and the WhatsApp Calling runbook

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_start_whatsapp_attended_cache_watch
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile scripts/start_whatsapp_attended_cache_watch.py tests/test_start_whatsapp_attended_cache_watch.py
- scripts/start_whatsapp_attended_cache_watch.py --status voice-whatsapp-attended-cache-watch-20260614T225118Z.service
- git diff --check

## Live status
- Current watcher reports watch_status=waiting_for_fresh_audio, active_state=active, and empty JSON/log artifacts.