### PR TITLE
Classify WhatsApp Cloud probes as external setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,9 @@ includes `--require-whatsapp-cloud`, `--require-whatsapp-calling`,
 `--check-whatsapp-cloud-webhook`, so after real Cloud credentials are present it
 also makes an authenticated Graph API phone-number request, verifies the local
 Cloud adapter health contract, and verifies the local webhook challenge echo
-without printing token or phone-number values.
+without printing token or phone-number values. Failures from those explicit
+Cloud probes are reported as external Meta setup, not as local Baileys bridge or
+voice runtime failures.
 Use `--whatsapp-alpha-json-output` with any alpha profile when another local
 agent should consume the same structured `readiness_summary.next_actions`
 without rerunning the full stack gate. The stack verifier also echoes compact

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -127,8 +127,10 @@ still required, not as a local Baileys voice-note failure. Add
 `--check-whatsapp-cloud-api`, `--check-whatsapp-cloud-health`, and
 `--check-whatsapp-cloud-webhook` when credentials are expected to work and the
 report should prove the configured Cloud phone-number node, local Cloud adapter
-health, and local webhook challenge are reachable. The named profiles are
-`unattended`, `cached-receive`, `send`,
+health, and local webhook challenge are reachable. Failures from those explicit
+Cloud probes are classified as external Meta setup, so the same report can still
+show the local Baileys bridge and voice runtime as healthy. The named profiles
+are `unattended`, `cached-receive`, `send`,
 `attended-cache-receive`, and `attended-send-receive`. Use `cached-receive`
 when the report should also replay a cached inbound WhatsApp voice note through
 `voice stream-transcribe`:

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -49,6 +49,15 @@ CALLING_SIDECAR_REQUIRED_KEYS = (
     "WHATSAPP_CLOUD_CALLING_SIDECAR_URL",
     "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND",
 )
+BRIDGE_EXTERNAL_META_FAILURE_PREFIXES = (
+    "WhatsApp Cloud API phone number check failed:",
+    "WhatsApp Cloud health check failed:",
+    "WhatsApp Cloud webhook challenge check failed:",
+    "WhatsApp Cloud credentials missing:",
+    "WhatsApp Cloud config invalid:",
+    "WhatsApp Cloud Calling not ready;",
+    "WhatsApp Cloud Calling config invalid:",
+)
 
 
 def repo_root() -> Path:
@@ -155,6 +164,45 @@ def component(
         "failures": [] if success else output_failures(completed, payload),
         "summary": payload,
     }
+
+
+def component_local_success(item: dict[str, Any]) -> bool:
+    return bool(item.get("local_success", item.get("success")))
+
+
+def bridge_external_meta_failures(component: dict[str, Any]) -> list[str]:
+    if component.get("name") != "whatsapp_bridge_runtime":
+        return []
+    failures = [str(item) for item in component.get("failures") or []]
+    if not failures:
+        return []
+    external = [
+        failure
+        for failure in failures
+        if failure.startswith(BRIDGE_EXTERNAL_META_FAILURE_PREFIXES)
+    ]
+    return external if len(external) == len(failures) else []
+
+
+def classify_bridge_external_meta_failures(
+    components: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    external_failures: list[dict[str, Any]] = []
+    for item in components:
+        item["local_success"] = bool(item.get("success"))
+        external = bridge_external_meta_failures(item)
+        if not external:
+            continue
+        item["external_meta_only"] = True
+        item["local_success"] = True
+        external_failures.append(
+            {
+                "name": "whatsapp_cloud_probe",
+                "category": "external_meta_setup",
+                "failures": external,
+            }
+        )
+    return external_failures
 
 
 def script_path(name: str) -> str:
@@ -1113,15 +1161,18 @@ def build_readiness_summary(
 
 def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
     components = build_components(args)
+    external_probe_failures = classify_bridge_external_meta_failures(components)
     required_failures = [
-        item for item in components if item.get("required") and not item.get("success")
+        item
+        for item in components
+        if item.get("required") and not component_local_success(item)
     ]
     by_category: dict[str, dict[str, Any]] = {}
     for item in components:
         category = item["category"]
         bucket = by_category.setdefault(category, {"success": True, "components": []})
         bucket["components"].append(item["name"])
-        if item.get("required") and not item.get("success"):
+        if item.get("required") and not component_local_success(item):
             bucket["success"] = False
 
     bridge_checks = bridge_runtime_checks(components)
@@ -1146,7 +1197,7 @@ def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
     }
 
     external_failures: list[dict[str, Any]] = []
-    success = not required_failures
+    success = not required_failures and not external_probe_failures
     if args.require_whatsapp_calling and not external_meta_setup["calling_ready"]:
         success = False
         calling_detail = ", ".join(calling_missing + calling_invalid)
@@ -1254,6 +1305,7 @@ def build_readiness(args: argparse.Namespace) -> dict[str, Any]:
             }
             for item in required_failures
         ]
+        + external_probe_failures
         + external_failures
         + completion_failures,
     }

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -112,6 +112,7 @@ def write_fake_helpers(
     *,
     cloud_configured: bool = False,
     cloud_invalid: list[str] | None = None,
+    bridge_failures: list[str] | None = None,
     voice_note_payload: dict | None = None,
     inbound_cache_payload: dict | None = None,
 ) -> None:
