### PR TITLE
Expose attended watch prompt metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,11 +461,12 @@ scripts/start_whatsapp_attended_cache_watch.py \
   --hermes-config ~/.hermes/config.yaml
 ```
 
-It prints the unit name plus JSON/log/manifest artifact paths, then waits for a
-fresh `aud_*` file without polling the bridge `/messages` queue. The manifest
-is written before `systemd-run` starts the long watch, so a later session can
-inspect the launched command, wait window, expected agent metadata, and
-artifact paths even while JSON/log output is still empty.
+It prints the unit name plus JSON/log/manifest artifact paths, then sends the
+attended prompt voice note and waits for a fresh `aud_*` file without polling
+the bridge `/messages` queue. The manifest is written before `systemd-run`
+starts the long watch, so a later session can inspect the prompt text, send
+intent, launched command, wait window, expected agent metadata, audio cache
+directory, and artifact paths even while JSON/log output is still empty.
 Use `--status <unit-or-service>` with the printed unit name to summarize
 whether the watch is still waiting, failed, completed, or verified fresh
 receive evidence. Use `--list` to discover active watches and matching

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -317,6 +317,10 @@ The launcher prints the transient unit name, JSON artifact path, log path, and
 copyable `systemctl --user status ...` / `journalctl --user -u ... -f`
 commands. It runs `attended-cache-receive`, sends the voice-note prompt, then
 watches for a fresh `aud_*` cache file without polling `/messages`.
+Its manifest is written before the service starts and records the prompt text,
+send intent, expected audio cache directory, wait window, agent metadata, and
+copyable commands so a later session can inspect an active watch before JSON
+or log output exists.
 To inspect a launched watch without hand-parsing systemd or the saved JSON,
 run:
 

--- a/scripts/start_whatsapp_attended_cache_watch.py
+++ b/scripts/start_whatsapp_attended_cache_watch.py
@@ -17,6 +17,10 @@ from typing import Any
 
 DEFAULT_WAIT_SECONDS = 6 * 60 * 60
 DEFAULT_UNIT_PREFIX = "voice-whatsapp-attended-cache-watch"
+DEFAULT_ATTENDED_PROMPT_TEXT = (
+    "Please reply with a fresh WhatsApp voice note so I can verify the voice runtime."
+)
+ATTENDED_PROFILE = "attended-cache-receive"
 
 
 def repo_root() -> Path:
@@ -65,7 +69,9 @@ def build_alpha_command(args: argparse.Namespace) -> list[str]:
         "--hermes-config",
         str(args.hermes_config),
         "--profile",
-        "attended-cache-receive",
+        ATTENDED_PROFILE,
+        "--attended-prompt-text",
+        args.attended_prompt_text,
         "--wait-audio-cache-seconds",
         str(float(args.wait_seconds)),
     ]
@@ -75,6 +81,23 @@ def build_alpha_command(args: argparse.Namespace) -> list[str]:
         command.extend(["--expected-agent-name", args.expected_agent_name])
     command.append("--json")
     return command
+
+
+def attended_prompt_manifest(args: argparse.Namespace) -> dict[str, Any]:
+    audio_cache_dir = args.hermes_home / "audio_cache"
+    return {
+        "sends_prompt_voice_note": True,
+        "prompt_text": args.attended_prompt_text,
+        "send_profile": ATTENDED_PROFILE,
+        "send_format": "audio/ogg; codecs=opus",
+        "send_transport": "local_whatsapp_bridge_ptt",
+        "receive_watch": "non_draining_audio_cache",
+        "audio_cache_dir": str(audio_cache_dir),
+        "operator_action": (
+            "Send a fresh WhatsApp voice note to the configured agent chat "
+            "while this watch is running."
+        ),
+    }
 
 
 def build_watch(args: argparse.Namespace) -> dict[str, Any]:
@@ -116,12 +139,13 @@ def build_manifest(args: argparse.Namespace, watch: dict[str, Any]) -> dict[str,
     return {
         "schema": "voice.whatsapp_attended_cache_watch_manifest",
         "version": 1,
-        "profile": "attended-cache-receive",
+        "profile": ATTENDED_PROFILE,
         "drains_bridge_messages": False,
         "created_at_utc": utc_iso_timestamp(),
         "unit": watch["unit"],
         "service": watch["service"],
         "wait_seconds": float(args.wait_seconds),
+        "attended_prompt": attended_prompt_manifest(args),
         "voice_bin": str(args.voice_bin),
         "hermes_home": str(args.hermes_home),
         "hermes_config": str(args.hermes_config),
@@ -244,6 +268,7 @@ def summarize_manifest_payload(payload: dict[str, Any] | None) -> dict[str, Any]
         "json_path": artifacts.get("json"),
         "log_path": artifacts.get("log"),
         "manifest_path": artifacts.get("manifest"),
+        "attended_prompt": payload.get("attended_prompt"),
     }
 
 
@@ -438,6 +463,12 @@ def print_human(result: dict[str, Any]) -> None:
     print(f"log={result['log_path']}")
     print(f"manifest={result['manifest_path']}")
     print(f"wait_seconds={result['wait_seconds']}")
+    attended_prompt = (result.get("manifest") or {}).get("attended_prompt") or {}
+    if attended_prompt:
+        print(f"sends_prompt_voice_note={attended_prompt.get('sends_prompt_voice_note')}")
+        print(f"prompt_text={attended_prompt.get('prompt_text')}")
+        print(f"audio_cache_dir={attended_prompt.get('audio_cache_dir')}")
+        print(f"operator_action={attended_prompt.get('operator_action')}")
     print(f"alpha_command={shlex.join(result['alpha_command'])}")
     print(f"systemd_command={shlex.join(result['systemd_command'])}")
     print(f"status_command={shlex.join(result['status_command'])}")
@@ -473,6 +504,16 @@ def print_status_human(result: dict[str, Any]) -> None:
             f"expected_agent_number={manifest_summary.get('expected_agent_number')} "
             f"expected_agent_name={manifest_summary.get('expected_agent_name')}"
         )
+        attended_prompt = manifest_summary.get("attended_prompt")
+        attended_prompt = attended_prompt if isinstance(attended_prompt, dict) else {}
+        if attended_prompt:
+            print(
+                "attended_prompt="
+                f"sends_prompt_voice_note="
+                f"{attended_prompt.get('sends_prompt_voice_note')} "
+                f"prompt_text={attended_prompt.get('prompt_text')} "
+                f"audio_cache_dir={attended_prompt.get('audio_cache_dir')}"
+            )
     alpha = result.get("alpha") or {}
     if alpha:
         print(
@@ -527,7 +568,9 @@ def print_list_human(result: dict[str, Any]) -> None:
             f"status={watch.get('watch_status')} "
             f"active_state={(watch.get('systemd') or {}).get('ActiveState')} "
             f"json_size={json_artifact.get('size_bytes')} "
-            f"manifest_wait_seconds={manifest_summary.get('wait_seconds')}"
+            f"manifest_wait_seconds={manifest_summary.get('wait_seconds')} "
+            "sends_prompt_voice_note="
+            f"{(manifest_summary.get('attended_prompt') or {}).get('sends_prompt_voice_note')}"
         )
 
 
@@ -554,6 +597,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--hermes-home", type=Path, default=default_hermes_home())
     parser.add_argument("--hermes-config", type=Path, default=default_hermes_config())
     parser.add_argument("--wait-seconds", type=float, default=DEFAULT_WAIT_SECONDS)
+    parser.add_argument("--attended-prompt-text", default=DEFAULT_ATTENDED_PROMPT_TEXT)
     parser.add_argument("--expected-agent-number", default=os.environ.get("WHATSAPP_AGENT_NUMBER"))
     parser.add_argument("--expected-agent-name", default=os.environ.get("WHATSAPP_AGENT_NAME"))
     parser.add_argument("--output-dir", type=Path, default=Path("/tmp"))
@@ -565,7 +609,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=Path,
         default=repo_root() / "scripts" / "verify_whatsapp_alpha_readiness.py",
     )
-    parser.add_argument("--systemd-run-bin", default=os.environ.get("SYSTEMD_RUN_BIN", "systemd-run"))
+    parser.add_argument(
+        "--systemd-run-bin",
+        default=os.environ.get("SYSTEMD_RUN_BIN", "systemd-run"),
+    )
     parser.add_argument("--systemctl-bin", default=os.environ.get("SYSTEMCTL_BIN", "systemctl"))
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--json", action="store_true")

--- a/tests/test_start_whatsapp_attended_cache_watch.py
+++ b/tests/test_start_whatsapp_attended_cache_watch.py
@@ -77,12 +77,27 @@ class WhatsAppAttendedCacheWatchLauncherTests(unittest.TestCase):
         self.assertEqual(manifest["wait_seconds"], 120.0)
         self.assertEqual(manifest["expected_agent_number"], "13236478455")
         self.assertEqual(manifest["expected_agent_name"], "Quill")
+        prompt = manifest["attended_prompt"]
+        self.assertTrue(prompt["sends_prompt_voice_note"])
+        self.assertEqual(
+            prompt["prompt_text"],
+            "Please reply with a fresh WhatsApp voice note so I can verify the voice runtime.",
+        )
+        self.assertEqual(prompt["send_format"], "audio/ogg; codecs=opus")
+        self.assertEqual(prompt["send_transport"], "local_whatsapp_bridge_ptt")
+        self.assertEqual(prompt["receive_watch"], "non_draining_audio_cache")
+        self.assertEqual(
+            prompt["audio_cache_dir"],
+            str(tmp_path / "hermes" / "audio_cache"),
+        )
         self.assertEqual(manifest["artifacts"]["json"], payload["json_path"])
         self.assertEqual(manifest["artifacts"]["log"], payload["log_path"])
         self.assertEqual(manifest["artifacts"]["manifest"], payload["manifest_path"])
         alpha = payload["alpha_command"]
         self.assertIn("--profile", alpha)
         self.assertIn("attended-cache-receive", alpha)
+        self.assertIn("--attended-prompt-text", alpha)
+        self.assertIn(prompt["prompt_text"], alpha)
         self.assertIn("--wait-audio-cache-seconds", alpha)
         self.assertIn("120.0", alpha)
         self.assertIn("--expected-agent-number", alpha)
@@ -154,8 +169,14 @@ class WhatsAppAttendedCacheWatchLauncherTests(unittest.TestCase):
         self.assertEqual(manifest["wait_seconds"], 30.0)
         self.assertFalse(manifest["drains_bridge_messages"])
         self.assertEqual(manifest["profile"], "attended-cache-receive")
+        self.assertTrue(manifest["attended_prompt"]["sends_prompt_voice_note"])
+        self.assertEqual(
+            manifest["attended_prompt"]["audio_cache_dir"],
+            str(tmp_path / "hermes" / "audio_cache"),
+        )
         self.assertIn("alpha", manifest["commands"])
         self.assertIn("--wait-audio-cache-seconds", manifest["commands"]["alpha"])
+        self.assertIn("--attended-prompt-text", manifest["commands"]["alpha"])
         self.assertEqual(
             manifest["artifacts"]["json"],
             str(tmp_path / "voice-whatsapp-attended-cache-watch-20260614T225118Z.json"),
@@ -290,6 +311,11 @@ class WhatsAppAttendedCacheWatchLauncherTests(unittest.TestCase):
                         "created_at_utc": "2026-06-14T22:51:18Z",
                         "wait_seconds": 120.0,
                         "drains_bridge_messages": False,
+                        "attended_prompt": {
+                            "sends_prompt_voice_note": True,
+                            "prompt_text": "reply with a voice note",
+                            "audio_cache_dir": str(tmp_path / "audio_cache"),
+                        },
                         "expected_agent_number": "13236478455",
                         "expected_agent_name": "Quill",
                         "artifacts": {
@@ -333,6 +359,10 @@ class WhatsAppAttendedCacheWatchLauncherTests(unittest.TestCase):
         )
         self.assertEqual(payload["manifest_summary"]["wait_seconds"], 120.0)
         self.assertFalse(payload["manifest_summary"]["drains_bridge_messages"])
+        self.assertEqual(
+            payload["manifest_summary"]["attended_prompt"]["prompt_text"],
+            "reply with a voice note",
+        )
 
     def test_list_discovers_active_units_and_artifacts(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -410,6 +440,11 @@ class WhatsAppAttendedCacheWatchLauncherTests(unittest.TestCase):
                         "created_at_utc": "2026-06-14T22:51:18Z",
                         "wait_seconds": 60.0,
                         "drains_bridge_messages": False,
+                        "attended_prompt": {
+                            "sends_prompt_voice_note": True,
+                            "prompt_text": "reply with a voice note",
+                            "audio_cache_dir": str(tmp_path / "audio_cache"),
+                        },
                     }
                 ),
                 encoding="utf-8",
@@ -446,6 +481,11 @@ class WhatsAppAttendedCacheWatchLauncherTests(unittest.TestCase):
         self.assertEqual(
             by_unit["watch-manifest"]["manifest_summary"]["wait_seconds"],
             60.0,
+        )
+        self.assertTrue(
+            by_unit["watch-manifest"]["manifest_summary"]["attended_prompt"][
+                "sends_prompt_voice_note"
+            ]
         )
 
     def test_stop_requests_systemd_stop_and_reports_artifacts(self):


### PR DESCRIPTION
## Summary
- include attended prompt/send metadata in cache watch manifests before the long systemd job starts
- pass the prompt text explicitly to the alpha readiness verifier
- show prompt/cache handoff details in dry-run/status/list output and docs

## Tests
- python3 -m py_compile scripts/start_whatsapp_attended_cache_watch.py tests/test_start_whatsapp_attended_cache_watch.py
- python3 -m unittest tests.test_start_whatsapp_attended_cache_watch tests.test_verify_local_hermes_voice_stack tests.test_verify_whatsapp_alpha_readiness
- python3 -m unittest discover tests
- git diff --check