### PR TITLE
Include PTT transport in attended watch proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,9 +527,10 @@ printed. The stack verifier echoes compact `whatsapp_alpha_json_*` summary
 lines for every alpha profile, including readiness status, completion state,
 next actions, attended receive status, and Cloud/Calling missing or invalid key
 groups. When a verified attended watch is available, the compact summary also
-reports whether the watch sent the prompt as a voice note and whether it used
-the non-draining audio-cache receive path. A verified attended receive also
-stores compact redacted proof under `pending_gates.attended_fresh_receive.evidence`.
+reports whether the watch sent the prompt as a voice note, the local PTT
+transport and Ogg/Opus MIME it used, and whether it used the non-draining
+audio-cache receive path. A verified attended receive also stores compact
+redacted proof under `pending_gates.attended_fresh_receive.evidence`.
 
 When the WebRTC Python dependencies are installed, add
 `--run-webrtc-loopback-smoke --webrtc-python /tmp/voice-webrtc-venv/bin/python`

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -188,11 +188,12 @@ When the top-level stack gate runs an alpha profile, it echoes compact
 include the alpha profile, readiness status, completion state, next action IDs,
 attended receive status, and Cloud/Calling missing or invalid key groups. When
 a verified attended watch is available, the compact summary also shows whether
-the watch sent its prompt as a voice note and whether it used the non-draining
-audio-cache receive path. When a gate is still pending, the same summary also
-echoes the copyable attended receive command, fallback draining command, Cloud
-verification command, Calling verification command, and complete-alpha command
-if those commands are present in the report. If the alpha profile exits
+the watch sent its prompt as a voice note, the local PTT transport and Ogg/Opus
+MIME it used, and whether it used the non-draining audio-cache receive path.
+When a gate is still pending, the same summary also echoes the copyable attended
+receive command, fallback draining command, Cloud verification command, Calling
+verification command, and complete-alpha command if those commands are present
+in the report. If the alpha profile exits
 non-zero while writing a valid JSON report, such as a `--require-complete` run
 with pending gates, the stack gate
 still prints this summary before returning the alpha failure status. If a

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -539,10 +539,13 @@ if watch is not None:
     alpha = watch.get("alpha") or {}
     manifest = watch.get("manifest_summary") or {}
     prompt = manifest.get("attended_prompt") or {}
+    send_mime = str(prompt.get("send_format") or "").replace(" ", "") or None
     print(
         "whatsapp_alpha_json_attended_watch_evidence="
         f"verified unit={watch.get('unit')} "
         f"sends_prompt_voice_note={prompt.get('sends_prompt_voice_note')} "
+        f"send_transport={prompt.get('send_transport')} "
+        f"send_mime={send_mime} "
         f"watch_drains_messages={manifest.get('drains_bridge_messages')} "
         f"fresh_count={alpha.get('fresh_count')} "
         f"latest_audio={audio_cache.get('latest_file')} "

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -1479,7 +1479,9 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
                           "manifest_summary": {{
                             "drains_bridge_messages": false,
                             "attended_prompt": {{
-                              "sends_prompt_voice_note": true
+                              "sends_prompt_voice_note": true,
+                              "send_format": "audio/ogg; codecs=opus",
+                              "send_transport": "local_whatsapp_bridge_ptt"
                             }}
                           }},
                           "audio_cache": {{
@@ -1583,6 +1585,8 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn(
             "whatsapp_alpha_json_attended_watch_evidence=verified "
             "unit=watch-done sends_prompt_voice_note=True "
+            "send_transport=local_whatsapp_bridge_ptt "
+            "send_mime=audio/ogg;codecs=opus "
             "watch_drains_messages=False fresh_count=1 "
             "latest_audio=aud_new.ogg latest_audio_fresh=True",
             result.stdout,


### PR DESCRIPTION
## Summary
- include attended-watch send transport and MIME in the compact alpha proof line
- surface `send_transport=local_whatsapp_bridge_ptt` and `send_mime=audio/ogg;codecs=opus` next to the verified fresh receive evidence
- update README/runbook wording so the compact proof documents the PTT/Ogg-Opus shape

## Verification
- `python3 -m unittest tests.test_verify_local_hermes_voice_stack`
- `bash -n scripts/verify_local_hermes_voice_stack.sh`
- `python3 -m unittest discover tests`
- `git diff --check`
- live stack smoke: `scripts/verify_local_hermes_voice_stack.sh --check-whatsapp-cloud-health --whatsapp-alpha-profile cached-receive` printed `whatsapp_alpha_json_attended_watch_evidence=... send_transport=local_whatsapp_bridge_ptt send_mime=audio/ogg;codecs=opus ...`
