### PR TITLE
Classify alpha external Meta setup in stack summary

### DIFF
--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -588,6 +588,44 @@ if calling:
 PY
 }
 
+whatsapp_alpha_json_external_meta_only() {
+  local json_path="$1"
+  python3 - "$json_path" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(1)
+
+summary = payload.get("readiness_summary") or {}
+if summary.get("local_checks_passed") is not True:
+    raise SystemExit(1)
+if summary.get("external_meta_setup_required") is not True:
+    raise SystemExit(1)
+
+actions = [
+    str(action.get("id"))
+    for action in (summary.get("next_actions") or [])
+    if isinstance(action, dict) and action.get("id")
+]
+if actions != ["configure_whatsapp_cloud_calling"]:
+    raise SystemExit(1)
+
+failures = payload.get("failures") or []
+if not failures:
+    raise SystemExit(1)
+if all(
+    isinstance(failure, dict) and failure.get("category") == "external_meta_setup"
+    for failure in failures
+):
+    raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --voice-bin)
@@ -1182,9 +1220,14 @@ if [[ -n "$whatsapp_alpha_profile" ]]; then
     echo "whatsapp_alpha_json=$whatsapp_alpha_json_output"
     print_whatsapp_alpha_json_summary "$whatsapp_alpha_json_output" "$whatsapp_attended_watch_json"
     if [[ "$whatsapp_alpha_exit" != "0" ]]; then
-      echo "error: WhatsApp alpha readiness profile failed with exit $whatsapp_alpha_exit" >&2
+      if whatsapp_alpha_json_external_meta_only "$whatsapp_alpha_json_output"; then
+        echo "error: WhatsApp alpha readiness profile external Meta setup pending with exit $whatsapp_alpha_exit" >&2
+        whatsapp_alpha_status="$whatsapp_alpha_profile:external_meta_setup_pending"
+      else
+        echo "error: WhatsApp alpha readiness profile failed with exit $whatsapp_alpha_exit" >&2
+        whatsapp_alpha_status="$whatsapp_alpha_profile:failed"
+      fi
       overall_status="$whatsapp_alpha_exit"
-      whatsapp_alpha_status="$whatsapp_alpha_profile:failed"
     else
       whatsapp_alpha_status="$whatsapp_alpha_profile"
     fi

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -1584,6 +1584,120 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             result.stdout,
         )
 
+    def test_whatsapp_alpha_json_output_classifies_external_meta_only_alpha(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            alpha = tmp_path / "verify_alpha.py"
+            voice = tmp_path / "voice"
+            json_output = tmp_path / "alpha.json"
+
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_executable(
+                alpha,
+                textwrap.dedent(
+                    f"""\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    printf 'alpha' >> {str(log_path)!r}
+                    printf '\\0' >> {str(log_path)!r}
+                    printf '%s\\0' "$@" >> {str(log_path)!r}
+                    printf '\\n' >> {str(log_path)!r}
+                    cat <<'JSON'
+                    {{
+                      "profile": "cached-receive",
+                      "readiness_summary": {{
+                        "status": "local_ready_pending_gates",
+                        "complete": false,
+                        "local_checks_passed": true,
+                        "attended_fresh_receive_verified": true,
+                        "external_meta_setup_required": true,
+                        "operator_action_required": true,
+                        "next_actions": [
+                          {{"id": "configure_whatsapp_cloud_calling"}}
+                        ]
+                      }},
+                      "pending_gates": {{
+                        "attended_fresh_receive": {{
+                          "status": "verified",
+                          "cached_receive_verified": true
+                        }},
+                        "whatsapp_cloud": {{
+                          "status": "external_setup_required",
+                          "setup_handoff": {{
+                            "missing": ["WHATSAPP_CLOUD_PHONE_NUMBER_ID"],
+                            "invalid": []
+                          }}
+                        }},
+                        "whatsapp_cloud_calling": {{
+                          "status": "external_setup_required",
+                          "setup_handoff": {{
+                            "missing": ["WHATSAPP_CLOUD_PHONE_NUMBER_ID"],
+                            "invalid": []
+                          }}
+                        }}
+                      }},
+                      "failures": [
+                        {{
+                          "name": "whatsapp_cloud_probe",
+                          "category": "external_meta_setup",
+                          "failures": ["WhatsApp Cloud health check failed"]
+                        }}
+                      ]
+                    }}
+                    JSON
+                    exit 1
+                    """
+                ),
+            )
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--skip-hermes-config",
+                    "--skip-hermes-gateway",
+                    "--skip-cli-mcp",
+                    "--skip-sidecar",
+                    "--skip-whatsapp-bridge",
+                    "--skip-systemd",
+                    "--skip-daemon",
+                    "--whatsapp-alpha-profile",
+                    "cached-receive",
+                    "--whatsapp-alpha-json-output",
+                    str(json_output),
+                ],
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "WHATSAPP_ALPHA_READINESS_SCRIPT": str(alpha),
+                },
+            )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "whatsapp_alpha_json_next_actions=configure_whatsapp_cloud_calling",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_alpha=cached-receive:external_meta_setup_pending",
+            result.stdout,
+        )
+        self.assertIn(
+            "error: WhatsApp alpha readiness profile external Meta setup pending "
+            "with exit 1",
+            result.stderr,
+        )
+        self.assertNotIn(
+            "error: WhatsApp alpha readiness profile failed with exit 1",
+            result.stderr,
+        )
+
     def test_whatsapp_alpha_json_output_summarizes_nonzero_alpha(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)


### PR DESCRIPTION
## Summary
- classify nonzero alpha JSON results as `external_meta_setup_pending` when local checks passed, attended receive is verified, and all failures are external Meta setup
- keep other nonzero alpha profiles as ordinary `:failed` results
- add stack-wrapper coverage for the external-only alpha path

## Verification
- `python3 -m unittest tests.test_verify_local_hermes_voice_stack`
- `bash -n scripts/verify_local_hermes_voice_stack.sh`
- `python3 -m unittest discover tests`
- `git diff --check`
- live stack smoke with `--check-whatsapp-cloud-health --whatsapp-alpha-profile cached-receive --whatsapp-alpha-json-output /tmp/...json` now prints `whatsapp_alpha=cached-receive:external_meta_setup_pending` while preserving final nonzero status for missing Meta credentials
