### PR TITLE
List attended WhatsApp cache watches

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,8 @@ It prints the unit name plus JSON/log artifact paths, then waits for a fresh
 `aud_*` file without polling the bridge `/messages` queue.
 Use `--status <unit-or-service>` with the printed unit name to summarize
 whether the watch is still waiting, failed, completed, or verified fresh
-receive evidence.
+receive evidence. Use `--list` to discover active watches and matching
+artifacts from a later session.
 
 To fail unless every alpha gate is complete, include the strict completion flag:
 

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -327,6 +327,12 @@ scripts/start_whatsapp_attended_cache_watch.py \
 
 Status output reports whether the watch is still waiting, has no artifact yet,
 failed, completed, or verified fresh receive evidence.
+To discover active watches and matching `/tmp` artifacts from a later session,
+run:
+
+```bash
+scripts/start_whatsapp_attended_cache_watch.py --list
+```
 
 Cloud/Calling readiness requires these external Meta settings in addition to
 the local sidecar:

--- a/scripts/start_whatsapp_attended_cache_watch.py
+++ b/scripts/start_whatsapp_attended_cache_watch.py
@@ -200,8 +200,8 @@ def classify_watch_status(
     return "no_artifact"
 
 
-def inspect_status(args: argparse.Namespace) -> dict[str, Any]:
-    unit, service = normalize_status_unit(args.status)
+def inspect_unit(unit_or_service: str, args: argparse.Namespace) -> dict[str, Any]:
+    unit, service = normalize_status_unit(unit_or_service)
     output_dir = args.output_dir.expanduser().resolve()
     json_path = output_dir / f"{unit}.json"
     log_path = output_dir / f"{unit}.log"
@@ -250,9 +250,67 @@ def inspect_status(args: argparse.Namespace) -> dict[str, Any]:
     }
 
 
+def inspect_status(args: argparse.Namespace) -> dict[str, Any]:
+    return inspect_unit(args.status, args)
+
+
+def list_systemd_watch_units(args: argparse.Namespace) -> list[str]:
+    command = [
+        str(args.systemctl_bin),
+        "--user",
+        "list-units",
+        "--type=service",
+        "--all",
+        "--no-legend",
+        "--no-pager",
+    ]
+    completed = subprocess.run(
+        command,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    units: list[str] = []
+    for line in completed.stdout.splitlines():
+        parts = line.split()
+        if not parts:
+            continue
+        service = parts[0]
+        unit = service.removesuffix(".service")
+        if unit.startswith(f"{args.unit_prefix}-"):
+            units.append(unit)
+    return units
+
+
+def list_artifact_watch_units(args: argparse.Namespace) -> list[str]:
+    output_dir = args.output_dir.expanduser().resolve()
+    units: set[str] = set()
+    for pattern in (f"{args.unit_prefix}-*.json", f"{args.unit_prefix}-*.log"):
+        for path in output_dir.glob(pattern):
+            if path.is_file():
+                units.add(path.stem)
+    return sorted(units)
+
+
+def list_watches(args: argparse.Namespace) -> dict[str, Any]:
+    units = sorted(
+        set(list_systemd_watch_units(args)) | set(list_artifact_watch_units(args)),
+        reverse=True,
+    )
+    watches = [inspect_unit(unit, args) for unit in units]
+    return {
+        "unit_prefix": args.unit_prefix,
+        "output_dir": str(args.output_dir.expanduser().resolve()),
+        "count": len(watches),
+        "watches": watches,
+    }
+
+
 def validate_args(args: argparse.Namespace) -> list[str]:
     failures: list[str] = []
-    if not args.status and args.wait_seconds <= 0:
+    if args.status and args.list:
+        failures.append("--status and --list cannot be combined")
+    if not args.status and not args.list and args.wait_seconds <= 0:
         failures.append("--wait-seconds must be positive")
     if not args.unit_prefix:
         failures.append("--unit-prefix must not be empty")
@@ -306,6 +364,21 @@ def print_status_human(result: dict[str, Any]) -> None:
     print(f"journal_command={shlex.join(result['journal_command'])}")
 
 
+def print_list_human(result: dict[str, Any]) -> None:
+    print("ok: WhatsApp attended cache watch list")
+    print(f"unit_prefix={result['unit_prefix']}")
+    print(f"output_dir={result['output_dir']}")
+    print(f"count={result['count']}")
+    for index, watch in enumerate(result.get("watches") or [], start=1):
+        json_artifact = watch.get("json") or {}
+        print(
+            f"watch[{index}]={watch.get('unit')} "
+            f"status={watch.get('watch_status')} "
+            f"active_state={(watch.get('systemd') or {}).get('ActiveState')} "
+            f"json_size={json_artifact.get('size_bytes')}"
+        )
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -313,6 +386,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         metavar="UNIT",
         default=None,
         help="inspect a started attended watch unit instead of starting a new one",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="list attended watch units and artifacts matching --unit-prefix",
     )
     parser.add_argument("--voice-bin", default=default_voice_bin())
     parser.add_argument("--hermes-home", type=Path, default=default_hermes_home())
