### PR TITLE
Preserve alpha handoff settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,10 +497,12 @@ separated from local daemon, bridge, and Hermes failures. It also prints the
 resolved Cloud webhook bind defaults and malformed webhook keys, so strict
 Cloud/Calling failures can distinguish missing credentials from invalid
 `WHATSAPP_CLOUD_WEBHOOK_*` settings. The generated complete-alpha handoff
+keeps the selected `voice` binary, Hermes config, bridge URL, sidecar URL,
+audio cache override, and expected agent identity from the current run. It also
 includes `--require-whatsapp-cloud`, `--require-whatsapp-calling`, and
-`--check-whatsapp-cloud-api`, so after real Cloud credentials are present it
-also makes an authenticated Graph API phone-number request without printing
-token or phone-number values.
+`--check-whatsapp-cloud-api`, so after real Cloud credentials are present it also
+makes an authenticated Graph API phone-number request without printing token or
+phone-number values.
 Use `--whatsapp-alpha-json-output` with any alpha profile when another local
 agent should consume the same structured `readiness_summary.next_actions`
 without rerunning the full stack gate. The stack verifier also echoes compact

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -152,8 +152,10 @@ For the external Meta gates, the JSON report includes safe setup handoffs under
 `pending_gates.whatsapp_cloud.setup_handoff` and
 `pending_gates.whatsapp_cloud_calling.setup_handoff`. These handoffs list the
 required key names, which keys are missing, redacted source labels for values
-that were found, and the exact follow-up verifier commands. Secret values are
-never printed. The Cloud handoff also reports the resolved local webhook
+that were found, and the exact follow-up verifier commands. Those commands
+preserve the selected `voice` binary, Hermes config, bridge URL, sidecar URL,
+audio cache override, and expected agent identity from the current run. Secret
+values are never printed. The Cloud handoff also reports the resolved local webhook
 binding (`host`, `port`, `path`, and `api_version`), which values came from env
 sources versus Hermes defaults, and malformed webhook keys under `invalid`.
 `readiness_summary.next_actions` repeats the same non-secret commands,

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -164,6 +164,36 @@ def script_path(name: str) -> str:
     return str(path)
 
 
+def alpha_handoff_base_command(args: argparse.Namespace) -> list[str]:
+    command = [
+        "scripts/verify_whatsapp_alpha_readiness.py",
+        "--voice-bin",
+        str(args.voice_bin),
+        "--hermes-home",
+        str(args.hermes_home.expanduser().resolve()),
+        "--hermes-config",
+        str(args.hermes_config.expanduser().resolve()),
+        "--bridge-url",
+        args.bridge_url,
+        "--sidecar-url",
+        args.sidecar_url,
+        "--attended-prompt-text",
+        args.attended_prompt_text,
+    ]
+    if args.whatsapp_audio_cache_dir:
+        command.extend(
+            [
+                "--whatsapp-audio-cache-dir",
+                str(args.whatsapp_audio_cache_dir.expanduser().resolve()),
+            ]
+        )
+    if args.expected_agent_number:
+        command.extend(["--expected-agent-number", args.expected_agent_number])
+    if args.expected_agent_name:
+        command.extend(["--expected-agent-name", args.expected_agent_name])
+    return command
+
+
 def audio_cache_dir(args: argparse.Namespace, hermes_home: Path) -> Path:
     if args.whatsapp_audio_cache_dir:
         return args.whatsapp_audio_cache_dir.expanduser().resolve()
@@ -516,8 +546,8 @@ def bridge_audio_event_evidence(inbound: dict[str, Any]) -> dict[str, Any]:
 def attended_receive_gate(
     components: list[dict[str, Any]],
     *,
-    hermes_home: Path,
     audio_cache_dir: Path,
+    base_command: list[str],
     preferred_wait_audio_cache_seconds: float = DEFAULT_ATTENDED_CACHE_RECEIVE_SECONDS,
     fallback_wait_inbound_seconds: float = DEFAULT_ATTENDED_DRAIN_RECEIVE_SECONDS,
 ) -> dict[str, Any]:
