### PR TITLE
Report Calling gaps in stack bridge summary

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -195,7 +195,10 @@ alpha profile exits non-zero while writing a valid JSON report, such as a
 summary before returning the alpha failure status. If a direct bridge Cloud
 probe fails first, the stack gate reports `failure_category=external_meta_setup`,
 continues into the requested alpha profile, and marks
-`whatsapp_bridge=external_meta_setup_pending` in the final summary.
+`whatsapp_bridge=external_meta_setup_pending` in the final summary. The compact
+bridge summary includes both `whatsapp_bridge_json_cloud` and
+`whatsapp_bridge_json_calling` lines so Cloud credential gaps and Calling
+sidecar gaps remain separate.
 
 Use the complete gate only when the local bridge, attended receive, Cloud API,
 and Calling setup are all expected to pass:

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -376,6 +376,16 @@ print(
     + " calling_ready="
     + ("yes" if cloud.get("calling_ready") else "no")
 )
+print(
+    "whatsapp_bridge_json_calling="
+    + ("ready" if cloud.get("calling_ready") else "not_ready")
+    + " sidecar_configured="
+    + str(cloud.get("calling_sidecar_configured"))
+    + " missing="
+    + csv(cloud.get("calling_missing"))
+    + " invalid="
+    + csv(cloud.get("calling_invalid"))
+)
 if cloud_api.get("checked"):
     print(
         "whatsapp_bridge_json_cloud_api="

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -96,6 +96,7 @@ def write_external_meta_bridge_helper(path: Path, label: str, log_path: Path) ->
                 "whatsapp_cloud": {{
                   "cloud_configured": false,
                   "calling_ready": false,
+                  "calling_sidecar_configured": true,
                   "cloud_missing": [
                     "WHATSAPP_CLOUD_PHONE_NUMBER_ID",
                     "WHATSAPP_CLOUD_ACCESS_TOKEN",
@@ -103,6 +104,13 @@ def write_external_meta_bridge_helper(path: Path, label: str, log_path: Path) ->
                     "WHATSAPP_CLOUD_VERIFY_TOKEN"
                   ],
                   "cloud_invalid": [],
+                  "calling_missing": [
+                    "WHATSAPP_CLOUD_PHONE_NUMBER_ID",
+                    "WHATSAPP_CLOUD_ACCESS_TOKEN",
+                    "WHATSAPP_CLOUD_APP_SECRET",
+                    "WHATSAPP_CLOUD_VERIFY_TOKEN"
+                  ],
+                  "calling_invalid": [],
                   "cloud_health": {{
                     "checked": true,
                     "ok": false,
@@ -492,6 +500,12 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn("--check-whatsapp-cloud-health", entries[1])
         self.assertIn(
             "whatsapp_bridge_json_cloud_health=failed",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_bridge_json_calling=not_ready sidecar_configured=True "
+            "missing=WHATSAPP_CLOUD_PHONE_NUMBER_ID,WHATSAPP_CLOUD_ACCESS_TOKEN,"
+            "WHATSAPP_CLOUD_APP_SECRET,WHATSAPP_CLOUD_VERIFY_TOKEN invalid=none",
             result.stdout,
         )
         self.assertIn(


### PR DESCRIPTION
## Summary
- add a compact `whatsapp_bridge_json_calling` line to the top-level stack gate bridge JSON summary
- expose Calling readiness, Calling sidecar configured state, and Calling missing/invalid keys separately from Cloud credential gaps
- document that compact bridge summaries include both Cloud and Calling lines

## Verification
- python3 -m unittest tests.test_verify_local_hermes_voice_stack
- bash -n scripts/verify_local_hermes_voice_stack.sh
- scripts/verify_local_hermes_voice_stack.sh --voice-bin /home/ubuntu/.local/bin/voice --hermes-home /home/ubuntu/.hermes --skip-hermes-config --skip-hermes-gateway --skip-cli-mcp --skip-sidecar --skip-daemon --skip-whatsapp-attended-watch-status --skip-hermes-tts-smoke --skip-hermes-stt-smoke --check-whatsapp-cloud-health --whatsapp-alpha-profile cached-receive --whatsapp-alpha-json-output /tmp/voice-stack-alpha-health-calling-summary.json (expected status 1; prints `whatsapp_bridge_json_calling` with missing Cloud keys)
- python3 -m unittest discover tests
- git diff --check