### PR TITLE
Verify WhatsApp Cloud adapter health

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,10 +508,11 @@ Cloud/Calling failures can distinguish missing credentials from invalid
 keeps the selected `voice` binary, Hermes config, bridge URL, sidecar URL,
 audio cache override, and expected agent identity from the current run. It also
 includes `--require-whatsapp-cloud`, `--require-whatsapp-calling`,
-`--check-whatsapp-cloud-api`, and `--check-whatsapp-cloud-webhook`, so after real
-Cloud credentials are present it also makes an authenticated Graph API
-phone-number request and verifies the local webhook challenge echo without
-printing token or phone-number values.
+`--check-whatsapp-cloud-api`, `--check-whatsapp-cloud-health`, and
+`--check-whatsapp-cloud-webhook`, so after real Cloud credentials are present it
+also makes an authenticated Graph API phone-number request, verifies the local
+Cloud adapter health contract, and verifies the local webhook challenge echo
+without printing token or phone-number values.
 Use `--whatsapp-alpha-json-output` with any alpha profile when another local
 agent should consume the same structured `readiness_summary.next_actions`
 without rerunning the full stack gate. The stack verifier also echoes compact

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -75,10 +75,11 @@ WhatsApp-ready Ogg/Opus output, the Baileys bridge identity, the Hermes gateway
 voice-stream service, and the WebRTC sidecar contract. Add
 `--require-whatsapp-cloud` or `--require-whatsapp-calling` only when the host is
 expected to have real Meta Cloud credentials. Once those credentials are on
-disk, add `--check-whatsapp-cloud-api` and
-`--check-whatsapp-cloud-webhook` to make an authenticated Graph API
-phone-number request and confirm the local Cloud webhook echoes Meta's
-subscription challenge without printing token or phone-number values.
+disk, add `--check-whatsapp-cloud-api`, `--check-whatsapp-cloud-health`, and
+`--check-whatsapp-cloud-webhook` to make an authenticated Graph API phone-number
+request, confirm the local Cloud adapter loaded the expected config, and confirm
+the local Cloud webhook echoes Meta's subscription challenge without printing
+token or phone-number values.
 
 The same stack gate can run the categorized alpha report as an explicit opt-in:
 
@@ -123,10 +124,11 @@ voice-note, live-call local sidecar, or external Meta setup. Use
 `--require-whatsapp-calling` when a host is expected to be ready for real Cloud
 Calling; otherwise missing Meta credentials are reported as external setup
 still required, not as a local Baileys voice-note failure. Add
-`--check-whatsapp-cloud-api` and `--check-whatsapp-cloud-webhook` when
-credentials are expected to work and the report should prove the configured
-Cloud phone-number node plus local webhook challenge are reachable. The named
-profiles are `unattended`, `cached-receive`, `send`,
+`--check-whatsapp-cloud-api`, `--check-whatsapp-cloud-health`, and
+`--check-whatsapp-cloud-webhook` when credentials are expected to work and the
+report should prove the configured Cloud phone-number node, local Cloud adapter
+health, and local webhook challenge are reachable. The named profiles are
+`unattended`, `cached-receive`, `send`,
 `attended-cache-receive`, and `attended-send-receive`. Use `cached-receive`
 when the report should also replay a cached inbound WhatsApp voice note through
 `voice stream-transcribe`:
@@ -200,6 +202,7 @@ scripts/verify_whatsapp_alpha_readiness.py \
   --require-whatsapp-cloud \
   --require-whatsapp-calling \
   --check-whatsapp-cloud-api \
