### PR TITLE
Add Voxtral runtime cache fast path

### DIFF
--- a/crates/voice-audio/src/lib.rs
+++ b/crates/voice-audio/src/lib.rs
@@ -464,6 +464,23 @@ mod tests {
         let bytes = std::fs::read(&path).expect("read wav");
         assert!(bytes.starts_with(b"RIFF"));
         assert_eq!(&bytes[8..12], b"WAVE");
+
+        let mut reader = hound::WavReader::open(&path).expect("read saved wav");
+        let spec = reader.spec();
+        assert_eq!(spec.channels, 1);
+        assert_eq!(spec.sample_rate, 24_000);
+        assert_eq!(spec.bits_per_sample, 32);
+        assert_eq!(spec.sample_format, hound::SampleFormat::Float);
+
+        let decoded = reader
+            .samples::<f32>()
+            .collect::<Result<Vec<_>, _>>()
+            .expect("decode saved wav samples");
+        assert_eq!(decoded.len(), samples.len());
+        let rms = (decoded.iter().map(|sample| sample * sample).sum::<f32>()
+            / decoded.len() as f32)
+            .sqrt();
+        assert!(rms > 0.0);
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/voice-tts/src/lib.rs
+++ b/crates/voice-tts/src/lib.rs
@@ -257,3 +257,39 @@ fn find_safetensors(dir: &Path) -> Result<PathBuf> {
     }
     Err(VoicersError::Model(format!("no safetensors in {:?}", dir)))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_path(extension: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "voice_tts_test_{}_{}.{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("unnamed"),
+            extension
+        ))
+    }
+
+    #[test]
+    fn save_wav_writes_mono_float_samples() {
+        let path = temp_path("wav");
+        let samples = vec![0.0, 0.25, -0.25, 0.5, -0.5];
+        save_wav(&samples, &path, 24_000).expect("save wav");
+
+        let mut reader = hound::WavReader::open(&path).expect("read saved wav");
+        let spec = reader.spec();
+        assert_eq!(spec.channels, 1);
+        assert_eq!(spec.sample_rate, 24_000);
+        assert_eq!(spec.bits_per_sample, 32);
+        assert_eq!(spec.sample_format, hound::SampleFormat::Float);
+
+        let decoded = reader
+            .samples::<f32>()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .expect("decode saved wav samples");
+        assert_eq!(decoded, samples);
+
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/crates/voice-voxtral/src/assets.rs
+++ b/crates/voice-voxtral/src/assets.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use hf_hub::api::sync::Api;
 
-use crate::{Result, VoxtralConfig, VoxtralError, VOXTRAL_PRESET_VOICES};
+use crate::{get_preset_voice, Result, VoxtralConfig, VoxtralError, VOXTRAL_PRESET_VOICES};
 
 pub const DEFAULT_REPO: &str = "mistralai/Voxtral-4B-TTS-2603";
 pub const CONFIG_FILE: &str = "params.json";
@@ -93,6 +93,26 @@ impl VoxtralAssetResolver {
         }
     }
 
+    pub fn resolve_voice_embedding(&self, voice: &str) -> Result<PathBuf> {
+        match &self.source {
+            VoxtralSource::Local(dir) => {
+                let voice_dir = dir.join(VOICE_EMBEDDING_DIR);
+                require_file(voice_dir.join(format!("{voice}.pt")), voice)
+            }
+            VoxtralSource::Hub(repo_id) => {
+                if get_preset_voice(voice).is_none() {
+                    return Err(VoxtralError::InvalidConfig(format!(
+                        "unknown Voxtral preset voice {voice:?}"
+                    )));
+                }
+                let api = Api::new().map_err(|e| VoxtralError::Hub(e.to_string()))?;
+                let repo = api.model(repo_id.to_string());
+                repo.get(&format!("{VOICE_EMBEDDING_DIR}/{voice}.pt"))
+                    .map_err(|e| VoxtralError::Hub(e.to_string()))
+            }
+        }
+    }
+
     pub fn load_config(&self) -> Result<VoxtralConfig> {
         VoxtralConfig::from_path(self.resolve_config()?)
     }
@@ -107,16 +127,11 @@ impl VoxtralAssetResolver {
         };
         let voice_embedding_dir = dir.join(VOICE_EMBEDDING_DIR);
         let voice_embedding_dir = voice_embedding_dir.is_dir().then_some(voice_embedding_dir);
