### PR TITLE
Report expected WhatsApp agent identity enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,10 @@ The stack bridge summary also prints non-secret Baileys provenance:
 `whatsapp_bridge_json_sources` shows the resolved session directory, Hermes env
 file, bridge process session, expected agent identity, and home channel, while
 `whatsapp_bridge_json_session_artifacts` reports auth/session file counts.
+Set `WHATSAPP_AGENT_NUMBER` or pass `--expected-whatsapp-agent-number` when the
+paired number should be checked against an independent expected value; add
+`--require-expected-whatsapp-agent-number` to fail if that expected value is
+missing.
 
 The stack verifier runs alpha profiles through JSON internally so nonzero alpha
 results can still be classified as local runtime, attended receive, or external

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -219,6 +219,10 @@ listener config. It also prints `whatsapp_bridge_json_sources` with the
 resolved Baileys session directory, Hermes env file, bridge process session,
 expected agent identity, and home channel, plus
 `whatsapp_bridge_json_session_artifacts` with auth/session file counts.
+Set `WHATSAPP_AGENT_NUMBER` or pass `--expected-whatsapp-agent-number` to make
+that identity check independent from the observed Baileys credentials; add
+`--require-expected-whatsapp-agent-number` when missing expected identity should
+fail the stack gate.
 
 Use the complete gate only when the local bridge, attended receive, Cloud API,
 and Calling setup are all expected to pass:

--- a/scripts/verify_local_hermes_voice_stack.sh
+++ b/scripts/verify_local_hermes_voice_stack.sh
@@ -44,6 +44,7 @@ whatsapp_env_file="${WHATSAPP_ENV_FILE:-}"
 whatsapp_audio_cache_dir="${WHATSAPP_AUDIO_CACHE_DIR:-}"
 expected_whatsapp_agent_number="${WHATSAPP_AGENT_NUMBER:-}"
 expected_whatsapp_agent_name="${WHATSAPP_AGENT_NAME:-}"
+require_expected_whatsapp_agent_number="${REQUIRE_EXPECTED_WHATSAPP_AGENT_NUMBER:-0}"
 require_whatsapp_cloud="${REQUIRE_WHATSAPP_CLOUD:-0}"
 require_whatsapp_calling="${REQUIRE_WHATSAPP_CALLING:-0}"
 require_whatsapp_alpha_complete="${REQUIRE_WHATSAPP_ALPHA_COMPLETE:-0}"
@@ -114,6 +115,8 @@ Options:
                                require Baileys creds to be paired to this number
   --expected-whatsapp-agent-name NAME
                                require Baileys creds to expose this profile name
+  --require-expected-whatsapp-agent-number
+                               fail unless an expected WhatsApp agent number is configured
   --require-whatsapp-cloud     fail when WhatsApp Cloud credentials are missing
   --require-whatsapp-calling   fail when Cloud Calling credentials/readiness are missing
   --require-whatsapp-alpha-complete
@@ -165,6 +168,7 @@ Environment aliases:
   RUN_WEBRTC_LOOPBACK_SMOKE=1
   WHATSAPP_BRIDGE_URL, WHATSAPP_SESSION_DIR, WHATSAPP_ENV_FILE
   WHATSAPP_AUDIO_CACHE_DIR, WHATSAPP_AGENT_NUMBER, WHATSAPP_AGENT_NAME
+  REQUIRE_EXPECTED_WHATSAPP_AGENT_NUMBER=1
   REQUIRE_WHATSAPP_CLOUD=1, REQUIRE_WHATSAPP_CALLING=1
   REQUIRE_WHATSAPP_ALPHA_COMPLETE=1, CHECK_WHATSAPP_CLOUD_API=1
   CHECK_WHATSAPP_CLOUD_HEALTH=1, CHECK_WHATSAPP_CLOUD_WEBHOOK=1
