### PR TITLE
Include attended watch transport in alpha evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,8 @@ groups. When a verified attended watch is available, the compact summary also
 reports whether the watch sent the prompt as a voice note, the local PTT
 transport and Ogg/Opus MIME it used, and whether it used the non-draining
 audio-cache receive path. A verified attended receive also stores compact
-redacted proof under `pending_gates.attended_fresh_receive.evidence`.
+redacted proof under `pending_gates.attended_fresh_receive.evidence`, including
+the attended-watch send format, send transport, and receive-watch mode.
 
 When the WebRTC Python dependencies are installed, add
 `--run-webrtc-loopback-smoke --webrtc-python /tmp/voice-webrtc-venv/bin/python`

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -190,6 +190,9 @@ attended receive status, and Cloud/Calling missing or invalid key groups. When
 a verified attended watch is available, the compact summary also shows whether
 the watch sent its prompt as a voice note, the local PTT transport and Ogg/Opus
 MIME it used, and whether it used the non-draining audio-cache receive path.
+The saved alpha JSON mirrors those details under
+`pending_gates.attended_fresh_receive.evidence` as `watch_send_format`,
+`watch_send_transport`, and `watch_receive_watch`.
 When a gate is still pending, the same summary also echoes the copyable attended
 receive command, fallback draining command, Cloud verification command, Calling
 verification command, and complete-alpha command if those commands are present

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -371,6 +371,9 @@ def verified_attended_watch_evidence(args: argparse.Namespace) -> dict[str, Any]
                 "watch_sends_prompt_voice_note": attended_prompt.get(
                     "sends_prompt_voice_note"
                 ),
+                "watch_send_format": attended_prompt.get("send_format"),
+                "watch_send_transport": attended_prompt.get("send_transport"),
+                "watch_receive_watch": attended_prompt.get("receive_watch"),
             }
         )
         return proof

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -93,6 +93,9 @@ def write_verified_attended_watch(
         "expected_agent_name": expected_agent_name,
         "attended_prompt": {
             "sends_prompt_voice_note": True,
+            "send_format": "audio/ogg; codecs=opus",
+            "send_transport": "local_whatsapp_bridge_ptt",
+            "receive_watch": "non_draining_audio_cache",
             "audio_cache_dir": str(directory / "audio_cache"),
         },
     }
@@ -1027,6 +1030,13 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
         self.assertEqual(evidence["watch_profile"], "attended-cache-receive")
         self.assertEqual(evidence["watch_expected_agent_number"], "13236478455")
         self.assertEqual(evidence["watch_expected_agent_name"], "Quill")
+        self.assertTrue(evidence["watch_sends_prompt_voice_note"])
+        self.assertEqual(evidence["watch_send_format"], "audio/ogg; codecs=opus")
+        self.assertEqual(
+            evidence["watch_send_transport"],
+            "local_whatsapp_bridge_ptt",
+        )
+        self.assertEqual(evidence["watch_receive_watch"], "non_draining_audio_cache")
         self.assertEqual(evidence["audio"][0]["name"], "aud_watch.ogg")
         summary = payload["readiness_summary"]
         self.assertTrue(summary["attended_fresh_receive_verified"])


### PR DESCRIPTION
## Summary
- copy attended-watch send format, send transport, and receive-watch mode into saved alpha JSON evidence
- assert the fields in the alpha readiness fixture
- document that structured evidence mirrors the compact stack proof

## Verification
- python3 -m unittest tests.test_verify_whatsapp_alpha_readiness
- python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_alpha_readiness.py
- python3 -m unittest discover tests
- git diff --check
- live alpha JSON smoke against installed local stack: local_checks_passed=True, attended_fresh_receive_verified=True, watch_send_transport=local_whatsapp_bridge_ptt, watch_send_format=audio/ogg; codecs=opus, watch_receive_watch=non_draining_audio_cache; exit stayed 1 only because external Meta Cloud/Calling setup remains pending