### PR TITLE
Report aggregate stack failure category

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,9 @@ when the local Telegram bot token should already be configured.
 When a step fails, the aggregate verifier prints `failure_category=...` with
 values such as `voice_runtime`, `hermes_config`, `upstream_hermes`,
 `whatsapp_bridge_or_credentials`, `whatsapp_attended_watch`,
-`telegram_setup`, or `webrtc_sidecar`.
+`telegram_setup`, or `webrtc_sidecar`. When the stack continues after a
+classified nonzero check, such as external Meta setup or an alpha profile, the
+final footer also prints `stack_failure_category=...`.
 
 To include the categorized WhatsApp alpha report in the same command, add
 `--whatsapp-alpha-profile unattended`, `cached-receive`, `send`,

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -198,11 +198,14 @@ external Meta setup remains, the final summary marks
 `whatsapp_alpha=<profile>:external_meta_setup_pending`. If a direct bridge Cloud
 probe fails first, the stack gate reports `failure_category=external_meta_setup`,
 continues into the requested alpha profile, and marks
-`whatsapp_bridge=external_meta_setup_pending` in the final summary. The compact
-bridge summary includes both `whatsapp_bridge_json_cloud` and
-`whatsapp_bridge_json_calling` lines so Cloud credential gaps and Calling
-sidecar gaps remain separate, plus `whatsapp_bridge_json_webhook` when the
-bridge JSON includes the Cloud webhook listener config.
+`whatsapp_bridge=external_meta_setup_pending` in the final summary. The same
+footer includes `stack_failure_category=external_meta_setup` when the continuing
+failures are only external Meta setup, or `stack_failure_category=whatsapp_alpha`
+for a non-external alpha failure. The compact bridge summary includes both
+`whatsapp_bridge_json_cloud` and `whatsapp_bridge_json_calling` lines so Cloud
+credential gaps and Calling sidecar gaps remain separate, plus
+`whatsapp_bridge_json_webhook` when the bridge JSON includes the Cloud webhook
+listener config.
 
 Use the complete gate only when the local bridge, attended receive, Cloud API,
 and Calling setup are all expected to pass:

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -51,6 +51,7 @@ check_whatsapp_cloud_api="${CHECK_WHATSAPP_CLOUD_API:-0}"
 check_whatsapp_cloud_health="${CHECK_WHATSAPP_CLOUD_HEALTH:-0}"
 check_whatsapp_cloud_webhook="${CHECK_WHATSAPP_CLOUD_WEBHOOK:-0}"
 overall_status=0
+stack_failure_category=""
 temp_files=()
 
 cleanup_temp_files() {
@@ -225,6 +226,15 @@ run_step() {
   fi
 }
 
+mark_stack_failure() {
+  local category="$1"
+  if [[ -z "$stack_failure_category" ]]; then
+    stack_failure_category="$category"
+  elif [[ "$stack_failure_category" != "$category" ]]; then
+    stack_failure_category="multiple"
+  fi
+}
+
 run_whatsapp_bridge_step() {
   local label="WhatsApp bridge identity and credential readiness"
   local json_path
@@ -249,6 +259,7 @@ run_whatsapp_bridge_step() {
     echo "failure_category=external_meta_setup" >&2
     echo "failure_step=$label" >&2
     echo "failure_status=$status" >&2
+    mark_stack_failure "external_meta_setup"
     overall_status="$status"
     return 0
   fi
@@ -1237,9 +1248,11 @@ if [[ -n "$whatsapp_alpha_profile" ]]; then
     if whatsapp_alpha_json_external_meta_only "$whatsapp_alpha_json_path"; then
       echo "error: WhatsApp alpha readiness profile external Meta setup pending with exit $whatsapp_alpha_exit" >&2
       whatsapp_alpha_status="$whatsapp_alpha_profile:external_meta_setup_pending"
+      mark_stack_failure "external_meta_setup"
     else
       echo "error: WhatsApp alpha readiness profile failed with exit $whatsapp_alpha_exit" >&2
       whatsapp_alpha_status="$whatsapp_alpha_profile:failed"
+      mark_stack_failure "whatsapp_alpha"
     fi
     overall_status="$whatsapp_alpha_exit"
   else
@@ -1263,6 +1276,9 @@ echo "cli_mcp=$cli_mcp_status"
 echo "whatsapp_contract=checked"
 echo "telegram_voice_contract=$telegram_voice_contract_status"
 echo "whatsapp_bridge=$whatsapp_bridge_status"
+if [[ "$overall_status" != "0" && -n "$stack_failure_category" ]]; then
+  echo "stack_failure_category=$stack_failure_category"
+fi
 echo "whatsapp_inbound_cache=$whatsapp_inbound_cache_status"
 echo "whatsapp_alpha=$whatsapp_alpha_status"
 echo "whatsapp_attended_watch=$whatsapp_attended_watch_status"

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -531,6 +531,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             "whatsapp_bridge=external_meta_setup_pending",
             result.stdout,
         )
+        self.assertIn("stack_failure_category=external_meta_setup", result.stdout)
         self.assertIn(
             "error: local Hermes voice stack external Meta setup check failed",
             result.stderr,
@@ -1689,6 +1690,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             "whatsapp_alpha=cached-receive:external_meta_setup_pending",
             result.stdout,
         )
+        self.assertIn("stack_failure_category=external_meta_setup", result.stdout)
         self.assertIn(
             "error: WhatsApp alpha readiness profile external Meta setup pending "
             "with exit 1",
@@ -1803,6 +1805,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             "whatsapp_alpha=cached-receive:external_meta_setup_pending",
             result.stdout,
         )
+        self.assertIn("stack_failure_category=external_meta_setup", result.stdout)
         self.assertNotIn("whatsapp_alpha_json=/tmp/", result.stdout)
 
     def test_whatsapp_alpha_json_output_summarizes_nonzero_alpha(self):
@@ -1937,6 +1940,7 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             result.stdout,
         )
         self.assertIn("whatsapp_alpha=attended-cache-receive:failed", result.stdout)
+        self.assertIn("stack_failure_category=whatsapp_alpha", result.stdout)
         self.assertNotIn("ok: local Hermes voice stack verifier passed", result.stdout)
         self.assertIn(
             "error: WhatsApp alpha readiness profile failed with exit 3",


### PR DESCRIPTION
## Summary
- track aggregate continuing failure category in the stack verifier footer
- print `stack_failure_category=external_meta_setup` for external-only bridge/alpha pending states and `stack_failure_category=whatsapp_alpha` for non-external alpha failures
- update README/runbook wording for the new footer line

## Verification
- `python3 -m unittest tests.test_verify_local_hermes_voice_stack`
- `bash -n scripts/verify_local_hermes_voice_stack.sh`
- `python3 -m unittest discover tests`
- `git diff --check`
- live stack smoke: `scripts/verify_local_hermes_voice_stack.sh --check-whatsapp-cloud-health --whatsapp-alpha-profile cached-receive` now prints `stack_failure_category=external_meta_setup` with `whatsapp_bridge=external_meta_setup_pending` and `whatsapp_alpha=cached-receive:external_meta_setup_pending`
