### PR TITLE
Run alpha profiles through JSON in stack gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,13 +515,16 @@ Cloud adapter health contract, and verifies the local webhook challenge echo
 without printing token or phone-number values. Failures from those explicit
 Cloud probes are reported as external Meta setup, not as local Baileys bridge or
 voice runtime failures.
-Use `--whatsapp-alpha-json-output` with any alpha profile when another local
-agent should consume the same structured `readiness_summary.next_actions`
-without rerunning the full stack gate. The stack verifier also echoes compact
-`whatsapp_alpha_json_*` summary lines after saving the artifact, including
-readiness status, completion state, next actions, attended receive status, and
-Cloud/Calling missing or invalid key groups. A verified attended receive also
-stores compact redacted proof under
+The stack verifier runs alpha profiles through JSON internally so nonzero alpha
+results can still be classified as local runtime, attended receive, or external
+Meta setup. Use `--whatsapp-alpha-json-output` with any alpha profile when
+another local agent should consume the same structured
+`readiness_summary.next_actions` without rerunning the full stack gate; without
+that flag the temporary JSON report is removed after the compact summary is
+printed. The stack verifier echoes compact `whatsapp_alpha_json_*` summary
+lines for every alpha profile, including readiness status, completion state,
+next actions, attended receive status, and Cloud/Calling missing or invalid key
+groups. A verified attended receive also stores compact redacted proof under
 `pending_gates.attended_fresh_receive.evidence`.
 
 When the WebRTC Python dependencies are installed, add

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -102,10 +102,11 @@ should poll and drain the bridge `/messages` queue. The stack gate also accepts
 down to the lower-level alpha script. For attended profiles, the default alpha
 voice note asks the recipient to reply with a fresh voice note. Use
 `--whatsapp-alpha-text` when the prompt should be different without changing
-the generic stack smoke text used by the other checks. When
-`--whatsapp-alpha-json-output` is set, the stack gate runs the alpha profile
-with `--json` and saves that structured report for another agent or runbook
-step to consume.
+the generic stack smoke text used by the other checks. The stack gate runs
+alpha profiles with `--json` internally so it can classify nonzero alpha results
+from the structured report. Set `--whatsapp-alpha-json-output` when that report
+should be saved for another agent or runbook step to consume; otherwise the
+temporary JSON report is removed after the compact summary is printed.
 
 Cached receive profiles also pass the newest cached inbound `aud_*` file to
 the Hermes config verifier, so the configured STT command provider is exercised
@@ -182,17 +183,19 @@ information with:
 - `whatsapp_calling_verify_command`
 - `whatsapp_calling_complete_command`
 
-When the top-level stack gate is run with `--whatsapp-alpha-json-output`, it
-saves the alpha report and then echoes compact `whatsapp_alpha_json_*` summary
-lines for the saved artifact. Those lines include the alpha profile, readiness
-status, completion state, next action IDs, attended receive status, and
-Cloud/Calling missing or invalid key groups. When a gate is still pending, the
-same summary also echoes the copyable attended receive command, fallback
-draining command, Cloud verification command, Calling verification command, and
-complete-alpha command if those commands are present in the saved JSON. If the
-alpha profile exits non-zero while writing a valid JSON report, such as a
-`--require-complete` run with pending gates, the stack gate still prints this
-summary before returning the alpha failure status. If a direct bridge Cloud
+When the top-level stack gate runs an alpha profile, it echoes compact
+`whatsapp_alpha_json_*` summary lines from the alpha JSON report. Those lines
+include the alpha profile, readiness status, completion state, next action IDs,
+attended receive status, and Cloud/Calling missing or invalid key groups. When
+a gate is still pending, the same summary also echoes the copyable attended
+receive command, fallback draining command, Cloud verification command, Calling
+verification command, and complete-alpha command if those commands are present
+in the report. If the alpha profile exits non-zero while writing a valid JSON
+report, such as a `--require-complete` run with pending gates, the stack gate
+still prints this summary before returning the alpha failure status. If a
+nonzero alpha report proves local checks and attended receive passed and only
+external Meta setup remains, the final summary marks
+`whatsapp_alpha=<profile>:external_meta_setup_pending`. If a direct bridge Cloud
 probe fails first, the stack gate reports `failure_category=external_meta_setup`,
 continues into the requested alpha profile, and marks
 `whatsapp_bridge=external_meta_setup_pending` in the final summary. The compact

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -450,8 +450,12 @@ import sys
 
 path = sys.argv[1]
 watch_path = sys.argv[2] if len(sys.argv) > 2 else ""
