### PR TITLE
Prefer installed voice for attended watches

### DIFF
--- a/scripts/start_whatsapp_attended_cache_watch.py
+++ b/scripts/start_whatsapp_attended_cache_watch.py
@@ -42,11 +42,13 @@ def default_voice_bin() -> str:
     env_value = os.environ.get("VOICE_BIN")
     if env_value:
         return env_value
+    found = shutil.which("voice")
+    if found:
+        return found
     release_bin = repo_root() / "target" / "release" / "voice"
     if release_bin.is_file() and os.access(release_bin, os.X_OK):
         return str(release_bin)
-    found = shutil.which("voice")
-    return found or "voice"
+    return "voice"
 
 
 def utc_timestamp() -> str:

--- a/tests/test_start_whatsapp_attended_cache_watch.py
+++ b/tests/test_start_whatsapp_attended_cache_watch.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 import json
+import os
 import subprocess
 import tempfile
 import textwrap
@@ -27,6 +28,47 @@ def command_log_entries(log_path: Path) -> list[list[str]]:
 
 
 class WhatsAppAttendedCacheWatchLauncherTests(unittest.TestCase):
+    def test_dry_run_prefers_installed_voice_on_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            bin_dir = tmp_path / "bin"
+            bin_dir.mkdir()
+            fake_voice = bin_dir / "voice"
+            write_executable(
+                fake_voice,
+                "#!/usr/bin/env bash\n"
+                "echo fake voice\n",
+            )
+            env = {
+                **os.environ,
+                "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+            }
+            env.pop("VOICE_BIN", None)
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--dry-run",
+                    "--json",
+                    "--timestamp",
+                    "20260614T225118Z",
+                    "--output-dir",
+                    str(tmp_path),
+                    "--hermes-home",
+                    str(tmp_path / "hermes"),
+                    "--hermes-config",
+                    str(tmp_path / "hermes" / "config.yaml"),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["manifest"]["voice_bin"], str(fake_voice))
+        self.assertIn(str(fake_voice), payload["alpha_command"])
+
     def test_dry_run_reports_repeatable_unit_and_commands(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)


### PR DESCRIPTION
## Summary
- make the attended cache watch launcher resolve `voice` the same way the alpha verifier does: `VOICE_BIN`, then installed `voice` on `PATH`, then `target/release/voice`
- add a regression test proving an installed `voice` wins over any repo build

## Tests
- `python3 -m py_compile scripts/start_whatsapp_attended_cache_watch.py tests/test_start_whatsapp_attended_cache_watch.py`
- `python3 -m unittest tests.test_start_whatsapp_attended_cache_watch`
- `python3 -m unittest discover tests`
- `git diff --check`
- dry run confirmed local default resolves `/home/ubuntu/.local/bin/voice`
