### PR TITLE
Show attended watch deadlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,9 +472,11 @@ intent, launched command, wait window, expected agent metadata, audio cache
 directory, and artifact paths even while JSON/log output is still empty.
 Use `--status <unit-or-service>` with the printed unit name to summarize
 whether the watch is still waiting, failed, completed, or verified fresh
-receive evidence. Use `--list` to discover active watches and matching
-artifacts from a later session. Use `--stop <unit-or-service>` to stop a stale
-watch without deleting its JSON/log/manifest artifacts.
+receive evidence. Status and list output also include the computed deadline and
+remaining wait time from the manifest, so long attended windows can be checked
+without hand-parsing timestamps. Use `--list` to discover active watches and
+matching artifacts from a later session. Use `--stop <unit-or-service>` to stop
+a stale watch without deleting its JSON/log/manifest artifacts.
 
 To fail unless every alpha gate is complete, include the strict completion flag:
 

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -332,7 +332,9 @@ scripts/start_whatsapp_attended_cache_watch.py \
 ```
 
 Status output reports whether the watch is still waiting, has no artifact yet,
-failed, completed, or verified fresh receive evidence.
+failed, completed, or verified fresh receive evidence. When a manifest is
+available, status and list output also show the computed deadline and remaining
+wait time for the active receive window.
 To discover active watches and matching `/tmp` artifacts from a later session,
 run:
 

--- a/scripts/start_whatsapp_attended_cache_watch.py
+++ b/scripts/start_whatsapp_attended_cache_watch.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import argparse
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import json
 import os
 from pathlib import Path
@@ -274,6 +274,53 @@ def summarize_manifest_payload(payload: dict[str, Any] | None) -> dict[str, Any]
     }
 
 
+def format_utc(dt: datetime) -> str:
+    return (
+        dt.astimezone(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def parse_utc(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def summarize_watch_timing(manifest_summary: dict[str, Any]) -> dict[str, Any]:
+    created_at = parse_utc(manifest_summary.get("created_at_utc"))
+    wait_seconds = manifest_summary.get("wait_seconds")
+    try:
+        wait_seconds = float(wait_seconds)
+    except (TypeError, ValueError):
+        wait_seconds = None
+
+    if created_at is None or wait_seconds is None:
+        return {}
+
+    now = datetime.now(timezone.utc)
+    deadline = created_at + timedelta(seconds=wait_seconds)
+    elapsed_seconds = (now - created_at).total_seconds()
+    remaining_seconds = (deadline - now).total_seconds()
+    return {
+        "created_at_utc": format_utc(created_at),
+        "deadline_utc": format_utc(deadline),
+        "wait_seconds": wait_seconds,
+        "elapsed_seconds": round(elapsed_seconds, 3),
+        "remaining_seconds": round(max(0.0, remaining_seconds), 3),
+        "expired": remaining_seconds <= 0,
+    }
+
+
 def classify_watch_status(
     *,
     systemd_state: dict[str, str],
@@ -326,6 +373,7 @@ def inspect_unit(unit_or_service: str, args: argparse.Namespace) -> dict[str, An
     log_artifact.pop("payload", None)
     manifest_artifact = artifact_status(manifest_path)
     manifest_summary = summarize_manifest_payload(manifest_artifact.get("payload"))
+    timing_summary = summarize_watch_timing(manifest_summary)
     manifest_artifact.pop("payload", None)
     alpha_summary = summarize_alpha_payload(json_artifact.get("payload"))
     watch_status = classify_watch_status(
@@ -346,6 +394,7 @@ def inspect_unit(unit_or_service: str, args: argparse.Namespace) -> dict[str, An
         "log": log_artifact,
         "manifest": manifest_artifact,
         "manifest_summary": manifest_summary,
+        "timing": timing_summary,
         "alpha": alpha_summary,
         "status_command": ["systemctl", "--user", "status", service],
         "journal_command": ["journalctl", "--user", "-u", service, "-f"],
@@ -516,6 +565,15 @@ def print_status_human(result: dict[str, Any]) -> None:
                 f"prompt_text={attended_prompt.get('prompt_text')} "
                 f"audio_cache_dir={attended_prompt.get('audio_cache_dir')}"
             )
+    timing = result.get("timing") or {}
+    if timing:
+        print(
+            "timing="
+            f"deadline_utc={timing.get('deadline_utc')} "
+            f"elapsed_seconds={timing.get('elapsed_seconds')} "
+            f"remaining_seconds={timing.get('remaining_seconds')} "
+            f"expired={timing.get('expired')}"
+        )
     alpha = result.get("alpha") or {}
     if alpha:
         print(
@@ -565,12 +623,15 @@ def print_list_human(result: dict[str, Any]) -> None:
     for index, watch in enumerate(result.get("watches") or [], start=1):
         json_artifact = watch.get("json") or {}
         manifest_summary = watch.get("manifest_summary") or {}
+        timing = watch.get("timing") or {}
         print(
             f"watch[{index}]={watch.get('unit')} "
             f"status={watch.get('watch_status')} "
             f"active_state={(watch.get('systemd') or {}).get('ActiveState')} "
             f"json_size={json_artifact.get('size_bytes')} "
             f"manifest_wait_seconds={manifest_summary.get('wait_seconds')} "
+            f"remaining_seconds={timing.get('remaining_seconds')} "
+            f"deadline_utc={timing.get('deadline_utc')} "
             "sends_prompt_voice_note="
             f"{(manifest_summary.get('attended_prompt') or {}).get('sends_prompt_voice_note')}"
         )

--- a/tests/test_start_whatsapp_attended_cache_watch.py
+++ b/tests/test_start_whatsapp_attended_cache_watch.py
@@ -405,6 +405,10 @@ class WhatsAppAttendedCacheWatchLauncherTests(unittest.TestCase):
             payload["manifest_summary"]["attended_prompt"]["prompt_text"],
             "reply with a voice note",
         )
+        self.assertEqual(payload["timing"]["created_at_utc"], "2026-06-14T22:51:18Z")
+        self.assertEqual(payload["timing"]["deadline_utc"], "2026-06-14T22:53:18Z")
+        self.assertEqual(payload["timing"]["wait_seconds"], 120.0)
+        self.assertTrue(payload["timing"]["expired"])
 
     def test_list_discovers_active_units_and_artifacts(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -523,6 +527,10 @@ class WhatsAppAttendedCacheWatchLauncherTests(unittest.TestCase):
         self.assertEqual(
             by_unit["watch-manifest"]["manifest_summary"]["wait_seconds"],
             60.0,
+        )
+        self.assertEqual(
+            by_unit["watch-manifest"]["timing"]["deadline_utc"],
+            "2026-06-14T22:52:18Z",
         )
         self.assertTrue(
             by_unit["watch-manifest"]["manifest_summary"]["attended_prompt"][


### PR DESCRIPTION
## Summary

- add timing summaries to attended WhatsApp cache watch status/list output
- compute `deadline_utc`, `elapsed_seconds`, `remaining_seconds`, and `expired` from the saved manifest
- document that long attended receive windows can be checked without hand-parsing timestamps

## Why

Long attended receive watches intentionally leave the result JSON empty until fresh audio arrives or the wait expires. The manifest already has `created_at_utc` and `wait_seconds`; this makes that information operational in `--status`, `--list`, and the aggregate stack gate.

## Verification

- `python3 -m unittest tests.test_start_whatsapp_attended_cache_watch`
- `python3 -m py_compile scripts/start_whatsapp_attended_cache_watch.py tests/test_start_whatsapp_attended_cache_watch.py`
- `scripts/start_whatsapp_attended_cache_watch.py --status voice-whatsapp-attended-cache-watch-20260614T235857Z --output-dir /tmp`
- `scripts/start_whatsapp_attended_cache_watch.py --list --output-dir /tmp --unit-prefix voice-whatsapp-attended-cache-watch`
- `python3 -m unittest discover tests`
- `bash -n scripts/verify_local_hermes_voice_stack.sh scripts/verify_whatsapp_voice_contract.sh scripts/verify_telegram_voice_contract.sh scripts/verify_hermes_command_tts.sh`
- `git diff --check`
- live aggregate stack gate passed with `whatsapp_attended_watch=checked`

## Live local evidence

```text
watch[1]=voice-whatsapp-attended-cache-watch-20260614T235857Z status=waiting_for_fresh_audio active_state=active json_size=0 manifest_wait_seconds=21600.0 remaining_seconds=19894.551 deadline_utc=2026-06-15T05:58:57Z sends_prompt_voice_note=True
```

Still pending for the broader alpha: fresh attended inbound WhatsApp voice-note evidence and external WhatsApp Cloud/Calling credentials.
