### PR TITLE
Verify WhatsApp Cloud webhook challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,10 +507,11 @@ Cloud/Calling failures can distinguish missing credentials from invalid
 `WHATSAPP_CLOUD_WEBHOOK_*` settings. The generated complete-alpha handoff
 keeps the selected `voice` binary, Hermes config, bridge URL, sidecar URL,
 audio cache override, and expected agent identity from the current run. It also
-includes `--require-whatsapp-cloud`, `--require-whatsapp-calling`, and
-`--check-whatsapp-cloud-api`, so after real Cloud credentials are present it also
-makes an authenticated Graph API phone-number request without printing token or
-phone-number values.
+includes `--require-whatsapp-cloud`, `--require-whatsapp-calling`,
+`--check-whatsapp-cloud-api`, and `--check-whatsapp-cloud-webhook`, so after real
+Cloud credentials are present it also makes an authenticated Graph API
+phone-number request and verifies the local webhook challenge echo without
+printing token or phone-number values.
 Use `--whatsapp-alpha-json-output` with any alpha profile when another local
 agent should consume the same structured `readiness_summary.next_actions`
 without rerunning the full stack gate. The stack verifier also echoes compact

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -75,9 +75,10 @@ WhatsApp-ready Ogg/Opus output, the Baileys bridge identity, the Hermes gateway
 voice-stream service, and the WebRTC sidecar contract. Add
 `--require-whatsapp-cloud` or `--require-whatsapp-calling` only when the host is
 expected to have real Meta Cloud credentials. Once those credentials are on
-disk, add `--check-whatsapp-cloud-api` to make an authenticated Graph API
-phone-number request and confirm the configured `WHATSAPP_CLOUD_PHONE_NUMBER_ID`
-is reachable without printing token or phone-number values.
+disk, add `--check-whatsapp-cloud-api` and
+`--check-whatsapp-cloud-webhook` to make an authenticated Graph API
+phone-number request and confirm the local Cloud webhook echoes Meta's
+subscription challenge without printing token or phone-number values.
 
 The same stack gate can run the categorized alpha report as an explicit opt-in:
 
@@ -122,9 +123,10 @@ voice-note, live-call local sidecar, or external Meta setup. Use
 `--require-whatsapp-calling` when a host is expected to be ready for real Cloud
 Calling; otherwise missing Meta credentials are reported as external setup
 still required, not as a local Baileys voice-note failure. Add
-`--check-whatsapp-cloud-api` when credentials are expected to work and the
-report should prove the configured Cloud phone-number node is reachable. The
-named profiles are `unattended`, `cached-receive`, `send`,
+`--check-whatsapp-cloud-api` and `--check-whatsapp-cloud-webhook` when
+credentials are expected to work and the report should prove the configured
+Cloud phone-number node plus local webhook challenge are reachable. The named
+profiles are `unattended`, `cached-receive`, `send`,
 `attended-cache-receive`, and `attended-send-receive`. Use `cached-receive`
 when the report should also replay a cached inbound WhatsApp voice note through
 `voice stream-transcribe`:
@@ -198,6 +200,7 @@ scripts/verify_whatsapp_alpha_readiness.py \
   --require-whatsapp-cloud \
   --require-whatsapp-calling \
   --check-whatsapp-cloud-api \