-with open(path, "r", encoding="utf-8") as handle:
-    payload = json.load(handle)
+try:
+    with open(path, "r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+except (OSError, json.JSONDecodeError) as exc:
+    print(f"whatsapp_alpha_json_summary=unreadable error={exc}")
+    raise SystemExit(0)
 
 
 def csv(values):
@@ -1205,34 +1209,40 @@ if [[ -n "$whatsapp_alpha_profile" ]]; then
   if [[ "$require_whatsapp_alpha_complete" == "1" ]]; then
     whatsapp_alpha_args+=(--require-complete)
   fi
+  whatsapp_alpha_json_path="$whatsapp_alpha_json_output"
+  if [[ -z "$whatsapp_alpha_json_path" ]]; then
+    whatsapp_alpha_json_path="$(mktemp "${TMPDIR:-/tmp}/voice-whatsapp-alpha.XXXXXX.json")"
+    temp_files+=("$whatsapp_alpha_json_path")
+  fi
   if [[ -n "$whatsapp_alpha_json_output" ]]; then
-    output_dir="$(dirname -- "$whatsapp_alpha_json_output")"
+    output_dir="$(dirname -- "$whatsapp_alpha_json_path")"
     if [[ "$output_dir" != "." ]]; then
       mkdir -p "$output_dir"
     fi
-    whatsapp_alpha_args+=(--json)
-    echo
-    echo "==> WhatsApp alpha readiness profile ($whatsapp_alpha_profile)"
-    set +e
-    "${whatsapp_alpha_args[@]}" >"$whatsapp_alpha_json_output"
-    whatsapp_alpha_exit=$?
-    set -e
-    echo "whatsapp_alpha_json=$whatsapp_alpha_json_output"
-    print_whatsapp_alpha_json_summary "$whatsapp_alpha_json_output" "$whatsapp_attended_watch_json"
-    if [[ "$whatsapp_alpha_exit" != "0" ]]; then
-      if whatsapp_alpha_json_external_meta_only "$whatsapp_alpha_json_output"; then
-        echo "error: WhatsApp alpha readiness profile external Meta setup pending with exit $whatsapp_alpha_exit" >&2
-        whatsapp_alpha_status="$whatsapp_alpha_profile:external_meta_setup_pending"
-      else
-        echo "error: WhatsApp alpha readiness profile failed with exit $whatsapp_alpha_exit" >&2
-        whatsapp_alpha_status="$whatsapp_alpha_profile:failed"
-      fi
-      overall_status="$whatsapp_alpha_exit"
-    else
-      whatsapp_alpha_status="$whatsapp_alpha_profile"
-    fi
+  fi
+  whatsapp_alpha_args+=(--json)
+  echo
+  echo "==> WhatsApp alpha readiness profile ($whatsapp_alpha_profile)"
+  set +e
+  "${whatsapp_alpha_args[@]}" >"$whatsapp_alpha_json_path"
+  whatsapp_alpha_exit=$?
+  set -e
+  if [[ -n "$whatsapp_alpha_json_output" ]]; then
+    echo "whatsapp_alpha_json=$whatsapp_alpha_json_path"
   else
-    run_step "WhatsApp alpha readiness profile ($whatsapp_alpha_profile)" "${whatsapp_alpha_args[@]}"
+    echo "whatsapp_alpha_json=<temporary; pass --whatsapp-alpha-json-output to retain>"
+  fi
+  print_whatsapp_alpha_json_summary "$whatsapp_alpha_json_path" "$whatsapp_attended_watch_json"
+  if [[ "$whatsapp_alpha_exit" != "0" ]]; then
+    if whatsapp_alpha_json_external_meta_only "$whatsapp_alpha_json_path"; then
+      echo "error: WhatsApp alpha readiness profile external Meta setup pending with exit $whatsapp_alpha_exit" >&2
+      whatsapp_alpha_status="$whatsapp_alpha_profile:external_meta_setup_pending"
+    else
+      echo "error: WhatsApp alpha readiness profile failed with exit $whatsapp_alpha_exit" >&2
+      whatsapp_alpha_status="$whatsapp_alpha_profile:failed"
+    fi
+    overall_status="$whatsapp_alpha_exit"
+  else
     whatsapp_alpha_status="$whatsapp_alpha_profile"
   fi
 else

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -1019,6 +1019,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                 "--check-whatsapp-cloud-health",
                 "--check-whatsapp-cloud-webhook",
                 "--require-complete",
+                "--json",
             ],
         )
 
