### PR TITLE
Detect stale WhatsApp bridge scripts

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -59,6 +59,8 @@ The verifier checks:
 - the bridge health endpoint is connected
 - `~/.hermes/whatsapp/session/creds.json` has a paired WhatsApp identity
 - the running `whatsapp-bridge/bridge.js` process uses the expected session
+- the bridge `/health` `scriptHash` matches the running `bridge.js` file, so a
+  stale long-lived bridge process is detected before receive tests rely on it
 - LID-to-phone mapping files match the paired identity
 - WhatsApp Cloud and Calling environment keys are present or missing
 

--- a/scripts/verify_whatsapp_bridge_runtime.py
+++ b/scripts/verify_whatsapp_bridge_runtime.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -222,6 +223,14 @@ def read_json_file(path: Path) -> tuple[Any | None, str | None]:
         return None, f"could not read {path}: {exc}"
 
 
+def file_script_hash(path: Path) -> tuple[str | None, str | None]:
+    try:
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError as exc:
+        return None, f"could not read bridge script for hashing: {exc}"
+    return digest[:16], None
+
+
 def session_artifact_counts(session_dir: Path) -> dict[str, int]:
     counts = {
         "pre_key": 0,
@@ -380,6 +389,48 @@ def fetch_bridge_health(bridge_url: str, *, timeout: float) -> tuple[dict[str, A
     if not isinstance(payload, dict):
         return None, "bridge health JSON must be an object"
     return payload, None
+
+
+def build_bridge_script_hash_check(
+    bridge_health: dict[str, Any],
+    bridge_process: dict[str, Any],
+) -> dict[str, Any]:
+    reported = bridge_health.get("scriptHash")
+    selected = bridge_process.get("selected") if isinstance(bridge_process, dict) else None
+    script = selected.get("script") if isinstance(selected, dict) else None
+    result: dict[str, Any] = {
+        "checked": False,
+        "ok": False,
+        "reported": reported if isinstance(reported, str) and reported else None,
+        "computed": None,
+        "script": script,
+        "reason": None,
+    }
+
+    if bridge_health.get("skipped"):
+        result["reason"] = "bridge health check skipped"
+        return result
+    if not result["reported"]:
+        result["reason"] = "bridge health did not report scriptHash"
+        return result
+    if bridge_process.get("skipped"):
+        result["reason"] = "bridge process check skipped"
+        return result
+    if not script:
+        result["reason"] = "bridge process script path unavailable"
+        return result
+
+    computed, error = file_script_hash(Path(str(script)).expanduser())
+    if error:
+        result["reason"] = error
+        return result
+
+    result["checked"] = True
+    result["computed"] = computed
+    result["ok"] = computed == result["reported"]
+    if not result["ok"]:
+        result["reason"] = "bridge health scriptHash does not match running script path"
+    return result
 
 
 def env_presence(env_sources: dict[str, dict[str, str]], keys: tuple[str, ...]) -> dict[str, Any]:
@@ -871,6 +922,21 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
                     f"bridge process mode={process_mode!r}, expected {expected_mode!r}"
                 )
 
+    bridge_script_hash = build_bridge_script_hash_check(bridge_health, bridge_process)
+    if bridge_script_hash["checked"] and not bridge_script_hash["ok"]:
+        failures.append(
+            "WhatsApp bridge script hash mismatch: "
+            f"health reported {bridge_script_hash.get('reported')}, "
+            f"computed {bridge_script_hash.get('computed')} from "
+            f"{bridge_script_hash.get('script')}"
+        )
+    elif (
+        not bridge_script_hash["checked"]
+        and not args.skip_bridge_health
+        and not args.skip_process_check
+    ):
+        warnings.append(str(bridge_script_hash.get("reason")))
+
     cloud = build_cloud_summary(env_sources)
     if args.check_whatsapp_cloud_api:
         cloud_api = build_cloud_api_check(
@@ -921,6 +987,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         "lid_mapping": lid_mapping,
         "bridge_health": bridge_health,
         "bridge_process": bridge_process,
+        "bridge_script_hash": bridge_script_hash,
         "env_key_sources": {
             source: sorted(key for key in values if key.startswith("WHATSAPP"))
             for source, values in env_sources.items()
@@ -973,6 +1040,7 @@ def human_summary(result: dict[str, Any]) -> None:
     identity = checks.get("baileys_identity") or {}
     health = checks.get("bridge_health") or {}
     process = (checks.get("bridge_process") or {}).get("selected") or {}
+    bridge_script_hash = checks.get("bridge_script_hash") or {}
     cloud = checks.get("whatsapp_cloud") or {}
     webhook = cloud.get("webhook") or {}
     cloud_api = cloud.get("cloud_api") or {}
@@ -1002,6 +1070,16 @@ def human_summary(result: dict[str, Any]) -> None:
             "bridge_process="
             f"pid={process.get('pid')} mode={process.get('mode') or '<unknown>'} "
             f"session={process.get('session') or '<unknown>'}"
+        )
+    if bridge_script_hash:
+        if bridge_script_hash.get("checked"):
+            hash_status = "matched" if bridge_script_hash.get("ok") else "mismatch"
+        else:
+            hash_status = "unchecked"
+        print(
+            "bridge_script_hash="
+            f"{hash_status} reported={bridge_script_hash.get('reported') or '<missing>'} "
+            f"computed={bridge_script_hash.get('computed') or '<missing>'}"
         )
     print(
         "whatsapp_local="

--- a/tests/test_verify_whatsapp_bridge_runtime.py
+++ b/tests/test_verify_whatsapp_bridge_runtime.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import hashlib
 import importlib.util
 import json
 from pathlib import Path
@@ -133,6 +134,101 @@ class WhatsAppBridgeRuntimeVerifierTests(unittest.TestCase):
 
         self.assertFalse(result["success"])
         self.assertIn("does not match expected", "\n".join(result["failures"]))
+
+    def test_bridge_script_hash_matches_health_report(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(
+                tmp_path,
+                skip_bridge_health=False,
+                skip_process_check=False,
+            )
+            write_baileys_session(args.session_dir)
+            args.env_file.parent.mkdir(parents=True, exist_ok=True)
+            args.env_file.write_text("WHATSAPP_MODE=bot\n", encoding="utf-8")
+            bridge_script = tmp_path / "whatsapp-bridge" / "bridge.js"
+            bridge_script.parent.mkdir()
+            bridge_script.write_text("console.log('bridge');\n", encoding="utf-8")
+            script_hash = hashlib.sha256(bridge_script.read_bytes()).hexdigest()[:16]
+
+            original_fetch = self.script.fetch_bridge_health
+            original_processes = self.script.find_bridge_processes
+            self.script.fetch_bridge_health = lambda *_args, **_kwargs: (
+                {
+                    "status": "connected",
+                    "queueLength": 0,
+                    "scriptHash": script_hash,
+                },
+                None,
+            )
+            self.script.find_bridge_processes = lambda **_kwargs: [
+                {
+                    "pid": 1234,
+                    "script": str(bridge_script),
+                    "port": "3000",
+                    "session": str(args.session_dir),
+                    "mode": "bot",
+                }
+            ]
+            try:
+                result = self.script.verify(args)
+            finally:
+                self.script.fetch_bridge_health = original_fetch
+                self.script.find_bridge_processes = original_processes
+
+        self.assertTrue(result["success"], result["failures"])
+        hash_check = result["checks"]["bridge_script_hash"]
+        self.assertTrue(hash_check["checked"])
+        self.assertTrue(hash_check["ok"])
+        self.assertEqual(hash_check["reported"], script_hash)
+        self.assertEqual(hash_check["computed"], script_hash)
+
+    def test_bridge_script_hash_mismatch_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(
+                tmp_path,
+                skip_bridge_health=False,
+                skip_process_check=False,
+            )
+            write_baileys_session(args.session_dir)
+            args.env_file.parent.mkdir(parents=True, exist_ok=True)
+            args.env_file.write_text("WHATSAPP_MODE=bot\n", encoding="utf-8")
+            bridge_script = tmp_path / "whatsapp-bridge" / "bridge.js"
+            bridge_script.parent.mkdir()
+            bridge_script.write_text("console.log('new bridge');\n", encoding="utf-8")
+
+            original_fetch = self.script.fetch_bridge_health
+            original_processes = self.script.find_bridge_processes
+            self.script.fetch_bridge_health = lambda *_args, **_kwargs: (
+                {
+                    "status": "connected",
+                    "queueLength": 0,
+                    "scriptHash": "stale00000000000",
+                },
+                None,
+            )
+            self.script.find_bridge_processes = lambda **_kwargs: [
+                {
+                    "pid": 1234,
+                    "script": str(bridge_script),
+                    "port": "3000",
+                    "session": str(args.session_dir),
+                    "mode": "bot",
+                }
+            ]
+            try:
+                result = self.script.verify(args)
+            finally:
+                self.script.fetch_bridge_health = original_fetch
+                self.script.find_bridge_processes = original_processes
+
+        self.assertFalse(result["success"])
+        self.assertIn("script hash mismatch", "\n".join(result["failures"]))
+        hash_check = result["checks"]["bridge_script_hash"]
+        self.assertTrue(hash_check["checked"])
+        self.assertFalse(hash_check["ok"])
+        self.assertEqual(hash_check["reported"], "stale00000000000")
 
     def test_require_cloud_fails_when_cloud_credentials_are_missing(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- compare the WhatsApp bridge `/health.scriptHash` to the selected running `bridge.js` file
- fail the bridge verifier when the connected process is serving stale bridge code
- print a `bridge_script_hash=matched|mismatch|unchecked` summary line and document the check

## Why

The bridge already reports a short script hash to guard against long-lived stale bridge processes. Voice's verifier now uses it, so a connected bridge cannot silently pass readiness while running older code that may not match the audio-cache receive behavior we rely on.

## Verification

- `python3 -m unittest tests.test_verify_whatsapp_bridge_runtime`
- `python3 -m py_compile scripts/verify_whatsapp_bridge_runtime.py tests/test_verify_whatsapp_bridge_runtime.py`
- `scripts/verify_whatsapp_bridge_runtime.py --hermes-home /home/ubuntu/.hermes --expected-agent-number 13236478455 --expected-agent-name Quill`
- `python3 -m unittest discover tests`
- `bash -n scripts/verify_local_hermes_voice_stack.sh scripts/verify_whatsapp_voice_contract.sh scripts/verify_telegram_voice_contract.sh`
- `git diff --check`
- live aggregate stack gate passed with `bridge_script_hash=matched`, `telegram_voice_contract=checked`, and `whatsapp_attended_watch=checked`

## Live local evidence

```text
bridge=http://127.0.0.1:3000 status=connected queue=0
baileys_session=paired name=Quill number=13236478455 lid=186999436771390 platform=smbi
bridge_process=pid=1248929 mode=bot session=/home/ubuntu/.hermes/whatsapp/session
bridge_script_hash=matched reported=3b41e22f632c81f6 computed=3b41e22f632c81f6
```

Still pending for the broader alpha: fresh attended inbound WhatsApp voice-note evidence and external WhatsApp Cloud/Calling credentials.