+  --check-whatsapp-cloud-webhook \
   --require-complete
 ```
 

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -48,6 +48,7 @@ require_whatsapp_cloud="${REQUIRE_WHATSAPP_CLOUD:-0}"
 require_whatsapp_calling="${REQUIRE_WHATSAPP_CALLING:-0}"
 require_whatsapp_alpha_complete="${REQUIRE_WHATSAPP_ALPHA_COMPLETE:-0}"
 check_whatsapp_cloud_api="${CHECK_WHATSAPP_CLOUD_API:-0}"
+check_whatsapp_cloud_webhook="${CHECK_WHATSAPP_CLOUD_WEBHOOK:-0}"
 overall_status=0
 temp_files=()
 
@@ -117,6 +118,8 @@ Options:
                                fail unless all WhatsApp alpha readiness gates are complete
   --check-whatsapp-cloud-api   call the Meta Graph API phone-number endpoint when Cloud
                                credentials are configured
+  --check-whatsapp-cloud-webhook
+                               verify the local Cloud webhook subscription challenge echo
   --run-whatsapp-inbound-cache-smoke
                                transcribe a bridge-downloaded aud_* file from the audio cache
   --run-telegram-voice-contract
@@ -523,6 +526,10 @@ while [[ $# -gt 0 ]]; do
       check_whatsapp_cloud_api=1
       shift
       ;;
+    --check-whatsapp-cloud-webhook)
+      check_whatsapp_cloud_webhook=1
+      shift
+      ;;
     --run-whatsapp-inbound-cache-smoke)
       run_whatsapp_inbound_cache_smoke=1
       shift
@@ -807,6 +814,9 @@ if [[ "$skip_whatsapp_bridge" != "1" ]]; then
   if [[ "$check_whatsapp_cloud_api" == "1" ]]; then
     whatsapp_bridge_args+=(--check-whatsapp-cloud-api)
   fi
+  if [[ "$check_whatsapp_cloud_webhook" == "1" ]]; then
+    whatsapp_bridge_args+=(--check-whatsapp-cloud-webhook)
+  fi
   run_step "WhatsApp bridge identity and credential readiness" "${whatsapp_bridge_args[@]}"
   whatsapp_bridge_status="checked"
 else
@@ -948,6 +958,9 @@ if [[ -n "$whatsapp_alpha_profile" ]]; then
   fi
   if [[ "$check_whatsapp_cloud_api" == "1" ]]; then
     whatsapp_alpha_args+=(--check-whatsapp-cloud-api)
+  fi
+  if [[ "$check_whatsapp_cloud_webhook" == "1" ]]; then
+    whatsapp_alpha_args+=(--check-whatsapp-cloud-webhook)
   fi
   if [[ "$require_whatsapp_alpha_complete" == "1" ]]; then
     whatsapp_alpha_args+=(--require-complete)

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -434,6 +434,8 @@ def build_components(args: argparse.Namespace) -> list[dict[str, Any]]:
         bridge_cmd.extend(["--expected-agent-name", args.expected_agent_name])
     if args.check_whatsapp_cloud_api:
         bridge_cmd.append("--check-whatsapp-cloud-api")
+    if args.check_whatsapp_cloud_webhook:
+        bridge_cmd.append("--check-whatsapp-cloud-webhook")
     if args.skip_systemd:
         bridge_cmd.append("--skip-systemd")
     components.append(
@@ -821,6 +823,7 @@ def cloud_setup_handoff(
         *base_command,
         "--require-whatsapp-cloud",
         "--check-whatsapp-cloud-api",
+        "--check-whatsapp-cloud-webhook",
     ]
     steps = [] if configured else [
         "Create or select the Meta app, WABA, and Cloud API phone number for Quill.",
@@ -875,6 +878,7 @@ def calling_setup_handoff(
         "--require-whatsapp-cloud",
         "--require-whatsapp-calling",
         "--check-whatsapp-cloud-api",
+        "--check-whatsapp-cloud-webhook",
     ]
     complete_command = [
         *base_command,
@@ -885,6 +889,7 @@ def calling_setup_handoff(
         "--require-whatsapp-cloud",
         "--require-whatsapp-calling",
         "--check-whatsapp-cloud-api",
+        "--check-whatsapp-cloud-webhook",
         "--require-complete",
     ]
     steps = [] if ready else [
@@ -1344,6 +1349,14 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "when Cloud credentials are configured, call the Meta Graph API "
             "phone-number endpoint without printing credential values"
+        ),
+    )
+    parser.add_argument(
+        "--check-whatsapp-cloud-webhook",
+        action="store_true",
+        help=(
+            "when the Cloud webhook is running, verify the local Meta "
+            "subscription challenge echo without printing credential values"
         ),
     )
     parser.add_argument(

--- a/scripts/verify_whatsapp_bridge_runtime.py
+++ b/scripts/verify_whatsapp_bridge_runtime.py
@@ -25,6 +25,7 @@ DEFAULT_WHATSAPP_CLOUD_WEBHOOK_HOST = "0.0.0.0"
 DEFAULT_WHATSAPP_CLOUD_WEBHOOK_PORT = 8090
 DEFAULT_WHATSAPP_CLOUD_WEBHOOK_PATH = "/whatsapp/webhook"
 DEFAULT_WHATSAPP_CLOUD_API_VERSION = "v20.0"
+DEFAULT_WHATSAPP_CLOUD_WEBHOOK_CHALLENGE = "voice-cloud-webhook-check"
 WHATSAPP_CLOUD_PHONE_NUMBER_FIELDS = (
     "id",
     "display_phone_number",
@@ -616,6 +617,110 @@ def build_cloud_summary(env_sources: dict[str, dict[str, str]]) -> dict[str, Any
     }
 
 
+def local_webhook_url(webhook: dict[str, Any]) -> str | None:
+    port = webhook.get("port")
+    path = webhook.get("path") or DEFAULT_WHATSAPP_CLOUD_WEBHOOK_PATH
+    if not isinstance(port, int) or not isinstance(path, str) or not path.startswith("/"):
+        return None
+    host = str(webhook.get("host") or DEFAULT_WHATSAPP_CLOUD_WEBHOOK_HOST).strip()
+    if host in ("", "0.0.0.0", "::", "[::]"):
+        host = "127.0.0.1"
+    elif ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    return f"http://{host}:{port}{path}"
+
+
+def fetch_webhook_challenge(
+    *,
+    url: str,
+    verify_token: str,
+    challenge: str,
+    timeout: float,
+) -> tuple[int | None, str | None, dict[str, Any] | None]:
+    query = urlencode(
+        {
+            "hub.mode": "subscribe",
+            "hub.verify_token": verify_token,
+            "hub.challenge": challenge,
+        }
+    )
+    target = f"{url}{'&' if '?' in url else '?'}{query}"
+    request = Request(target, headers={"Accept": "text/plain"})
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            status = getattr(response, "status", 200)
+            body = response.read().decode("utf-8", errors="replace")
+    except HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8", errors="replace"), {
+            "message": f"webhook challenge returned HTTP {exc.code}"
+        }
+    except URLError as exc:
+        return None, None, {"message": f"webhook challenge request failed: {exc.reason}"}
+    except OSError as exc:
+        return None, None, {"message": f"webhook challenge request failed: {exc}"}
+    return int(status), body, None
+
+
+def build_cloud_webhook_challenge_check(
+    env_sources: dict[str, dict[str, str]],
+    *,
+    webhook: dict[str, Any],
+    challenge: str,
+    timeout: float,
+) -> dict[str, Any]:
+    verify_token, token_sources = first_env_value(
+        env_sources,
+        "WHATSAPP_CLOUD_VERIFY_TOKEN",
+    )
+    url = local_webhook_url(webhook)
+    check: dict[str, Any] = {
+        "checked": True,
+        "ok": False,
+        "local_url": url,
+        "verify_token_present": verify_token is not None,
+        "verify_token_sources": token_sources,
+        "challenge_present": bool(challenge),
+        "challenge_echoed": False,
+        "missing": [],
+        "invalid": [],
+    }
+    if not verify_token:
+        check["missing"].append("WHATSAPP_CLOUD_VERIFY_TOKEN")
+    if not challenge:
+        check["invalid"].append("WHATSAPP_CLOUD_WEBHOOK_CHALLENGE")
+    if not url:
+        check["invalid"].extend(str(key) for key in webhook.get("invalid") or [])
+        if not check["invalid"]:
+            check["invalid"].append("WHATSAPP_CLOUD_WEBHOOK_PORT")
+    if check["missing"] or check["invalid"]:
+        check["error"] = {
+            "message": (
+                "Cloud webhook challenge requires a local webhook URL, "
+                "verify token, and non-empty challenge"
+            )
+        }
+        return check
+
+    status, body, error = fetch_webhook_challenge(
+        url=str(url),
+        verify_token=str(verify_token),
+        challenge=challenge,
+        timeout=timeout,
+    )
+    check["http_status"] = status
+    if error:
+        check["error"] = error
+        return check
+    check["challenge_echoed"] = body == challenge
+    if not check["challenge_echoed"]:
+        check["error"] = {
+            "message": "webhook challenge did not echo the configured challenge"
+        }
+        return check
+    check["ok"] = True
+    return check
+
+
 def graph_error_summary(body: bytes) -> dict[str, Any]:
     try:
         payload = json.loads(body.decode("utf-8", errors="replace"))
@@ -952,6 +1057,24 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
             )
     else:
         cloud["cloud_api"] = {"checked": False}
+    if args.check_whatsapp_cloud_webhook:
+        webhook_challenge = build_cloud_webhook_challenge_check(
+            env_sources,
+            webhook=cloud["webhook"],
+            challenge=args.whatsapp_cloud_webhook_challenge,
+            timeout=args.timeout,
+        )
+        cloud["webhook_challenge"] = webhook_challenge
+        if not webhook_challenge.get("ok"):
+            failures.append(
+                "WhatsApp Cloud webhook challenge check failed: "
+                + str(
+                    (webhook_challenge.get("error") or {}).get("message")
+                    or "unknown error"
+                )
+            )
+    else:
+        cloud["webhook_challenge"] = {"checked": False}
     if args.require_whatsapp_cloud and cloud["cloud_missing"]:
         failures.append(
             "WhatsApp Cloud credentials missing: "
@@ -1027,6 +1150,22 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--check-whatsapp-cloud-webhook",
+        action="store_true",
+        help=(
+            "send Meta's local webhook subscription challenge shape to the "
+            "configured Cloud webhook and require the challenge echo"
+        ),
+    )
+    parser.add_argument(
+        "--whatsapp-cloud-webhook-challenge",
+        default=os.environ.get(
+            "WHATSAPP_CLOUD_WEBHOOK_CHALLENGE",
+            DEFAULT_WHATSAPP_CLOUD_WEBHOOK_CHALLENGE,
+        ),
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
         "--graph-api-base-url",
         default=os.environ.get("GRAPH_API_BASE_URL", DEFAULT_GRAPH_API_BASE_URL),
         help=argparse.SUPPRESS,
@@ -1043,6 +1182,7 @@ def human_summary(result: dict[str, Any]) -> None:
     bridge_script_hash = checks.get("bridge_script_hash") or {}
     cloud = checks.get("whatsapp_cloud") or {}
     webhook = cloud.get("webhook") or {}
+    webhook_challenge = cloud.get("webhook_challenge") or {}
     cloud_api = cloud.get("cloud_api") or {}
     local_config = checks.get("whatsapp_local_config") or {}
 
@@ -1115,6 +1255,24 @@ def human_summary(result: dict[str, Any]) -> None:
         + " invalid="
         + (",".join(webhook.get("invalid") or []) or "none")
     )
+    if webhook_challenge.get("checked"):
+        challenge_error = webhook_challenge.get("error") or {}
+        print(
+            "whatsapp_cloud_webhook_challenge="
+            + ("ok" if webhook_challenge.get("ok") else "failed")
+            + f" local_url={webhook_challenge.get('local_url') or '<invalid>'}"
+            + f" http_status={webhook_challenge.get('http_status') or '<none>'}"
+            + " verify_token_present="
+            + str(webhook_challenge.get("verify_token_present"))
+            + " challenge_echoed="
+            + str(webhook_challenge.get("challenge_echoed"))
+            + " missing="
+            + (",".join(webhook_challenge.get("missing") or []) or "none")
+            + " invalid="
+            + (",".join(webhook_challenge.get("invalid") or []) or "none")
+            + " error="
+            + str(challenge_error.get("message") or "none")
+        )
     if cloud_api.get("checked"):
         phone = cloud_api.get("phone_number") or {}
         error = cloud_api.get("error") or {}

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -779,6 +779,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                     "--require-whatsapp-calling",
                     "--require-whatsapp-alpha-complete",
                     "--check-whatsapp-cloud-api",
+                    "--check-whatsapp-cloud-webhook",
                     "--skip-hermes-config",
                     "--skip-hermes-gateway",
                     "--skip-cli-mcp",
@@ -856,6 +857,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 "--require-whatsapp-cloud",
                 "--require-whatsapp-calling",
                 "--check-whatsapp-cloud-api",
+                "--check-whatsapp-cloud-webhook",
                 "--require-complete",
             ],
         )

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -407,6 +407,10 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             "--check-whatsapp-cloud-api",
             cloud_handoff["verify_command"],
         )
+        self.assertIn(
+            "--check-whatsapp-cloud-webhook",
+            cloud_handoff["verify_command"],
+        )
         self.assertEqual(len(cloud_handoff["steps"]), 4)
         self.assertNotIn("phone-id", json.dumps(cloud_handoff))
         self.assertEqual(cloud_handoff["invalid"], [])
@@ -440,10 +444,15 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             "--check-whatsapp-cloud-api",
             calling_handoff["verify_command"],
         )
+        self.assertIn(
+            "--check-whatsapp-cloud-webhook",
+            calling_handoff["verify_command"],
+        )
         complete_command = calling_handoff["complete_verification_command"]
         self.assertIn("--require-whatsapp-cloud", complete_command)
         self.assertIn("--require-whatsapp-calling", complete_command)
         self.assertIn("--check-whatsapp-cloud-api", complete_command)
+        self.assertIn("--check-whatsapp-cloud-webhook", complete_command)
         self.assertIn("--require-complete", complete_command)
         self.assertIn("--wait-audio-cache-seconds", complete_command)
         self.assertIn(str(tmp_path / "voice"), complete_command)
@@ -517,6 +526,10 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         )
         self.assertIn(
             "--check-whatsapp-cloud-api",
+            meta_action["complete_verification_command"],
+        )
+        self.assertIn(
+            "--check-whatsapp-cloud-webhook",
             meta_action["complete_verification_command"],
         )
 
@@ -761,6 +774,7 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertIn("--require-whatsapp-cloud", result.stdout)
         self.assertIn("--require-whatsapp-calling", result.stdout)
         self.assertIn("--check-whatsapp-cloud-api", result.stdout)
+        self.assertIn("--check-whatsapp-cloud-webhook", result.stdout)
         self.assertIn("--require-complete", result.stdout)
         self.assertIn(
             "whatsapp_calling_step[1]=Complete WhatsApp Cloud setup first",
@@ -779,6 +793,18 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             component["name"]: component for component in payload["components"]
         }["whatsapp_bridge_runtime"]
         self.assertIn("--check-whatsapp-cloud-api", bridge["command"])
+
+    def test_cloud_webhook_check_is_forwarded_to_bridge_verifier(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = self.run_readiness(
+                Path(tmp),
+                "--check-whatsapp-cloud-webhook",
+            )
+
+        bridge = {
+            component["name"]: component for component in payload["components"]
+        }["whatsapp_bridge_runtime"]
+        self.assertIn("--check-whatsapp-cloud-webhook", bridge["command"])
 
     def test_inbound_cache_smoke_adds_receive_component(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_verify_whatsapp_bridge_runtime.py
+++ b/tests/test_verify_whatsapp_bridge_runtime.py
@@ -71,6 +71,8 @@ def make_args(tmp_path: Path, **overrides):
         "require_whatsapp_cloud": False,
         "require_whatsapp_calling": False,
         "check_whatsapp_cloud_api": False,
+        "check_whatsapp_cloud_webhook": False,
+        "whatsapp_cloud_webhook_challenge": "unit-challenge",
         "graph_api_base_url": "https://graph.facebook.com",
     }
     values.update(overrides)
@@ -507,6 +509,84 @@ class WhatsAppBridgeRuntimeVerifierTests(unittest.TestCase):
         self.assertEqual(cloud_api["http_status"], 403)
         self.assertEqual(cloud_api["error"]["code"], 100)
         self.assertNotIn("secret-token", json.dumps(result))
+
+    def test_cloud_webhook_challenge_uses_local_url_without_leaking_token(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(tmp_path, check_whatsapp_cloud_webhook=True)
+            write_baileys_session(args.session_dir)
+            args.env_file.parent.mkdir(parents=True, exist_ok=True)
+            args.env_file.write_text(
+                "\n".join(
+                    [
+                        "WHATSAPP_MODE=bot",
+                        "WHATSAPP_CLOUD_PHONE_NUMBER_ID=7794189252778687",
+                        "WHATSAPP_CLOUD_ACCESS_TOKEN=secret-access-token",
+                        "WHATSAPP_CLOUD_APP_SECRET=secret-app",
+                        "WHATSAPP_CLOUD_VERIFY_TOKEN=secret-verify-token",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            original_fetch = self.script.fetch_webhook_challenge
+            calls = []
+
+            def fake_fetch(**kwargs):
+                calls.append(kwargs)
+                return 200, kwargs["challenge"], None
+
+            self.script.fetch_webhook_challenge = fake_fetch
+            try:
+                result = self.script.verify(args)
+            finally:
+                self.script.fetch_webhook_challenge = original_fetch
+
+        self.assertTrue(result["success"], result["failures"])
+        self.assertEqual(calls[0]["url"], "http://127.0.0.1:8090/whatsapp/webhook")
+        self.assertEqual(calls[0]["verify_token"], "secret-verify-token")
+        self.assertEqual(calls[0]["challenge"], "unit-challenge")
+        challenge = result["checks"]["whatsapp_cloud"]["webhook_challenge"]
+        self.assertTrue(challenge["checked"])
+        self.assertTrue(challenge["ok"])
+        self.assertTrue(challenge["verify_token_present"])
+        self.assertTrue(challenge["challenge_echoed"])
+        self.assertEqual(challenge["local_url"], "http://127.0.0.1:8090/whatsapp/webhook")
+        serialized = json.dumps(result)
+        self.assertNotIn("secret-access-token", serialized)
+        self.assertNotIn("secret-verify-token", serialized)
+
+    def test_cloud_webhook_challenge_fails_without_verify_token(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(tmp_path, check_whatsapp_cloud_webhook=True)
+            write_baileys_session(args.session_dir)
+            args.env_file.parent.mkdir(parents=True, exist_ok=True)
+            args.env_file.write_text(
+                "\n".join(
+                    [
+                        "WHATSAPP_MODE=bot",
+                        "WHATSAPP_CLOUD_PHONE_NUMBER_ID=7794189252778687",
+                        "WHATSAPP_CLOUD_ACCESS_TOKEN=secret-access-token",
+                        "WHATSAPP_CLOUD_APP_SECRET=secret-app",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.script.verify(args)
+
+        self.assertFalse(result["success"])
+        self.assertIn(
+            "WhatsApp Cloud webhook challenge check failed",
+            "\n".join(result["failures"]),
+        )
+        challenge = result["checks"]["whatsapp_cloud"]["webhook_challenge"]
+        self.assertFalse(challenge["ok"])
+        self.assertEqual(challenge["missing"], ["WHATSAPP_CLOUD_VERIFY_TOKEN"])
+        self.assertNotIn("secret-access-token", json.dumps(result))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add an opt-in WhatsApp Cloud webhook subscription challenge check to the bridge verifier
- thread --check-whatsapp-cloud-webhook through the alpha readiness and local stack gates
- document the post-credential Graph API plus local webhook challenge verification path

## Telegram compatibility
- reran the Telegram voice contract verifier with the installed voice binary and current Hermes env
- bot voice messages are compatible; Telegram voice calls/live streaming remain out of scope for the Bot API verifier

## Verification
- python3 -m unittest tests.test_verify_whatsapp_bridge_runtime tests.test_verify_whatsapp_alpha_readiness tests.test_verify_local_hermes_voice_stack
- python3 -m py_compile scripts/verify_whatsapp_bridge_runtime.py scripts/verify_whatsapp_alpha_readiness.py
- bash -n scripts/verify_local_hermes_voice_stack.sh
- python3 -m unittest discover tests
- git diff --check
- scripts/verify_whatsapp_bridge_runtime.py --hermes-home /home/ubuntu/.hermes --json
- scripts/verify_telegram_voice_contract.sh --voice-bin /home/ubuntu/.local/bin/voice --skip-daemon --skip-hermes-tts-smoke --require-telegram-credentials