+  --check-whatsapp-cloud-health \
   --check-whatsapp-cloud-webhook \
   --require-complete
 ```

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -48,6 +48,7 @@ require_whatsapp_cloud="${REQUIRE_WHATSAPP_CLOUD:-0}"
 require_whatsapp_calling="${REQUIRE_WHATSAPP_CALLING:-0}"
 require_whatsapp_alpha_complete="${REQUIRE_WHATSAPP_ALPHA_COMPLETE:-0}"
 check_whatsapp_cloud_api="${CHECK_WHATSAPP_CLOUD_API:-0}"
+check_whatsapp_cloud_health="${CHECK_WHATSAPP_CLOUD_HEALTH:-0}"
 check_whatsapp_cloud_webhook="${CHECK_WHATSAPP_CLOUD_WEBHOOK:-0}"
 overall_status=0
 temp_files=()
@@ -118,6 +119,8 @@ Options:
                                fail unless all WhatsApp alpha readiness gates are complete
   --check-whatsapp-cloud-api   call the Meta Graph API phone-number endpoint when Cloud
                                credentials are configured
+  --check-whatsapp-cloud-health
+                               verify the local Cloud adapter /health contract
   --check-whatsapp-cloud-webhook
                                verify the local Cloud webhook subscription challenge echo
   --run-whatsapp-inbound-cache-smoke
@@ -163,6 +166,7 @@ Environment aliases:
   WHATSAPP_AUDIO_CACHE_DIR, WHATSAPP_AGENT_NUMBER, WHATSAPP_AGENT_NAME
   REQUIRE_WHATSAPP_CLOUD=1, REQUIRE_WHATSAPP_CALLING=1
   REQUIRE_WHATSAPP_ALPHA_COMPLETE=1, CHECK_WHATSAPP_CLOUD_API=1
+  CHECK_WHATSAPP_CLOUD_HEALTH=1, CHECK_WHATSAPP_CLOUD_WEBHOOK=1
   RUN_WHATSAPP_INBOUND_CACHE_SMOKE=1, WHATSAPP_ALPHA_PROFILE
   WHATSAPP_ALPHA_TEXT, WHATSAPP_ALPHA_VOICE_NOTE_CHAT_ID
   WHATSAPP_ALPHA_WAIT_AUDIO_CACHE_SECONDS, WHATSAPP_ALPHA_WAIT_INBOUND_SECONDS
@@ -526,6 +530,10 @@ while [[ $# -gt 0 ]]; do
       check_whatsapp_cloud_api=1
       shift
       ;;
+    --check-whatsapp-cloud-health)
+      check_whatsapp_cloud_health=1
+      shift
+      ;;
     --check-whatsapp-cloud-webhook)
       check_whatsapp_cloud_webhook=1
       shift
@@ -814,6 +822,9 @@ if [[ "$skip_whatsapp_bridge" != "1" ]]; then
   if [[ "$check_whatsapp_cloud_api" == "1" ]]; then
     whatsapp_bridge_args+=(--check-whatsapp-cloud-api)
   fi
+  if [[ "$check_whatsapp_cloud_health" == "1" ]]; then
+    whatsapp_bridge_args+=(--check-whatsapp-cloud-health)
+  fi
   if [[ "$check_whatsapp_cloud_webhook" == "1" ]]; then
     whatsapp_bridge_args+=(--check-whatsapp-cloud-webhook)
   fi
@@ -958,6 +969,9 @@ if [[ -n "$whatsapp_alpha_profile" ]]; then
   fi
   if [[ "$check_whatsapp_cloud_api" == "1" ]]; then
     whatsapp_alpha_args+=(--check-whatsapp-cloud-api)
+  fi
+  if [[ "$check_whatsapp_cloud_health" == "1" ]]; then
+    whatsapp_alpha_args+=(--check-whatsapp-cloud-health)
   fi
   if [[ "$check_whatsapp_cloud_webhook" == "1" ]]; then
     whatsapp_alpha_args+=(--check-whatsapp-cloud-webhook)

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -434,6 +434,8 @@ def build_components(args: argparse.Namespace) -> list[dict[str, Any]]:
         bridge_cmd.extend(["--expected-agent-name", args.expected_agent_name])
     if args.check_whatsapp_cloud_api:
         bridge_cmd.append("--check-whatsapp-cloud-api")
+    if args.check_whatsapp_cloud_health:
+        bridge_cmd.append("--check-whatsapp-cloud-health")
     if args.check_whatsapp_cloud_webhook:
         bridge_cmd.append("--check-whatsapp-cloud-webhook")
     if args.skip_systemd:
@@ -823,6 +825,7 @@ def cloud_setup_handoff(
         *base_command,
         "--require-whatsapp-cloud",
         "--check-whatsapp-cloud-api",
+        "--check-whatsapp-cloud-health",
         "--check-whatsapp-cloud-webhook",
     ]
     steps = [] if configured else [
@@ -878,6 +881,7 @@ def calling_setup_handoff(
         "--require-whatsapp-cloud",
         "--require-whatsapp-calling",
         "--check-whatsapp-cloud-api",
+        "--check-whatsapp-cloud-health",
         "--check-whatsapp-cloud-webhook",
     ]
     complete_command = [
@@ -889,6 +893,7 @@ def calling_setup_handoff(
         "--require-whatsapp-cloud",
         "--require-whatsapp-calling",
         "--check-whatsapp-cloud-api",
+        "--check-whatsapp-cloud-health",
         "--check-whatsapp-cloud-webhook",
         "--require-complete",
     ]
@@ -1349,6 +1354,14 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "when Cloud credentials are configured, call the Meta Graph API "
             "phone-number endpoint without printing credential values"
+        ),
+    )
+    parser.add_argument(
+        "--check-whatsapp-cloud-health",
+        action="store_true",
+        help=(
+            "when the Cloud webhook is running, verify the local adapter "
+            "/health contract without printing credential values"
         ),
     )
     parser.add_argument(

--- a/scripts/verify_whatsapp_bridge_runtime.py
+++ b/scripts/verify_whatsapp_bridge_runtime.py
@@ -630,6 +630,157 @@ def local_webhook_url(webhook: dict[str, Any]) -> str | None:
     return f"http://{host}:{port}{path}"
 
 
+def local_cloud_health_url(webhook: dict[str, Any]) -> str | None:
+    port = webhook.get("port")
+    if not isinstance(port, int):
+        return None
+    host = str(webhook.get("host") or DEFAULT_WHATSAPP_CLOUD_WEBHOOK_HOST).strip()
+    if host in ("", "0.0.0.0", "::", "[::]"):
+        host = "127.0.0.1"
+    elif ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    return f"http://{host}:{port}/health"
+
+
+def fetch_cloud_health(
+    *,
+    url: str,
+    timeout: float,
+) -> tuple[dict[str, Any] | None, int | None, dict[str, Any] | None]:
+    request = Request(url, headers={"Accept": "application/json"})
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            status = getattr(response, "status", 200)
+            body = response.read()
+    except HTTPError as exc:
+        return None, exc.code, {"message": f"Cloud health returned HTTP {exc.code}"}
+    except URLError as exc:
+        return None, None, {"message": f"Cloud health request failed: {exc.reason}"}
+    except OSError as exc:
+        return None, None, {"message": f"Cloud health request failed: {exc}"}
+
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        return None, status, {"message": f"Cloud health did not return JSON: {exc}"}
+    if not isinstance(payload, dict):
+        return None, status, {"message": "Cloud health JSON must be an object"}
+    return payload, int(status), None
+
+
+def build_cloud_health_check(
+    env_sources: dict[str, dict[str, str]],
+    *,
+    webhook: dict[str, Any],
+    require_calling_sidecar: bool,
+    timeout: float,
+) -> dict[str, Any]:
+    phone_number_id, phone_sources = first_env_value(
+        env_sources,
+        "WHATSAPP_CLOUD_PHONE_NUMBER_ID",
+    )
+    url = local_cloud_health_url(webhook)
+    check: dict[str, Any] = {
+        "checked": True,
+        "ok": False,
+        "local_url": url,
+        "phone_number_id_present": phone_number_id is not None,
+        "phone_number_id_sources": phone_sources,
+        "require_calling_sidecar": require_calling_sidecar,
+        "missing": [],
+        "invalid": [],
+    }
+    if not phone_number_id:
+        check["missing"].append("WHATSAPP_CLOUD_PHONE_NUMBER_ID")
+    if not url:
+        check["invalid"].extend(str(key) for key in webhook.get("invalid") or [])
+        if not check["invalid"]:
+            check["invalid"].append("WHATSAPP_CLOUD_WEBHOOK_PORT")
+    if check["missing"] or check["invalid"]:
+        check["error"] = {
+            "message": (
+                "Cloud health check requires a local health URL and phone number ID"
+            )
+        }
+        return check
+
+    payload, status, error = fetch_cloud_health(url=str(url), timeout=timeout)
+    check["http_status"] = status
+    if error:
+        check["error"] = error
+        return check
+
+    payload = payload or {}
+    health = {
+        "status": payload.get("status"),
+        "platform": payload.get("platform"),
+        "phone_number_id_matches_config": str(payload.get("phone_number_id") or "")
+        == str(phone_number_id),
+        "webhook_path_matches_config": str(payload.get("webhook_path") or "")
+        == str(webhook.get("path") or DEFAULT_WHATSAPP_CLOUD_WEBHOOK_PATH),
+        "verify_token_configured": payload.get("verify_token_configured") is True,
+        "app_secret_configured": payload.get("app_secret_configured") is True,
+        "calling_sidecar_configured": payload.get("calling_sidecar_configured") is True,
+        "calling_sidecar_contract_loaded": (
+            payload.get("calling_sidecar_contract_loaded") is True
+        ),
+        "calling_sidecar_tts_stream_configured": (
+            payload.get("calling_sidecar_tts_stream_configured") is True
+        ),
+        "ffmpeg_present": payload.get("ffmpeg_present") is True,
+        "accepted": (
+            payload.get("accepted") if isinstance(payload.get("accepted"), int) else None
+        ),
+        "duplicates": (
+            payload.get("duplicates")
+            if isinstance(payload.get("duplicates"), int)
+            else None
+        ),
+        "rejected_signature": (
+            payload.get("rejected_signature")
+            if isinstance(payload.get("rejected_signature"), int)
+            else None
+        ),
+    }
+    check["health"] = health
+    if health["status"] != "ok":
+        check["error"] = {"message": "Cloud health status was not ok"}
+        return check
+    if health["platform"] != "whatsapp_cloud":
+        check["error"] = {"message": "Cloud health reported the wrong platform"}
+        return check
+    if not health["phone_number_id_matches_config"]:
+        check["error"] = {
+            "message": "Cloud health phone number ID did not match configuration"
+        }
+        return check
+    if not health["webhook_path_matches_config"]:
+        check["error"] = {
+            "message": "Cloud health webhook path did not match configuration"
+        }
+        return check
+    if not health["verify_token_configured"]:
+        check["error"] = {"message": "Cloud health verify token is not configured"}
+        return check
+    if not health["app_secret_configured"]:
+        check["error"] = {"message": "Cloud health app secret is not configured"}
+        return check
+    if require_calling_sidecar:
+        if not health["calling_sidecar_configured"]:
+            check["error"] = {
+                "message": "Cloud health Calling sidecar is not configured"
+            }
+            return check
+        if not health["calling_sidecar_tts_stream_configured"]:
+            check["error"] = {
+                "message": "Cloud health Calling sidecar TTS stream is not configured"
+            }
+            return check
+
+    check["ok"] = True
+    return check
+
+
 def fetch_webhook_challenge(
     *,
     url: str,
@@ -1043,6 +1194,24 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         warnings.append(str(bridge_script_hash.get("reason")))
 
     cloud = build_cloud_summary(env_sources)
+    if args.check_whatsapp_cloud_health:
+        cloud_health = build_cloud_health_check(
+            env_sources,
+            webhook=cloud["webhook"],
+            require_calling_sidecar=args.require_whatsapp_calling,
+            timeout=args.timeout,
+        )
+        cloud["cloud_health"] = cloud_health
+        if not cloud_health.get("ok"):
+            failures.append(
+                "WhatsApp Cloud health check failed: "
+                + str(
+                    (cloud_health.get("error") or {}).get("message")
+                    or "unknown error"
+                )
+            )
+    else:
+        cloud["cloud_health"] = {"checked": False}
     if args.check_whatsapp_cloud_api:
         cloud_api = build_cloud_api_check(
             env_sources,
@@ -1150,6 +1319,14 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--check-whatsapp-cloud-health",
+        action="store_true",
+        help=(
+            "call the local WhatsApp Cloud adapter /health endpoint and verify "
+            "the gateway loaded the expected Cloud config"
+        ),
+    )
+    parser.add_argument(
         "--check-whatsapp-cloud-webhook",
         action="store_true",
         help=(
@@ -1182,6 +1359,7 @@ def human_summary(result: dict[str, Any]) -> None:
     bridge_script_hash = checks.get("bridge_script_hash") or {}
     cloud = checks.get("whatsapp_cloud") or {}
     webhook = cloud.get("webhook") or {}
+    cloud_health = cloud.get("cloud_health") or {}
     webhook_challenge = cloud.get("webhook_challenge") or {}
     cloud_api = cloud.get("cloud_api") or {}
     local_config = checks.get("whatsapp_local_config") or {}
@@ -1255,6 +1433,35 @@ def human_summary(result: dict[str, Any]) -> None:
         + " invalid="
         + (",".join(webhook.get("invalid") or []) or "none")
     )
+    if cloud_health.get("checked"):
+        health = cloud_health.get("health") or {}
+        health_error = cloud_health.get("error") or {}
+        print(
+            "whatsapp_cloud_health="
+            + ("ok" if cloud_health.get("ok") else "failed")
+            + f" local_url={cloud_health.get('local_url') or '<invalid>'}"
+            + f" http_status={cloud_health.get('http_status') or '<none>'}"
+            + " phone_number_id_present="
+            + str(cloud_health.get("phone_number_id_present"))
+            + " phone_number_id_matches_config="
+            + str(health.get("phone_number_id_matches_config"))
+            + " webhook_path_matches_config="
+            + str(health.get("webhook_path_matches_config"))
+            + " verify_token_configured="
+            + str(health.get("verify_token_configured"))
+            + " app_secret_configured="
+            + str(health.get("app_secret_configured"))
+            + " calling_sidecar_configured="
+            + str(health.get("calling_sidecar_configured"))
+            + " calling_sidecar_tts_stream_configured="
+            + str(health.get("calling_sidecar_tts_stream_configured"))
+            + " missing="
+            + (",".join(cloud_health.get("missing") or []) or "none")
+            + " invalid="
+            + (",".join(cloud_health.get("invalid") or []) or "none")
+            + " error="
+            + str(health_error.get("message") or "none")
+        )
     if webhook_challenge.get("checked"):
         challenge_error = webhook_challenge.get("error") or {}
         print(

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -779,6 +779,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                     "--require-whatsapp-calling",
                     "--require-whatsapp-alpha-complete",
                     "--check-whatsapp-cloud-api",
+                    "--check-whatsapp-cloud-health",
                     "--check-whatsapp-cloud-webhook",
                     "--skip-hermes-config",
                     "--skip-hermes-gateway",
@@ -857,6 +858,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 "--require-whatsapp-cloud",
                 "--require-whatsapp-calling",
                 "--check-whatsapp-cloud-api",
+                "--check-whatsapp-cloud-health",
                 "--check-whatsapp-cloud-webhook",
                 "--require-complete",
             ],
@@ -1026,7 +1028,9 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                               "--hermes-home",
                               "/home/ubuntu/.hermes",
                               "--require-whatsapp-cloud",
-                              "--check-whatsapp-cloud-api"
+                              "--check-whatsapp-cloud-api",
+                              "--check-whatsapp-cloud-health",
+                              "--check-whatsapp-cloud-webhook"
                             ]
                           }}
                         }},
@@ -1046,7 +1050,9 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                               "/home/ubuntu/.hermes",
                               "--require-whatsapp-cloud",
                               "--require-whatsapp-calling",
-                              "--check-whatsapp-cloud-api"
+                              "--check-whatsapp-cloud-api",
+                              "--check-whatsapp-cloud-health",
+                              "--check-whatsapp-cloud-webhook"
                             ],
                             "complete_verification_command": [
                               "scripts/verify_whatsapp_alpha_readiness.py",
@@ -1057,6 +1063,8 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                               "--require-whatsapp-cloud",
                               "--require-whatsapp-calling",
                               "--check-whatsapp-cloud-api",
+                              "--check-whatsapp-cloud-health",
+                              "--check-whatsapp-cloud-webhook",
                               "--require-complete"
                             ]
                           }}
@@ -1135,7 +1143,9 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn(
             "whatsapp_alpha_json_cloud_verify_command="
             "scripts/verify_whatsapp_alpha_readiness.py --hermes-home "
-            "/home/ubuntu/.hermes --require-whatsapp-cloud --check-whatsapp-cloud-api",
+            "/home/ubuntu/.hermes --require-whatsapp-cloud "
+            "--check-whatsapp-cloud-api --check-whatsapp-cloud-health "
+            "--check-whatsapp-cloud-webhook",
             result.stdout,
         )
         self.assertIn(
@@ -1148,7 +1158,8 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             "whatsapp_alpha_json_calling_verify_command="
             "scripts/verify_whatsapp_alpha_readiness.py --hermes-home "
             "/home/ubuntu/.hermes --require-whatsapp-cloud "
-            "--require-whatsapp-calling --check-whatsapp-cloud-api",
+            "--require-whatsapp-calling --check-whatsapp-cloud-api "
+            "--check-whatsapp-cloud-health --check-whatsapp-cloud-webhook",
             result.stdout,
         )
         self.assertIn(
@@ -1156,7 +1167,8 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             "scripts/verify_whatsapp_alpha_readiness.py --hermes-home "
             "/home/ubuntu/.hermes --profile attended-cache-receive "
             "--require-whatsapp-cloud --require-whatsapp-calling "
-            "--check-whatsapp-cloud-api "
+            "--check-whatsapp-cloud-api --check-whatsapp-cloud-health "
+            "--check-whatsapp-cloud-webhook "
             "--require-complete",
             result.stdout,
         )
@@ -1484,6 +1496,8 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                               "--require-whatsapp-cloud",
                               "--require-whatsapp-calling",
                               "--check-whatsapp-cloud-api",
+                              "--check-whatsapp-cloud-health",
+                              "--check-whatsapp-cloud-webhook",
                               "--require-complete"
                             ]
                           }}

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -408,6 +408,10 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             cloud_handoff["verify_command"],
         )
         self.assertIn(
+            "--check-whatsapp-cloud-health",
+            cloud_handoff["verify_command"],
+        )
+        self.assertIn(
             "--check-whatsapp-cloud-webhook",
             cloud_handoff["verify_command"],
         )
@@ -445,6 +449,10 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             calling_handoff["verify_command"],
         )
         self.assertIn(
+            "--check-whatsapp-cloud-health",
+            calling_handoff["verify_command"],
+        )
+        self.assertIn(
             "--check-whatsapp-cloud-webhook",
             calling_handoff["verify_command"],
         )
@@ -452,6 +460,7 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertIn("--require-whatsapp-cloud", complete_command)
         self.assertIn("--require-whatsapp-calling", complete_command)
         self.assertIn("--check-whatsapp-cloud-api", complete_command)
+        self.assertIn("--check-whatsapp-cloud-health", complete_command)
         self.assertIn("--check-whatsapp-cloud-webhook", complete_command)
         self.assertIn("--require-complete", complete_command)
         self.assertIn("--wait-audio-cache-seconds", complete_command)
@@ -526,6 +535,10 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         )
         self.assertIn(
             "--check-whatsapp-cloud-api",
+            meta_action["complete_verification_command"],
+        )
+        self.assertIn(
+            "--check-whatsapp-cloud-health",
             meta_action["complete_verification_command"],
         )
         self.assertIn(
@@ -774,6 +787,7 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertIn("--require-whatsapp-cloud", result.stdout)
         self.assertIn("--require-whatsapp-calling", result.stdout)
         self.assertIn("--check-whatsapp-cloud-api", result.stdout)
+        self.assertIn("--check-whatsapp-cloud-health", result.stdout)
         self.assertIn("--check-whatsapp-cloud-webhook", result.stdout)
         self.assertIn("--require-complete", result.stdout)
         self.assertIn(
@@ -805,6 +819,18 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             component["name"]: component for component in payload["components"]
         }["whatsapp_bridge_runtime"]
         self.assertIn("--check-whatsapp-cloud-webhook", bridge["command"])
+
+    def test_cloud_health_check_is_forwarded_to_bridge_verifier(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = self.run_readiness(
+                Path(tmp),
+                "--check-whatsapp-cloud-health",
+            )
+
+        bridge = {
+            component["name"]: component for component in payload["components"]
+        }["whatsapp_bridge_runtime"]
+        self.assertIn("--check-whatsapp-cloud-health", bridge["command"])
 
     def test_inbound_cache_smoke_adds_receive_component(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_verify_whatsapp_bridge_runtime.py
+++ b/tests/test_verify_whatsapp_bridge_runtime.py
@@ -71,6 +71,7 @@ def make_args(tmp_path: Path, **overrides):
         "require_whatsapp_cloud": False,
         "require_whatsapp_calling": False,
         "check_whatsapp_cloud_api": False,
+        "check_whatsapp_cloud_health": False,
         "check_whatsapp_cloud_webhook": False,
         "whatsapp_cloud_webhook_challenge": "unit-challenge",
         "graph_api_base_url": "https://graph.facebook.com",
@@ -508,6 +509,179 @@ class WhatsAppBridgeRuntimeVerifierTests(unittest.TestCase):
         self.assertFalse(cloud_api["ok"])
         self.assertEqual(cloud_api["http_status"], 403)
         self.assertEqual(cloud_api["error"]["code"], 100)
+        self.assertNotIn("secret-token", json.dumps(result))
+
+    def test_cloud_health_check_uses_local_health_without_leaking_secrets(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(tmp_path, check_whatsapp_cloud_health=True)
+            write_baileys_session(args.session_dir)
+            args.env_file.parent.mkdir(parents=True, exist_ok=True)
+            args.env_file.write_text(
+                "\n".join(
+                    [
+                        "WHATSAPP_MODE=bot",
+                        "WHATSAPP_CLOUD_PHONE_NUMBER_ID=7794189252778687",
+                        "WHATSAPP_CLOUD_ACCESS_TOKEN=secret-token",
+                        "WHATSAPP_CLOUD_APP_SECRET=secret-app",
+                        "WHATSAPP_CLOUD_VERIFY_TOKEN=secret-verify",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            original_fetch = self.script.fetch_cloud_health
+            calls = []
+
+            def fake_fetch(**kwargs):
+                calls.append(kwargs)
+                return (
+                    {
+                        "status": "ok",
+                        "platform": "whatsapp_cloud",
+                        "phone_number_id": "7794189252778687",
+                        "webhook_path": "/whatsapp/webhook",
+                        "verify_token_configured": True,
+                        "app_secret_configured": True,
+                        "ffmpeg_present": True,
+                        "accepted": 1,
+                        "duplicates": 0,
+                        "rejected_signature": 0,
+                    },
+                    200,
+                    None,
+                )
+
+            self.script.fetch_cloud_health = fake_fetch
+            try:
+                result = self.script.verify(args)
+            finally:
+                self.script.fetch_cloud_health = original_fetch
+
+        self.assertTrue(result["success"], result["failures"])
+        self.assertEqual(calls[0]["url"], "http://127.0.0.1:8090/health")
+        cloud_health = result["checks"]["whatsapp_cloud"]["cloud_health"]
+        self.assertTrue(cloud_health["checked"])
+        self.assertTrue(cloud_health["ok"])
+        self.assertEqual(cloud_health["http_status"], 200)
+        health = cloud_health["health"]
+        self.assertTrue(health["phone_number_id_matches_config"])
+        self.assertTrue(health["webhook_path_matches_config"])
+        self.assertTrue(health["verify_token_configured"])
+        self.assertTrue(health["app_secret_configured"])
+        self.assertTrue(health["ffmpeg_present"])
+        self.assertEqual(health["accepted"], 1)
+        serialized = json.dumps(result)
+        self.assertNotIn("secret-token", serialized)
+        self.assertNotIn("secret-verify", serialized)
+        self.assertNotIn("secret-app", serialized)
+
+    def test_cloud_health_check_can_require_calling_sidecar(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(
+                tmp_path,
+                check_whatsapp_cloud_health=True,
+                require_whatsapp_calling=True,
+            )
+            write_baileys_session(args.session_dir)
+            args.env_file.parent.mkdir(parents=True, exist_ok=True)
+            args.env_file.write_text(
+                "\n".join(
+                    [
+                        "WHATSAPP_MODE=bot",
+                        "WHATSAPP_CLOUD_PHONE_NUMBER_ID=7794189252778687",
+                        "WHATSAPP_CLOUD_ACCESS_TOKEN=secret-token",
+                        "WHATSAPP_CLOUD_APP_SECRET=secret-app",
+                        "WHATSAPP_CLOUD_VERIFY_TOKEN=secret-verify",
+                        "WHATSAPP_CLOUD_CALLING_SIDECAR_URL=http://127.0.0.1:8787",
+                        "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND=voice stream",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            original_fetch = self.script.fetch_cloud_health
+
+            def fake_fetch(**_kwargs):
+                return (
+                    {
+                        "status": "ok",
+                        "platform": "whatsapp_cloud",
+                        "phone_number_id": "7794189252778687",
+                        "webhook_path": "/whatsapp/webhook",
+                        "verify_token_configured": True,
+                        "app_secret_configured": True,
+                        "calling_sidecar_configured": True,
+                        "calling_sidecar_contract_loaded": True,
+                        "calling_sidecar_tts_stream_configured": True,
+                    },
+                    200,
+                    None,
+                )
+
+            self.script.fetch_cloud_health = fake_fetch
+            try:
+                result = self.script.verify(args)
+            finally:
+                self.script.fetch_cloud_health = original_fetch
+
+        self.assertTrue(result["success"], result["failures"])
+        cloud_health = result["checks"]["whatsapp_cloud"]["cloud_health"]
+        self.assertTrue(cloud_health["ok"])
+        self.assertTrue(cloud_health["require_calling_sidecar"])
+        self.assertTrue(cloud_health["health"]["calling_sidecar_configured"])
+        self.assertTrue(cloud_health["health"]["calling_sidecar_tts_stream_configured"])
+
+    def test_cloud_health_check_fails_on_mismatched_phone_number(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(tmp_path, check_whatsapp_cloud_health=True)
+            write_baileys_session(args.session_dir)
+            args.env_file.parent.mkdir(parents=True, exist_ok=True)
+            args.env_file.write_text(
+                "\n".join(
+                    [
+                        "WHATSAPP_MODE=bot",
+                        "WHATSAPP_CLOUD_PHONE_NUMBER_ID=7794189252778687",
+                        "WHATSAPP_CLOUD_ACCESS_TOKEN=secret-token",
+                        "WHATSAPP_CLOUD_APP_SECRET=secret-app",
+                        "WHATSAPP_CLOUD_VERIFY_TOKEN=secret-verify",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            original_fetch = self.script.fetch_cloud_health
+
+            def fake_fetch(**_kwargs):
+                return (
+                    {
+                        "status": "ok",
+                        "platform": "whatsapp_cloud",
+                        "phone_number_id": "wrong-phone",
+                        "webhook_path": "/whatsapp/webhook",
+                        "verify_token_configured": True,
+                        "app_secret_configured": True,
+                    },
+                    200,
+                    None,
+                )
+
+            self.script.fetch_cloud_health = fake_fetch
+            try:
+                result = self.script.verify(args)
+            finally:
+                self.script.fetch_cloud_health = original_fetch
+
+        self.assertFalse(result["success"])
+        self.assertIn("WhatsApp Cloud health check failed", "\n".join(result["failures"]))
+        cloud_health = result["checks"]["whatsapp_cloud"]["cloud_health"]
+        self.assertFalse(cloud_health["ok"])
+        self.assertFalse(cloud_health["health"]["phone_number_id_matches_config"])
         self.assertNotIn("secret-token", json.dumps(result))
 
     def test_cloud_webhook_challenge_uses_local_url_without_leaking_token(self):


### PR DESCRIPTION
## Summary
- add an opt-in WhatsApp Cloud adapter /health check to the bridge verifier
- validate local health status, platform, phone-number ID, webhook path, verify/app-secret flags, and Calling sidecar flags when Calling is required
- thread --check-whatsapp-cloud-health through alpha readiness and the local stack gate
- update docs so post-credential verification includes Graph API, local health, and webhook challenge checks

## Verification
- python3 -m unittest tests.test_verify_whatsapp_bridge_runtime tests.test_verify_whatsapp_alpha_readiness tests.test_verify_local_hermes_voice_stack
- python3 -m py_compile scripts/verify_whatsapp_bridge_runtime.py scripts/verify_whatsapp_alpha_readiness.py
- bash -n scripts/verify_local_hermes_voice_stack.sh
- git diff --check
- python3 -m unittest discover tests
- scripts/verify_whatsapp_bridge_runtime.py --hermes-home /home/ubuntu/.hermes --json
- scripts/verify_whatsapp_bridge_runtime.py --hermes-home /home/ubuntu/.hermes --check-whatsapp-cloud-health --json (expected missing WHATSAPP_CLOUD_PHONE_NUMBER_ID on this host)