### PR TITLE
Report attended watch cache freshness

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,9 +474,12 @@ Use `--status <unit-or-service>` with the printed unit name to summarize
 whether the watch is still waiting, failed, completed, or verified fresh
 receive evidence. Status and list output also include the computed deadline and
 remaining wait time from the manifest, so long attended windows can be checked
-without hand-parsing timestamps. Use `--list` to discover active watches and
-matching artifacts from a later session. Use `--stop <unit-or-service>` to stop
-a stale watch without deleting its JSON/log/manifest artifacts.
+without hand-parsing timestamps. When the manifest names an audio cache
+directory, status and list output also show the latest cached `aud_*` file and
+whether it is newer than the watch start time. Use `--list` to discover active
+watches and matching artifacts from a later session. Use `--stop
+<unit-or-service>` to stop a stale watch without deleting its JSON/log/manifest
+artifacts.
 
 To fail unless every alpha gate is complete, include the strict completion flag:
 

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -336,7 +336,9 @@ scripts/start_whatsapp_attended_cache_watch.py \
 Status output reports whether the watch is still waiting, has no artifact yet,
 failed, completed, or verified fresh receive evidence. When a manifest is
 available, status and list output also show the computed deadline and remaining
-wait time for the active receive window.
+wait time for the active receive window. If the manifest includes the audio
+cache directory, status and list output also report the latest cached `aud_*`
+file and whether it is newer than the watch start time.
 To discover active watches and matching `/tmp` artifacts from a later session,
 run:
 

--- a/scripts/start_whatsapp_attended_cache_watch.py
+++ b/scripts/start_whatsapp_attended_cache_watch.py
@@ -21,6 +21,7 @@ DEFAULT_ATTENDED_PROMPT_TEXT = (
     "Please reply with a fresh WhatsApp voice note so I can verify the voice runtime."
 )
 ATTENDED_PROFILE = "attended-cache-receive"
+AUDIO_CACHE_SUFFIXES = {".ogg", ".opus", ".m4a"}
 
 
 def repo_root() -> Path:
