### PR TITLE
Report WhatsApp bridge provenance in stack summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,11 @@ Cloud adapter health contract, and verifies the local webhook challenge echo
 without printing token or phone-number values. Failures from those explicit
 Cloud probes are reported as external Meta setup, not as local Baileys bridge or
 voice runtime failures.
+The stack bridge summary also prints non-secret Baileys provenance:
+`whatsapp_bridge_json_sources` shows the resolved session directory, Hermes env
+file, bridge process session, expected agent identity, and home channel, while
+`whatsapp_bridge_json_session_artifacts` reports auth/session file counts.
+
 The stack verifier runs alpha profiles through JSON internally so nonzero alpha
 results can still be classified as local runtime, attended receive, or external
 Meta setup. Use `--whatsapp-alpha-json-output` with any alpha profile when

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -215,7 +215,10 @@ for a non-external alpha failure. The compact bridge summary includes both
 `whatsapp_bridge_json_cloud` and `whatsapp_bridge_json_calling` lines so Cloud
 credential gaps and Calling sidecar gaps remain separate, plus
 `whatsapp_bridge_json_webhook` when the bridge JSON includes the Cloud webhook
-listener config.
+listener config. It also prints `whatsapp_bridge_json_sources` with the
+resolved Baileys session directory, Hermes env file, bridge process session,
+expected agent identity, and home channel, plus
+`whatsapp_bridge_json_session_artifacts` with auth/session file counts.
 
 Use the complete gate only when the local bridge, attended receive, Cloud API,
 and Calling setup are all expected to pass:

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -361,6 +361,11 @@ except (OSError, json.JSONDecodeError) as exc:
 def csv(values):
     return ",".join(str(value) for value in (values or [])) or "none"
 
+def pair_csv(values):
+    if not isinstance(values, dict) or not values:
+        return "none"
+    return ",".join(f"{key}={values[key]}" for key in sorted(values))
+
 def calling_cloud_missing(cloud):
     return cloud.get("calling_cloud_missing") or [
         key for key in (cloud.get("calling_missing") or [])
@@ -377,6 +382,8 @@ def calling_sidecar_missing(cloud):
 checks = payload.get("checks") or {}
 identity = checks.get("baileys_identity") or {}
 health = checks.get("bridge_health") or {}
+local_config = checks.get("whatsapp_local_config") or {}
+bridge_process = (checks.get("bridge_process") or {}).get("selected") or {}
 cloud = checks.get("whatsapp_cloud") or {}
 webhook = cloud.get("webhook") or {}
 cloud_health = cloud.get("cloud_health") or {}
@@ -390,6 +397,21 @@ print(
     + f" queue={health.get('queueLength', 'unknown')}"
     + f" name={identity.get('name') or '<unknown>'}"
     + f" number={identity.get('number') or '<unknown>'}"
+)
+print(
+    "whatsapp_bridge_json_sources="
+    + f"session_dir={checks.get('session_dir') or '<unknown>'} "
+    + f"env_file={checks.get('env_file') or '<unknown>'} "
+    + f"bridge_process_session={bridge_process.get('session') or '<unknown>'} "
+    + f"expected_number={checks.get('expected_agent_number') or '<none>'} "
+    + f"expected_name={checks.get('expected_agent_name') or '<none>'} "
+    + f"home_channel={local_config.get('home_channel') or '<missing>'} "
+    + f"home_channel_kind={local_config.get('home_channel_kind') or '<unknown>'} "
+    + f"allowed_users={local_config.get('allowed_users_count', 0)}"
+)
+print(
+    "whatsapp_bridge_json_session_artifacts="
+    + pair_csv(checks.get("session_artifacts") or {})
 )
 print(
     "whatsapp_bridge_json_cloud="

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -84,6 +84,10 @@ def write_external_meta_bridge_helper(path: Path, label: str, log_path: Path) ->
             {{
               "success": false,
               "checks": {{
+                "env_file": "/home/ubuntu/.hermes/.env",
+                "session_dir": "/home/ubuntu/.hermes/whatsapp/session",
+                "expected_agent_number": "13236478455",
+                "expected_agent_name": "Quill",
                 "baileys_identity": {{
                   "name": "Quill",
                   "number": "13236478455",
@@ -92,6 +96,23 @@ def write_external_meta_bridge_helper(path: Path, label: str, log_path: Path) ->
                 "bridge_health": {{
                   "status": "connected",
                   "queueLength": 0
+                }},
+                "bridge_process": {{
+                  "selected": {{
+                    "pid": 12345,
+                    "mode": "bot",
+                    "session": "/home/ubuntu/.hermes/whatsapp/session"
+                  }}
+                }},
+                "whatsapp_local_config": {{
+                  "home_channel": "20530681934008@lid",
+                  "home_channel_kind": "lid",
+                  "allowed_users_count": 2
+                }},
+                "session_artifacts": {{
+                  "lid_mapping": 6,
+                  "pre_key": 810,
+                  "session": 3
                 }},
                 "whatsapp_cloud": {{
                   "cloud_configured": false,
@@ -508,6 +529,21 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
         self.assertIn("--check-whatsapp-cloud-health", entries[1])
         self.assertIn(
             "whatsapp_bridge_json_cloud_health=failed",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_bridge_json_sources=session_dir="
+            "/home/ubuntu/.hermes/whatsapp/session "
+            "env_file=/home/ubuntu/.hermes/.env "
+            "bridge_process_session=/home/ubuntu/.hermes/whatsapp/session "
+            "expected_number=13236478455 expected_name=Quill "
+            "home_channel=20530681934008@lid home_channel_kind=lid "
+            "allowed_users=2",
+            result.stdout,
+        )
+        self.assertIn(
+            "whatsapp_bridge_json_session_artifacts="
+            "lid_mapping=6,pre_key=810,session=3",
             result.stdout,
         )
         self.assertIn(


### PR DESCRIPTION
## Summary
- add non-secret WhatsApp bridge provenance lines to the aggregate stack summary
- report resolved Baileys session dir, Hermes env file, bridge process session, expected agent metadata, home channel, and auth/session artifact counts
- document the new stack summary lines

## Verification
- python3 -m unittest tests.test_verify_local_hermes_voice_stack
- bash -n scripts/verify_local_hermes_voice_stack.sh
- python3 -m py_compile tests/test_verify_local_hermes_voice_stack.py
- git diff --check
- python3 -m unittest discover tests
- live stack smoke: `scripts/verify_local_hermes_voice_stack.sh --check-whatsapp-cloud-health --whatsapp-alpha-profile cached-receive` now prints `whatsapp_bridge_json_sources=session_dir=/home/ubuntu/.hermes/whatsapp/session env_file=/home/ubuntu/.hermes/.env bridge_process_session=/home/ubuntu/.hermes/whatsapp/session ... home_channel=20530681934008@lid ...` and `whatsapp_bridge_json_session_artifacts=app_state_sync_key=3,lid_mapping=6,other_json=11,pre_key=810,sender_key=0,session=3,tctoken=2`; final category remains `external_meta_setup` because Meta Cloud credentials are still missing