@@ -404,7 +408,10 @@ print(
     + f"env_file={checks.get('env_file') or '<unknown>'} "
     + f"bridge_process_session={bridge_process.get('session') or '<unknown>'} "
     + f"expected_number={checks.get('expected_agent_number') or '<none>'} "
+    + f"expected_number_enforced={checks.get('expected_agent_number_enforced')} "
+    + f"expected_number_required={checks.get('expected_agent_number_required')} "
     + f"expected_name={checks.get('expected_agent_name') or '<none>'} "
+    + f"expected_name_enforced={checks.get('expected_agent_name_enforced')} "
     + f"home_channel={local_config.get('home_channel') or '<missing>'} "
     + f"home_channel_kind={local_config.get('home_channel_kind') or '<unknown>'} "
     + f"allowed_users={local_config.get('allowed_users_count', 0)}"
@@ -807,6 +814,10 @@ while [[ $# -gt 0 ]]; do
       expected_whatsapp_agent_name="$2"
       shift 2
       ;;
+    --require-expected-whatsapp-agent-number)
+      require_expected_whatsapp_agent_number=1
+      shift
+      ;;
     --require-whatsapp-cloud)
       require_whatsapp_cloud=1
       shift
@@ -1102,6 +1113,9 @@ if [[ "$skip_whatsapp_bridge" != "1" ]]; then
   fi
   if [[ -n "$expected_whatsapp_agent_name" ]]; then
     whatsapp_bridge_args+=(--expected-agent-name "$expected_whatsapp_agent_name")
+  fi
+  if [[ "$require_expected_whatsapp_agent_number" == "1" ]]; then
+    whatsapp_bridge_args+=(--require-expected-agent-number)
   fi
   if [[ "$skip_systemd" == "1" ]]; then
     whatsapp_bridge_args+=(--skip-systemd)

--- a/scripts/verify_whatsapp_bridge_runtime.py
+++ b/scripts/verify_whatsapp_bridge_runtime.py
@@ -1078,6 +1078,11 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
     expected_agent_number = normalize_whatsapp_identifier(args.expected_agent_number)
     expected_agent_name = args.expected_agent_name
     expected_mode = args.expected_mode or env_sources["env_file"].get("WHATSAPP_MODE")
+    if args.require_expected_agent_number and not expected_agent_number:
+        failures.append(
+            "Expected WhatsApp agent number is required but not configured; "
+            "set WHATSAPP_AGENT_NUMBER or pass --expected-agent-number"
+        )
     local_config = build_local_config_summary(env_sources)
     if local_config["enabled"] is False:
         failures.append("WHATSAPP_ENABLED is explicitly disabled")
@@ -1274,6 +1279,9 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         "session_dir": str(session_dir),
         "expected_agent_number": expected_agent_number,
         "expected_agent_name": expected_agent_name,
+        "expected_agent_number_enforced": bool(expected_agent_number),
+        "expected_agent_name_enforced": bool(expected_agent_name),
+        "expected_agent_number_required": bool(args.require_expected_agent_number),
         "expected_mode": expected_mode,
         "whatsapp_local_config": local_config,
         "baileys_identity": identity,
@@ -1305,6 +1313,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--service-name", default=DEFAULT_SERVICE_NAME)
     parser.add_argument("--expected-agent-number", default=os.environ.get("WHATSAPP_AGENT_NUMBER"))
     parser.add_argument("--expected-agent-name", default=os.environ.get("WHATSAPP_AGENT_NAME"))
+    parser.add_argument(
+        "--require-expected-agent-number",
+        action="store_true",
+        help=(
+            "fail unless an expected WhatsApp agent number is configured via "
+            "WHATSAPP_AGENT_NUMBER or --expected-agent-number"
+        ),
+    )
     parser.add_argument("--expected-mode", default=None)
     parser.add_argument("--timeout", type=float, default=10.0)
     parser.add_argument("--skip-bridge-health", action="store_true")
@@ -1384,6 +1400,14 @@ def human_summary(result: dict[str, Any]) -> None:
         f"number={identity.get('number') or '<unknown>'} "
         f"lid={identity.get('lid_number') or '<unknown>'} "
         f"platform={identity.get('platform') or '<unknown>'}"
+    )
+    print(
+        "expected_agent_identity="
+        f"number={checks.get('expected_agent_number') or '<none>'} "
+        f"number_enforced={checks.get('expected_agent_number_enforced')} "
+        f"number_required={checks.get('expected_agent_number_required')} "
+        f"name={checks.get('expected_agent_name') or '<none>'} "
+        f"name_enforced={checks.get('expected_agent_name_enforced')}"
     )
     if process:
         print(

--- a/tests/test_verify_local_hermes_voice_stack.py
+++ b/tests/test_verify_local_hermes_voice_stack.py
@@ -88,6 +88,9 @@ def write_external_meta_bridge_helper(path: Path, label: str, log_path: Path) ->
                 "session_dir": "/home/ubuntu/.hermes/whatsapp/session",
                 "expected_agent_number": "13236478455",
                 "expected_agent_name": "Quill",
+                "expected_agent_number_enforced": true,
+                "expected_agent_name_enforced": true,
+                "expected_agent_number_required": false,
                 "baileys_identity": {{
                   "name": "Quill",
                   "number": "13236478455",
@@ -536,7 +539,9 @@ class LocalHermesVoiceStackVerifierTests(unittest.TestCase):
             "/home/ubuntu/.hermes/whatsapp/session "
             "env_file=/home/ubuntu/.hermes/.env "
             "bridge_process_session=/home/ubuntu/.hermes/whatsapp/session "
-            "expected_number=13236478455 expected_name=Quill "
+            "expected_number=13236478455 expected_number_enforced=True "
+            "expected_number_required=False expected_name=Quill "
+            "expected_name_enforced=True "
             "home_channel=20530681934008@lid home_channel_kind=lid "
             "allowed_users=2",
             result.stdout,

--- a/tests/test_verify_whatsapp_bridge_runtime.py
+++ b/tests/test_verify_whatsapp_bridge_runtime.py
@@ -63,6 +63,7 @@ def make_args(tmp_path: Path, **overrides):
         "service_name": "hermes-gateway.service",
         "expected_agent_number": "13236478455",
         "expected_agent_name": "Quill",
+        "require_expected_agent_number": False,
         "expected_mode": None,
         "timeout": 1.0,
         "skip_bridge_health": True,
@@ -137,6 +138,29 @@ class WhatsAppBridgeRuntimeVerifierTests(unittest.TestCase):
 
         self.assertFalse(result["success"])
         self.assertIn("does not match expected", "\n".join(result["failures"]))
+
+    def test_require_expected_agent_number_fails_when_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            args = make_args(
+                tmp_path,
+                expected_agent_number=None,
+                require_expected_agent_number=True,
+            )
+            write_baileys_session(args.session_dir)
+            args.env_file.parent.mkdir(parents=True, exist_ok=True)
+            args.env_file.write_text("WHATSAPP_MODE=bot\n", encoding="utf-8")
+
+            result = self.script.verify(args)
+
+        self.assertFalse(result["success"])
+        self.assertIn(
+            "Expected WhatsApp agent number is required but not configured",
+            "\n".join(result["failures"]),
+        )
+        checks = result["checks"]
+        self.assertFalse(checks["expected_agent_number_enforced"])
+        self.assertTrue(checks["expected_agent_number_required"])
 
     def test_bridge_script_hash_matches_health_report(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- report whether expected WhatsApp agent number/name checks are actually enforced
- add `--require-expected-agent-number` to the bridge verifier and `--require-expected-whatsapp-agent-number` to the aggregate stack gate
- document how to make the Quill identity check independent from the observed Baileys credentials

## Verification
- python3 -m unittest tests.test_verify_whatsapp_bridge_runtime tests.test_verify_local_hermes_voice_stack
- bash -n scripts/verify_local_hermes_voice_stack.sh
- python3 -m py_compile scripts/verify_whatsapp_bridge_runtime.py tests/test_verify_whatsapp_bridge_runtime.py tests/test_verify_local_hermes_voice_stack.py
- git diff --check
- python3 -m unittest discover tests
- live bridge strict check without expected number fails with `Expected WhatsApp agent number is required but not configured` while still reporting observed Quill identity
- live default stack smoke reports `expected_number=<none> expected_number_enforced=False expected_number_required=False`
- live strict stack smoke with `--expected-whatsapp-agent-number 13236478455 --expected-whatsapp-agent-name Quill --require-expected-whatsapp-agent-number` reports `expected_number=13236478455 expected_number_enforced=True expected_number_required=True expected_name=Quill expected_name_enforced=True`; final failure category remains `external_meta_setup` because Meta Cloud credentials are still missing