### PR TITLE
Require expected identity in alpha handoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ scripts/verify_local_hermes_voice_stack.sh \
   --hermes-home ~/.hermes \
   --whatsapp-alpha-profile attended-cache-receive \
   --whatsapp-alpha-json-output ./whatsapp-alpha.json \
+  --require-expected-whatsapp-agent-number \
   --require-whatsapp-alpha-complete
 ```
 

--- a/docs/whatsapp-calling-webrtc.md
+++ b/docs/whatsapp-calling-webrtc.md
@@ -87,6 +87,7 @@ The same stack gate can run the categorized alpha report as an explicit opt-in:
 scripts/verify_local_hermes_voice_stack.sh \
   --hermes-home ~/.hermes \
   --whatsapp-alpha-profile cached-receive \
+  --require-expected-whatsapp-agent-number \
   --whatsapp-alpha-json-output ./whatsapp-alpha.json
 ```
 
@@ -232,6 +233,7 @@ and Calling setup are all expected to pass:
 scripts/verify_whatsapp_alpha_readiness.py \
   --hermes-home ~/.hermes \
   --profile attended-cache-receive \
+  --require-expected-agent-number \
   --require-whatsapp-cloud \
   --require-whatsapp-calling \
   --check-whatsapp-cloud-api \

--- a/scripts/verify_whatsapp_alpha_readiness.py
+++ b/scripts/verify_whatsapp_alpha_readiness.py
@@ -249,6 +249,8 @@ def alpha_handoff_base_command(args: argparse.Namespace) -> list[str]:
         command.extend(["--expected-agent-number", args.expected_agent_number])
     if args.expected_agent_name:
         command.extend(["--expected-agent-name", args.expected_agent_name])
+    if args.require_expected_agent_number:
+        command.append("--require-expected-agent-number")
     return command
 
 
@@ -483,6 +485,8 @@ def build_components(args: argparse.Namespace) -> list[dict[str, Any]]:
         bridge_cmd.extend(["--expected-agent-number", args.expected_agent_number])
     if args.expected_agent_name:
         bridge_cmd.extend(["--expected-agent-name", args.expected_agent_name])
+    if args.require_expected_agent_number:
+        bridge_cmd.append("--require-expected-agent-number")
     if args.check_whatsapp_cloud_api:
         bridge_cmd.append("--check-whatsapp-cloud-api")
     if args.check_whatsapp_cloud_health:
@@ -1352,6 +1356,15 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--expected-agent-number", default=os.environ.get("WHATSAPP_AGENT_NUMBER"))
     parser.add_argument("--expected-agent-name", default=os.environ.get("WHATSAPP_AGENT_NAME"))
+    parser.add_argument(
+        "--require-expected-agent-number",
+        "--require-expected-whatsapp-agent-number",
+        action="store_true",
+        help=(
+            "fail the bridge identity check unless an expected WhatsApp agent "
+            "number is configured"
+        ),
+    )
     parser.add_argument("--text", default=DEFAULT_TEXT)
     parser.add_argument(
         "--attended-prompt-text",

--- a/tests/test_verify_whatsapp_alpha_readiness.py
+++ b/tests/test_verify_whatsapp_alpha_readiness.py
@@ -620,6 +620,7 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
                 "13236478455",
                 "--expected-agent-name",
                 "Quill",
+                "--require-expected-agent-number",
                 "--bridge-url",
                 "http://127.0.0.1:3999",
                 "--sidecar-url",
@@ -653,6 +654,7 @@ class WhatsAppAlphaReadinessTests(unittest.TestCase):
             self.assertIn("13236478455", command)
             self.assertIn("--expected-agent-name", command)
             self.assertIn("Quill", command)
+            self.assertIn("--require-expected-agent-number", command)
 
     def test_require_complete_fails_when_alpha_gates_are_pending(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- add strict expected-agent identity forwarding to `verify_whatsapp_alpha_readiness.py`
- preserve the identity requirement in generated Cloud/Calling verify and complete handoff commands
- update strict runbook examples to require expected WhatsApp identity

## Verification
- python3 -m unittest tests.test_verify_whatsapp_alpha_readiness
- python3 -m py_compile scripts/verify_whatsapp_alpha_readiness.py tests/test_verify_whatsapp_alpha_readiness.py
- git diff --check
- python3 -m unittest discover tests
- live standalone alpha smoke with `--require-expected-agent-number`: bridge command includes `--require-expected-agent-number`, local checks passed, attended receive verified, and the result remains `external_meta_setup_required=True` because Meta Cloud credentials are still missing