@@ -321,6 +322,60 @@ def summarize_watch_timing(manifest_summary: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def summarize_audio_cache(manifest_summary: dict[str, Any]) -> dict[str, Any]:
+    attended_prompt = manifest_summary.get("attended_prompt")
+    attended_prompt = attended_prompt if isinstance(attended_prompt, dict) else {}
+    audio_cache_dir = attended_prompt.get("audio_cache_dir")
+    if not isinstance(audio_cache_dir, str) or not audio_cache_dir:
+        return {}
+
+    created_at = parse_utc(manifest_summary.get("created_at_utc"))
+    cache_dir = Path(audio_cache_dir).expanduser()
+    summary: dict[str, Any] = {
+        "path": str(cache_dir),
+        "exists": cache_dir.is_dir(),
+        "candidate_count": 0,
+        "latest_path": None,
+        "latest_file": None,
+        "latest_mtime_utc": None,
+        "latest_size_bytes": None,
+        "latest_age_seconds": None,
+        "fresh_since_created": None if created_at is None else False,
+    }
+    if not cache_dir.is_dir():
+        return summary
+
+    candidates = [
+        path
+        for path in cache_dir.iterdir()
+        if path.is_file()
+        and path.name.startswith("aud_")
+        and path.suffix.lower() in AUDIO_CACHE_SUFFIXES
+    ]
+    summary["candidate_count"] = len(candidates)
+    if not candidates:
+        return summary
+
+    latest = max(candidates, key=lambda path: path.stat().st_mtime)
+    stat = latest.stat()
+    latest_mtime = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
+    summary.update(
+        {
+            "latest_path": str(latest),
+            "latest_file": latest.name,
+            "latest_mtime_utc": format_utc(latest_mtime),
+            "latest_size_bytes": stat.st_size,
+            "latest_age_seconds": round(
+                max(0.0, (datetime.now(timezone.utc) - latest_mtime).total_seconds()),
+                3,
+            ),
+        }
+    )
+    if created_at is not None:
+        summary["fresh_since_created"] = latest_mtime > created_at
+    return summary
+
+
 def classify_watch_status(
     *,
     systemd_state: dict[str, str],
@@ -374,6 +429,7 @@ def inspect_unit(unit_or_service: str, args: argparse.Namespace) -> dict[str, An
     manifest_artifact = artifact_status(manifest_path)
     manifest_summary = summarize_manifest_payload(manifest_artifact.get("payload"))
     timing_summary = summarize_watch_timing(manifest_summary)
+    audio_cache_summary = summarize_audio_cache(manifest_summary)
     manifest_artifact.pop("payload", None)
     alpha_summary = summarize_alpha_payload(json_artifact.get("payload"))
     watch_status = classify_watch_status(
@@ -395,6 +451,7 @@ def inspect_unit(unit_or_service: str, args: argparse.Namespace) -> dict[str, An
         "manifest": manifest_artifact,
         "manifest_summary": manifest_summary,
         "timing": timing_summary,
+        "audio_cache": audio_cache_summary,
         "alpha": alpha_summary,
         "status_command": ["systemctl", "--user", "status", service],
         "journal_command": ["journalctl", "--user", "-u", service, "-f"],
@@ -574,6 +631,17 @@ def print_status_human(result: dict[str, Any]) -> None:
             f"remaining_seconds={timing.get('remaining_seconds')} "
             f"expired={timing.get('expired')}"
         )
+    audio_cache = result.get("audio_cache") or {}
+    if audio_cache:
+        print(
+            "audio_cache="
+            f"path={audio_cache.get('path')} "
+            f"exists={audio_cache.get('exists')} "
+            f"candidate_count={audio_cache.get('candidate_count')} "
+            f"latest_file={audio_cache.get('latest_file')} "
+            f"latest_mtime_utc={audio_cache.get('latest_mtime_utc')} "
+            f"fresh_since_created={audio_cache.get('fresh_since_created')}"
+        )
     alpha = result.get("alpha") or {}
     if alpha:
         print(
@@ -624,6 +692,7 @@ def print_list_human(result: dict[str, Any]) -> None:
         json_artifact = watch.get("json") or {}
         manifest_summary = watch.get("manifest_summary") or {}
         timing = watch.get("timing") or {}
+        audio_cache = watch.get("audio_cache") or {}
         print(
             f"watch[{index}]={watch.get('unit')} "
             f"status={watch.get('watch_status')} "
@@ -632,6 +701,8 @@ def print_list_human(result: dict[str, Any]) -> None:
             f"manifest_wait_seconds={manifest_summary.get('wait_seconds')} "
             f"remaining_seconds={timing.get('remaining_seconds')} "
             f"deadline_utc={timing.get('deadline_utc')} "
+            f"latest_audio={audio_cache.get('latest_file')} "
+            f"latest_audio_fresh={audio_cache.get('fresh_since_created')} "
             "sends_prompt_voice_note="
             f"{(manifest_summary.get('attended_prompt') or {}).get('sends_prompt_voice_note')}"
         )

--- a/tests/test_start_whatsapp_attended_cache_watch.py
+++ b/tests/test_start_whatsapp_attended_cache_watch.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
-from pathlib import Path
+from datetime import datetime, timezone
 import json
 import os
+from pathlib import Path
 import subprocess
 import tempfile
 import textwrap
@@ -344,6 +345,16 @@ class WhatsAppAttendedCacheWatchLauncherTests(unittest.TestCase):
                 encoding="utf-8",
             )
             (tmp_path / "watch.log").write_text("done\n", encoding="utf-8")
+            audio_cache = tmp_path / "audio_cache"
+            audio_cache.mkdir()
+            stale_audio = audio_cache / "aud_stale.ogg"
+            stale_audio.write_bytes(b"stale")
+            fresh_audio = audio_cache / "aud_fresh.ogg"
+            fresh_audio.write_bytes(b"fresh-audio")
+            stale_time = datetime(2026, 6, 14, 22, 50, tzinfo=timezone.utc).timestamp()
+            fresh_time = datetime(2026, 6, 14, 22, 52, tzinfo=timezone.utc).timestamp()
+            os.utime(stale_audio, (stale_time, stale_time))
+            os.utime(fresh_audio, (fresh_time, fresh_time))
             (tmp_path / "watch.manifest.json").write_text(
                 json.dumps(
                     {
@@ -356,7 +367,7 @@ class WhatsAppAttendedCacheWatchLauncherTests(unittest.TestCase):
                         "attended_prompt": {
                             "sends_prompt_voice_note": True,
                             "prompt_text": "reply with a voice note",
-                            "audio_cache_dir": str(tmp_path / "audio_cache"),
+                            "audio_cache_dir": str(audio_cache),
                         },
                         "expected_agent_number": "13236478455",
                         "expected_agent_name": "Quill",
@@ -409,6 +420,20 @@ class WhatsAppAttendedCacheWatchLauncherTests(unittest.TestCase):
         self.assertEqual(payload["timing"]["deadline_utc"], "2026-06-14T22:53:18Z")
         self.assertEqual(payload["timing"]["wait_seconds"], 120.0)
         self.assertTrue(payload["timing"]["expired"])
+        self.assertEqual(payload["audio_cache"]["path"], str(audio_cache))
+        self.assertTrue(payload["audio_cache"]["exists"])
+        self.assertEqual(payload["audio_cache"]["candidate_count"], 2)
+        self.assertEqual(payload["audio_cache"]["latest_file"], "aud_fresh.ogg")
+        self.assertEqual(payload["audio_cache"]["latest_path"], str(fresh_audio))
+        self.assertEqual(
+            payload["audio_cache"]["latest_mtime_utc"],
+            "2026-06-14T22:52:00Z",
+        )
+        self.assertEqual(
+            payload["audio_cache"]["latest_size_bytes"],
+            len(b"fresh-audio"),
+        )
+        self.assertTrue(payload["audio_cache"]["fresh_since_created"])
 
     def test_list_discovers_active_units_and_artifacts(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- add an audio-cache snapshot to attended WhatsApp cache watch status/list output
- report the latest cached `aud_*` file, mtime, size, and whether it is newer than the watch start time
- document the new operator signal in README and the WhatsApp/WebRTC runbook

## Why

The active attended receive watcher can be running for hours with empty JSON/log artifacts. Status already reported the wait deadline, but it still required manual cache inspection to know whether the configured `~/.hermes/audio_cache` had received anything fresh for that watch. This makes the freshness decision explicit and read-only.

Live local output now includes:

```text
audio_cache=path=/home/ubuntu/.hermes/audio_cache exists=True candidate_count=3 latest_file=aud_d392b9bbe796.ogg latest_mtime_utc=2026-06-14T01:06:50Z fresh_since_created=False
```

and list output includes:

```text
watch[1]=voice-whatsapp-attended-cache-watch-20260614T235857Z status=waiting_for_fresh_audio active_state=active json_size=0 manifest_wait_seconds=21600.0 remaining_seconds=18639.359 deadline_utc=2026-06-15T05:58:57Z latest_audio=aud_d392b9bbe796.ogg latest_audio_fresh=False sends_prompt_voice_note=True
```

## Verification

- `python3 -m unittest tests.test_start_whatsapp_attended_cache_watch`
- `python3 -m py_compile scripts/start_whatsapp_attended_cache_watch.py tests/test_start_whatsapp_attended_cache_watch.py`
- `python3 -m unittest discover tests`
- `bash -n scripts/verify_local_hermes_voice_stack.sh scripts/verify_whatsapp_voice_contract.sh scripts/verify_telegram_voice_contract.sh scripts/verify_hermes_command_tts.sh`
- `git diff --check`
- live aggregate stack gate passed with `whatsapp_attended_watch=checked` and `latest_audio_fresh=False`

Progress on #183.
