### PR TITLE
Report attended watch status in stack gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,9 @@ scripts/verify_local_hermes_voice_stack.sh \
 That single gate checks plain CLI/MCP daemon behavior, Hermes' active command
 provider, the voice-owned config installer dry-run, direct Ogg/Opus voice note
 output, daemon-backed streaming, `stream-transcribe`, and the local WebRTC
-sidecar service. It requires the daemon and sidecar by default. For narrower checks, run
+sidecar service. It also reports active and saved attended WhatsApp receive
+watchers so the same gate shows whether a fresh-reply window is already
+running. It requires the daemon and sidecar by default. For narrower checks, run
 `scripts/verify_cli_mcp_surface.py`, `scripts/verify_hermes_voice_config.py`,
 `scripts/verify_whatsapp_voice_contract.sh`,
 `scripts/verify_telegram_voice_contract.sh`, or
@@ -434,7 +436,8 @@ preflight output in the aggregate gate; add `--require-telegram-credentials`
 when the local Telegram bot token should already be configured.
 When a step fails, the aggregate verifier prints `failure_category=...` with
 values such as `voice_runtime`, `hermes_config`, `upstream_hermes`,
-`whatsapp_bridge_or_credentials`, `telegram_setup`, or `webrtc_sidecar`.
+`whatsapp_bridge_or_credentials`, `whatsapp_attended_watch`,
+`telegram_setup`, or `webrtc_sidecar`.
 
 To include the categorized WhatsApp alpha report in the same command, add
 `--whatsapp-alpha-profile unattended`, `cached-receive`, `send`,

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -155,10 +155,12 @@ expected Hermes home, exports `WHATSAPP_CLOUD_CALLING_SIDECAR_URL`, and uses a
 `voice stream --raw-output -` command for the WhatsApp Calling sidecar path.
 The aggregate stack verifier also dry-runs `install_hermes_voice_config.py`
 against the active config, so one command now checks both config drift
-detection and the voice-owned repair path.
+detection and the voice-owned repair path. It also reports active and saved
+attended WhatsApp receive watchers with `whatsapp_attended_watch=checked`, so
+the same gate shows whether a fresh-reply window is already running.
 If any step fails, it emits `failure_category=...` so automation can distinguish
 voice runtime, Hermes config/service, WhatsApp bridge or credential, inbound
-audio, and WebRTC sidecar failures.
+audio, attended watch status, and WebRTC sidecar failures.
 
 ## CLI Smoke Test
 

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -338,6 +338,10 @@ run:
 scripts/start_whatsapp_attended_cache_watch.py --list
 ```
 
+The aggregate stack gate runs the same non-draining status check by default and
+prints `whatsapp_attended_watch=checked`, so a release or host-health run also
+shows whether an attended receive window is already active.
+
 To stop a stale watch without deleting its JSON/log artifacts:
 
 ```bash

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -17,6 +17,7 @@ skip_hermes_stt_smoke="${SKIP_HERMES_STT_SMOKE:-0}"
 skip_hermes_gateway="${SKIP_HERMES_GATEWAY:-0}"
 skip_sidecar="${SKIP_SIDECAR:-0}"
 skip_whatsapp_bridge="${SKIP_WHATSAPP_BRIDGE:-0}"
+skip_whatsapp_attended_watch_status="${SKIP_WHATSAPP_ATTENDED_WATCH_STATUS:-0}"
 skip_systemd="${SKIP_SYSTEMD:-0}"
 skip_cli_mcp="${SKIP_CLI_MCP:-0}"
 skip_daemon="${SKIP_DAEMON:-0}"
@@ -31,6 +32,8 @@ whatsapp_alpha_voice_note_chat_id="${WHATSAPP_ALPHA_VOICE_NOTE_CHAT_ID:-}"
 whatsapp_alpha_wait_audio_cache_seconds="${WHATSAPP_ALPHA_WAIT_AUDIO_CACHE_SECONDS:-}"
 whatsapp_alpha_wait_inbound_seconds="${WHATSAPP_ALPHA_WAIT_INBOUND_SECONDS:-}"
 whatsapp_alpha_json_output="${WHATSAPP_ALPHA_JSON_OUTPUT:-}"
