### PR TITLE
Split Calling setup missing key summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,8 @@ transport and Ogg/Opus MIME it used, and whether it used the non-draining
 audio-cache receive path. A verified attended receive also stores compact
 redacted proof under `pending_gates.attended_fresh_receive.evidence`, including
 the attended-watch send format, send transport, and receive-watch mode.
+Calling summaries split missing setup into `cloud_missing` for Meta credentials
+and `sidecar_missing` for local WebRTC sidecar environment keys.
 
 When the WebRTC Python dependencies are installed, add
 `--run-webrtc-loopback-smoke --webrtc-python /tmp/voice-webrtc-venv/bin/python`

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -193,6 +193,9 @@ MIME it used, and whether it used the non-draining audio-cache receive path.
 The saved alpha JSON mirrors those details under
 `pending_gates.attended_fresh_receive.evidence` as `watch_send_format`,
 `watch_send_transport`, and `watch_receive_watch`.
+Calling summaries also split missing setup into `cloud_missing` for Meta Cloud
+credentials and `sidecar_missing` for local WebRTC sidecar environment keys, so
+an external Meta approval gap is not confused with local sidecar drift.
 When a gate is still pending, the same summary also echoes the copyable attended
 receive command, fallback draining command, Cloud verification command, Calling
 verification command, and complete-alpha command if those commands are present

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -361,6 +361,19 @@ except (OSError, json.JSONDecodeError) as exc:
 def csv(values):
     return ",".join(str(value) for value in (values or [])) or "none"
 
+def calling_cloud_missing(cloud):
+    return cloud.get("calling_cloud_missing") or [
+        key for key in (cloud.get("calling_missing") or [])
+        if str(key).startswith("WHATSAPP_CLOUD_")
+        and not str(key).startswith("WHATSAPP_CLOUD_CALLING_SIDECAR_")
+    ]
+
+def calling_sidecar_missing(cloud):
+    return cloud.get("calling_sidecar_missing") or [
+        key for key in (cloud.get("calling_missing") or [])
+        if str(key).startswith("WHATSAPP_CLOUD_CALLING_SIDECAR_")
+    ]
+
 checks = payload.get("checks") or {}
 identity = checks.get("baileys_identity") or {}
 health = checks.get("bridge_health") or {}
@@ -395,6 +408,10 @@ print(
     + str(cloud.get("calling_sidecar_configured"))
     + " missing="
     + csv(cloud.get("calling_missing"))
+    + " cloud_missing="
+    + csv(calling_cloud_missing(cloud))
+    + " sidecar_missing="
+    + csv(calling_sidecar_missing(cloud))
     + " invalid="
     + csv(cloud.get("calling_invalid"))
 )
@@ -501,6 +518,19 @@ def verified_watch(path):
             return watch
     return None
 
+def handoff_cloud_missing(handoff):
+    return handoff.get("cloud_missing") or [
+        key for key in (handoff.get("missing") or [])
+        if str(key).startswith("WHATSAPP_CLOUD_")
+        and not str(key).startswith("WHATSAPP_CLOUD_CALLING_SIDECAR_")
+    ]
+
+def handoff_sidecar_missing(handoff):
+    return handoff.get("sidecar_missing") or [
+        key for key in (handoff.get("missing") or [])
+        if str(key).startswith("WHATSAPP_CLOUD_CALLING_SIDECAR_")
+    ]
+
 
 summary = payload.get("readiness_summary") or {}
 pending = payload.get("pending_gates") or {}
@@ -596,6 +626,8 @@ if calling:
         "whatsapp_alpha_json_calling="
         f"{calling.get('status')} "
         f"missing={csv(calling_handoff.get('missing') or calling.get('missing'))} "
+        f"cloud_missing={csv(handoff_cloud_missing(calling_handoff))} "
+        f"sidecar_missing={csv(handoff_sidecar_missing(calling_handoff))} "
         f"invalid={csv(calling_handoff.get('invalid') or calling.get('invalid'))}"
     )
     if calling.get("status") != "ready":

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -1634,6 +1634,10 @@ def human_summary(result: dict[str, Any]) -> None:
             f"sidecar_configured={calling_handoff.get('calling_sidecar_configured')} "
             "missing="
             + (",".join(calling_handoff.get("missing") or []) or "none")
+            + " cloud_missing="
+            + (",".join(calling_handoff.get("cloud_missing") or []) or "none")
+            + " sidecar_missing="
+            + (",".join(calling_handoff.get("sidecar_missing") or []) or "none")
             + " invalid="
             + (",".join(calling_handoff.get("invalid") or []) or "none")
         )

--- a/scripts/verify_whatsapp_bridge_runtime.py
+++ b/scripts/verify_whatsapp_bridge_runtime.py
@@ -612,6 +612,8 @@ def build_cloud_summary(env_sources: dict[str, dict[str, str]]) -> dict[str, Any
         "calling_sidecar_configured": not sidecar_missing,
         "calling_ready": not calling_missing and not cloud_invalid,
         "calling_missing": calling_missing,
+        "calling_cloud_missing": cloud_missing,
+        "calling_sidecar_missing": sidecar_missing,
         "calling_invalid": cloud_invalid,
         "calling": calling_presence,
     }
@@ -1506,6 +1508,10 @@ def human_summary(result: dict[str, Any]) -> None:
         + ("yes" if cloud.get("calling_ready") else "no")
         + " missing="
         + (",".join(cloud.get("calling_missing") or []) or "none")
