### PR TITLE
Let alpha readiness consume attended watch proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,11 @@ whether it is newer than the watch start time. Use `--list` to discover active
 watches and matching artifacts from a later session. Use `--stop
 <unit-or-service>` to stop a stale watch without deleting its JSON/log/manifest
 artifacts.
+When the aggregate stack gate runs with `--whatsapp-alpha-profile` and attended
+watch status is enabled, it passes the watch artifact directory and unit prefix
+into the alpha readiness script. A previously verified non-draining watch can
+therefore satisfy `pending_gates.attended_fresh_receive` in the saved alpha JSON
+without asking the operator to rerun the attended receive window.
 
 To fail unless every alpha gate is complete, include the strict completion flag:
 

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -147,6 +147,13 @@ redacted transcript length. The draining bridge fallback records audio-event
 count, observed media types, media URL count, and whether `/messages` was
 drained; chat IDs, sender IDs, and media URL paths are reduced to presence or
 count fields.
+To reuse a long-running watcher result in a later alpha report, pass
+`--attended-watch-output-dir` and `--attended-watch-unit-prefix`. The script
+will read matching JSON/manifest artifacts, require a verified
+`attended-cache-receive` run for the expected agent identity, and mark
+`pending_gates.attended_fresh_receive` verified from that saved proof. The
+aggregate stack verifier supplies those flags automatically when attended-watch
+status is enabled.
 
 For the external Meta gates, the JSON report includes safe setup handoffs under
 `pending_gates.whatsapp_cloud.setup_handoff` and
@@ -348,7 +355,10 @@ scripts/start_whatsapp_attended_cache_watch.py --list
 
 The aggregate stack gate runs the same non-draining status check by default and
 prints `whatsapp_attended_watch=checked`, so a release or host-health run also
-shows whether an attended receive window is already active.
+shows whether an attended receive window is already active. When the same run
+also writes an alpha JSON report, verified watch artifacts are fed into alpha
+readiness so the machine-readable next actions only include the remaining
+Cloud/Calling setup.
 
 To stop a stale watch without deleting its JSON/log artifacts:
 

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -902,6 +902,12 @@ if [[ -n "$whatsapp_alpha_profile" ]]; then
   if [[ -n "$whatsapp_audio_cache_dir" ]]; then
     whatsapp_alpha_args+=(--whatsapp-audio-cache-dir "$whatsapp_audio_cache_dir")
   fi
+  if [[ "$skip_whatsapp_attended_watch_status" != "1" && "$skip_systemd" != "1" ]]; then
+    whatsapp_alpha_args+=(
+      --attended-watch-output-dir "$whatsapp_attended_watch_output_dir"
+      --attended-watch-unit-prefix "$whatsapp_attended_watch_unit_prefix"
+    )
+  fi
   if [[ -n "$whatsapp_alpha_voice_note_chat_id" ]]; then
     whatsapp_alpha_args+=(--voice-note-chat-id "$whatsapp_alpha_voice_note_chat_id")
   fi

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -20,6 +20,7 @@ DEFAULT_TEXT = "WhatsApp alpha readiness smoke."
 DEFAULT_ATTENDED_PROMPT_TEXT = (
     "Please reply with a fresh WhatsApp voice note so I can verify the voice runtime."
 )
+DEFAULT_ATTENDED_WATCH_UNIT_PREFIX = "voice-whatsapp-attended-cache-watch"
 PROFILE_CHOICES = (
     "unattended",
     "cached-receive",
@@ -187,6 +188,15 @@ def alpha_handoff_base_command(args: argparse.Namespace) -> list[str]:
                 str(args.whatsapp_audio_cache_dir.expanduser().resolve()),
             ]
         )
+    if args.attended_watch_output_dir:
+        command.extend(
+            [
+                "--attended-watch-output-dir",
+                str(args.attended_watch_output_dir.expanduser().resolve()),
+                "--attended-watch-unit-prefix",
+                args.attended_watch_unit_prefix,
+            ]
+        )
     if args.expected_agent_number:
         command.extend(["--expected-agent-number", args.expected_agent_number])
     if args.expected_agent_name:
@@ -213,6 +223,111 @@ def latest_cached_inbound_audio(audio_dir: Path) -> Path | None:
     if not candidates:
         return None
     return max(candidates, key=lambda path: path.stat().st_mtime)