-        let voice_embeddings = if include_weights {
-            let dir = voice_embedding_dir.as_ref().ok_or_else(|| {
-                VoxtralError::InvalidConfig(format!(
-                    "missing required {VOICE_EMBEDDING_DIR} directory"
-                ))
-            })?;
-            resolve_local_voice_embeddings(dir)?
-        } else {
-            BTreeMap::new()
-        };
+        let voice_embeddings = voice_embedding_dir
+            .as_ref()
+            .map(|dir| resolve_local_voice_embeddings(dir))
+            .transpose()?
+            .unwrap_or_default();
 
         Ok(VoxtralAssetPaths {
             params_json,
@@ -143,19 +158,7 @@ impl VoxtralAssetResolver {
         } else {
             None
         };
-        let voice_embeddings = if include_weights {
-            let mut embeddings = BTreeMap::new();
-            for voice in VOXTRAL_PRESET_VOICES {
-                let filename = format!("{VOICE_EMBEDDING_DIR}/{}.pt", voice.id);
-                let path = repo
-                    .get(&filename)
-                    .map_err(|e| VoxtralError::Hub(e.to_string()))?;
-                embeddings.insert(voice.id.to_string(), path);
-            }
-            embeddings
-        } else {
-            BTreeMap::new()
-        };
+        let voice_embeddings: BTreeMap<String, PathBuf> = BTreeMap::new();
         let voice_embedding_dir = voice_embeddings
             .values()
             .next()
@@ -174,8 +177,10 @@ impl VoxtralAssetResolver {
 fn resolve_local_voice_embeddings(dir: &Path) -> Result<BTreeMap<String, PathBuf>> {
     let mut embeddings = BTreeMap::new();
     for voice in VOXTRAL_PRESET_VOICES {
-        let path = require_file(dir.join(format!("{}.pt", voice.id)), voice.id)?;
-        embeddings.insert(voice.id.to_string(), path);
+        let path = dir.join(format!("{}.pt", voice.id));
+        if path.is_file() {
+            embeddings.insert(voice.id.to_string(), path);
+        }
     }
     Ok(embeddings)
 }
@@ -231,6 +236,37 @@ mod tests {
         assert_eq!(assets.weights, None);
         assert!(assets.voice_embeddings.is_empty());
         assert!(resolver.resolve_all().is_err());
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn local_inference_resolution_accepts_partial_voice_directory() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "voice-voxtral-assets-partial-{}-{stamp}",
+            std::process::id()
+        ));
+        let voice_dir = dir.join(VOICE_EMBEDDING_DIR);
+        std::fs::create_dir_all(&voice_dir).unwrap();
+        std::fs::write(dir.join(CONFIG_FILE), "{}").unwrap();
+        std::fs::write(dir.join(TOKENIZER_FILE), "{}").unwrap();
+        std::fs::write(dir.join(WEIGHTS_FILE), b"").unwrap();
+        std::fs::write(voice_dir.join("casual_male.pt"), b"").unwrap();
+
+        let resolver = VoxtralAssetResolver::new(VoxtralSource::Local(dir.clone()));
+        let assets = resolver.resolve_all().unwrap();
+
+        assert_eq!(assets.voice_embeddings.len(), 1);
+        assert_eq!(
+            assets.voice_embeddings.get("casual_male"),
+            Some(&voice_dir.join("casual_male.pt"))
+        );
+        assert!(resolver.resolve_voice_embedding("casual_male").is_ok());
+        assert!(resolver.resolve_voice_embedding("casual_female").is_err());
 
         std::fs::remove_dir_all(dir).unwrap();
     }

--- a/crates/voice-voxtral/src/bin/voxtral-perf.rs
+++ b/crates/voice-voxtral/src/bin/voxtral-perf.rs
@@ -1,0 +1,404 @@
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use candle_core::{DType, Device};
+use serde::Serialize;
+use voice_voxtral::{VoxtralGenerationOptions, VoxtralTtsRuntime};
+
+#[derive(Debug)]
+struct Args {
+    model_dir: String,
+    device: PerfDevice,
+    dtype: DType,
+    voices: Vec<String>,
+    text: String,
+    max_frames: usize,
+    flow_steps: usize,
+    seed: u64,
+    warm_runs: usize,
+    output_dir: Option<PathBuf>,
+    use_kv_cache: bool,
+    json: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum PerfDevice {
+    #[cfg_attr(not(target_os = "macos"), default)]
+    Cpu,
+    #[cfg_attr(target_os = "macos", default)]
+    Metal,
+}
+
+#[derive(Debug, Serialize)]
+struct PerfReport {
+    model_dir: String,
+    device: PerfDevice,
+    dtype: String,
+    text: String,
+    voices: Vec<String>,
+    warm_runs: usize,
+    max_frames: usize,
+    flow_steps: usize,
+    seed: u64,
+    use_kv_cache: bool,
+    output_dir: Option<String>,
+    module_loads: usize,
+    load: LoadReport,
+    generations: Vec<GenerationReport>,
+    totals: TotalsReport,
+}
+
+#[derive(Debug, Serialize)]
+struct LoadReport {
+    model_ms: f64,
+    module_ms: f64,
+    total_ms: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct GenerationReport {
+    run: usize,
+    voice: String,
+    frames: usize,
+    ended: bool,
+    samples: usize,
+    sample_rate: u32,
+    language_cache: bool,
+    voice_cache_hit: bool,
+    cached_voices_after: usize,
+    voice_load_ms: f64,
+    prompt_ms: f64,
+    language_ms: f64,
+    acoustic_ms: f64,
+    decode_loop_ms: f64,
+    first_frame_ms: Option<f64>,
+    codec_ms: f64,
+    total_ms: f64,
+    output_wav: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct TotalsReport {
+    generation_ms: f64,
+    voice_cache_hits: usize,
+    voice_cache_misses: usize,
+    cached_voices: usize,
+}
+
+impl Args {
+    fn parse() -> Result<Self, Box<dyn Error>> {
+        let mut model_dir: Option<String> = None;
+        let mut device = PerfDevice::default();
+        let mut dtype = DType::F16;
+        let mut voices = vec!["casual_male".to_string()];
+        let mut text = "Voxtral sounds better when the runtime stays warm.".to_string();
+        let mut max_frames = 50usize;
+        let mut flow_steps = 7usize;
+        let mut seed = 0x5658_5452_414c;
+        let mut warm_runs = 1usize;
+        let mut output_dir = None;
+        let mut use_kv_cache = false;
+        let mut json = false;
+
+        let mut args = env::args().skip(1);
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--model-dir" | "--model" => {
+                    model_dir = Some(args.next().ok_or("--model-dir requires a value")?);
+                }
+                "--device" => {
+                    device = parse_device(&args.next().ok_or("--device requires a value")?)?;
+                }
+                "--dtype" => {
+                    dtype = parse_dtype(&args.next().ok_or("--dtype requires a value")?)?;
+                }
+                "--voices" => {
+                    voices = parse_voices(&args.next().ok_or("--voices requires a value")?)?;
+                }
+                "--text" => {
+                    text = args.next().ok_or("--text requires a value")?;
+                }
+                "--max-frames" => {
+                    max_frames = args
+                        .next()
+                        .ok_or("--max-frames requires a value")?
+                        .parse()?;
+                }
+                "--flow-steps" => {
+                    flow_steps = args
+                        .next()
+                        .ok_or("--flow-steps requires a value")?
+                        .parse()?;
+                }
+                "--seed" => {
+                    seed = args.next().ok_or("--seed requires a value")?.parse()?;
+                }
+                "--warm-runs" => {
+                    warm_runs = args.next().ok_or("--warm-runs requires a value")?.parse()?;
+                }
+                "--output-dir" => {
+                    output_dir = Some(PathBuf::from(
+                        args.next().ok_or("--output-dir requires a value")?,
+                    ));
+                }
+                "--kv-cache" => use_kv_cache = true,
+                "--json" => json = true,
+                "-h" | "--help" => {
+                    print_help();
+                    std::process::exit(0);
+                }
+                _ => return Err(format!("unknown argument {arg:?}").into()),
+            }
+        }
+
+        let model_dir =
+            model_dir.ok_or("missing --model-dir PATH or HuggingFace repo id for Voxtral TTS")?;
+        if voices.is_empty() {
+            return Err("--voices must include at least one voice".into());
+        }
+        if max_frames == 0 {
+            return Err("--max-frames must be greater than zero".into());
+        }
+        if flow_steps == 0 {
+            return Err("--flow-steps must be greater than zero".into());
+        }
+        if warm_runs == 0 {
+            return Err("--warm-runs must be greater than zero".into());
+        }
+
+        Ok(Self {
+            model_dir,
+            device,
+            dtype,
+            voices,
+            text,
+            max_frames,
+            flow_steps,
+            seed,
+            warm_runs,
+            output_dir,
+            use_kv_cache,
+            json,
+        })
+    }
+}
+
+impl PerfDevice {
+    fn load(self) -> Result<Device, Box<dyn Error>> {
+        match self {
+            Self::Cpu => Ok(Device::Cpu),
+            Self::Metal => Device::new_metal(0).map_err(|e| e.to_string().into()),
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::parse()?;
+    let device = args.device.load()?;
+    let (mut runtime, load_trace) =
+        VoxtralTtsRuntime::load_with_trace(&args.model_dir, args.dtype, device)?;
+
+    let mut generations = Vec::with_capacity(args.voices.len() * args.warm_runs);
+    for run in 0..args.warm_runs {
+        for voice in &args.voices {
+            let (audio, trace) = runtime.generate_audio_with_trace(
+                &args.text,
+                voice,
+                VoxtralGenerationOptions {
+                    max_frames: args.max_frames,
+                    seed: args.seed,
+                    flow_steps: args.flow_steps,
+                    use_kv_cache: args.use_kv_cache,
+                    ..Default::default()
+                },
+            )?;
+            let output_wav = if let Some(output_dir) = &args.output_dir {
+                fs::create_dir_all(output_dir)?;
+                let path = output_dir.join(format!("run{}_{}.wav", run + 1, file_stem(voice)));
+                write_wav_pcm16(&path, &audio.samples, audio.sample_rate)?;
+                Some(path.display().to_string())
+            } else {
+                None
+            };
+            generations.push(GenerationReport {
+                run: run + 1,
+                voice: voice.clone(),
+                frames: audio.frames,
+                ended: audio.ended,
+                samples: audio.samples.len(),
+                sample_rate: audio.sample_rate,
+                language_cache: trace.language_cache,
+                voice_cache_hit: trace.voice_cache_hit,
+                cached_voices_after: runtime.cached_voice_count(),
+                voice_load_ms: ms(trace.voice_load),
+                prompt_ms: ms(trace.prompt),
+                language_ms: ms(trace.language),
+                acoustic_ms: ms(trace.acoustic),
+                decode_loop_ms: ms(trace.decode_loop),
+                first_frame_ms: trace.first_frame.map(ms),
+                codec_ms: ms(trace.codec),
+                total_ms: ms(trace.total),
+                output_wav,
+            });
+        }
+    }
+
+    let generation_ms = generations
+        .iter()
+        .map(|generation| generation.total_ms)
+        .sum::<f64>();
+    let voice_cache_hits = generations
+        .iter()
+        .filter(|generation| generation.voice_cache_hit)
+        .count();
+    let voice_cache_misses = generations.len() - voice_cache_hits;
+    let report = PerfReport {
+        model_dir: args.model_dir,
+        device: args.device,
+        dtype: format!("{:?}", args.dtype),
+        text: args.text,
+        voices: args.voices,
+        warm_runs: args.warm_runs,
+        max_frames: args.max_frames,
+        flow_steps: args.flow_steps,
+        seed: args.seed,
+        use_kv_cache: args.use_kv_cache,
+        output_dir: args
+            .output_dir
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        module_loads: 1,
+        load: LoadReport {
+            model_ms: ms(load_trace.model_load),
+            module_ms: ms(load_trace.module_load),
+            total_ms: ms(load_trace.total),
+        },
+        totals: TotalsReport {
+            generation_ms,
+            voice_cache_hits,
+            voice_cache_misses,
+            cached_voices: runtime.cached_voice_count(),
+        },
+        generations,
+    };
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_human(&report);
+    }
+
+    Ok(())
+}
+
+fn parse_device(raw: &str) -> Result<PerfDevice, Box<dyn Error>> {
+    match raw {
+        "cpu" => Ok(PerfDevice::Cpu),
+        "metal" => Ok(PerfDevice::Metal),
+        _ => Err(format!("unsupported device {raw:?}; expected cpu or metal").into()),
+    }
+}
+
+fn parse_dtype(raw: &str) -> Result<DType, Box<dyn Error>> {
+    match raw {
+        "f32" => Ok(DType::F32),
+        "f16" => Ok(DType::F16),
+        "bf16" => Ok(DType::BF16),
+        _ => Err(format!("unsupported dtype {raw:?}; expected f32, f16, or bf16").into()),
+    }
+}
+
+fn parse_voices(raw: &str) -> Result<Vec<String>, Box<dyn Error>> {
+    let voices = raw
+        .split(',')
+        .map(str::trim)
+        .filter(|voice| !voice.is_empty())
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    if voices.is_empty() {
+        Err("--voices must include at least one non-empty voice".into())
+    } else {
+        Ok(voices)
+    }
+}
+
+fn ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}
+
+fn print_human(report: &PerfReport) {
+    println!("voxtral_perf.model_dir={}", report.model_dir);
+    println!("voxtral_perf.device={:?}", report.device);
+    println!("voxtral_perf.dtype={}", report.dtype);
+    println!("voxtral_perf.kv_cache={}", report.use_kv_cache);
+    println!("voxtral_perf.module_loads={}", report.module_loads);
+    println!("voxtral_perf.load.model_ms={:.1}", report.load.model_ms);
+    println!("voxtral_perf.load.module_ms={:.1}", report.load.module_ms);
+    println!("voxtral_perf.load.total_ms={:.1}", report.load.total_ms);
+    for generation in &report.generations {
+        println!(
+            "voxtral_perf.generation.run={} voice={} kv_cache={} cache_hit={} frames={} total_ms={:.1} first_frame_ms={:.1} language_ms={:.1} acoustic_ms={:.1} codec_ms={:.1} output_wav={}",
+            generation.run,
+            generation.voice,
+            generation.language_cache,
+            generation.voice_cache_hit,
+            generation.frames,
+            generation.total_ms,
+            generation.first_frame_ms.unwrap_or(0.0),
+            generation.language_ms,
+            generation.acoustic_ms,
+            generation.codec_ms,
+            generation.output_wav.as_deref().unwrap_or("")
+        );
+    }
+}
+
+fn file_stem(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn write_wav_pcm16(path: &Path, samples: &[f32], sample_rate: u32) -> Result<(), Box<dyn Error>> {
+    let data_bytes = samples.len() as u32 * 2;
+    let riff_size = 36u32
+        .checked_add(data_bytes)
+        .ok_or("WAV output is too large")?;
+    let mut file = fs::File::create(path)?;
+    file.write_all(b"RIFF")?;
+    file.write_all(&riff_size.to_le_bytes())?;
+    file.write_all(b"WAVE")?;
+    file.write_all(b"fmt ")?;
+    file.write_all(&16u32.to_le_bytes())?;
+    file.write_all(&1u16.to_le_bytes())?;
+    file.write_all(&1u16.to_le_bytes())?;
+    file.write_all(&sample_rate.to_le_bytes())?;
+    file.write_all(&(sample_rate * 2).to_le_bytes())?;
+    file.write_all(&2u16.to_le_bytes())?;
+    file.write_all(&16u16.to_le_bytes())?;
+    file.write_all(b"data")?;
+    file.write_all(&data_bytes.to_le_bytes())?;
+    for sample in samples {
+        let pcm = (sample.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
+        file.write_all(&pcm.to_le_bytes())?;
+    }
+    Ok(())
+}
+
+fn print_help() {
+    println!(
+        "Usage: voxtral-perf --model-dir PATH [--voices casual_male,casual_female] [--text TEXT] [--warm-runs N] [--max-frames N] [--flow-steps N] [--kv-cache] [--output-dir DIR] [--device cpu|metal] [--dtype f32|f16|bf16] [--json]"
+    );
+}

--- a/crates/voice-voxtral/src/generation.rs
+++ b/crates/voice-voxtral/src/generation.rs
@@ -1,10 +1,12 @@
+use std::collections::BTreeMap;
 use std::f32::consts::TAU;
+use std::time::{Duration, Instant};
 
 use candle_core::{DType, Device, Tensor};
 
 use crate::{
     build_prompt_embeddings, build_prompt_token_ids, load_voice_embedding, Result, VoxtralError,
-    VoxtralModel,
+    VoxtralInferenceModules, VoxtralModel, VoxtralTokenizerMetadata,
 };
 
 #[derive(Debug, Clone)]
@@ -13,6 +15,7 @@ pub struct VoxtralGenerationOptions {
     pub seed: u64,
     pub flow_steps: usize,
     pub cfg_alpha: f32,
+    pub use_kv_cache: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -23,6 +26,35 @@ pub struct VoxtralGeneratedAudio {
     pub ended: bool,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct VoxtralGenerationTrace {
+    pub language_cache: bool,
+    pub voice_cache_hit: bool,
+    pub voice_load: Duration,
+    pub prompt: Duration,
+    pub language: Duration,
+    pub acoustic: Duration,
+    pub decode_loop: Duration,
+    pub codec: Duration,
+    pub first_frame: Option<Duration>,
+    pub total: Duration,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct VoxtralRuntimeLoadTrace {
+    pub model_load: Duration,
+    pub module_load: Duration,
+    pub total: Duration,
+}
+
+pub struct VoxtralTtsRuntime {
+    model: VoxtralModel,
+    modules: VoxtralInferenceModules,
+    dtype: DType,
+    device: Device,
+    voice_cache: BTreeMap<String, Tensor>,
+}
+
 impl Default for VoxtralGenerationOptions {
     fn default() -> Self {
         Self {
@@ -30,7 +62,161 @@ impl Default for VoxtralGenerationOptions {
             seed: 0x5658_5452_414c,
             flow_steps: 7,
             cfg_alpha: 1.2,
+            use_kv_cache: false,
         }
+    }
+}
+
+impl VoxtralTtsRuntime {
+    pub fn load(path_or_repo: &str, dtype: DType, device: Device) -> Result<Self> {
+        Ok(Self::load_with_trace(path_or_repo, dtype, device)?.0)
+    }
+
+    pub fn load_with_trace(
+        path_or_repo: &str,
+        dtype: DType,
+        device: Device,
+    ) -> Result<(Self, VoxtralRuntimeLoadTrace)> {
+        let total_start = Instant::now();
+        let model_start = Instant::now();
+        let model = VoxtralModel::load(path_or_repo)?;
+        let model_load = model_start.elapsed();
+        Self::from_model_with_trace(model, dtype, device, total_start, model_load)
+    }
+
+    pub fn load_from_dir(
+        dir: impl AsRef<std::path::Path>,
+        dtype: DType,
+        device: Device,
+    ) -> Result<Self> {
+        Ok(Self::load_from_dir_with_trace(dir, dtype, device)?.0)
+    }
+
+    pub fn load_from_dir_with_trace(
+        dir: impl AsRef<std::path::Path>,
+        dtype: DType,
+        device: Device,
+    ) -> Result<(Self, VoxtralRuntimeLoadTrace)> {
+        let total_start = Instant::now();
+        let model_start = Instant::now();
+        let model = VoxtralModel::load_from_dir(dir)?;
+        let model_load = model_start.elapsed();
+        Self::from_model_with_trace(model, dtype, device, total_start, model_load)
+    }
+
+    pub fn load_default(path_or_repo: &str) -> Result<Self> {
+        Ok(Self::load_default_with_trace(path_or_repo)?.0)
+    }
+
+    pub fn load_default_with_trace(path_or_repo: &str) -> Result<(Self, VoxtralRuntimeLoadTrace)> {
+        #[cfg(target_os = "macos")]
+        {
+            let device = Device::new_metal(0).map_err(|e| VoxtralError::Candle(e.to_string()))?;
+            Self::load_with_trace(path_or_repo, DType::F16, device)
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            Self::load_with_trace(path_or_repo, DType::F32, Device::Cpu)
+        }
+    }
+
+    fn from_model_with_trace(
+        model: VoxtralModel,
+        dtype: DType,
+        device: Device,
+        total_start: Instant,
+        model_load: Duration,
+    ) -> Result<(Self, VoxtralRuntimeLoadTrace)> {
+        let module_start = Instant::now();
+        let modules = model.load_inference_modules(dtype, &device)?;
+        let module_load = module_start.elapsed();
+        let trace = VoxtralRuntimeLoadTrace {
+            model_load,
+            module_load,
+            total: total_start.elapsed(),
+        };
+
+        Ok((
+            Self {
+                model,
+                modules,
+                dtype,
+                device,
+                voice_cache: BTreeMap::new(),
+            },
+            trace,
+        ))
+    }
+
+    pub fn config(&self) -> &crate::VoxtralConfig {
+        self.model.config()
+    }
+
+    pub fn dtype(&self) -> DType {
+        self.dtype
+    }
+
+    pub fn device(&self) -> &Device {
+        &self.device
+    }
+
+    pub fn cached_voice_count(&self) -> usize {
+        self.voice_cache.len()
+    }
+
+    pub fn preload_voice(&mut self, voice: &str) -> Result<()> {
+        self.voice_embedding(voice).map(|_| ())
+    }
+
+    pub fn generate_audio(
+        &mut self,
+        text: &str,
+        voice: &str,
+        options: VoxtralGenerationOptions,
+    ) -> Result<VoxtralGeneratedAudio> {
+        Ok(self.generate_audio_with_trace(text, voice, options)?.0)
+    }
+
+    pub fn generate_audio_with_trace(
+        &mut self,
+        text: &str,
+        voice: &str,
+        options: VoxtralGenerationOptions,
+    ) -> Result<(VoxtralGeneratedAudio, VoxtralGenerationTrace)> {
+        let total_start = Instant::now();
+        let (voice_embeddings, voice_cache_hit, voice_load) = self.voice_embedding(voice)?;
+        let (audio, mut trace) = generate_audio_inner(GenerateAudioInner {
+            config: self.model.config(),
+            tokenizer: self
+                .model
+                .tokenizer()
+                .ok_or_else(|| VoxtralError::InvalidTokenizer("missing tekken.json".into()))?,
+            modules: &self.modules,
+            text,
+            voice,
+            voice_embeddings: &voice_embeddings,
+            device: &self.device,
+            options,
+        })?;
+        trace.voice_cache_hit = voice_cache_hit;
+        trace.voice_load = voice_load;
+        trace.total = total_start.elapsed();
+        Ok((audio, trace))
+    }
+
+    fn voice_embedding(&mut self, voice: &str) -> Result<(Tensor, bool, Duration)> {
+        if let Some(embedding) = self.voice_cache.get(voice) {
+            return Ok((embedding.clone(), true, Duration::ZERO));
+        }
+
+        let start = Instant::now();
+        let voice_path = self.model.resolve_voice_embedding_path(voice)?;
+        let embedding = load_voice_embedding(&voice_path, self.dtype, &self.device)?;
+        let elapsed = start.elapsed();
+        self.voice_cache
+            .insert(voice.to_string(), embedding.clone());
+        Ok((embedding, false, elapsed))
     }
 }
 
@@ -65,114 +251,187 @@ impl VoxtralModel {
         let tokenizer = self
             .tokenizer()
             .ok_or_else(|| VoxtralError::InvalidTokenizer("missing tekken.json".into()))?;
-        let assets = self.assets().ok_or_else(|| {
-            VoxtralError::InvalidCheckpoint("model was loaded without resolved assets".into())
-        })?;
-        let voice_path = assets.voice_embeddings.get(voice).ok_or_else(|| {
-            VoxtralError::InvalidCheckpoint(format!("voice embedding {voice:?} was not resolved"))
-        })?;
         let modules = self.load_inference_modules(dtype, device)?;
-
-        let encoder = tokenizer.encoder()?;
-        let text_token_ids = encoder.encode(text)?;
+        let voice_path = self.resolve_voice_embedding_path(voice)?;
         let voice_embeddings = load_voice_embedding(voice_path, dtype, device)?;
-        let voice_frames = candle(voice_embeddings.dim(0))?;
-        if let Some(expected_voice_frames) = tokenizer.voice_audio_tokens(voice) {
-            if expected_voice_frames != voice_frames {
-                return Err(VoxtralError::InvalidCheckpoint(format!(
-                    "voice {voice:?} has {voice_frames} rows but tekken metadata expects {expected_voice_frames}"
-                )));
-            }
-        }
+        Ok(generate_audio_inner(GenerateAudioInner {
+            config,
+            tokenizer,
+            modules: &modules,
+            text,
+            voice,
+            voice_embeddings: &voice_embeddings,
+            device,
+            options,
+        })?
+        .0)
+    }
+}
 
-        let prompt = build_prompt_token_ids(config, tokenizer, voice_frames, &text_token_ids)?;
-        let prompt_embeddings =
-            build_prompt_embeddings(&modules.embeddings, &prompt, &voice_embeddings, device)?;
-        let audio_token_id = usize::try_from(config.multimodal.audio_model_args.audio_token_id)
-            .map_err(|_| {
-                VoxtralError::InvalidConfig(format!(
-                    "audio_token_id must be non-negative, got {}",
-                    config.multimodal.audio_model_args.audio_token_id
-                ))
-            })?;
-        let audio_embedding = candle(
+struct GenerateAudioInner<'a> {
+    config: &'a crate::VoxtralConfig,
+    tokenizer: &'a VoxtralTokenizerMetadata,
+    modules: &'a VoxtralInferenceModules,
+    text: &'a str,
+    voice: &'a str,
+    voice_embeddings: &'a Tensor,
+    device: &'a Device,
+    options: VoxtralGenerationOptions,
+}
+
+fn generate_audio_inner(
+    request: GenerateAudioInner<'_>,
+) -> Result<(VoxtralGeneratedAudio, VoxtralGenerationTrace)> {
+    let GenerateAudioInner {
+        config,
+        tokenizer,
+        modules,
+        text,
+        voice,
+        voice_embeddings,
+        device,
+        options,
+    } = request;
+    let total_start = Instant::now();
+    let mut trace = VoxtralGenerationTrace::default();
+    let dtype = voice_embeddings.dtype();
+
+    let prompt_start = Instant::now();
+    let encoder = tokenizer.encoder()?;
+    let text_token_ids = encoder.encode(text)?;
+    let voice_frames = candle(voice_embeddings.dim(0))?;
+    if let Some(expected_voice_frames) = tokenizer.voice_audio_tokens(voice) {
+        if expected_voice_frames != voice_frames {
+            return Err(VoxtralError::InvalidCheckpoint(format!(
+                "voice {voice:?} has {voice_frames} rows but tekken metadata expects {expected_voice_frames}"
+            )));
+        }
+    }
+
+    let prompt = build_prompt_token_ids(config, tokenizer, voice_frames, &text_token_ids)?;
+    let prompt_embeddings =
+        build_prompt_embeddings(&modules.embeddings, &prompt, voice_embeddings, device)?;
+    let audio_token_id = usize::try_from(config.multimodal.audio_model_args.audio_token_id)
+        .map_err(|_| {
+            VoxtralError::InvalidConfig(format!(
+                "audio_token_id must be non-negative, got {}",
+                config.multimodal.audio_model_args.audio_token_id
+            ))
+        })?;
+    let audio_embedding = candle(
+        modules
+            .embeddings
+            .token_embeddings(&[audio_token_id], device),
+    )?;
+    let mut decode_embeddings = candle(Tensor::cat(&[prompt_embeddings, audio_embedding], 1))?;
+    let mut decode_input = decode_embeddings.clone();
+    let mut language_cache = options.use_kv_cache.then(|| modules.language.new_cache());
+    let timesteps = flow_timesteps(options.flow_steps)?;
+    trace.language_cache = options.use_kv_cache;
+    trace.prompt = prompt_start.elapsed();
+
+    let loop_start = Instant::now();
+    let mut code_frames = Vec::with_capacity(options.max_frames * config.num_codebooks());
+    let mut ended = false;
+
+    for frame_idx in 0..options.max_frames {
+        let language_start = Instant::now();
+        let hidden = if let Some(cache) = language_cache.as_mut() {
+            let start_pos = cache.len();
+            candle(modules.language.forward_causal_cached(
+                &decode_input,
+                start_pos,
+                config.rope_theta,
+                cache,
+            ))?
+        } else {
+            candle(
+                modules
+                    .language
+                    .forward_causal(&decode_embeddings, 0, config.rope_theta),
+            )?
+        };
+        let last_pos = candle(hidden.dim(1))? - 1;
+        let last_hidden = candle(
+            hidden
+                .narrow(1, last_pos, 1)
+                .and_then(|hidden| hidden.reshape((1, config.dim))),
+        )?;
+        trace.language += language_start.elapsed();
+
+        let acoustic_start = Instant::now();
+        let initial_noise = deterministic_noise(
+            options.seed,
+            frame_idx,
+            config.multimodal.audio_model_args.n_acoustic_codebook,
+            dtype,
+            device,
+        )?;
+        let frame_codes = candle(modules.acoustic.predict_frame_codes_from_noise(
+            config,
+            &last_hidden,
+            &initial_noise,
+            &timesteps,
+            options.cfg_alpha,
+        ))?;
+        trace.acoustic += acoustic_start.elapsed();
+        trace
+            .first_frame
+            .get_or_insert_with(|| loop_start.elapsed());
+
+        let frame = candle(frame_codes.to_vec2::<u32>())?.remove(0);
+        if frame[0] == 1 {
+            ended = true;
+            break;
+        }
+        code_frames.extend_from_slice(&frame);
+
+        let next_embedding = candle(
             modules
                 .embeddings
-                .token_embeddings(&[audio_token_id], device),
+                .audio_codes_embedding(config, &frame_codes),
         )?;
-        let mut decode_embeddings = candle(Tensor::cat(&[prompt_embeddings, audio_embedding], 1))?;
-        let timesteps = flow_timesteps(options.flow_steps)?;
-        let mut code_frames = Vec::with_capacity(options.max_frames * config.num_codebooks());
-        let mut ended = false;
-
-        for frame_idx in 0..options.max_frames {
-            let hidden = candle(modules.language.forward_causal(
-                &decode_embeddings,
-                0,
-                config.rope_theta,
-            ))?;
-            let last_pos = candle(decode_embeddings.dim(1))? - 1;
-            let last_hidden = candle(
-                hidden
-                    .narrow(1, last_pos, 1)
-                    .and_then(|hidden| hidden.reshape((1, config.dim))),
-            )?;
-            let initial_noise = deterministic_noise(
-                options.seed,
-                frame_idx,
-                config.multimodal.audio_model_args.n_acoustic_codebook,
-                dtype,
-                device,
-            )?;
-            let frame_codes = candle(modules.acoustic.predict_frame_codes_from_noise(
-                config,
-                &last_hidden,
-                &initial_noise,
-                &timesteps,
-                options.cfg_alpha,
-            ))?;
-            let frame = candle(frame_codes.to_vec2::<u32>())?.remove(0);
-            if frame[0] == 1 {
-                ended = true;
-                break;
-            }
-            code_frames.extend_from_slice(&frame);
-
-            let next_embedding = candle(
-                modules
-                    .embeddings
-                    .audio_codes_embedding(config, &frame_codes),
-            )?;
-            let next_embedding = candle(next_embedding.unsqueeze(1))?;
+        let next_embedding = candle(next_embedding.unsqueeze(1))?;
+        if language_cache.is_some() {
+            decode_input = next_embedding;
+        } else {
             decode_embeddings = candle(Tensor::cat(&[decode_embeddings, next_embedding], 1))?;
         }
+    }
+    trace.decode_loop = loop_start.elapsed();
 
-        let frames = code_frames.len() / config.num_codebooks();
-        if frames == 0 {
-            return Err(VoxtralError::Unsupported(
-                "generation produced no audio frames".into(),
-            ));
-        }
-        let codes = candle(Tensor::from_vec(
-            code_frames,
-            (frames, config.num_codebooks()),
-            device,
-        ))?;
-        let codes = candle(codes.transpose(0, 1))?;
-        let codes = candle(codes.unsqueeze(0))?;
-        let waveform = candle(modules.codec.decode_codes_to_waveform(&codes))?;
-        let samples = candle(waveform.to_dtype(DType::F32))?
-            .to_vec3::<f32>()
-            .map_err(|e| VoxtralError::Candle(e.to_string()))?[0][0]
-            .clone();
+    let frames = code_frames.len() / config.num_codebooks();
+    if frames == 0 {
+        return Err(VoxtralError::Unsupported(
+            "generation produced no audio frames".into(),
+        ));
+    }
 
-        Ok(VoxtralGeneratedAudio {
+    let codec_start = Instant::now();
+    let codes = candle(Tensor::from_vec(
+        code_frames,
+        (frames, config.num_codebooks()),
+        device,
+    ))?;
+    let codes = candle(codes.transpose(0, 1))?;
+    let codes = candle(codes.unsqueeze(0))?;
+    let waveform = candle(modules.codec.decode_codes_to_waveform(&codes))?;
+    let samples = candle(waveform.to_dtype(DType::F32))?
+        .to_vec3::<f32>()
+        .map_err(|e| VoxtralError::Candle(e.to_string()))?[0][0]
+        .clone();
+    trace.codec = codec_start.elapsed();
+    trace.total = total_start.elapsed();
+
+    Ok((
+        VoxtralGeneratedAudio {
             samples,
             sample_rate: config.sample_rate(),
             frames,
             ended,
-        })
-    }
+        },
+        trace,
+    ))
 }
 
 fn flow_timesteps(steps: usize) -> Result<Vec<f32>> {

--- a/crates/voice-voxtral/src/lib.rs
+++ b/crates/voice-voxtral/src/lib.rs
@@ -35,7 +35,10 @@ pub use config::{
     MultimodalConfig, VoxtralConfig,
 };
 pub use error::{Result, VoxtralError};
-pub use generation::{VoxtralGeneratedAudio, VoxtralGenerationOptions};
+pub use generation::{
+    VoxtralGeneratedAudio, VoxtralGenerationOptions, VoxtralGenerationTrace,
+    VoxtralRuntimeLoadTrace, VoxtralTtsRuntime,
+};
 pub use model::VoxtralModel;
 pub use prompt::{
     build_prompt_embeddings, build_prompt_token_ids, VoxtralPrompt,
@@ -83,7 +86,8 @@ pub use tokenizer::{
 };
 pub use transformer::{
     VoxtralAcousticTransformer, VoxtralAttention, VoxtralFeedForward, VoxtralInferenceModules,
-    VoxtralLanguageBackbone, VoxtralMultimodalEmbeddings, VoxtralTransformerBlock,
+    VoxtralLanguageBackbone, VoxtralLanguageCache, VoxtralMultimodalEmbeddings,
+    VoxtralTransformerBlock,
 };
 pub use voice_embedding::{
     load_voice_embedding, load_voice_embedding_with_hidden_dim, VOXTRAL_VOICE_EMBEDDING_HIDDEN_DIM,

--- a/crates/voice-voxtral/src/model.rs
+++ b/crates/voice-voxtral/src/model.rs
@@ -12,6 +12,7 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct VoxtralModel {
     config: VoxtralConfig,
+    resolver: Option<VoxtralAssetResolver>,
     assets: Option<VoxtralAssetPaths>,
     tokenizer: Option<VoxtralTokenizerMetadata>,
     weights: Option<VoxtralWeightMetadata>,
@@ -21,6 +22,7 @@ impl VoxtralModel {
     pub fn new(config: VoxtralConfig) -> Self {
         Self {
             config,
+            resolver: None,
             assets: None,
             tokenizer: None,
             weights: None,
@@ -60,6 +62,7 @@ impl VoxtralModel {
 
         Ok(Self {
             config,
+            resolver: Some(resolver.clone()),
             assets: Some(assets),
             tokenizer,
             weights: Some(weights),
@@ -84,6 +87,20 @@ impl VoxtralModel {
 
     pub fn checkpoint_summary(&self) -> Option<crate::VoxtralCheckpointSummary> {
         self.weights.as_ref().map(|weights| weights.summary())
+    }
+
+    pub fn resolve_voice_embedding_path(&self, voice: &str) -> Result<std::path::PathBuf> {
+        if let Some(path) = self
+            .assets
+            .as_ref()
+            .and_then(|assets| assets.voice_embeddings.get(voice))
+        {
+            return Ok(path.clone());
+        }
+        let resolver = self.resolver.as_ref().ok_or_else(|| {
+            VoxtralError::InvalidCheckpoint("model was created without asset resolver".into())
+        })?;
+        resolver.resolve_voice_embedding(voice)
     }
 
     /// Open a Candle VarBuilder over the mmaped safetensors checkpoint.

--- a/crates/voice-voxtral/src/transformer.rs
+++ b/crates/voice-voxtral/src/transformer.rs
@@ -55,6 +55,17 @@ pub struct VoxtralAttention {
     pub head_dim: usize,
 }
 
+#[derive(Debug, Clone)]
+pub struct VoxtralLanguageCache {
+    layers: Vec<VoxtralAttentionCache>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct VoxtralAttentionCache {
+    key: Option<Tensor>,
+    value: Option<Tensor>,
+}
+
 pub struct VoxtralFeedForward {
     pub w1: Linear,
     pub w2: Linear,
@@ -159,6 +170,127 @@ impl VoxtralLanguageBackbone {
             hidden_states = layer.forward_causal(&hidden_states, start_pos, rope_theta)?;
         }
         self.norm.forward(&hidden_states)
+    }
+
+    pub fn new_cache(&self) -> VoxtralLanguageCache {
+        VoxtralLanguageCache::new(self.layers.len())
+    }
+
+    pub fn forward_causal_cached(
+        &self,
+        hidden_states: &Tensor,
+        start_pos: usize,
+        rope_theta: f64,
+        cache: &mut VoxtralLanguageCache,
+    ) -> Result<Tensor> {
+        if cache.layers.len() != self.layers.len() {
+            candle_core::bail!(
+                "language cache has {} layers, expected {}",
+                cache.layers.len(),
+                self.layers.len()
+            );
+        }
+
+        let mut hidden_states = hidden_states.clone();
+        for (layer_idx, layer) in self.layers.iter().enumerate() {
+            hidden_states = layer.forward_causal_cached(
+                &hidden_states,
+                start_pos,
+                rope_theta,
+                cache.layer_mut(layer_idx)?,
+            )?;
+        }
+        self.norm.forward(&hidden_states)
+    }
+}
+
+impl VoxtralLanguageCache {
+    pub fn new(layer_count: usize) -> Self {
+        Self {
+            layers: vec![VoxtralAttentionCache::default(); layer_count],
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.layers
+            .first()
+            .map(VoxtralAttentionCache::len)
+            .unwrap_or(0)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn layer_mut(&mut self, layer_idx: usize) -> Result<&mut VoxtralAttentionCache> {
+        self.layers.get_mut(layer_idx).ok_or_else(|| {
+            candle_core::Error::Msg(format!("missing language cache for layer {layer_idx}"))
+        })
+    }
+}
+
+impl VoxtralAttentionCache {
+    fn len(&self) -> usize {
+        self.key.as_ref().map(|key| key.dims()[2]).unwrap_or(0)
+    }
+
+    fn update(&mut self, key: Tensor, value: Tensor) -> Result<(Tensor, Tensor)> {
+        let key_dims = key.dims();
+        let value_dims = value.dims();
+        if key_dims.len() != 4 || value_dims.len() != 4 {
+            candle_core::bail!(
+                "attention cache expects rank-4 key/value tensors, got {:?} and {:?}",
+                key_dims,
+                value_dims
+            );
+        }
+        if key_dims[0] != value_dims[0]
+            || key_dims[1] != value_dims[1]
+            || key_dims[2] != value_dims[2]
+            || key_dims[3] != value_dims[3]
+        {
+            candle_core::bail!("key/value cache dims differ: {key_dims:?} vs {value_dims:?}");
+        }
+
+        match (&self.key, &self.value) {
+            (None, None) => {
+                self.key = Some(key.clone());
+                self.value = Some(value.clone());
+                Ok((key, value))
+            }
+            (Some(cached_key), Some(cached_value)) => {
+                let cached_key_dims = cached_key.dims();
+                let cached_value_dims = cached_value.dims();
+                if cached_key_dims.len() != 4 || cached_value_dims.len() != 4 {
+                    candle_core::bail!(
+                        "cached key/value tensors must be rank 4, got {:?} and {:?}",
+                        cached_key_dims,
+                        cached_value_dims
+                    );
+                }
+                if cached_key_dims[0] != key_dims[0]
+                    || cached_key_dims[1] != key_dims[1]
+                    || cached_key_dims[3] != key_dims[3]
+                    || cached_value_dims[0] != value_dims[0]
+                    || cached_value_dims[1] != value_dims[1]
+                    || cached_value_dims[3] != value_dims[3]
+                {
+                    candle_core::bail!(
+                        "new key/value dims {:?}/{:?} are incompatible with cached dims {:?}/{:?}",
+                        key_dims,
+                        value_dims,
+                        cached_key_dims,
+                        cached_value_dims
+                    );
+                }
+                let full_key = Tensor::cat(&[cached_key, &key], 2)?;
+                let full_value = Tensor::cat(&[cached_value, &value], 2)?;
+                self.key = Some(full_key.clone());
+                self.value = Some(full_value.clone());
+                Ok((full_key, full_value))
+            }
+            _ => candle_core::bail!("attention cache is partially initialized"),
+        }
     }
 }
 
@@ -452,6 +584,26 @@ impl VoxtralTransformerBlock {
         let ffn_output = self.feed_forward.forward(&ffn_input)?;
         ffn_output + residual
     }
+
+    fn forward_causal_cached(
+        &self,
+        hidden_states: &Tensor,
+        start_pos: usize,
+        rope_theta: f64,
+        cache: &mut VoxtralAttentionCache,
+    ) -> Result<Tensor> {
+        let residual = hidden_states.clone();
+        let attention_input = self.attention_norm.forward(hidden_states)?;
+        let attention_output =
+            self.attention
+                .forward_causal_cached(&attention_input, start_pos, rope_theta, cache)?;
+        let hidden_states = (attention_output + residual)?;
+
+        let residual = hidden_states.clone();
+        let ffn_input = self.ffn_norm.forward(&hidden_states)?;
+        let ffn_output = self.feed_forward.forward(&ffn_input)?;
+        ffn_output + residual
+    }
 }
 
 impl VoxtralAttention {
@@ -562,6 +714,71 @@ impl VoxtralAttention {
         let scale = 1.0f64 / (self.head_dim as f64).sqrt();
         let scores = (query.matmul(&key.transpose(D::Minus2, D::Minus1)?)? * scale)?;
         let mask = causal_mask(seq_len, scores.dtype(), scores.device())?;
+        let scores = scores.broadcast_add(&mask)?;
+        let weights = candle_nn::ops::softmax_last_dim(&scores)?;
+        let output = weights.matmul(&value)?.transpose(1, 2)?.reshape((
+            batch,
+            seq_len,
+            self.n_heads * self.head_dim,
+        ))?;
+
+        self.wo.forward_compat(&output)
+    }
+
+    fn forward_causal_cached(
+        &self,
+        hidden_states: &Tensor,
+        start_pos: usize,
+        rope_theta: f64,
+        cache: &mut VoxtralAttentionCache,
+    ) -> Result<Tensor> {
+        let (batch, seq_len, _dim) = hidden_states.dims3()?;
+        if cache.len() != start_pos {
+            candle_core::bail!(
+                "attention cache length {} does not match start_pos {start_pos}",
+                cache.len()
+            );
+        }
+        let repeat = self.n_heads / self.n_kv_heads;
+
+        let query = self
+            .wq
+            .forward_compat(hidden_states)?
+            .reshape((batch, seq_len, self.n_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let key = self
+            .wk
+            .forward_compat(hidden_states)?
+            .reshape((batch, seq_len, self.n_kv_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let value = self
+            .wv
+            .forward_compat(hidden_states)?
+            .reshape((batch, seq_len, self.n_kv_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+
+        let (cos, sin) = rope_frequencies(
+            seq_len,
+            self.head_dim,
+            start_pos,
+            rope_theta,
+            query.dtype(),
+            query.device(),
+        )?;
+        let query = candle_nn::rotary_emb::rope_i(&query, &cos, &sin)?;
+        let key = candle_nn::rotary_emb::rope_i(&key, &cos, &sin)?;
+        let (key, value) = cache.update(key, value)?;
+        let key_len = key.dim(2)?;
+        let key = repeat_kv_heads(&key, repeat)?;
+        let value = repeat_kv_heads(&value, repeat)?;
+
+        let scale = 1.0f64 / (self.head_dim as f64).sqrt();
+        let scores = (query.matmul(&key.transpose(D::Minus2, D::Minus1)?)? * scale)?;
+        let mask =
+            causal_mask_with_offset(seq_len, key_len, start_pos, scores.dtype(), scores.device())?;
         let scores = scores.broadcast_add(&mask)?;
         let weights = candle_nn::ops::softmax_last_dim(&scores)?;
         let output = weights.matmul(&value)?.transpose(1, 2)?.reshape((
@@ -716,6 +933,27 @@ fn causal_mask(seq_len: usize, dtype: DType, device: &Device) -> Result<Tensor> 
     Tensor::from_vec(values, (1, 1, seq_len, seq_len), device)?.to_dtype(dtype)
 }
 
+fn causal_mask_with_offset(
+    query_len: usize,
+    key_len: usize,
+    start_pos: usize,
+    dtype: DType,
+    device: &Device,
+) -> Result<Tensor> {
+    let mut values = Vec::with_capacity(query_len * key_len);
+    for query_pos in 0..query_len {
+        let absolute_query_pos = start_pos + query_pos;
+        for key_pos in 0..key_len {
+            if key_pos <= absolute_query_pos {
+                values.push(0.0);
+            } else {
+                values.push(f32::NEG_INFINITY);
+            }
+        }
+    }
+    Tensor::from_vec(values, (1, 1, query_len, key_len), device)?.to_dtype(dtype)
+}
+
 fn time_embedding(timestep: &Tensor, dim: usize) -> Result<Tensor> {
     let timestep = match timestep.dims() {
         [_batch] => timestep.unsqueeze(1)?,
@@ -754,6 +992,8 @@ fn semantic_logits_mask(config: &VoxtralConfig, device: &candle_core::Device) ->
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use std::collections::HashMap;
+
     use candle_core::{DType, Device};
     use candle_nn::VarBuilder;
 
@@ -895,6 +1135,44 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn cached_language_forward_matches_full_prefix() {
+        let config = tiny_config();
+        let device = Device::Cpu;
+        let tensors = deterministic_language_tensors(&config, &device);
+        let vb = VarBuilder::from_tensors(tensors, DType::F32, &device);
+        let language = VoxtralLanguageBackbone::load(&config, vb).unwrap();
+        let input_values = (0..4 * config.dim)
+            .map(|idx| ((idx % 13) as f32 - 6.0) * 0.03)
+            .collect::<Vec<_>>();
+        let input = Tensor::from_vec(input_values, (1, 4, config.dim), &device).unwrap();
+
+        let full = language
+            .forward_causal(&input, 0, config.rope_theta)
+            .unwrap();
+        let mut cache = language.new_cache();
+        let prefill_input = input.narrow(1, 0, 3).unwrap();
+        let step_input = input.narrow(1, 3, 1).unwrap();
+        let prefill = language
+            .forward_causal_cached(&prefill_input, 0, config.rope_theta, &mut cache)
+            .unwrap();
+        let step = language
+            .forward_causal_cached(&step_input, 3, config.rope_theta, &mut cache)
+            .unwrap();
+
+        assert_eq!(cache.len(), 4);
+        assert_eq!(prefill.dims(), &[1, 3, config.dim]);
+        assert_eq!(step.dims(), &[1, 1, config.dim]);
+        assert!(
+            max_abs_diff(&full.narrow(1, 0, 3).unwrap(), &prefill) < 1e-4,
+            "cached prefill diverged from full-prefix forward"
+        );
+        assert!(
+            max_abs_diff(&full.narrow(1, 3, 1).unwrap(), &step) < 1e-4,
+            "cached decode step diverged from full-prefix forward"
+        );
+    }
+
+    #[test]
     fn embeds_tiny_audio_codes_for_next_language_step() {
         let config = tiny_config();
         let vb = VarBuilder::zeros(DType::F32, &Device::Cpu);
@@ -1028,5 +1306,115 @@ pub(crate) mod tests {
             &[1, semantic_codebook_output_size(model.config())]
         );
         assert_eq!(frame_codes.dims(), &[1, model.config().num_codebooks()]);
+    }
+
+    fn deterministic_language_tensors(
+        config: &VoxtralConfig,
+        device: &Device,
+    ) -> HashMap<String, Tensor> {
+        let mut tensors = HashMap::new();
+        for layer_idx in 0..config.n_layers {
+            let prefix = format!("layers.{layer_idx}");
+            insert_test_tensor(
+                &mut tensors,
+                format!("{prefix}.attention.wq.weight"),
+                &[config.n_heads * config.head_dim, config.dim],
+                device,
+            );
+            insert_test_tensor(
+                &mut tensors,
+                format!("{prefix}.attention.wk.weight"),
+                &[config.n_kv_heads * config.head_dim, config.dim],
+                device,
+            );
+            insert_test_tensor(
+                &mut tensors,
+                format!("{prefix}.attention.wv.weight"),
+                &[config.n_kv_heads * config.head_dim, config.dim],
+                device,
+            );
+            insert_test_tensor(
+                &mut tensors,
+                format!("{prefix}.attention.wo.weight"),
+                &[config.dim, config.n_heads * config.head_dim],
+                device,
+            );
+            insert_test_tensor(
+                &mut tensors,
+                format!("{prefix}.feed_forward.w1.weight"),
+                &[config.hidden_dim, config.dim],
+                device,
+            );
+            insert_test_tensor(
+                &mut tensors,
+                format!("{prefix}.feed_forward.w2.weight"),
+                &[config.dim, config.hidden_dim],
+                device,
+            );
+            insert_test_tensor(
+                &mut tensors,
+                format!("{prefix}.feed_forward.w3.weight"),
+                &[config.hidden_dim, config.dim],
+                device,
+            );
+            insert_norm_tensor(
+                &mut tensors,
+                format!("{prefix}.attention_norm.weight"),
+                config.dim,
+                device,
+            );
+            insert_norm_tensor(
+                &mut tensors,
+                format!("{prefix}.ffn_norm.weight"),
+                config.dim,
+                device,
+            );
+        }
+        insert_norm_tensor(&mut tensors, "norm.weight".to_string(), config.dim, device);
+        tensors
+    }
+
+    fn insert_test_tensor(
+        tensors: &mut HashMap<String, Tensor>,
+        name: String,
+        dims: &[usize],
+        device: &Device,
+    ) {
+        let len = dims.iter().product::<usize>();
+        let seed = name.bytes().fold(0usize, |acc, byte| {
+            acc.wrapping_mul(31).wrapping_add(byte as usize)
+        });
+        let values = (0..len)
+            .map(|idx| (((idx + seed) % 29) as f32 - 14.0) * 0.015)
+            .collect::<Vec<_>>();
+        tensors.insert(
+            name,
+            Tensor::from_vec(values, dims.to_vec(), device).unwrap(),
+        );
+    }
+
+    fn insert_norm_tensor(
+        tensors: &mut HashMap<String, Tensor>,
+        name: String,
+        dim: usize,
+        device: &Device,
+    ) {
+        tensors.insert(
+            name,
+            Tensor::from_vec(vec![1.0f32; dim], (dim,), device).unwrap(),
+        );
+    }
+
+    fn max_abs_diff(left: &Tensor, right: &Tensor) -> f32 {
+        left.broadcast_sub(right)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .flatten_all()
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap()
+            .into_iter()
+            .fold(0.0, f32::max)
     }
 }


### PR DESCRIPTION
## Summary

- Adds a reusable `VoxtralTtsRuntime` that loads Voxtral TTS modules once, lazily loads voice embeddings, and caches selected voices across generations.
- Makes Voxtral voice asset resolution lazy so local/HF runs do not need to resolve every preset voice up front.
- Adds `voxtral-perf`, a one-process perf harness with cold load, voice load/cache, prompt, language, acoustic, first-frame, codec, and total timings, plus optional WAV output.
- Adds an opt-in language KV-cache path for Voxtral TTS autoregressive decoding with a nonzero-weight full-prefix parity test.
- Adds WAV metadata tests and verifies generated output is mono with nonzero signal, not stereo with a dead channel.

## Verification

```bash
cargo test -p voice-voxtral
cargo test -p voice-eval
cargo check --workspace
cargo clippy --workspace -- -D warnings
cargo check -p voice-voxtral --bins
```

Whisper/WER default no-cache guard:

```bash
cargo run -p voice-eval -- \
  --tts-backend voxtral \
  --tts-model /Users/kylekelley/.cache/voice/voxtral/Voxtral-4B-TTS-2603 \
  --voice casual_male \
  --text "Voxtral support is running from native Rust on this Mac." \
  --output-wav /tmp/voxtral-fastpath.wav \
  --max-frames 50 \
  --json
```

Result: WER `0.0`, 24 kHz, 90,240 samples, 3.76 s.

Channel check:

```bash
ffprobe -v error -select_streams a:0 \
  -show_entries stream=codec_name,sample_rate,channels,channel_layout,bits_per_sample,duration \
  -of default=noprint_wrappers=1 /tmp/voxtral-fastpath.wav
```

Result: `pcm_f32le`, 24 kHz, `channels=1`, 32-bit float, 3.76 s. `ffmpeg astats` reported nonzero RMS and no NaNs/Infs.

## Perf Notes

Short 8-frame smoke, same prompt, 2 flow steps, two warm runs:

- No KV cache: generation total `3497.1 ms`, language `729.4/734.4 ms`.
- KV cache: generation total `1727.6 ms`, language `316.7/301.0 ms`.

50-frame prompt:

- No KV cache: `10946.5 ms` total, `4440.4 ms` language, ended at 47 frames.
- KV cache: `6194.5 ms` total, `1828.9 ms` language, hit the 50-frame limit.

80-frame KV cache WER probe:

- KV cache ended at 69 frames, `8658.4 ms` total, `2491.2 ms` language.
- Whisper scored WER `0.0` against `Voxtral support is running from native Rust on this Mac.`

## Draft Status

Draft for review because the KV-cache path is intentionally opt-in. It passes a deterministic nonzero-weight parity test and produces WER-clean audio with enough frame budget, but Metal/F16 generation is not frame-identical to the full-prefix path on this prompt. The default no-cache path remains unchanged and WER-clean.