@@ -194,7 +195,7 @@ def write_fake_helpers(
     }
     cloud_is_configured = cloud_configured and not cloud_invalid
     bridge_payload = {
-        "success": True,
+        "success": not bridge_failures,
         "checks": {
             "env_file": str(directory.parent / "hermes" / ".env"),
             "env_key_sources": env_key_sources,
@@ -222,7 +223,7 @@ def write_fake_helpers(
                 "webhook": webhook,
             }
         },
-        "failures": [],
+        "failures": bridge_failures or [],
     }
     json_script(directory / "verify_whatsapp_bridge_runtime.py", bridge_payload)
 
@@ -242,6 +243,7 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         *args: str,
         cloud_configured: bool = False,
         cloud_invalid: list[str] | None = None,
+        bridge_failures: list[str] | None = None,
         skip_voice_note_smoke: bool = True,
         voice_note_payload: dict | None = None,
         inbound_cache_payload: dict | None = None,
@@ -251,6 +253,7 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             *args,
             cloud_configured=cloud_configured,
             cloud_invalid=cloud_invalid,
+            bridge_failures=bridge_failures,
             skip_voice_note_smoke=skip_voice_note_smoke,
             voice_note_payload=voice_note_payload,
             inbound_cache_payload=inbound_cache_payload,
@@ -264,6 +267,7 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         *args: str,
         cloud_configured: bool = False,
         cloud_invalid: list[str] | None = None,
+        bridge_failures: list[str] | None = None,
         skip_voice_note_smoke: bool = True,
         voice_note_payload: dict | None = None,
         inbound_cache_payload: dict | None = None,
@@ -274,6 +278,7 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             helpers,
             cloud_configured=cloud_configured,
             cloud_invalid=cloud_invalid,
+            bridge_failures=bridge_failures,
             voice_note_payload=voice_note_payload,
             inbound_cache_payload=inbound_cache_payload,
         )
@@ -831,6 +836,60 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             component["name"]: component for component in payload["components"]
         }["whatsapp_bridge_runtime"]
         self.assertIn("--check-whatsapp-cloud-health", bridge["command"])
+
+    def test_cloud_probe_failure_is_external_not_local_runtime(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self.run_readiness_process(
+                Path(tmp),
+                "--check-whatsapp-cloud-health",
+                bridge_failures=[
+                    "WhatsApp Cloud health check failed: Cloud health check "
+                    "requires a local health URL and phone number ID"
+                ],
+            )
+
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout)
+        self.assertFalse(payload["success"])
+        self.assertTrue(payload["by_category"]["bridge_pairing"]["success"])
+        bridge = {
+            component["name"]: component for component in payload["components"]
+        }["whatsapp_bridge_runtime"]
+        self.assertFalse(bridge["success"])
+        self.assertTrue(bridge["local_success"])
+        self.assertTrue(bridge["external_meta_only"])
+        summary = payload["readiness_summary"]
+        self.assertTrue(summary["local_checks_passed"])
+        action_ids = [action["id"] for action in summary["next_actions"]]
+        self.assertNotIn("fix_local_runtime", action_ids)
+        self.assertIn("configure_whatsapp_cloud_calling", action_ids)
+        failures = payload["failures"]
+        self.assertEqual(failures[0]["category"], "external_meta_setup")
+        self.assertEqual(failures[0]["name"], "whatsapp_cloud_probe")
+
+    def test_base_bridge_failure_still_counts_as_local_runtime(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self.run_readiness_process(
+                Path(tmp),
+                bridge_failures=["bridge health returned HTTP 500"],
+            )
+
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout)
+        self.assertFalse(payload["by_category"]["bridge_pairing"]["success"])
+        bridge = {
+            component["name"]: component for component in payload["components"]
+        }["whatsapp_bridge_runtime"]
+        self.assertFalse(bridge["success"])
+        self.assertFalse(bridge["local_success"])
+        self.assertNotIn("external_meta_only", bridge)
+        summary = payload["readiness_summary"]
+        self.assertFalse(summary["local_checks_passed"])
+        action_ids = [action["id"] for action in summary["next_actions"]]
+        self.assertIn("fix_local_runtime", action_ids)
+        failures = payload["failures"]
+        self.assertEqual(failures[0]["category"], "bridge_pairing")
+        self.assertEqual(failures[0]["name"], "whatsapp_bridge_runtime")
 
     def test_inbound_cache_smoke_adds_receive_component(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- treat bridge failures from explicit WhatsApp Cloud probe checks as external Meta setup in alpha readiness
- keep local bridge-pairing readiness green when the base Baileys bridge is healthy and only Cloud API/health/webhook proof failed
- preserve true bridge failures as local bridge-pairing failures
- document that explicit Cloud probe failures stay separate from local voice/Baileys runtime failures

## Verification
- python3 -m unittest tests.test_verify_whatsapp_alpha_readiness
- python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py
- scripts/verify_whatsapp_alpha_readiness.py --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --skip-systemd --skip-daemon --skip-sidecar --skip-hermes-tts-smoke --skip-voice-note-smoke --check-whatsapp-cloud-health --json (expected external_meta_setup failure for missing WHATSAPP_CLOUD_PHONE_NUMBER_ID; local_checks_passed=True)
- python3 -m unittest discover tests
- git diff --check