### PR TITLE
Report effective WhatsApp alpha actions from watcher proof

### DIFF
--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -49,6 +49,15 @@ require_whatsapp_calling="${REQUIRE_WHATSAPP_CALLING:-0}"
 require_whatsapp_alpha_complete="${REQUIRE_WHATSAPP_ALPHA_COMPLETE:-0}"
 check_whatsapp_cloud_api="${CHECK_WHATSAPP_CLOUD_API:-0}"
 overall_status=0
+temp_files=()
+
+cleanup_temp_files() {
+  local path
+  for path in "${temp_files[@]:-}"; do
+    rm -f "$path"
+  done
+}
+trap cleanup_temp_files EXIT
 
 hermes_config_verify_script="${HERMES_CONFIG_VERIFY_SCRIPT:-$repo_root/scripts/verify_hermes_voice_config.py}"
 hermes_config_install_script="${HERMES_CONFIG_INSTALL_SCRIPT:-$repo_root/scripts/install_hermes_voice_config.py}"
@@ -247,12 +256,14 @@ step_failure_category() {
 
 print_whatsapp_alpha_json_summary() {
   local json_path="$1"
-  python3 - "$json_path" <<'PY'
+  local attended_watch_json_path="${2:-}"
+  python3 - "$json_path" "$attended_watch_json_path" <<'PY'
 import json
 import shlex
 import sys
 
 path = sys.argv[1]
+watch_path = sys.argv[2] if len(sys.argv) > 2 else ""
 with open(path, "r", encoding="utf-8") as handle:
     payload = json.load(handle)
 
@@ -267,6 +278,29 @@ def command_line(parts):
     return shlex.join([str(part) for part in parts])
 
 
+def verified_watch(path):
+    if not path:
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return None
+    watches = payload.get("watches") if isinstance(payload, dict) else None
+    if not isinstance(watches, list):
+        return None
+    for watch in watches:
+        if not isinstance(watch, dict):
+            continue
+        alpha = watch.get("alpha") or {}
+        if (
+            watch.get("watch_status") == "verified"
+            and alpha.get("attended_fresh_receive_verified") is True
+        ):
+            return watch
+    return None
+
+
 summary = payload.get("readiness_summary") or {}
 pending = payload.get("pending_gates") or {}
 attended = pending.get("attended_fresh_receive") or {}
@@ -279,6 +313,12 @@ actions = [
     for action in (summary.get("next_actions") or [])
     if action.get("id")
 ]
+watch = verified_watch(watch_path)
+effective_actions = list(actions)
+if watch is not None and "run_attended_fresh_receive" in effective_actions:
+    effective_actions = [
+        action for action in effective_actions if action != "run_attended_fresh_receive"
+    ]
 
 print(f"whatsapp_alpha_json_profile={payload.get('profile')}")
 print(
@@ -293,6 +333,18 @@ print(
     f"operator_action_required={summary.get('operator_action_required')}"
 )
 print(f"whatsapp_alpha_json_next_actions={csv(actions)}")
+if watch is not None:
+    audio_cache = watch.get("audio_cache") or {}
+    alpha = watch.get("alpha") or {}
+    print(
+        "whatsapp_alpha_json_attended_watch_evidence="
+        f"verified unit={watch.get('unit')} "
+        f"fresh_count={alpha.get('fresh_count')} "
+        f"latest_audio={audio_cache.get('latest_file')} "
+        f"latest_audio_fresh={audio_cache.get('fresh_since_created')}"
+    )
+    if effective_actions != actions:
+        print(f"whatsapp_alpha_json_effective_next_actions={csv(effective_actions)}")
 if attended:
     print(
         "whatsapp_alpha_json_attended_fresh_receive="
@@ -801,9 +853,16 @@ if [[ "$skip_whatsapp_attended_watch_status" != "1" && "$skip_systemd" != "1" ]]
     --unit-prefix "$whatsapp_attended_watch_unit_prefix"
   )
   run_step "WhatsApp attended cache watch status" "${attended_watch_args[@]}"
+  whatsapp_attended_watch_json="$(mktemp "${TMPDIR:-/tmp}/voice-whatsapp-attended-watch.XXXXXX.json")"
+  temp_files+=("$whatsapp_attended_watch_json")
+  if ! "${attended_watch_args[@]}" --json >"$whatsapp_attended_watch_json"; then
+    rm -f "$whatsapp_attended_watch_json"
+    whatsapp_attended_watch_json=""
+  fi
   whatsapp_attended_watch_status="checked"
 else
   whatsapp_attended_watch_status="skipped"
+  whatsapp_attended_watch_json=""
 fi
 
 if [[ "$run_webrtc_loopback_smoke" == "1" ]]; then
@@ -900,7 +959,7 @@ if [[ -n "$whatsapp_alpha_profile" ]]; then
     whatsapp_alpha_exit=$?
     set -e
     echo "whatsapp_alpha_json=$whatsapp_alpha_json_output"
-    print_whatsapp_alpha_json_summary "$whatsapp_alpha_json_output"
+    print_whatsapp_alpha_json_summary "$whatsapp_alpha_json_output" "$whatsapp_attended_watch_json"
     if [[ "$whatsapp_alpha_exit" != "0" ]]; then
       echo "error: WhatsApp alpha readiness profile failed with exit $whatsapp_alpha_exit" >&2
       overall_status="$whatsapp_alpha_exit"

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -272,7 +272,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn("==> WhatsApp attended cache watch status", result.stdout)
         self.assertIn("ok: WhatsApp attended cache watch list", result.stdout)
         self.assertIn("whatsapp_attended_watch=checked", result.stdout)
-        self.assertEqual([entry[0] for entry in entries], ["whatsapp", "watch"])
+        self.assertEqual([entry[0] for entry in entries], ["whatsapp", "watch", "watch"])
         self.assertEqual(
             entries[1],
             [
@@ -284,6 +284,8 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 "watch",
             ],
         )
+        self.assertEqual(entries[2][0], "watch")
+        self.assertIn("--json", entries[2])
 
     def test_step_failure_reports_hermes_config_category(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1265,6 +1267,148 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             "scripts/verify_whatsapp_alpha_readiness.py --hermes-home "
             "/home/ubuntu/.hermes --profile attended-send-receive "
             "--wait-inbound-seconds 60.0",
+            result.stdout,
+        )
+
+    def test_whatsapp_alpha_json_summary_prints_effective_actions_from_verified_watch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            watch = tmp_path / "start_watch.py"
+            alpha = tmp_path / "verify_alpha.py"
+            voice = tmp_path / "voice"
+            json_output = tmp_path / "alpha.json"
+
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_executable(
+                watch,
+                textwrap.dedent(
+                    f"""\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    printf 'watch' >> {str(log_path)!r}
+                    printf '\\0' >> {str(log_path)!r}
+                    printf '%s\\0' "$@" >> {str(log_path)!r}
+                    printf '\\n' >> {str(log_path)!r}
+                    if [[ "$*" == *"--json"* ]]; then
+                      cat <<'JSON'
+                    {{
+                      "watches": [
+                        {{
+                          "unit": "watch-done",
+                          "watch_status": "verified",
+                          "alpha": {{
+                            "attended_fresh_receive_verified": true,
+                            "fresh_count": 1
+                          }},
+                          "audio_cache": {{
+                            "latest_file": "aud_new.ogg",
+                            "fresh_since_created": true
+                          }}
+                        }}
+                      ]
+                    }}
+                    JSON
+                    else
+                      echo "ok: WhatsApp attended cache watch list"
+                      echo "watch[1]=watch-done status=verified latest_audio=aud_new.ogg latest_audio_fresh=True"
+                    fi
+                    """
+                ),
+            )
+            write_executable(
+                alpha,
+                textwrap.dedent(
+                    f"""\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    printf 'alpha' >> {str(log_path)!r}
+                    printf '\\0' >> {str(log_path)!r}
+                    printf '%s\\0' "$@" >> {str(log_path)!r}
+                    printf '\\n' >> {str(log_path)!r}
+                    cat <<'JSON'
+                    {{
+                      "profile": "cached-receive",
+                      "readiness_summary": {{
+                        "status": "local_ready_pending_gates",
+                        "complete": false,
+                        "local_checks_passed": true,
+                        "attended_fresh_receive_verified": false,
+                        "external_meta_setup_required": true,
+                        "operator_action_required": true,
+                        "next_actions": [
+                          {{"id": "run_attended_fresh_receive"}},
+                          {{"id": "configure_whatsapp_cloud_calling"}}
+                        ]
+                      }},
+                      "pending_gates": {{
+                        "attended_fresh_receive": {{
+                          "status": "pending_attended",
+                          "cached_receive_verified": true,
+                          "command": [
+                            "scripts/verify_whatsapp_alpha_readiness.py",
+                            "--profile",
+                            "attended-cache-receive"
+                          ]
+                        }},
+                        "whatsapp_cloud": {{"status": "external_setup_required"}},
+                        "whatsapp_cloud_calling": {{"status": "external_setup_required"}}
+                      }}
+                    }}
+                    JSON
+                    """
+                ),
+            )
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--skip-hermes-config",
+                    "--skip-hermes-gateway",
+                    "--skip-cli-mcp",
+                    "--skip-sidecar",
+                    "--skip-whatsapp-bridge",
+                    "--skip-daemon",
+                    "--whatsapp-attended-watch-output-dir",
+                    str(tmp_path / "watch-artifacts"),
+                    "--whatsapp-attended-watch-unit-prefix",
+                    "watch",
+                    "--whatsapp-alpha-profile",
+                    "cached-receive",
+                    "--whatsapp-alpha-json-output",
+                    str(json_output),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "WHATSAPP_ATTENDED_WATCH_SCRIPT": str(watch),
+                    "WHATSAPP_ALPHA_READINESS_SCRIPT": str(alpha),
+                },
+            )
+            entries = command_log_entries(log_path)
+
+        self.assertEqual([entry[0] for entry in entries], ["whatsapp", "watch", "watch", "alpha"])
+        self.assertIn(
+            "whatsapp_alpha_json_next_actions="
+            "run_attended_fresh_receive,configure_whatsapp_cloud_calling",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_alpha_json_attended_watch_evidence=verified "
+            "unit=watch-done fresh_count=1 latest_audio=aud_new.ogg "
+            "latest_audio_fresh=True",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_alpha_json_effective_next_actions="
+            "configure_whatsapp_cloud_calling",
             result.stdout,
         )
 


### PR DESCRIPTION
## Summary
- capture attended watch status as JSON during the local stack verifier run
- surface verified watcher evidence beside the raw WhatsApp alpha JSON summary
- print effective next actions with the already-satisfied attended receive gate removed

## Verification
- `git diff --check`
- `python3 -m unittest tests.test_verify_local_hermes_voice_stack`
- `python3 -m unittest discover tests`
- `bash -n scripts/verify_local_hermes_voice_stack.sh scripts/verify_telegram_voice_contract.sh scripts/verify_whatsapp_voice_contract.sh scripts/start_whatsapp_attended_cache_watch.py`
- `scripts/verify_telegram_voice_contract.sh --voice-bin /home/ubuntu/.local/bin/voice --skip-daemon --skip-hermes-tts-smoke`
- `scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --hermes-config /home/ubuntu/.hermes/config.yaml --expected-whatsapp-agent-number 13236478455 --expected-whatsapp-agent-name Quill --whatsapp-alpha-profile cached-receive --whatsapp-alpha-json-output /tmp/voice-whatsapp-alpha-post-proof.json --skip-stt-smoke --skip-hermes-stt-smoke --skip-hermes-tts-smoke`