@@ -1697,6 +1698,112 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             "error: WhatsApp alpha readiness profile failed with exit 1",
             result.stderr,
         )
+
+    def test_whatsapp_alpha_profile_classifies_external_meta_without_saved_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_path = tmp_path / "commands.log"
+            whatsapp = tmp_path / "verify_whatsapp.sh"
+            alpha = tmp_path / "verify_alpha.py"
+            voice = tmp_path / "voice"
+
+            write_helper(whatsapp, "whatsapp", log_path)
+            write_executable(
+                alpha,
+                textwrap.dedent(
+                    f"""\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    printf 'alpha' >> {str(log_path)!r}
+                    printf '\\0' >> {str(log_path)!r}
+                    printf '%s\\0' "$@" >> {str(log_path)!r}
+                    printf '\\n' >> {str(log_path)!r}
+                    cat <<'JSON'
+                    {{
+                      "profile": "cached-receive",
+                      "readiness_summary": {{
+                        "status": "local_ready_pending_gates",
+                        "complete": false,
+                        "local_checks_passed": true,
+                        "attended_fresh_receive_verified": true,
+                        "external_meta_setup_required": true,
+                        "operator_action_required": true,
+                        "next_actions": [
+                          {{"id": "configure_whatsapp_cloud_calling"}}
+                        ]
+                      }},
+                      "pending_gates": {{
+                        "attended_fresh_receive": {{
+                          "status": "verified",
+                          "cached_receive_verified": true
+                        }},
+                        "whatsapp_cloud": {{
+                          "status": "external_setup_required",
+                          "setup_handoff": {{
+                            "missing": ["WHATSAPP_CLOUD_PHONE_NUMBER_ID"],
+                            "invalid": []
+                          }}
+                        }},
+                        "whatsapp_cloud_calling": {{
+                          "status": "external_setup_required",
+                          "setup_handoff": {{
+                            "missing": ["WHATSAPP_CLOUD_PHONE_NUMBER_ID"],
+                            "invalid": []
+                          }}
+                        }}
+                      }},
+                      "failures": [
+                        {{
+                          "name": "whatsapp_cloud_probe",
+                          "category": "external_meta_setup",
+                          "failures": ["WhatsApp Cloud health check failed"]
+                        }}
+                      ]
+                    }}
+                    JSON
+                    exit 1
+                    """
+                ),
+            )
+            write_executable(voice, "#!/usr/bin/env bash\nexit 0\n")
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--voice-bin",
+                    str(voice),
+                    "--skip-hermes-config",
+                    "--skip-hermes-gateway",
+                    "--skip-cli-mcp",
+                    "--skip-sidecar",
+                    "--skip-whatsapp-bridge",
+                    "--skip-systemd",
+                    "--skip-daemon",
+                    "--whatsapp-alpha-profile",
+                    "cached-receive",
+                ],
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "WHATSAPP_CONTRACT_VERIFY_SCRIPT": str(whatsapp),
+                    "WHATSAPP_ALPHA_READINESS_SCRIPT": str(alpha),
+                },
+            )
+
+            entries = command_log_entries(log_path)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "whatsapp_alpha_json=<temporary; pass --whatsapp-alpha-json-output to retain>",
+            result.stdout,
+        )
+        self.assertIn("--json", entries[1])
+        self.assertIn(
+            "whatsapp_alpha=cached-receive:external_meta_setup_pending",
+            result.stdout,
+        )
+        self.assertNotIn("whatsapp_alpha_json=/tmp/", result.stdout)
 
     def test_whatsapp_alpha_json_output_summarizes_nonzero_alpha(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- run stack alpha profiles through `--json` internally even when `--whatsapp-alpha-json-output` is not requested
- keep temporary alpha reports ephemeral unless the user asks to retain them
- preserve compact `whatsapp_alpha_json_*` summaries and external-Meta-only classification for the default alpha path
- update README/runbook wording to match the new retained-vs-temporary JSON behavior

## Verification
- `python3 -m unittest tests.test_verify_local_hermes_voice_stack`
- `bash -n scripts/verify_local_hermes_voice_stack.sh`
- `python3 -m unittest discover tests`
- `git diff --check`
- live stack smoke without `--whatsapp-alpha-json-output`: `scripts/verify_local_hermes_voice_stack.sh --check-whatsapp-cloud-health --whatsapp-alpha-profile cached-receive` printed `whatsapp_alpha_json=<temporary; pass --whatsapp-alpha-json-output to retain>` and `whatsapp_alpha=cached-receive:external_meta_setup_pending` while preserving final nonzero status for missing Meta credentials