@@ -535,18 +565,14 @@ def attended_receive_gate(
         "drains_bridge_messages": False,
         "reason": "fresh WhatsApp inbound voice-note receive has not been run",
         "command": [
-            "scripts/verify_whatsapp_alpha_readiness.py",
-            "--hermes-home",
-            str(hermes_home),
+            *base_command,
             "--profile",
             "attended-cache-receive",
             "--wait-audio-cache-seconds",
             str(preferred_wait_audio_cache_seconds),
         ],
         "fallback_draining_command": [
-            "scripts/verify_whatsapp_alpha_readiness.py",
-            "--hermes-home",
-            str(hermes_home),
+            *base_command,
             "--profile",
             "attended-send-receive",
             "--wait-inbound-seconds",
@@ -656,7 +682,7 @@ def cloud_setup_handoff(
     *,
     external_meta_setup: dict[str, Any],
     bridge_checks: dict[str, Any],
-    hermes_home: Path,
+    base_command: list[str],
 ) -> dict[str, Any]:
     cloud = bridge_checks.get("whatsapp_cloud") or {}
     cloud_required = cloud.get("cloud_required") or {}
@@ -665,9 +691,7 @@ def cloud_setup_handoff(
     invalid = [str(key) for key in external_meta_setup.get("cloud_invalid") or []]
     configured = bool(external_meta_setup.get("cloud_configured"))
     verify_command = [
-        "scripts/verify_whatsapp_alpha_readiness.py",
-        "--hermes-home",
-        str(hermes_home),
+        *base_command,
         "--require-whatsapp-cloud",
         "--check-whatsapp-cloud-api",
     ]
@@ -705,7 +729,8 @@ def calling_setup_handoff(
     *,
     external_meta_setup: dict[str, Any],
     bridge_checks: dict[str, Any],
-    hermes_home: Path,
+    base_command: list[str],
+    complete_wait_audio_cache_seconds: float,
 ) -> dict[str, Any]:
     cloud = bridge_checks.get("whatsapp_cloud") or {}
     calling = cloud.get("calling") or {}
@@ -719,19 +744,17 @@ def calling_setup_handoff(
     ]
     ready = bool(external_meta_setup.get("calling_ready"))
     verify_command = [
-        "scripts/verify_whatsapp_alpha_readiness.py",
-        "--hermes-home",
-        str(hermes_home),
+        *base_command,
         "--require-whatsapp-cloud",
         "--require-whatsapp-calling",
         "--check-whatsapp-cloud-api",
     ]
     complete_command = [
-        "scripts/verify_whatsapp_alpha_readiness.py",
-        "--hermes-home",
-        str(hermes_home),
+        *base_command,
         "--profile",
         "attended-cache-receive",
+        "--wait-audio-cache-seconds",
+        str(complete_wait_audio_cache_seconds),
         "--require-whatsapp-cloud",
         "--require-whatsapp-calling",
         "--check-whatsapp-cloud-api",
@@ -776,7 +799,8 @@ def external_meta_gate(
     external_meta_setup: dict[str, Any],
     *,
     bridge_checks: dict[str, Any],
-    hermes_home: Path,
+    base_command: list[str],
+    complete_wait_audio_cache_seconds: float,
 ) -> dict[str, Any]:
     cloud_missing = [str(key) for key in external_meta_setup.get("cloud_missing") or []]
     cloud_invalid = [str(key) for key in external_meta_setup.get("cloud_invalid") or []]
@@ -791,12 +815,13 @@ def external_meta_gate(
     cloud_handoff = cloud_setup_handoff(
         external_meta_setup=external_meta_setup,
         bridge_checks=bridge_checks,
-        hermes_home=hermes_home,
+        base_command=base_command,
     )
     calling_handoff = calling_setup_handoff(
         external_meta_setup=external_meta_setup,
         bridge_checks=bridge_checks,
-        hermes_home=hermes_home,
+        base_command=base_command,
+        complete_wait_audio_cache_seconds=complete_wait_audio_cache_seconds,
     )
     return {
         "whatsapp_cloud": {
@@ -1012,15 +1037,21 @@ def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
             }
         )
 
+    handoff_base_command = alpha_handoff_base_command(args)
+    complete_wait_audio_cache_seconds = (
+        args.wait_audio_cache_seconds
+        if args.profile == "attended-cache-receive"
+        else DEFAULT_ATTENDED_CACHE_RECEIVE_SECONDS
+    )
     pending_gates = {
         "attended_fresh_receive": attended_receive_gate(
             components,
-            hermes_home=args.hermes_home.expanduser().resolve(),
             audio_cache_dir=(
                 args.whatsapp_audio_cache_dir.expanduser().resolve()
                 if args.whatsapp_audio_cache_dir
                 else args.hermes_home.expanduser().resolve() / "audio_cache"
             ),
+            base_command=handoff_base_command,
             preferred_wait_audio_cache_seconds=(
                 args.wait_audio_cache_seconds
                 if args.profile == "attended-cache-receive"
@@ -1035,7 +1066,8 @@ def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
         **external_meta_gate(
             external_meta_setup,
             bridge_checks=bridge_checks,
-            hermes_home=args.hermes_home.expanduser().resolve(),
+            base_command=handoff_base_command,
+            complete_wait_audio_cache_seconds=complete_wait_audio_cache_seconds,
         ),
     }
     readiness_summary = build_readiness_summary(

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -243,7 +243,8 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
 
     def test_readiness_succeeds_for_baileys_alpha_when_cloud_is_missing(self):
         with tempfile.TemporaryDirectory() as tmp:
-            payload = self.run_readiness(Path(tmp))
+            tmp_path = Path(tmp)
+            payload = self.run_readiness(tmp_path)
 
         self.assertTrue(payload["success"])
         self.assertEqual(payload["external_meta_setup"]["cloud_configured"], False)
@@ -262,6 +263,15 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             "attended-cache-receive",
             gates["attended_fresh_receive"]["command"],
         )
+        self.assertIn("--voice-bin", gates["attended_fresh_receive"]["command"])
+        self.assertIn(str(tmp_path / "voice"), gates["attended_fresh_receive"]["command"])
+        self.assertIn("--hermes-config", gates["attended_fresh_receive"]["command"])
+        self.assertIn(str(tmp_path / "config.yaml"), gates["attended_fresh_receive"]["command"])
+        self.assertIn("--bridge-url", gates["attended_fresh_receive"]["command"])
+        self.assertIn("http://127.0.0.1:3000", gates["attended_fresh_receive"]["command"])
+        self.assertIn("--sidecar-url", gates["attended_fresh_receive"]["command"])
+        self.assertIn("http://127.0.0.1:8787", gates["attended_fresh_receive"]["command"])
+        self.assertIn("--attended-prompt-text", gates["attended_fresh_receive"]["command"])
         self.assertIn(
             "--wait-audio-cache-seconds",
             gates["attended_fresh_receive"]["command"],
@@ -273,6 +283,10 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         )
         self.assertIn(
             "--wait-inbound-seconds",
+            gates["attended_fresh_receive"]["fallback_draining_command"],
+        )
+        self.assertIn(
+            str(tmp_path / "voice"),
             gates["attended_fresh_receive"]["fallback_draining_command"],
         )
         self.assertIn(
@@ -319,6 +333,8 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             cloud_handoff["available_source_keys"]["systemd_service"],
         )
         self.assertIn("--require-whatsapp-cloud", cloud_handoff["verify_command"])
+        self.assertIn(str(tmp_path / "voice"), cloud_handoff["verify_command"])
+        self.assertIn(str(tmp_path / "config.yaml"), cloud_handoff["verify_command"])
         self.assertIn(
             "--check-whatsapp-cloud-api",
             cloud_handoff["verify_command"],
@@ -361,6 +377,8 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertIn("--require-whatsapp-calling", complete_command)
         self.assertIn("--check-whatsapp-cloud-api", complete_command)
         self.assertIn("--require-complete", complete_command)
+        self.assertIn("--wait-audio-cache-seconds", complete_command)
+        self.assertIn(str(tmp_path / "voice"), complete_command)
         self.assertEqual(len(calling_handoff["steps"]), 5)
         summary = payload["readiness_summary"]
         self.assertEqual(summary["status"], "local_ready_pending_gates")
@@ -457,6 +475,50 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         }["configure_whatsapp_cloud_calling"]
         self.assertEqual(action["missing_by_gate"]["whatsapp_cloud"], [])
         self.assertEqual(action["invalid_by_gate"]["whatsapp_cloud"], invalid)
+
+    def test_handoff_commands_include_explicit_host_overrides(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            cache_dir = tmp_path / "custom-audio-cache"
+            payload = self.run_readiness(
+                tmp_path,
+                "--expected-agent-number",
+                "13236478455",
+                "--expected-agent-name",
+                "Quill",
+                "--bridge-url",
+                "http://127.0.0.1:3999",
+                "--sidecar-url",
+                "http://127.0.0.1:9888",
+                "--whatsapp-audio-cache-dir",
+                str(cache_dir),
+            )
+
+        gates = payload["pending_gates"]
+        commands = [
+            gates["attended_fresh_receive"]["command"],
+            gates["attended_fresh_receive"]["fallback_draining_command"],
+            gates["whatsapp_cloud"]["setup_handoff"]["verify_command"],
+            gates["whatsapp_cloud_calling"]["setup_handoff"]["verify_command"],
+            gates["whatsapp_cloud_calling"]["setup_handoff"][
+                "complete_verification_command"
+            ],
+        ]
+        for command in commands:
+            self.assertIn("--voice-bin", command)
+            self.assertIn(str(tmp_path / "voice"), command)
+            self.assertIn("--hermes-config", command)
+            self.assertIn(str(tmp_path / "config.yaml"), command)
+            self.assertIn("--bridge-url", command)
+            self.assertIn("http://127.0.0.1:3999", command)
+            self.assertIn("--sidecar-url", command)
+            self.assertIn("http://127.0.0.1:9888", command)
+            self.assertIn("--whatsapp-audio-cache-dir", command)
+            self.assertIn(str(cache_dir.resolve()), command)
+            self.assertIn("--expected-agent-number", command)
+            self.assertIn("13236478455", command)
+            self.assertIn("--expected-agent-name", command)
+            self.assertIn("Quill", command)
 
     def test_require_complete_fails_when_alpha_gates_are_pending(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- make alpha next-action handoff commands preserve the selected host settings from the current run
- include the active `voice` binary, Hermes config, bridge URL, sidecar URL, attended prompt, expected agent identity, and audio-cache override when present
- carry the attended cache wait window into the strict complete-alpha handoff

## Why

The JSON and compact stack-gate handoffs are what another local agent/operator will copy when the alpha is pending. Before this change, those commands only included `--hermes-home` plus the profile/requirement flags, which made them less replayable on a host with explicit installed binaries, config paths, bridge URLs, or expected Quill identity checks.

## Verification

- `python3 -m unittest tests.test_verify_whatsapp_alpha_readiness`
- `python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_alpha_readiness.py`
- `python3 -m unittest discover tests`
- `bash -n scripts/verify_local_hermes_voice_stack.sh scripts/verify_whatsapp_voice_contract.sh scripts/verify_telegram_voice_contract.sh scripts/verify_hermes_command_tts.sh`
- `git diff --check`
- live aggregate stack gate passed with `whatsapp_attended_watch=checked`

## Live local evidence

The aggregate stack gate now emits replayable commands like:

```text
whatsapp_alpha_json_attended_command=scripts/verify_whatsapp_alpha_readiness.py --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --hermes-config /home/ubuntu/.hermes/config.yaml --bridge-url http://127.0.0.1:3000 --sidecar-url http://127.0.0.1:8787 --attended-prompt-text 'Please reply with a fresh WhatsApp voice note so I can verify the voice runtime.' --expected-agent-number 13236478455 --expected-agent-name Quill --profile attended-cache-receive --wait-audio-cache-seconds 60.0
```

Still pending for the broader alpha: fresh attended inbound WhatsApp voice-note evidence and external WhatsApp Cloud/Calling credentials.
