### PR TITLE
Continue stack gate after Cloud probe failures

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -192,7 +192,10 @@ draining command, Cloud verification command, Calling verification command, and
 complete-alpha command if those commands are present in the saved JSON. If the
 alpha profile exits non-zero while writing a valid JSON report, such as a
 `--require-complete` run with pending gates, the stack gate still prints this
-summary before returning the alpha failure status.
+summary before returning the alpha failure status. If a direct bridge Cloud
+probe fails first, the stack gate reports `failure_category=external_meta_setup`,
+continues into the requested alpha profile, and marks
+`whatsapp_bridge=external_meta_setup_pending` in the final summary.
 
 Use the complete gate only when the local bridge, attended receive, Cloud API,
 and Calling setup are all expected to pass:

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -225,6 +225,41 @@ run_step() {
   fi
 }
 
+run_whatsapp_bridge_step() {
+  local label="WhatsApp bridge identity and credential readiness"
+  local json_path
+  json_path="$(mktemp)"
+  temp_files+=("$json_path")
+
+  echo
+  echo "==> $label"
+  set +e
+  "$@" --json >"$json_path"
+  local status=$?
+  set -e
+
+  print_whatsapp_bridge_json_summary "$json_path"
+
+  if [[ "$status" == "0" ]]; then
+    return 0
+  fi
+
+  if whatsapp_bridge_json_external_meta_only "$json_path"; then
+    echo "error: local Hermes voice stack external Meta setup check failed: $label" >&2
+    echo "failure_category=external_meta_setup" >&2
+    echo "failure_step=$label" >&2
+    echo "failure_status=$status" >&2
+    overall_status="$status"
+    return 0
+  fi
+
+  echo "error: local Hermes voice stack step failed: $label" >&2
+  echo "failure_category=$(step_failure_category "$label")" >&2
+  echo "failure_step=$label" >&2
+  echo "failure_status=$status" >&2
+  return "$status"
+}
+
 step_failure_category() {
   local label="$1"
   case "$label" in
@@ -259,6 +294,127 @@ step_failure_category() {
       echo "unknown"
       ;;
   esac
+}
+
+whatsapp_cloud_probe_enabled() {
+  [[ "$require_whatsapp_cloud" == "1" \
+    || "$require_whatsapp_calling" == "1" \
+    || "$check_whatsapp_cloud_api" == "1" \
+    || "$check_whatsapp_cloud_health" == "1" \
+    || "$check_whatsapp_cloud_webhook" == "1" ]]
+}
+
+whatsapp_bridge_json_external_meta_only() {
+  local json_path="$1"
+  python3 - "$json_path" <<'PY'
+import json
+import sys
+
+prefixes = (
+    "WhatsApp Cloud API phone number check failed:",
+    "WhatsApp Cloud health check failed:",
+    "WhatsApp Cloud webhook challenge check failed:",
+    "WhatsApp Cloud credentials missing:",
+    "WhatsApp Cloud config invalid:",
+    "WhatsApp Cloud Calling not ready;",
+    "WhatsApp Cloud Calling config invalid:",
+)
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(1)
+
+failures = [str(item) for item in payload.get("failures") or []]
+if failures and all(failure.startswith(prefixes) for failure in failures):
+    raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
+print_whatsapp_bridge_json_summary() {
+  local json_path="$1"
+  python3 - "$json_path" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+try:
+    with open(path, "r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+except (OSError, json.JSONDecodeError) as exc:
+    print(f"whatsapp_bridge_json=unreadable error={exc}")
+    raise SystemExit(0)
+
+def csv(values):
+    return ",".join(str(value) for value in (values or [])) or "none"
+
+checks = payload.get("checks") or {}
+identity = checks.get("baileys_identity") or {}
+health = checks.get("bridge_health") or {}
+cloud = checks.get("whatsapp_cloud") or {}
+cloud_health = cloud.get("cloud_health") or {}
+cloud_api = cloud.get("cloud_api") or {}
+webhook_challenge = cloud.get("webhook_challenge") or {}
+
+print(
+    "whatsapp_bridge_json="
+    + ("ok" if payload.get("success") else "failed")
+    + f" bridge_status={health.get('status', 'unknown')}"
+    + f" queue={health.get('queueLength', 'unknown')}"
+    + f" name={identity.get('name') or '<unknown>'}"
+    + f" number={identity.get('number') or '<unknown>'}"
+)
+print(
+    "whatsapp_bridge_json_cloud="
+    + ("configured" if cloud.get("cloud_configured") else "not_configured")
+    + " missing="
+    + csv(cloud.get("cloud_missing"))
+    + " invalid="
+    + csv(cloud.get("cloud_invalid"))
+    + " calling_ready="
+    + ("yes" if cloud.get("calling_ready") else "no")
+)
+if cloud_api.get("checked"):
+    print(
+        "whatsapp_bridge_json_cloud_api="
+        + ("ok" if cloud_api.get("ok") else "failed")
+        + f" http_status={cloud_api.get('http_status') or '<none>'}"
+        + " missing="
+        + csv(cloud_api.get("missing"))
+        + " invalid="
+        + csv(cloud_api.get("invalid"))
+    )
+if cloud_health.get("checked"):
+    error = cloud_health.get("error") or {}
+    print(
+        "whatsapp_bridge_json_cloud_health="
+        + ("ok" if cloud_health.get("ok") else "failed")
+        + f" local_url={cloud_health.get('local_url') or '<invalid>'}"
+        + " missing="
+        + csv(cloud_health.get("missing"))
+        + " invalid="
+        + csv(cloud_health.get("invalid"))
+        + " error="
+        + str(error.get("message") or "none")
+    )
+if webhook_challenge.get("checked"):
+    error = webhook_challenge.get("error") or {}
+    print(
+        "whatsapp_bridge_json_webhook_challenge="
+        + ("ok" if webhook_challenge.get("ok") else "failed")
+        + f" local_url={webhook_challenge.get('local_url') or '<invalid>'}"
+        + " missing="
+        + csv(webhook_challenge.get("missing"))
+        + " invalid="
+        + csv(webhook_challenge.get("invalid"))
+        + " error="
+        + str(error.get("message") or "none")
+    )
+for failure in payload.get("failures") or []:
+    print(f"whatsapp_bridge_json_failure={failure}")
+PY
 }
 
 print_whatsapp_alpha_json_summary() {
@@ -828,8 +984,17 @@ if [[ "$skip_whatsapp_bridge" != "1" ]]; then
   if [[ "$check_whatsapp_cloud_webhook" == "1" ]]; then
     whatsapp_bridge_args+=(--check-whatsapp-cloud-webhook)
   fi
-  run_step "WhatsApp bridge identity and credential readiness" "${whatsapp_bridge_args[@]}"
-  whatsapp_bridge_status="checked"
+  if whatsapp_cloud_probe_enabled; then
+    run_whatsapp_bridge_step "${whatsapp_bridge_args[@]}"
+    if [[ "$overall_status" == "0" ]]; then
+      whatsapp_bridge_status="checked"
+    else
+      whatsapp_bridge_status="external_meta_setup_pending"
+    fi
+  else
+    run_step "WhatsApp bridge identity and credential readiness" "${whatsapp_bridge_args[@]}"
+    whatsapp_bridge_status="checked"
+  fi
 else
   whatsapp_bridge_status="skipped"
 fi

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -69,6 +69,65 @@ def write_fake_python(path: Path, label: str, log_path: Path) -> None:
     )
 
 
+def write_external_meta_bridge_helper(path: Path, label: str, log_path: Path) -> None:
+    write_executable(
+        path,
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            printf '{label}' >> {str(log_path)!r}
+            printf '\\0' >> {str(log_path)!r}
+            printf '%s\\0' "$@" >> {str(log_path)!r}
+            printf '\\n' >> {str(log_path)!r}
+            cat <<'JSON'
+            {{
+              "success": false,
+              "checks": {{
+                "baileys_identity": {{
+                  "name": "Quill",
+                  "number": "13236478455",
+                  "lid_number": "186999436771390"
+                }},
+                "bridge_health": {{
+                  "status": "connected",
+                  "queueLength": 0
+                }},
+                "whatsapp_cloud": {{
+                  "cloud_configured": false,
+                  "calling_ready": false,
+                  "cloud_missing": [
+                    "WHATSAPP_CLOUD_PHONE_NUMBER_ID",
+                    "WHATSAPP_CLOUD_ACCESS_TOKEN",
+                    "WHATSAPP_CLOUD_APP_SECRET",
+                    "WHATSAPP_CLOUD_VERIFY_TOKEN"
+                  ],
+                  "cloud_invalid": [],
+                  "cloud_health": {{
+                    "checked": true,
+                    "ok": false,
+                    "local_url": "http://127.0.0.1:8090/health",
+                    "missing": ["WHATSAPP_CLOUD_PHONE_NUMBER_ID"],
+                    "invalid": [],
+                    "error": {{
+                      "message": "Cloud health check requires a local health URL and phone number ID"
+                    }}
+                  }},
+                  "cloud_api": {{"checked": false}},
+                  "webhook_challenge": {{"checked": false}}
+                }}
+              }},
+              "failures": [
+                "WhatsApp Cloud health check failed: Cloud health check requires a local health URL and phone number ID"
+              ]
+            }}
+            JSON
+            exit 1
+            """
+        ),
+    )
+
+
 def command_log_entries(log_path: Path) -> list[list[str]]:
     entries: list[list[str]] = []
     for line in log_path.read_bytes().splitlines():
@@ -382,6 +441,77 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn("failure_category=whatsapp_bridge_or_credentials", result.stderr)
         self.assertIn("failure_step=WhatsApp bridge identity and credential readiness", result.stderr)
         self.assertIn("failure_status=23", result.stderr)
+        self.assertNotIn("ok: local Hermes voice stack verifier passed", result.stdout)
+
+    def test_cloud_probe_bridge_failure_continues_to_alpha_as_external_setup(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            bridge = tmp_path / "verify_whatsapp_bridge.py"
+            alpha = tmp_path / "verify_alpha.py"
+            voice = tmp_path / "voice"
+
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_external_meta_bridge_helper(bridge, "bridge", log_path)
+            write_helper(alpha, "alpha", log_path)
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--hermes-config",
+                    str(tmp_path / "missing.yaml"),
+                    "--skip-hermes-config",
+                    "--skip-hermes-gateway",
+                    "--skip-cli-mcp",
+                    "--skip-sidecar",
+                    "--skip-systemd",
+                    "--skip-daemon",
+                    "--check-whatsapp-cloud-health",
+                    "--whatsapp-alpha-profile",
+                    "cached-receive",
+                ],
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "WHATSAPP_BRIDGE_VERIFY_SCRIPT": str(bridge),
+                    "WHATSAPP_ALPHA_READINESS_SCRIPT": str(alpha),
+                },
+            )
+
+            entries = command_log_entries(log_path)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual([entry[0] for entry in entries], ["whatsapp", "bridge", "alpha"])
+        self.assertIn("--json", entries[1])
+        self.assertIn("--check-whatsapp-cloud-health", entries[1])
+        self.assertIn(
+            "whatsapp_bridge_json_cloud_health=failed",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_bridge_json_failure=WhatsApp Cloud health check failed",
+            result.stdout,
+        )
+        self.assertIn("whatsapp_alpha=cached-receive", result.stdout)
+        self.assertIn(
+            "whatsapp_bridge=external_meta_setup_pending",
+            result.stdout,
+        )
+        self.assertIn(
+            "error: local Hermes voice stack external Meta setup check failed",
+            result.stderr,
+        )
+        self.assertIn("failure_category=external_meta_setup", result.stderr)
+        self.assertNotIn(
+            "failure_category=whatsapp_bridge_or_credentials",
+            result.stderr,
+        )
         self.assertNotIn("ok: local Hermes voice stack verifier passed", result.stdout)
 
     def test_skip_flags_disable_optional_release_checks(self):


### PR DESCRIPTION
## Summary
- run the direct WhatsApp bridge check in JSON mode when Cloud proof flags are enabled
- classify direct bridge Cloud API/health/webhook probe failures as external Meta setup instead of bridge/runtime failures
- continue into the requested alpha profile after an external-only Cloud probe failure, while preserving a nonzero final status
- print compact bridge JSON summary lines and document the aggregate behavior

## Verification
- python3 -m unittest tests.test_verify_local_hermes_voice_stack
- bash -n scripts/verify_local_hermes_voice_stack.sh
- python3 -m unittest discover tests
- git diff --check
- scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --skip-hermes-config --skip-hermes-gateway --skip-cli-mcp --skip-sidecar --skip-daemon --skip-whatsapp-attended-watch-status --skip-hermes-tts-smoke --skip-hermes-stt-smoke --check-whatsapp-cloud-health --whatsapp-alpha-profile cached-receive --whatsapp-alpha-json-output /tmp/voice-stack-alpha-health-classification.json (expected status 1; bridge external_meta_setup, alpha still ran)