+whatsapp_attended_watch_output_dir="${WHATSAPP_ATTENDED_WATCH_OUTPUT_DIR:-/tmp}"
+whatsapp_attended_watch_unit_prefix="${WHATSAPP_ATTENDED_WATCH_UNIT_PREFIX:-voice-whatsapp-attended-cache-watch}"
 run_webrtc_loopback_smoke="${RUN_WEBRTC_LOOPBACK_SMOKE:-0}"
 webrtc_python="${VOICE_WEBRTC_PYTHON:-python3}"
 webrtc_timeout="${VOICE_WEBRTC_TIMEOUT:-60}"
@@ -55,6 +58,7 @@ whatsapp_contract_verify_script="${WHATSAPP_CONTRACT_VERIFY_SCRIPT:-$repo_root/s
 whatsapp_bridge_verify_script="${WHATSAPP_BRIDGE_VERIFY_SCRIPT:-$repo_root/scripts/verify_whatsapp_bridge_runtime.py}"
 whatsapp_inbound_cache_verify_script="${WHATSAPP_INBOUND_CACHE_VERIFY_SCRIPT:-$repo_root/scripts/verify_whatsapp_inbound_audio_cache.py}"
 whatsapp_alpha_readiness_script="${WHATSAPP_ALPHA_READINESS_SCRIPT:-$repo_root/scripts/verify_whatsapp_alpha_readiness.py}"
+whatsapp_attended_watch_script="${WHATSAPP_ATTENDED_WATCH_SCRIPT:-$repo_root/scripts/start_whatsapp_attended_cache_watch.py}"
 telegram_contract_verify_script="${TELEGRAM_CONTRACT_VERIFY_SCRIPT:-$repo_root/scripts/verify_telegram_voice_contract.sh}"
 sidecar_service_verify_script="${SIDECAR_SERVICE_VERIFY_SCRIPT:-$repo_root/scripts/verify_webrtc_sidecar_service.py}"
 webrtc_loopback_smoke_script="${WEBRTC_LOOPBACK_SMOKE_SCRIPT:-$repo_root/examples/webrtc-sidecar/full_duplex_loopback_smoke.py}"
@@ -83,6 +87,8 @@ Options:
   --skip-hermes-gateway        skip running Hermes gateway service verification
   --skip-cli-mcp               skip plain CLI/MCP daemon surface verification
   --skip-whatsapp-bridge       skip local WhatsApp bridge identity verification
+  --skip-whatsapp-attended-watch-status
+                               skip reporting active/known attended receive watchers
   --skip-sidecar               skip WebRTC sidecar service verification
   --skip-systemd               skip Hermes gateway, sidecar, and daemon systemd service checks
   --skip-daemon                skip daemon-backed stream checks
@@ -123,6 +129,10 @@ Options:
                                override attended-send-receive bridge poll time
   --whatsapp-alpha-json-output PATH
                                save the categorized alpha readiness JSON report
+  --whatsapp-attended-watch-output-dir PATH
+                               artifact directory for attended watch status (default: /tmp)
+  --whatsapp-attended-watch-unit-prefix PREFIX
+                               systemd/artifact prefix for attended watch status
   --run-webrtc-loopback-smoke  run one local full-duplex WebRTC media turn
   --webrtc-python PATH         Python used for the WebRTC smoke (default: python3)
   --webrtc-timeout SECONDS     timeout passed to the WebRTC smoke (default: 60)
@@ -134,6 +144,7 @@ Environment aliases:
   SKIP_HERMES_CONFIG=1, SKIP_HERMES_INSTALL_DRY_RUN=1
   SKIP_HERMES_TTS_SMOKE=1, SKIP_HERMES_STT_SMOKE=1
   SKIP_SIDECAR=1, SKIP_HERMES_GATEWAY=1, SKIP_WHATSAPP_BRIDGE=1
+  SKIP_WHATSAPP_ATTENDED_WATCH_STATUS=1
   SKIP_SYSTEMD=1, SKIP_CLI_MCP=1, SKIP_DAEMON=1, SKIP_STT_SMOKE=1
   RUN_WEBRTC_LOOPBACK_SMOKE=1
   WHATSAPP_BRIDGE_URL, WHATSAPP_SESSION_DIR, WHATSAPP_ENV_FILE
@@ -144,6 +155,7 @@ Environment aliases:
   WHATSAPP_ALPHA_TEXT, WHATSAPP_ALPHA_VOICE_NOTE_CHAT_ID
   WHATSAPP_ALPHA_WAIT_AUDIO_CACHE_SECONDS, WHATSAPP_ALPHA_WAIT_INBOUND_SECONDS
   WHATSAPP_ALPHA_JSON_OUTPUT