+
+
+def load_json_object(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def attended_watch_unit_from_json_path(path: Path, unit_prefix: str) -> str | None:
+    name = path.name
+    if name.endswith(".manifest.json") or not name.endswith(".json"):
+        return None
+    unit = name[: -len(".json")]
+    if not unit.startswith(f"{unit_prefix}-"):
+        return None
+    return unit
+
+
+def attended_watch_manifest_matches(
+    manifest: dict[str, Any] | None,
+    args: argparse.Namespace,
+) -> bool:
+    if not isinstance(manifest, dict):
+        return False
+    if manifest.get("profile") != "attended-cache-receive":
+        return False
+    if manifest.get("drains_bridge_messages") is not False:
+        return False
+    attended_prompt = manifest.get("attended_prompt")
+    attended_prompt = attended_prompt if isinstance(attended_prompt, dict) else {}
+    if attended_prompt.get("sends_prompt_voice_note") is not True:
+        return False
+    if args.expected_agent_number and str(
+        manifest.get("expected_agent_number") or ""
+    ) != str(args.expected_agent_number):
+        return False
+    if args.expected_agent_name and str(manifest.get("expected_agent_name") or "") != str(
+        args.expected_agent_name
+    ):
+        return False
+    return True
+
+
+def verified_attended_watch_evidence(args: argparse.Namespace) -> dict[str, Any] | None:
+    if not args.attended_watch_output_dir:
+        return None
+    output_dir = args.attended_watch_output_dir.expanduser().resolve()
+    if not output_dir.is_dir():
+        return None
+
+    candidates: list[tuple[str, Path]] = []
+    for path in output_dir.glob(f"{args.attended_watch_unit_prefix}-*.json"):
+        unit = attended_watch_unit_from_json_path(path, args.attended_watch_unit_prefix)
+        if unit:
+            candidates.append((unit, path))
+
+    for unit, json_path in sorted(candidates, key=lambda item: item[0], reverse=True):
+        payload = load_json_object(json_path)
+        if payload is None:
+            continue
+        manifest_path = output_dir / f"{unit}.manifest.json"
+        manifest = load_json_object(manifest_path)
+        if not attended_watch_manifest_matches(manifest, args):
+            continue
+
+        summary = payload.get("readiness_summary")
+        summary = summary if isinstance(summary, dict) else {}
+        pending = payload.get("pending_gates")
+        pending = pending if isinstance(pending, dict) else {}
+        attended = pending.get("attended_fresh_receive")
+        attended = attended if isinstance(attended, dict) else {}
+        if (
+            summary.get("attended_fresh_receive_verified") is not True
+            or attended.get("status") != "verified"
+        ):
+            continue
+
+        evidence = attended.get("evidence")
+        proof = dict(evidence) if isinstance(evidence, dict) else {}
+        attended_prompt = manifest.get("attended_prompt")
+        attended_prompt = attended_prompt if isinstance(attended_prompt, dict) else {}
+        proof.setdefault("kind", "attended_watch_artifact")
+        proof.update(
+            {
+                "source": "attended_watch_artifact",
+                "watch_unit": unit,
+                "watch_json": str(json_path),
+                "watch_manifest": str(manifest_path),
+                "watch_profile": payload.get("profile"),
+                "watch_success": bool(payload.get("success")),
+                "watch_readiness_status": summary.get("status"),
+                "watch_created_at_utc": manifest.get("created_at_utc"),
+                "watch_wait_seconds": manifest.get("wait_seconds"),
+                "watch_expected_agent_number": manifest.get("expected_agent_number"),
+                "watch_expected_agent_name": manifest.get("expected_agent_name"),
+                "watch_sends_prompt_voice_note": attended_prompt.get(
+                    "sends_prompt_voice_note"
+                ),
+            }
+        )
+        return proof
+
+    return None
 
 
 def build_components(args: argparse.Namespace) -> list[dict[str, Any]]:
@@ -548,6 +663,7 @@ def attended_receive_gate(
     *,
     audio_cache_dir: Path,
     base_command: list[str],
+    attended_watch_evidence: dict[str, Any] | None = None,
     preferred_wait_audio_cache_seconds: float = DEFAULT_ATTENDED_CACHE_RECEIVE_SECONDS,
     fallback_wait_inbound_seconds: float = DEFAULT_ATTENDED_DRAIN_RECEIVE_SECONDS,
 ) -> dict[str, Any]:
@@ -649,6 +765,17 @@ def attended_receive_gate(
                 gate["reason"] = "fresh audio cache receive verifier failed"
                 gate["failures"] = item.get("failures") or []
             break
+    if gate["status"] == "pending_attended" and attended_watch_evidence is not None:
+        gate["status"] = "verified"
+        gate["component"] = "attended_watch_artifact"
+        gate["cached_receive_verified"] = True
+        gate["requires_operator"] = False
+        gate["drains_bridge_messages"] = bool(
+            attended_watch_evidence.get("drains_bridge_messages")
+        )
+        gate["reason"] = "verified attended cache watch artifact observed"
+        gate["watch_unit"] = attended_watch_evidence.get("watch_unit")
+        gate["evidence"] = attended_watch_evidence
     return gate
 
 
@@ -1043,6 +1170,7 @@ def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
         if args.profile == "attended-cache-receive"
         else DEFAULT_ATTENDED_CACHE_RECEIVE_SECONDS
     )
+    attended_watch_evidence = verified_attended_watch_evidence(args)
     pending_gates = {
         "attended_fresh_receive": attended_receive_gate(
             components,
@@ -1052,6 +1180,7 @@ def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
                 else args.hermes_home.expanduser().resolve() / "audio_cache"
             ),
             base_command=handoff_base_command,
+            attended_watch_evidence=attended_watch_evidence,
             preferred_wait_audio_cache_seconds=(
                 args.wait_audio_cache_seconds
                 if args.profile == "attended-cache-receive"
@@ -1142,6 +1271,20 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--bridge-url", default=os.environ.get("WHATSAPP_BRIDGE_URL", DEFAULT_BRIDGE_URL))
     parser.add_argument("--sidecar-url", default=DEFAULT_SIDECAR_URL)
     parser.add_argument("--whatsapp-audio-cache-dir", type=Path, default=None)
+    parser.add_argument(
+        "--attended-watch-output-dir",
+        type=Path,
+        default=None,
+        help=(
+            "optional directory containing start_whatsapp_attended_cache_watch.py "
+            "artifacts to use as persistent attended receive proof"
+        ),
+    )
+    parser.add_argument(
+        "--attended-watch-unit-prefix",
+        default=DEFAULT_ATTENDED_WATCH_UNIT_PREFIX,
+        help="unit/artifact prefix for attended cache watch proof discovery",
+    )
     parser.add_argument("--expected-agent-number", default=os.environ.get("WHATSAPP_AGENT_NUMBER"))
     parser.add_argument("--expected-agent-name", default=os.environ.get("WHATSAPP_AGENT_NAME"))
     parser.add_argument("--text", default=DEFAULT_TEXT)

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -39,6 +39,74 @@ def ok_shell(path: Path) -> None:
     )
 
 
+def write_verified_attended_watch(
+    directory: Path,
+    *,
+    unit_prefix: str = "voice-watch",
+    unit_suffix: str = "20260615T010000Z",
+    expected_agent_number: str = "13236478455",
+    expected_agent_name: str = "Quill",
+) -> str:
+    directory.mkdir(parents=True, exist_ok=True)
+    unit = f"{unit_prefix}-{unit_suffix}"
+    payload = {
+        "success": True,
+        "profile": "attended-cache-receive",
+        "readiness_summary": {
+            "status": "local_ready_pending_gates",
+            "attended_fresh_receive_verified": True,
+        },
+        "pending_gates": {
+            "attended_fresh_receive": {
+                "status": "verified",
+                "cached_receive_verified": True,
+                "drains_bridge_messages": False,
+                "evidence": {
+                    "kind": "audio_cache",
+                    "fresh": True,
+                    "fresh_count": 1,
+                    "baseline_count": 0,
+                    "final_count": 1,
+                    "audio": [
+                        {
+                            "name": "aud_watch.ogg",
+                            "codec": "opus",
+                            "stt": {
+                                "frames": 331,
+                                "text_redacted": True,
+                                "text_chars": 104,
+                            },
+                        }
+                    ],
+                },
+            }
+        },
+    }
+    manifest = {
+        "schema": "voice.whatsapp_attended_cache_watch_manifest",
+        "version": 1,
+        "profile": "attended-cache-receive",
+        "drains_bridge_messages": False,
+        "created_at_utc": "2026-06-15T01:00:00Z",
+        "wait_seconds": 21600.0,
+        "expected_agent_number": expected_agent_number,
+        "expected_agent_name": expected_agent_name,
+        "attended_prompt": {
+            "sends_prompt_voice_note": True,
+            "audio_cache_dir": str(directory / "audio_cache"),
+        },
+    }
+    (directory / f"{unit}.json").write_text(
+        json.dumps(payload, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    (directory / f"{unit}.manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return unit
+
+
 def write_fake_helpers(
     directory: Path,
     *,
@@ -778,6 +846,58 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
 
         components = {item["name"]: item for item in payload["components"]}
         self.assertNotIn("--stt-audio", components["hermes_voice_config"]["command"])
+
+    def test_cached_receive_profile_uses_verified_attended_watch_artifact(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            watch_dir = tmp_path / "watch-artifacts"
+            unit = write_verified_attended_watch(watch_dir)
+            payload = self.run_readiness(
+                tmp_path,
+                "--profile",
+                "cached-receive",
+                "--attended-watch-output-dir",
+                str(watch_dir),
+                "--attended-watch-unit-prefix",
+                "voice-watch",
+                "--expected-agent-number",
+                "13236478455",
+                "--expected-agent-name",
+                "Quill",
+            )
+
+        gate = payload["pending_gates"]["attended_fresh_receive"]
+        self.assertEqual(gate["status"], "verified")
+        self.assertEqual(gate["component"], "attended_watch_artifact")
+        self.assertEqual(gate["watch_unit"], unit)
+        self.assertFalse(gate["requires_operator"])
+        self.assertTrue(gate["cached_receive_verified"])
+        self.assertFalse(gate["drains_bridge_messages"])
+        self.assertEqual(
+            gate["reason"],
+            "verified attended cache watch artifact observed",
+        )
+        evidence = gate["evidence"]
+        self.assertEqual(evidence["kind"], "audio_cache")
+        self.assertEqual(evidence["source"], "attended_watch_artifact")
+        self.assertEqual(evidence["watch_unit"], unit)
+        self.assertEqual(evidence["watch_profile"], "attended-cache-receive")
+        self.assertEqual(evidence["watch_expected_agent_number"], "13236478455")
+        self.assertEqual(evidence["watch_expected_agent_name"], "Quill")
+        self.assertEqual(evidence["audio"][0]["name"], "aud_watch.ogg")
+        summary = payload["readiness_summary"]
+        self.assertTrue(summary["attended_fresh_receive_verified"])
+        self.assertEqual(
+            [action["id"] for action in summary["next_actions"]],
+            ["configure_whatsapp_cloud_calling"],
+        )
+        complete_command = payload["pending_gates"]["whatsapp_cloud_calling"][
+            "setup_handoff"
+        ]["complete_verification_command"]
+        self.assertIn("--attended-watch-output-dir", complete_command)
+        self.assertIn(str(watch_dir.resolve()), complete_command)
+        self.assertIn("--attended-watch-unit-prefix", complete_command)
+        self.assertIn("voice-watch", complete_command)
 
     def test_send_profile_posts_real_voice_note(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- add optional attended-watch artifact discovery to WhatsApp alpha readiness
- let verified non-draining attended-cache-receive artifacts satisfy `pending_gates.attended_fresh_receive` in the alpha JSON
- pass attended-watch output dir/prefix from the aggregate stack gate into alpha readiness
- document the saved-proof path and add coverage for cached-receive using watcher proof

## Verification
- `python3 -m unittest tests.test_verify_whatsapp_alpha_readiness`
- `python3 -m unittest tests.test_verify_local_hermes_voice_stack`
- `python3 -m unittest discover tests`
- `python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_alpha_readiness.py`
- `bash -n scripts/verify_local_hermes_voice_stack.sh scripts/verify_telegram_voice_contract.sh scripts/verify_whatsapp_voice_contract.sh scripts/start_whatsapp_attended_cache_watch.py`
- `git diff --check`
- `scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --hermes-config /home/ubuntu/.hermes/config.yaml --expected-whatsapp-agent-number 13236478455 --expected-whatsapp-agent-name Quill --whatsapp-alpha-profile cached-receive --whatsapp-alpha-json-output /tmp/voice-whatsapp-alpha-watch-proof-native.json --skip-stt-smoke --skip-hermes-stt-smoke --skip-hermes-tts-smoke`

Live stack result included `whatsapp_alpha_json_next_actions=configure_whatsapp_cloud_calling` and `attended_fresh_receive_verified=True` from saved watcher proof.