### PR TITLE
Report WhatsApp webhook config in stack JSON summary

### DIFF
--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -198,7 +198,8 @@ continues into the requested alpha profile, and marks
 `whatsapp_bridge=external_meta_setup_pending` in the final summary. The compact
 bridge summary includes both `whatsapp_bridge_json_cloud` and
 `whatsapp_bridge_json_calling` lines so Cloud credential gaps and Calling
-sidecar gaps remain separate.
+sidecar gaps remain separate, plus `whatsapp_bridge_json_webhook` when the
+bridge JSON includes the Cloud webhook listener config.
 
 Use the complete gate only when the local bridge, attended receive, Cloud API,
 and Calling setup are all expected to pass:

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -354,6 +354,7 @@ checks = payload.get("checks") or {}
 identity = checks.get("baileys_identity") or {}
 health = checks.get("bridge_health") or {}
 cloud = checks.get("whatsapp_cloud") or {}
+webhook = cloud.get("webhook") or {}
 cloud_health = cloud.get("cloud_health") or {}
 cloud_api = cloud.get("cloud_api") or {}
 webhook_challenge = cloud.get("webhook_challenge") or {}
@@ -386,6 +387,18 @@ print(
     + " invalid="
     + csv(cloud.get("calling_invalid"))
 )
+if webhook:
+    print(
+        "whatsapp_bridge_json_webhook="
+        + f"host={webhook.get('host') or '<unset>'}"
+        + f" port={webhook.get('port') or '<unset>'}"
+        + f" path={webhook.get('path') or '<unset>'}"
+        + f" api_version={webhook.get('api_version') or '<unset>'}"
+        + " defaulted="
+        + csv(webhook.get("defaulted"))
+        + " invalid="
+        + csv(webhook.get("invalid"))
+    )
 if cloud_api.get("checked"):
     print(
         "whatsapp_bridge_json_cloud_api="

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -111,6 +111,14 @@ def write_external_meta_bridge_helper(path: Path, label: str, log_path: Path) ->
                     "WHATSAPP_CLOUD_VERIFY_TOKEN"
                   ],
                   "calling_invalid": [],
+                  "webhook": {{
+                    "host": "127.0.0.1",
+                    "port": "8090",
+                    "path": "/webhook",
+                    "api_version": "v23.0",
+                    "defaulted": ["WHATSAPP_CLOUD_WEBHOOK_HOST"],
+                    "invalid": []
+                  }},
                   "cloud_health": {{
                     "checked": true,
                     "ok": false,
@@ -506,6 +514,12 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             "whatsapp_bridge_json_calling=not_ready sidecar_configured=True "
             "missing=WHATSAPP_CLOUD_PHONE_NUMBER_ID,WHATSAPP_CLOUD_ACCESS_TOKEN,"
             "WHATSAPP_CLOUD_APP_SECRET,WHATSAPP_CLOUD_VERIFY_TOKEN invalid=none",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_bridge_json_webhook=host=127.0.0.1 port=8090 "
+            "path=/webhook api_version=v23.0 "
+            "defaulted=WHATSAPP_CLOUD_WEBHOOK_HOST invalid=none",
             result.stdout,
         )
         self.assertIn(


### PR DESCRIPTION
## Summary
- print `whatsapp_bridge_json_webhook=...` from stack bridge JSON summaries when the bridge verifier reports Cloud webhook listener config
- cover the external Meta setup path in the local stack verifier tests
- document the compact bridge summary line alongside Cloud and Calling summaries

## Verification
- `python3 -m unittest tests.test_verify_local_hermes_voice_stack`
- `bash -n scripts/verify_local_hermes_voice_stack.sh`
- `python3 -m unittest discover tests`
- `git diff --check`
- live stack smoke: `scripts/verify_local_hermes_voice_stack.sh --check-whatsapp-cloud-health --whatsapp-alpha-profile cached-receive --whatsapp-alpha-json-output /tmp/...json` returned expected `STACK_STATUS=1` for missing external Meta credentials while printing `whatsapp_bridge_json_webhook=host=0.0.0.0 port=8090 path=/whatsapp/webhook api_version=v20.0 ...`