+  WHATSAPP_ATTENDED_WATCH_OUTPUT_DIR, WHATSAPP_ATTENDED_WATCH_UNIT_PREFIX
   RUN_TELEGRAM_VOICE_CONTRACT=1, TELEGRAM_ENV_FILE, HERMES_ENV
   REQUIRE_TELEGRAM_CREDENTIALS=1
   VOICE_WEBRTC_PYTHON, VOICE_WEBRTC_TIMEOUT
@@ -211,6 +223,9 @@ step_failure_category() {
       ;;
     "WhatsApp bridge identity and credential readiness")
       echo "whatsapp_bridge_or_credentials"
+      ;;
+    "WhatsApp attended cache watch status")
+      echo "whatsapp_attended_watch"
       ;;
     "WhatsApp inbound cached audio STT smoke")
       echo "whatsapp_inbound_audio"
@@ -390,6 +405,10 @@ while [[ $# -gt 0 ]]; do
       skip_whatsapp_bridge=1
       shift
       ;;
+    --skip-whatsapp-attended-watch-status)
+      skip_whatsapp_attended_watch_status=1
+      shift
+      ;;
     --skip-cli-mcp)
       skip_cli_mcp=1
       shift
@@ -499,6 +518,16 @@ while [[ $# -gt 0 ]]; do
       whatsapp_alpha_json_output="$2"
       shift 2
       ;;
+    --whatsapp-attended-watch-output-dir)
+      [[ $# -ge 2 ]] || fail "--whatsapp-attended-watch-output-dir requires a path"
+      whatsapp_attended_watch_output_dir="$2"
+      shift 2
+      ;;
+    --whatsapp-attended-watch-unit-prefix)
+      [[ $# -ge 2 ]] || fail "--whatsapp-attended-watch-unit-prefix requires a value"
+      whatsapp_attended_watch_unit_prefix="$2"
+      shift 2
+      ;;
     --run-webrtc-loopback-smoke)
       run_webrtc_loopback_smoke=1
       shift
@@ -563,6 +592,9 @@ if [[ "$run_telegram_voice_contract" == "1" ]]; then
 fi
 if [[ -n "$whatsapp_alpha_profile" ]]; then
   require_executable "$whatsapp_alpha_readiness_script" "WhatsApp alpha readiness verifier"
+fi
+if [[ "$skip_whatsapp_attended_watch_status" != "1" && "$skip_systemd" != "1" ]]; then
+  require_executable "$whatsapp_attended_watch_script" "WhatsApp attended watch launcher"
 fi
 if [[ "$skip_hermes_config" != "1" ]]; then
   require_executable "$hermes_config_verify_script" "Hermes voice config verifier"
@@ -761,6 +793,19 @@ else
   sidecar_status="skipped"
 fi
 
+if [[ "$skip_whatsapp_attended_watch_status" != "1" && "$skip_systemd" != "1" ]]; then
+  attended_watch_args=(
+    "$whatsapp_attended_watch_script"
+    --list
+    --output-dir "$whatsapp_attended_watch_output_dir"
+    --unit-prefix "$whatsapp_attended_watch_unit_prefix"
+  )
+  run_step "WhatsApp attended cache watch status" "${attended_watch_args[@]}"
+  whatsapp_attended_watch_status="checked"
+else
+  whatsapp_attended_watch_status="skipped"
+fi
+
 if [[ "$run_webrtc_loopback_smoke" == "1" ]]; then
   run_step "Full-duplex WebRTC media smoke" \
     "$webrtc_python" "$webrtc_loopback_smoke_script" \
@@ -887,6 +932,7 @@ echo "telegram_voice_contract=$telegram_voice_contract_status"
 echo "whatsapp_bridge=$whatsapp_bridge_status"
 echo "whatsapp_inbound_cache=$whatsapp_inbound_cache_status"
 echo "whatsapp_alpha=$whatsapp_alpha_status"
+echo "whatsapp_attended_watch=$whatsapp_attended_watch_status"
 if [[ -n "$whatsapp_alpha_json_output" ]]; then
   echo "whatsapp_alpha_json=$whatsapp_alpha_json_output"
 fi

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -141,6 +141,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn("telegram_voice_contract=skipped", result.stdout)
         self.assertIn("whatsapp_inbound_cache=skipped", result.stdout)
         self.assertIn("whatsapp_alpha=skipped", result.stdout)
+        self.assertIn("whatsapp_attended_watch=skipped", result.stdout)
         self.assertIn("webrtc_loopback=skipped", result.stdout)
         self.assertEqual(
             [entry[0] for entry in entries],
@@ -209,6 +210,78 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 "--sidecar-url",
                 "http://127.0.0.1:9999",
                 "--skip-systemd",
+            ],
+        )
+
+    def test_attended_watch_status_runs_when_systemd_checks_are_enabled(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            watch = tmp_path / "start_watch.py"
+            voice = tmp_path / "voice"
+            output_dir = tmp_path / "watch-artifacts"
+
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_executable(
+                watch,
+                textwrap.dedent(
+                    f"""\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    printf 'watch' >> {str(log_path)!r}
+                    printf '\\0' >> {str(log_path)!r}
+                    printf '%s\\0' "$@" >> {str(log_path)!r}
+                    printf '\\n' >> {str(log_path)!r}
+                    echo "ok: WhatsApp attended cache watch list"
+                    echo "count=1"
+                    echo "watch[1]=watch-active status=waiting_for_fresh_audio active_state=active"
+                    """
+                ),
+            )
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--skip-hermes-config",
+                    "--skip-hermes-gateway",
+                    "--skip-cli-mcp",
+                    "--skip-sidecar",
+                    "--skip-whatsapp-bridge",
+                    "--skip-daemon",
+                    "--whatsapp-attended-watch-output-dir",
+                    str(output_dir),
+                    "--whatsapp-attended-watch-unit-prefix",
+                    "watch",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "WHATSAPP_ATTENDED_WATCH_SCRIPT": str(watch),
+                },
+            )
+
+            entries = command_log_entries(log_path)
+
+        self.assertIn("==> WhatsApp attended cache watch status", result.stdout)
+        self.assertIn("ok: WhatsApp attended cache watch list", result.stdout)
+        self.assertIn("whatsapp_attended_watch=checked", result.stdout)
+        self.assertEqual([entry[0] for entry in entries], ["whatsapp", "watch"])
+        self.assertEqual(
+            entries[1],
+            [
+                "watch",
+                "--list",
+                "--output-dir",
+                str(output_dir),
+                "--unit-prefix",
+                "watch",
             ],
         )
 


### PR DESCRIPTION
## Summary

- add a WhatsApp attended cache watch status step to `verify_local_hermes_voice_stack.sh`
- expose skip/output-dir/unit-prefix controls and a `whatsapp_attended_watch` failure category/status line
- document that the aggregate stack gate now reports active/saved attended receive watchers

## Telegram compatibility check

I also checked the Telegram bot voice-message path while validating this stack gate. The local Telegram contract verifier passes against the installed `voice` binary and Hermes config with credentials required. It reports bot `sendVoice` / voice-message compatibility, with Telegram voice calls and live streaming intentionally out of scope.

Local Hermes env status from the verifier: `TELEGRAM_BOT_TOKEN` and `TELEGRAM_HOME_CHANNEL` are configured; `TELEGRAM_ALLOWED_USERS` and `TELEGRAM_WEBHOOK_URL` are not configured.

## Verification

- `python3 -m unittest tests.test_verify_local_hermes_voice_stack tests.test_verify_telegram_voice_contract`
- `python3 -m unittest discover tests`
- `bash -n scripts/verify_local_hermes_voice_stack.sh scripts/verify_telegram_voice_contract.sh scripts/verify_whatsapp_voice_contract.sh`
- `git diff --check`
- `scripts/verify_telegram_voice_contract.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-config /home/ubuntu/.hermes/config.yaml --require-telegram-credentials --skip-hermes-tts-smoke --skip-daemon`
- `cargo test -p voice-stt test_load_audio_file_decodes_ogg_opus_with_ffmpeg`
- `cargo test -p voice stream_transcribe_input_accepts_ogg_opus_files`
- live aggregate stack gate passed with `telegram_voice_contract=checked` and `whatsapp_attended_watch=checked`

## Live watch state

The current attended WhatsApp receive watcher is still active:

`voice-whatsapp-attended-cache-watch-20260614T235857Z status=waiting_for_fresh_audio active_state=active`

Fresh inbound WhatsApp voice-note verification is still pending, and WhatsApp Cloud/Calling credentials are still external setup gates.
