### PR TITLE
Summarize attended watch voice proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,8 +526,10 @@ that flag the temporary JSON report is removed after the compact summary is
 printed. The stack verifier echoes compact `whatsapp_alpha_json_*` summary
 lines for every alpha profile, including readiness status, completion state,
 next actions, attended receive status, and Cloud/Calling missing or invalid key
-groups. A verified attended receive also stores compact redacted proof under
-`pending_gates.attended_fresh_receive.evidence`.
+groups. When a verified attended watch is available, the compact summary also
+reports whether the watch sent the prompt as a voice note and whether it used
+the non-draining audio-cache receive path. A verified attended receive also
+stores compact redacted proof under `pending_gates.attended_fresh_receive.evidence`.
 
 When the WebRTC Python dependencies are installed, add
 `--run-webrtc-loopback-smoke --webrtc-python /tmp/voice-webrtc-venv/bin/python`

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -187,11 +187,14 @@ When the top-level stack gate runs an alpha profile, it echoes compact
 `whatsapp_alpha_json_*` summary lines from the alpha JSON report. Those lines
 include the alpha profile, readiness status, completion state, next action IDs,
 attended receive status, and Cloud/Calling missing or invalid key groups. When
-a gate is still pending, the same summary also echoes the copyable attended
-receive command, fallback draining command, Cloud verification command, Calling
-verification command, and complete-alpha command if those commands are present
-in the report. If the alpha profile exits non-zero while writing a valid JSON
-report, such as a `--require-complete` run with pending gates, the stack gate
+a verified attended watch is available, the compact summary also shows whether
+the watch sent its prompt as a voice note and whether it used the non-draining
+audio-cache receive path. When a gate is still pending, the same summary also
+echoes the copyable attended receive command, fallback draining command, Cloud
+verification command, Calling verification command, and complete-alpha command
+if those commands are present in the report. If the alpha profile exits
+non-zero while writing a valid JSON report, such as a `--require-complete` run
+with pending gates, the stack gate
 still prints this summary before returning the alpha failure status. If a
 nonzero alpha report proves local checks and attended receive passed and only
 external Meta setup remains, the final summary marks

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -537,9 +537,13 @@ print(f"whatsapp_alpha_json_next_actions={csv(actions)}")
 if watch is not None:
     audio_cache = watch.get("audio_cache") or {}
     alpha = watch.get("alpha") or {}
+    manifest = watch.get("manifest_summary") or {}
+    prompt = manifest.get("attended_prompt") or {}
     print(
         "whatsapp_alpha_json_attended_watch_evidence="
         f"verified unit={watch.get('unit')} "
+        f"sends_prompt_voice_note={prompt.get('sends_prompt_voice_note')} "
+        f"watch_drains_messages={manifest.get('drains_bridge_messages')} "
         f"fresh_count={alpha.get('fresh_count')} "
         f"latest_audio={audio_cache.get('latest_file')} "
         f"latest_audio_fresh={audio_cache.get('fresh_since_created')}"

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -1476,6 +1476,12 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                             "attended_fresh_receive_verified": true,
                             "fresh_count": 1
                           }},
+                          "manifest_summary": {{
+                            "drains_bridge_messages": false,
+                            "attended_prompt": {{
+                              "sends_prompt_voice_note": true
+                            }}
+                          }},
                           "audio_cache": {{
                             "latest_file": "aud_new.ogg",
                             "fresh_since_created": true
@@ -1576,8 +1582,9 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         )
         self.assertIn(
             "whatsapp_alpha_json_attended_watch_evidence=verified "
-            "unit=watch-done fresh_count=1 latest_audio=aud_new.ogg "
-            "latest_audio_fresh=True",
+            "unit=watch-done sends_prompt_voice_note=True "
+            "watch_drains_messages=False fresh_count=1 "
+            "latest_audio=aud_new.ogg latest_audio_fresh=True",
             result.stdout,
         )
         self.assertIn(


### PR DESCRIPTION
## Summary
- include attended-watch prompt/send proof in the compact alpha summary line
- report `sends_prompt_voice_note` and `watch_drains_messages` alongside fresh inbound audio evidence
- update README/runbook wording for the richer compact proof

## Verification
- `python3 -m unittest tests.test_verify_local_hermes_voice_stack`
- `bash -n scripts/verify_local_hermes_voice_stack.sh`
- `python3 -m unittest discover tests`
- `git diff --check`
- live stack smoke: `scripts/verify_local_hermes_voice_stack.sh --check-whatsapp-cloud-health --whatsapp-alpha-profile cached-receive` now prints `whatsapp_alpha_json_attended_watch_evidence=... sends_prompt_voice_note=True watch_drains_messages=False ...`
