### PR TITLE
Stop attended WhatsApp cache watches

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,8 @@ It prints the unit name plus JSON/log artifact paths, then waits for a fresh
 Use `--status <unit-or-service>` with the printed unit name to summarize
 whether the watch is still waiting, failed, completed, or verified fresh
 receive evidence. Use `--list` to discover active watches and matching
-artifacts from a later session.
+artifacts from a later session. Use `--stop <unit-or-service>` to stop a stale
+watch without deleting its JSON/log artifacts.
 
 To fail unless every alpha gate is complete, include the strict completion flag:
 

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -334,6 +334,13 @@ run:
 scripts/start_whatsapp_attended_cache_watch.py --list
 ```
 
+To stop a stale watch without deleting its JSON/log artifacts:
+
+```bash
+scripts/start_whatsapp_attended_cache_watch.py \
+  --stop voice-whatsapp-attended-cache-watch-20260614T225118Z.service
+```
+
 Cloud/Calling readiness requires these external Meta settings in addition to
 the local sidecar:
 

--- a/scripts/start_whatsapp_attended_cache_watch.py
+++ b/scripts/start_whatsapp_attended_cache_watch.py
@@ -306,11 +306,31 @@ def list_watches(args: argparse.Namespace) -> dict[str, Any]:
     }
 
 
+def stop_watch(args: argparse.Namespace) -> dict[str, Any]:
+    unit, service = normalize_status_unit(args.stop)
+    command = [str(args.systemctl_bin), "--user", "stop", service]
+    completed = subprocess.run(
+        command,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    status = inspect_unit(unit, args)
+    return {
+        **status,
+        "stop_command": command,
+        "stop_returncode": completed.returncode,
+        "stop_stdout": completed.stdout.strip(),
+        "stop_stderr": completed.stderr.strip(),
+    }
+
+
 def validate_args(args: argparse.Namespace) -> list[str]:
     failures: list[str] = []
-    if args.status and args.list:
-        failures.append("--status and --list cannot be combined")
-    if not args.status and not args.list and args.wait_seconds <= 0:
+    modes = [bool(args.status), bool(args.list), bool(args.stop)]
+    if sum(modes) > 1:
+        failures.append("--status, --list, and --stop are mutually exclusive")
+    if not any(modes) and args.wait_seconds <= 0:
         failures.append("--wait-seconds must be positive")
     if not args.unit_prefix:
         failures.append("--unit-prefix must not be empty")
@@ -364,6 +384,25 @@ def print_status_human(result: dict[str, Any]) -> None:
     print(f"journal_command={shlex.join(result['journal_command'])}")
 
 
+def print_stop_human(result: dict[str, Any]) -> None:
+    if result.get("stop_returncode") == 0:
+        print("ok: WhatsApp attended cache watch stop requested")
+    else:
+        print("error: WhatsApp attended cache watch stop failed", file=sys.stderr)
+    print(f"unit={result['unit']}")
+    print(f"service={result['service']}")
+    print(f"stop_returncode={result['stop_returncode']}")
+    if result.get("stop_stderr"):
+        print(f"stop_stderr={result['stop_stderr']}")
+    print(f"watch_status={result['watch_status']}")
+    print(f"active_state={result.get('systemd', {}).get('ActiveState')}")
+    print(f"sub_state={result.get('systemd', {}).get('SubState')}")
+    json_artifact = result.get("json") or {}
+    log_artifact = result.get("log") or {}
+    print(f"json={json_artifact.get('path')} size={json_artifact.get('size_bytes')}")
+    print(f"log={log_artifact.get('path')} size={log_artifact.get('size_bytes')}")
+
+
 def print_list_human(result: dict[str, Any]) -> None:
     print("ok: WhatsApp attended cache watch list")
     print(f"unit_prefix={result['unit_prefix']}")
@@ -391,6 +430,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--list",
         action="store_true",
         help="list attended watch units and artifacts matching --unit-prefix",
+    )
+    parser.add_argument(
+        "--stop",
+        metavar="UNIT",
+        default=None,
+        help="stop a started attended watch unit without deleting artifacts",
     )
     parser.add_argument("--voice-bin", default=default_voice_bin())
     parser.add_argument("--hermes-home", type=Path, default=default_hermes_home())
@@ -442,6 +487,13 @@ def main(argv: list[str] | None = None) -> int:
         else:
             print_list_human(result)
         return 0
+    if args.stop:
+        result = stop_watch(args)
+        if args.json:
+            print(json.dumps(result, indent=2, sort_keys=True))
+        else:
+            print_stop_human(result)
+        return int(result.get("stop_returncode") or 0)
 
     watch = build_watch(args)
     result = {

--- a/tests/test_start_whatsapp_attended_cache_watch.py
+++ b/tests/test_start_whatsapp_attended_cache_watch.py
@@ -359,20 +359,131 @@ class WhatsAppAttendedCacheWatchLauncherTests(unittest.TestCase):
         self.assertEqual(by_unit["watch-done"]["watch_status"], "verified")
         self.assertEqual(by_unit["watch-done"]["alpha"]["fresh_count"], 1)
 
-    def test_status_and_list_cannot_be_combined(self):
+    def test_stop_requests_systemd_stop_and_reports_artifacts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "systemctl.log"
+            fake_systemctl = tmp_path / "systemctl"
+            write_executable(
+                fake_systemctl,
+                textwrap.dedent(
+                    f"""\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    printf '%s\\0' "$@" >> {str(log_path)!r}
+                    printf '\\n' >> {str(log_path)!r}
+                    args="$*"
+                    if [[ "$args" == *" stop watch.service" ]]; then
+                      exit 0
+                    fi
+                    if [[ "$args" == *"show watch.service"* ]]; then
+                      cat <<'EOF'
+                    ActiveState=inactive
+                    SubState=dead
+                    MainPID=0
+                    EOF
+                      exit 0
+                    fi
+                    echo "unknown args: $args" >&2
+                    exit 1
+                    """
+                ),
+            )
+            (tmp_path / "watch.json").write_text("", encoding="utf-8")
+            (tmp_path / "watch.log").write_text("", encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--stop",
+                    "watch",
+                    "--output-dir",
+                    str(tmp_path),
+                    "--systemctl-bin",
+                    str(fake_systemctl),
+                    "--json",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            entries = command_log_entries(log_path)
+
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["stop_returncode"], 0)
+        self.assertEqual(payload["watch_status"], "empty_artifact")
+        self.assertTrue(payload["json"]["exists"])
+        self.assertEqual(entries[0], ["--user", "stop", "watch.service"])
+        self.assertIn("show", entries[1])
+
+    def test_stop_failure_returns_systemctl_status(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            fake_systemctl = tmp_path / "systemctl"
+            write_executable(
+                fake_systemctl,
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    args="$*"
+                    if [[ "$args" == *" stop watch.service" ]]; then
+                      echo "unit missing" >&2
+                      exit 4
+                    fi
+                    if [[ "$args" == *"show watch.service"* ]]; then
+                      cat <<'EOF'
+                    ActiveState=inactive
+                    SubState=dead
+                    MainPID=0
+                    EOF
+                      exit 0
+                    fi
+                    exit 1
+                    """
+                ),
+            )
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--stop",
+                    "watch",
+                    "--output-dir",
+                    str(tmp_path),
+                    "--systemctl-bin",
+                    str(fake_systemctl),
+                    "--json",
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+        payload = json.loads(result.stdout)
+        self.assertEqual(result.returncode, 4)
+        self.assertEqual(payload["stop_returncode"], 4)
+        self.assertIn("unit missing", payload["stop_stderr"])
+        self.assertEqual(payload["watch_status"], "no_artifact")
+
+    def test_status_list_and_stop_cannot_be_combined(self):
         result = subprocess.run(
             [
                 str(SCRIPT_PATH),
                 "--status",
                 "watch",
                 "--list",
+                "--stop",
+                "watch",
             ],
             capture_output=True,
             text=True,
         )
 
         self.assertEqual(result.returncode, 2)
-        self.assertIn("--status and --list cannot be combined", result.stderr)
+        self.assertIn(
+            "--status, --list, and --stop are mutually exclusive",
+            result.stderr,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add --stop UNIT to the attended WhatsApp cache watch launcher
- stop the transient systemd user unit without deleting JSON/log artifacts
- return status/artifact details after the stop request
- document stop mode in README and the WhatsApp Calling runbook

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_start_whatsapp_attended_cache_watch
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile scripts/start_whatsapp_attended_cache_watch.py tests/test_start_whatsapp_attended_cache_watch.py
- scripts/start_whatsapp_attended_cache_watch.py --list
- scripts/start_whatsapp_attended_cache_watch.py --status voice-whatsapp-attended-cache-watch-20260614T225118Z.service
- git diff --check

## Live note
- I did not stop the active live watcher. It still reports waiting_for_fresh_audio.