### PR TITLE
[codex] Fix delegated converse duration

### DIFF
--- a/crates/voice-cli/src/main.rs
+++ b/crates/voice-cli/src/main.rs
@@ -1804,12 +1804,27 @@ fn run_converse(args: ConverseArgs) {
 
     // Delegate to daemon if available
     if let Some(mut daemon) = voice_protocol::client::DaemonClient::connect() {
-        match daemon.converse(&text, Some(&args.voice)) {
+        match daemon.converse_with_duration(&text, Some(&args.voice), Some(args.duration * 1_000)) {
             Ok(resp) => {
-                // Extract and print the heard text
+                if interrupted() {
+                    std::process::exit(130);
+                }
+                // Extract and print the heard text from the worker's JSON result.
                 if let Some(result) = resp.result {
                     if let Some(r) = result.get("result").and_then(|v| v.as_str()) {
-                        println!("{}", r);
+                        if let Ok(value) = serde_json::from_str::<serde_json::Value>(r) {
+                            if let Some(text) = value
+                                .get("heard")
+                                .and_then(|heard| heard.get("text"))
+                                .and_then(|text| text.as_str())
+                            {
+                                println!("{text}");
+                            } else {
+                                println!("{r}");
+                            }
+                        } else {
+                            println!("{r}");
+                        }
                     }
                 } else if let Some(err) = resp.error {
                     eprintln!("Daemon error: {}", err.message);

--- a/crates/voice-cli/src/mcp.rs
+++ b/crates/voice-cli/src/mcp.rs
@@ -540,7 +540,11 @@ fn handle_tools_call(
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
                 let text = preprocess_for_daemon(raw, markdown, &session.subs);
-                Some(daemon.converse(&text, arguments.get("voice").and_then(|v| v.as_str())))
+                Some(daemon.converse_with_duration(
+                    &text,
+                    arguments.get("voice").and_then(|v| v.as_str()),
+                    arguments.get("max_duration_ms").and_then(|v| v.as_u64()),
+                ))
             }
             _ => None,
         };

--- a/crates/voice-daemon/src/queue.rs
+++ b/crates/voice-daemon/src/queue.rs
@@ -57,6 +57,7 @@ pub enum VoiceRequest {
     Converse {
         text: String,
         voice: Option<String>,
+        max_duration_ms: Option<u64>,
     },
 }
 
@@ -214,9 +215,17 @@ impl RequestQueue {
         client_id: String,
         text: String,
         voice: Option<String>,
+        max_duration_ms: Option<u64>,
     ) -> String {
-        self.enqueue(client_id, VoiceRequest::Converse { text, voice })
-            .await
+        self.enqueue(
+            client_id,
+            VoiceRequest::Converse {
+                text,
+                voice,
+                max_duration_ms,
+            },
+        )
+        .await
     }
 
     async fn enqueue(&self, client_id: String, request: VoiceRequest) -> String {

--- a/crates/voice-daemon/src/socket.rs
+++ b/crates/voice-daemon/src/socket.rs
@@ -528,7 +528,15 @@ async fn dispatch(
                 Ok(voice) => voice,
                 Err(resp) => return resp,
             };
-            VoiceRequest::Converse { text, voice }
+            let max_duration_ms = match optional_duration_param(&req, "max_duration_ms") {
+                Ok(duration) => duration,
+                Err(resp) => return resp,
+            };
+            VoiceRequest::Converse {
+                text,
+                voice,
+                max_duration_ms,
+            }
         }
         "replay_audio" => {
             let queue_id = match required_string_param(&req, "queue_id") {
@@ -706,9 +714,13 @@ async fn dispatch(
                     .enqueue_listen(client_id.to_string(), max_duration_ms)
                     .await
             }
-            VoiceRequest::Converse { text, voice } => {
+            VoiceRequest::Converse {
+                text,
+                voice,
+                max_duration_ms,
+            } => {
                 queue
-                    .enqueue_converse(client_id.to_string(), text, voice)
+                    .enqueue_converse(client_id.to_string(), text, voice, max_duration_ms)
                     .await
             }
         };

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -324,10 +324,15 @@ pub async fn run(
                         }
                     }
                 }
-                VoiceRequest::Converse { text, voice } => {
+                VoiceRequest::Converse {
+                    text,
+                    voice,
+                    max_duration_ms,
+                } => {
                     let text = text.clone();
                     let voice = voice.clone().or_else(|| Some(config.get_voice_name()));
                     let default_speed = Some(config.get_speed() as f64);
+                    let max_duration_ms = *max_duration_ms;
                     let tts = tts.clone();
                     let stt = stt.clone();
                     let queue_id = entry.id.clone(); // Capture for audio recording
@@ -343,8 +348,8 @@ pub async fn run(
                             Some(&queue_id),
                             &cancelled,
                         )?;
-                        let heard_json = listen(&stt, None, Some(&queue_id))?; // Pass queue_id for answer recording
-                                                                               // Parse both results and combine into the converse format
+                        let heard_json = listen(&stt, max_duration_ms, Some(&queue_id))?; // Pass queue_id for answer recording
+                                                                                          // Parse both results and combine into the converse format
                         let spoke: serde_json::Value =
                             serde_json::from_str(&spoke_json).unwrap_or_default();
                         let heard: serde_json::Value =

--- a/crates/voice-protocol/src/client.rs
+++ b/crates/voice-protocol/src/client.rs
@@ -12,6 +12,8 @@ use std::time::Duration;
 use voice_stream::TtsStreamEvent;
 
 const SOCKET_ENV: &str = "VOICE_DAEMON_SOCKET";
+const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(120);
+const DURATION_CALL_TIMEOUT_PAD: Duration = Duration::from_secs(120);
 
 /// A synchronous client connection to the voice daemon.
 pub struct DaemonClient {
@@ -51,9 +53,7 @@ impl DaemonClient {
     pub fn connect() -> Option<Self> {
         let path = daemon_socket_path();
         let stream = UnixStream::connect(&path).ok()?;
-        stream
-            .set_read_timeout(Some(Duration::from_secs(120)))
-            .ok()?;
+        stream.set_read_timeout(Some(DEFAULT_READ_TIMEOUT)).ok()?;
         stream
             .set_write_timeout(Some(Duration::from_secs(5)))
             .ok()?;
@@ -62,6 +62,25 @@ impl DaemonClient {
 
     /// Send a JSON-RPC request and get the response.
     pub fn call(&mut self, method: &str, params: Value) -> Result<Response, String> {
+        self.call_with_read_timeout(method, params, None)
+    }
+
+    fn call_with_read_timeout(
+        &mut self,
+        method: &str,
+        params: Value,
+        read_timeout: Option<Duration>,
+    ) -> Result<Response, String> {
+        if let Some(timeout) = read_timeout {
+            self.stream
+                .set_read_timeout(Some(timeout))
+                .map_err(|e| format!("set read timeout: {}", e))?;
+        }
+
+        self.call_inner(method, params)
+    }
+
+    fn call_inner(&mut self, method: &str, params: Value) -> Result<Response, String> {
         let req = rpc::Request::new(method, params).with_id(1);
         let json = serde_json::to_vec(&req).map_err(|e| format!("serialize: {}", e))?;
 
@@ -331,16 +350,37 @@ impl DaemonClient {
         if let Some(ms) = max_duration_ms {
             params["max_duration_ms"] = serde_json::json!(ms);
         }
-        self.call("listen", params)
+        self.call_with_read_timeout(
+            "listen",
+            params,
+            max_duration_ms.map(read_timeout_for_max_duration),
+        )
     }
 
     /// Convenience: send a converse request. Blocks until speak+listen completes.
     pub fn converse(&mut self, text: &str, voice: Option<&str>) -> Result<Response, String> {
+        self.converse_with_duration(text, voice, None)
+    }
+
+    /// Convenience: send a converse request with an optional max listen duration.
+    pub fn converse_with_duration(
+        &mut self,
+        text: &str,
+        voice: Option<&str>,
+        max_duration_ms: Option<u64>,
+    ) -> Result<Response, String> {
         let mut params = serde_json::json!({"text": text, "wait": true});
         if let Some(v) = voice {
             params["voice"] = Value::String(v.to_string());
         }
-        self.call("converse", params)
+        if let Some(ms) = max_duration_ms {
+            params["max_duration_ms"] = serde_json::json!(ms);
+        }
+        self.call_with_read_timeout(
+            "converse",
+            params,
+            max_duration_ms.map(read_timeout_for_max_duration),
+        )
     }
 
     /// Convenience: cancel all pending requests from this client.
@@ -382,12 +422,15 @@ impl DaemonClient {
     }
 }
 
+fn read_timeout_for_max_duration(max_duration_ms: u64) -> Duration {
+    Duration::from_millis(max_duration_ms).saturating_add(DURATION_CALL_TIMEOUT_PAD)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::frames::{read_frame_sync, write_frame_sync, Frame};
-    use crate::rpc::{Event, Response};
-    use std::io::Read;
+    use crate::rpc::{Event, Request, Response};
     use std::os::unix::net::UnixListener;
     use std::sync::Mutex;
     use std::thread;
@@ -419,8 +462,7 @@ mod tests {
 
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
-            let mut buf = [0u8; 64];
-            let _ = stream.read(&mut buf).unwrap();
+            let _ = read_frame_sync(&mut stream).unwrap().unwrap();
             write_frame_sync(&mut stream, &Frame::event(b"{}")).unwrap();
         });
 
@@ -453,8 +495,7 @@ mod tests {
 
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
-            let mut buf = [0u8; 128];
-            let _ = stream.read(&mut buf).unwrap();
+            let _ = read_frame_sync(&mut stream).unwrap().unwrap();
             let response =
                 Response::success(Some(1.into()), serde_json::json!({ "status": "idle" }));
             let payload = serde_json::to_vec(&response).unwrap();
@@ -474,6 +515,71 @@ mod tests {
         }
         let _ = std::fs::remove_file(path);
         server.join().unwrap();
+    }
+
+    #[test]
+    fn converse_with_duration_sends_max_duration_ms() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "voice-protocol-converse-test-{}.sock",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).unwrap();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let frame = read_frame_sync(&mut stream).unwrap().unwrap();
+            let request = frame.json::<Request>().unwrap();
+            assert_eq!(request.method, "converse");
+            assert_eq!(request.params["text"], "hello");
+            assert_eq!(request.params["voice"], "af_heart");
+            assert_eq!(request.params["max_duration_ms"], 1500);
+
+            let response = Response::success(
+                Some(1.into()),
+                serde_json::json!({
+                    "queue_id": "q",
+                    "status": "completed",
+                    "result": "{\"heard\":{\"text\":\"ok\"}}",
+                }),
+            );
+            write_frame_sync(
+                &mut stream,
+                &Frame::response(&serde_json::to_vec(&response).unwrap()),
+            )
+            .unwrap();
+        });
+
+        let old = std::env::var(SOCKET_ENV).ok();
+        std::env::set_var(SOCKET_ENV, &path);
+
+        let mut client = DaemonClient::connect().unwrap();
+        let response = client
+            .converse_with_duration("hello", Some("af_heart"), Some(1500))
+            .unwrap();
+
+        assert!(response.error.is_none());
+
+        match old {
+            Some(value) => std::env::set_var(SOCKET_ENV, value),
+            None => std::env::remove_var(SOCKET_ENV),
+        }
+        let _ = std::fs::remove_file(path);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn duration_calls_pad_read_timeout() {
+        assert_eq!(
+            read_timeout_for_max_duration(1_500),
+            Duration::from_millis(121_500)
+        );
+        assert_eq!(
+            read_timeout_for_max_duration(180_000),
+            Duration::from_secs(300)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the delegated `voice converse` path so CLI/MCP duration settings reach the daemon, the CLI prints the heard transcript instead of the daemon's nested JSON payload, and duration-bearing daemon calls have a matching socket read timeout.

## QA Findings

Repro command:

```bash
VOICE_SAVE_RECORDING=0 voice converse -d 1 "QA short converse duration test"
```

Expected:

- `-d 1` limits the listen phase to about 1 second after speech playback.
- CLI output is the heard transcript text, matching the local non-daemon output shape.

Actual with the globally installed binary before this patch:

```json
{"heard":{"duration_ms":3968,"text":"Great, is it working?","tokens":11},"spoke":{"chunks":1,"duration_ms":2824}}
```

The CLI delegated to the daemon, printed the worker's combined JSON string, and did not pass the requested duration. The daemon-side `converse` worker also called `listen(&stt, None, ...)`, so delegated `converse` used the daemon listen default instead of the CLI option.

Interrupt repro:

```bash
zsh -lc 'voice converse -d 1 "QA interrupt converse test" & pid=$!; sleep 4; kill -INT $pid; wait $pid'
```

Actual with the globally installed binary before this patch:

```text
Interrupted.
{"heard":{"duration_ms":13173,"text":"I think part of the problem is that I am not using my headphones.","tokens":20},"spoke":{"chunks":1,"duration_ms":2518}}
```

Root cause: while the CLI blocks on the synchronous daemon RPC, Ctrl+C only sets the CLI's local interrupt flag. The daemon keeps processing the active queue item and eventually returns a result, which the CLI printed.

Source-only timeout finding:

- `DaemonClient::connect()` used a fixed 120-second socket read timeout.
- `listen(max_duration_ms)` and delegated `converse(max_duration_ms)` can legitimately run longer than that when callers request long listens.
- The client could time out before the daemon returns, even though the daemon is still behaving according to the requested duration.

## Changes

- Added `DaemonClient::converse_with_duration(...)` and kept `converse(...)` as a compatibility wrapper.
- Threaded optional `max_duration_ms` through daemon request parsing, queue entries, and worker execution.
- Updated CLI `voice converse` daemon delegation to pass `--duration` as milliseconds.
- Updated MCP daemon delegation for `converse` to pass `max_duration_ms`.
- Updated CLI delegated `converse` output to print `heard.text` when the daemon returns the combined JSON result.
- Added an interrupt guard so a delegated `converse` that returns after Ctrl+C exits 130 instead of printing a stale daemon result.
- Duration-bearing daemon `listen` and `converse` calls now extend the client socket read timeout to `max_duration_ms + 120s`.
- Added protocol coverage that asserts `converse_with_duration` sends `max_duration_ms`.
- Added protocol coverage for the duration timeout calculation.
- Fixed protocol socket tests to read a full framed request instead of a fixed byte buffer, avoiding macOS CI races where the test server replies before the client finishes writing.

## Verification

```bash
cargo test -p voice-protocol
```

Passed: 11 tests.

```bash
for i in 1 2 3 4 5; do
  cargo test -p voice-protocol --lib client::tests::call_rejects_non_response_frame -- --exact --nocapture
  cargo test -p voice-protocol --lib client::tests::call_parses_response_frame -- --exact --nocapture
done
```

Passed.

```bash
git diff --check
```

Passed.

```bash
cargo check -p voice-daemon
```

Blocked before checking changed daemon code because this worktree contains Git LFS pointer files for required embedded assets:

- `crates/voice-tts/data/voices/af_heart.safetensors`
- `crates/voice-g2p/data/tagger/weights.json`

I did not run `git lfs pull` or touch model weights/generated audio per the requested scope.

Manual/live-mic checks still needed after installing this branch with real LFS assets:

```bash
voice converse -d 1 "QA short converse duration test"
zsh -lc 'voice converse -d 1 "QA interrupt converse test" & pid=$!; sleep 4; kill -INT $pid; wait $pid; echo exit:$?'
```

Expected after this patch:

- The first command prints only the heard transcript text, not the combined JSON object.
- The daemon listen phase receives `max_duration_ms=1000`.
- The interrupt command exits 130 from the CLI and does not print a late daemon JSON result.

## Coordination Notes

Non-interactive branch/conflict checks:

```bash
git fetch origin main
git diff --name-status origin/main...HEAD
git merge-tree "$(git merge-base HEAD quod/voxtral-tts-engine)" HEAD quod/voxtral-tts-engine
git merge-tree "$(git merge-base HEAD quod/voxtral-tts)" HEAD quod/voxtral-tts
git merge-tree "$(git merge-base HEAD converse-listen-duration)" HEAD converse-listen-duration
```

Current state:

- This branch is based on current `origin/main` (`0ed7674`).
- No uncommitted source changes remain.
- No text conflict detected against `quod/voxtral-tts-engine`.
- No text conflict detected against `quod/voxtral-runtime-fastpath`.
- Likely text conflict against `quod/voxtral-tts` in `crates/voice-cli/src/main.rs`.
- Likely text conflict against `converse-listen-duration` in `crates/voice-cli/src/main.rs`.
- I did not run additional live `voice converse` checks while Kyle is away.