+        + " cloud_missing="
+        + (",".join(cloud.get("calling_cloud_missing") or []) or "none")
+        + " sidecar_missing="
+        + (",".join(cloud.get("calling_sidecar_missing") or []) or "none")
         + " invalid="
         + (",".join(cloud.get("calling_invalid") or []) or "none")
     )

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -513,7 +513,10 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn(
             "whatsapp_bridge_json_calling=not_ready sidecar_configured=True "
             "missing=WHATSAPP_CLOUD_PHONE_NUMBER_ID,WHATSAPP_CLOUD_ACCESS_TOKEN,"
-            "WHATSAPP_CLOUD_APP_SECRET,WHATSAPP_CLOUD_VERIFY_TOKEN invalid=none",
+            "WHATSAPP_CLOUD_APP_SECRET,WHATSAPP_CLOUD_VERIFY_TOKEN "
+            "cloud_missing=WHATSAPP_CLOUD_PHONE_NUMBER_ID,"
+            "WHATSAPP_CLOUD_ACCESS_TOKEN,WHATSAPP_CLOUD_APP_SECRET,"
+            "WHATSAPP_CLOUD_VERIFY_TOKEN sidecar_missing=none invalid=none",
             result.stdout,
         )
         self.assertIn(
@@ -1311,7 +1314,10 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn(
             "whatsapp_alpha_json_calling=external_setup_required "
             "missing=WHATSAPP_CLOUD_PHONE_NUMBER_ID,WHATSAPP_CLOUD_ACCESS_TOKEN,"
-            "WHATSAPP_CLOUD_APP_SECRET,WHATSAPP_CLOUD_VERIFY_TOKEN invalid=none",
+            "WHATSAPP_CLOUD_APP_SECRET,WHATSAPP_CLOUD_VERIFY_TOKEN "
+            "cloud_missing=WHATSAPP_CLOUD_PHONE_NUMBER_ID,"
+            "WHATSAPP_CLOUD_ACCESS_TOKEN,WHATSAPP_CLOUD_APP_SECRET,"
+            "WHATSAPP_CLOUD_VERIFY_TOKEN sidecar_missing=none invalid=none",
             result.stdout,
         )
         self.assertIn(

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -816,6 +816,11 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             result.stdout,
         )
         self.assertIn(
+            "cloud_missing=WHATSAPP_CLOUD_PHONE_NUMBER_ID,WHATSAPP_CLOUD_ACCESS_TOKEN",
+            result.stdout,
+        )
+        self.assertIn("sidecar_missing=none", result.stdout)
+        self.assertIn(
             "whatsapp_calling_verify_command=scripts/verify_whatsapp_alpha_readiness.py",
             result.stdout,
         )

--- a/tests/test_verify_whatsapp_bridge_runtime.py
+++ b/tests/test_verify_whatsapp_bridge_runtime.py
@@ -282,6 +282,8 @@ class WhatsAppBridgeRuntimeVerifierTests(unittest.TestCase):
         self.assertTrue(summary["calling_sidecar_configured"])
         self.assertTrue(summary["calling_ready"])
         self.assertEqual(summary["calling_missing"], [])
+        self.assertEqual(summary["calling_cloud_missing"], [])
+        self.assertEqual(summary["calling_sidecar_missing"], [])
         self.assertEqual(summary["cloud_invalid"], [])
         self.assertEqual(summary["webhook"]["host"], "0.0.0.0")
         self.assertEqual(summary["webhook"]["port"], 8090)
@@ -290,6 +292,28 @@ class WhatsAppBridgeRuntimeVerifierTests(unittest.TestCase):
         self.assertIn(
             "WHATSAPP_CLOUD_WEBHOOK_PORT",
             summary["webhook"]["defaulted"],
+        )
+
+    def test_cloud_calling_summary_splits_cloud_and_sidecar_missing_keys(self):
+        summary = self.script.build_cloud_summary({"env_file": {}})
+
+        self.assertFalse(summary["cloud_configured"])
+        self.assertFalse(summary["calling_sidecar_configured"])
+        self.assertFalse(summary["calling_ready"])
+        self.assertIn(
+            "WHATSAPP_CLOUD_PHONE_NUMBER_ID",
+            summary["calling_cloud_missing"],
+        )
+        self.assertIn(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_URL",
+            summary["calling_sidecar_missing"],
+        )
+        self.assertEqual(
+            summary["calling_missing"],
+            [
+                *summary["calling_cloud_missing"],
+                *summary["calling_sidecar_missing"],
+            ],
         )
 
     def test_invalid_cloud_webhook_config_fails_strict_cloud_readiness(self):


### PR DESCRIPTION
## Summary
- split WhatsApp Calling missing setup into Cloud credential keys and local sidecar keys
- expose the split in bridge runtime text, stack bridge summaries, alpha JSON summaries, and standalone alpha handoff output
- document the new `cloud_missing` / `sidecar_missing` fields

## Verification
- python3 -m unittest tests.test_verify_whatsapp_bridge_runtime tests.test_verify_whatsapp_alpha_readiness tests.test_verify_local_hermes_voice_stack
- python3 -m py_compile scripts/verify_whatsapp_bridge_runtime.py scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_bridge_runtime.py tests/test_verify_whatsapp_alpha_readiness.py tests/test_verify_local_hermes_voice_stack.py
- git diff --check
- python3 -m unittest discover tests
- live stack smoke: `scripts/verify_local_hermes_voice_stack.sh --check-whatsapp-cloud-health --whatsapp-alpha-profile cached-receive` still reports `external_meta_setup`, with `cloud_missing=WHATSAPP_CLOUD_PHONE_NUMBER_ID,WHATSAPP_CLOUD_ACCESS_TOKEN,WHATSAPP_CLOUD_APP_SECRET,WHATSAPP_CLOUD_VERIFY_TOKEN` and `sidecar_missing=none` for both bridge and alpha summaries