@@ -356,6 +434,13 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps(result, indent=2, sort_keys=True))
         else:
             print_status_human(result)
+        return 0
+    if args.list:
+        result = list_watches(args)
+        if args.json:
+            print(json.dumps(result, indent=2, sort_keys=True))
+        else:
+            print_list_human(result)
         return 0
 
     watch = build_watch(args)

--- a/tests/test_start_whatsapp_attended_cache_watch.py
+++ b/tests/test_start_whatsapp_attended_cache_watch.py
@@ -272,6 +272,108 @@ class WhatsAppAttendedCacheWatchLauncherTests(unittest.TestCase):
         self.assertTrue(payload["alpha"]["attended_fresh_receive_verified"])
         self.assertEqual(payload["alpha"]["fresh_count"], 1)
 
+    def test_list_discovers_active_units_and_artifacts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            fake_systemctl = tmp_path / "systemctl"
+            write_executable(
+                fake_systemctl,
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    args="$*"
+                    if [[ "$args" == *"list-units"* ]]; then
+                      echo "watch-active.service loaded active running active watch"
+                      exit 0
+                    fi
+                    if [[ "$args" == *"show watch-active.service"* ]]; then
+                      cat <<'EOF'
+                    ActiveState=active
+                    SubState=running
+                    MainPID=12345
+                    EOF
+                      exit 0
+                    fi
+                    if [[ "$args" == *"show watch-done.service"* ]]; then
+                      cat <<'EOF'
+                    ActiveState=inactive
+                    SubState=dead
+                    MainPID=0
+                    EOF
+                      exit 0
+                    fi
+                    echo "unknown args: $args" >&2
+                    exit 1
+                    """
+                ),
+            )
+            (tmp_path / "watch-active.json").write_text("", encoding="utf-8")
+            (tmp_path / "watch-active.log").write_text("", encoding="utf-8")
+            (tmp_path / "watch-done.json").write_text(
+                json.dumps(
+                    {
+                        "success": True,
+                        "profile": "attended-cache-receive",
+                        "readiness_summary": {
+                            "attended_fresh_receive_verified": True,
+                        },
+                        "pending_gates": {
+                            "attended_fresh_receive": {
+                                "status": "verified",
+                                "evidence": {
+                                    "kind": "audio_cache",
+                                    "fresh_count": 1,
+                                },
+                            },
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--list",
+                    "--unit-prefix",
+                    "watch",
+                    "--output-dir",
+                    str(tmp_path),
+                    "--systemctl-bin",
+                    str(fake_systemctl),
+                    "--json",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["count"], 2)
+        by_unit = {watch["unit"]: watch for watch in payload["watches"]}
+        self.assertEqual(
+            by_unit["watch-active"]["watch_status"],
+            "waiting_for_fresh_audio",
+        )
+        self.assertEqual(by_unit["watch-done"]["watch_status"], "verified")
+        self.assertEqual(by_unit["watch-done"]["alpha"]["fresh_count"], 1)
+
+    def test_status_and_list_cannot_be_combined(self):
+        result = subprocess.run(
+            [
+                str(SCRIPT_PATH),
+                "--status",
+                "watch",
+                "--list",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("--status and --list cannot be combined", result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add --list to the attended WhatsApp cache watch launcher
- discover active systemd watch units and matching JSON/log artifacts in the output directory
- reuse status classification for each watch so later sessions can find waiting, completed, failed, or verified windows
- document --list in README and the WhatsApp Calling runbook

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_start_whatsapp_attended_cache_watch
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile scripts/start_whatsapp_attended_cache_watch.py tests/test_start_whatsapp_attended_cache_watch.py
- scripts/start_whatsapp_attended_cache_watch.py --list
- git diff --check

## Live list result
- The current host reports one active watch: voice-whatsapp-attended-cache-watch-20260614T225118Z with status=waiting_for_fresh_audio and json_size=0.