### PR TITLE
Add Pullfrog review workflow

### DIFF
--- a/.agents/reviewers/voice-code-review-rubric.md
+++ b/.agents/reviewers/voice-code-review-rubric.md
@@ -1,0 +1,90 @@
+# voice Code Review Rubric
+
+Use this rubric for Pullfrog and other second-pass review runs. It is reviewer
+guidance, not general implementation guidance.
+
+## Operating Mode
+
+Review as a senior voice code reviewer. Stay read-only. Inspect the diff first,
+then the nearest owning code, tests, `AGENTS.md`, release scripts, docs, and
+recent repository patterns when they are relevant. Be terse, adversarial, and
+evidence-backed.
+
+Primary goals:
+
+- Find concrete bugs, behavioral regressions, audio or transcript quality
+  regressions, model-loading mistakes, platform breakage, security issues,
+  concurrency hazards, broken tests, and missing tests that could allow the diff
+  to regress.
+- Also report repo-invariant architecture/style nits when they protect
+  maintainability or user-visible behavior. Examples: changing tensor shapes or
+  device placement without checking Kokoro/Whisper expectations, moving
+  CPU-only work onto a hot audio path, duplicating stream/daemon protocol
+  contracts instead of sharing `voice-stream` or `voice-protocol`, weakening
+  zero-network startup for builtin voices/configs, or letting docs/scripts drift
+  from the shipped CLI surface.
+
+Suppress comments that are only subjective preference, formatting, naming, or
+"could be cleaner" with no concrete invariant, user-visible behavior, runtime
+risk, or test gap. Group repeated instances under one finding. Prefer at most 12
+findings.
+
+## voice Checklist
+
+- Kokoro/TTS inference: preserve tensor shapes, style embedding indexing,
+  phoneme chunk limits, speed handling, sample rates, iSTFT overlap-add behavior,
+  Metal device placement, and CPU fallback behavior where supported.
+- Whisper/STT inference: preserve model selection, tokenizer/config loading,
+  mel preprocessing, resampling, greedy decode/KV-cache behavior, audio duration
+  handling, and meaningful transcript/error reporting.
+- G2P and pronunciation: protect misaki-compatible tokenization, POS tagging,
+  lexicon lookup, morphology, number/currency handling, stress assignment,
+  espeak-ng fallback, legacy symbol conversion, and sentence-boundary chunking.
+- Streaming and daemon contracts: keep `voice-stream` and `voice-protocol` as
+  the shared source of truth for frame shapes, event ordering, daemon RPCs,
+  cancellation, and stream-transcribe behavior. Reject duplicated or divergent
+  constants in CLI, sidecar, Hermes, Telegram, or WhatsApp paths.
+- CLI, MCP, and integrations: verify text/file/stdin resolution, markdown
+  stripping, substitution handling, output formats, daemon detection, JSON-RPC
+  shape, and bridge verifier scripts stay aligned with documented behavior.
+- Platform and release behavior: check Git LFS assumptions, embedded assets,
+  HuggingFace caching, macOS/Apple Silicon Metal paths, Linux CPU paths, release
+  packaging, crate publishing order, and shell/Python verifier portability.
+- Async and process lifecycle: review microphone recording, VAD, playback,
+  daemon startup/shutdown, sidecar services, long-running watch scripts, temp
+  files, and cancellation paths for stale state, blocking, races, or leaked
+  processes.
+- Tests: require focused tests at the changed boundary. Treat deleted tests as
+  suspicious unless the behavior was removed and replacement coverage exists.
+  Prefer deterministic unit or script-level tests for CLI/protocol/config
+  changes, and explicit manual/runtime verification notes for audio, GPU, mic,
+  daemon, or external messaging behavior.
+
+## Finding Contract
+
+Every finding must name a concrete failure mode or invariant drift, explain why
+the diff introduced or exposed it, identify the affected file and line when
+possible, and suggest the smallest useful fix. Do not invent findings. If there
+are no actionable issues, say there are no actionable findings.
+
+Use severity `nit` for non-blocking architecture/style findings. Use higher
+severity only when the finding can cause a bug, security issue, data loss, audio
+or transcript regression, platform breakage, protocol/runtime corruption, or a
+serious review blocker.
+
+Use one of these categories for each finding:
+
+- `correctness`
+- `model_inference`
+- `audio_quality`
+- `g2p_pronunciation`
+- `stt_transcription`
+- `streaming_daemon_protocol`
+- `cli_mcp_surface`
+- `platform_gpu`
+- `packaging_release`
+- `tests`
+- `generated_or_embedded_artifact`
+- `docs_config`
+- `style_maintainability`
+- `infra`

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -1,0 +1,198 @@
+# PULLFROG ACTION - DO NOT EDIT EXCEPT WHERE INDICATED
+name: Pullfrog
+run-name: ${{ inputs.name || github.workflow }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        type: string
+        description: Review prompt
+        required: true
+      name:
+        type: string
+        description: Run name
+      model_id:
+        type: string
+        description: Bedrock model or inference profile ID for OpenCode
+        default: us.anthropic.claude-sonnet-4-6
+
+permissions:
+  contents: read
+
+jobs:
+  pullfrog:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Build review prompt
+        id: review_prompt
+        env:
+          CALLER_PROMPT: ${{ inputs.prompt }}
+        shell: bash
+        run: |
+          delimiter="pullfrog_prompt_${RANDOM}_${RANDOM}"
+          {
+            echo "prompt<<${delimiter}"
+            cat .agents/reviewers/voice-code-review-rubric.md
+            cat <<'PULLFROG_PROMPT'
+
+            Pullfrog output contract:
+            - "✅" means the review completed and found no actionable issues.
+            - "⚠️" means the review found non-blocking risk, missing coverage,
+              uncertainty, or a repo-invariant architecture/style nit the human
+              should consider.
+            - "🚨" means the review found a blocker/high-confidence regression,
+              security/data-loss/platform risk, durable audio/transcript/runtime
+              corruption risk, or the review could not be trusted because of
+              infrastructure/tooling uncertainty.
+
+            Return the structured output by calling Pullfrog's set_output tool.
+            The output must match the provided JSON schema exactly. Do not add
+            markdown, prose, or extra keys outside the schema.
+
+            Caller prompt:
+          PULLFROG_PROMPT
+            printf '%s\n' "$CALLER_PROMPT"
+            echo "${delimiter}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run agent
+        id: review
+        uses: pullfrog/pullfrog@v0
+        with:
+          model: bedrock/byok
+          push: disabled
+          prompt: ${{ steps.review_prompt.outputs.prompt }}
+          output_schema: |
+            {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["verdict", "summary", "findings"],
+              "properties": {
+                "verdict": {
+                  "type": "string",
+                  "enum": ["✅", "⚠️", "🚨"],
+                  "description": "Overall review result."
+                },
+                "summary": {
+                  "type": "string",
+                  "description": "One concise sentence. Say there are no actionable findings when verdict is ✅."
+                },
+                "findings": {
+                  "type": "array",
+                  "maxItems": 12,
+                  "description": "Actionable findings only. Empty when verdict is ✅. Group repeated instances under one finding.",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "severity",
+                      "category",
+                      "file",
+                      "line",
+                      "title",
+                      "evidence",
+                      "suggested_fix",
+                      "confidence"
+                    ],
+                    "properties": {
+                      "severity": {
+                        "type": "string",
+                        "enum": ["blocker", "high", "medium", "low", "nit"]
+                      },
+                      "category": {
+                        "type": "string",
+                        "enum": [
+                          "correctness",
+                          "model_inference",
+                          "audio_quality",
+                          "g2p_pronunciation",
+                          "stt_transcription",
+                          "streaming_daemon_protocol",
+                          "cli_mcp_surface",
+                          "platform_gpu",
+                          "packaging_release",
+                          "tests",
+                          "generated_or_embedded_artifact",
+                          "docs_config",
+                          "style_maintainability",
+                          "infra"
+                        ]
+                      },
+                      "file": {
+                        "type": ["string", "null"],
+                        "description": "Repo-relative file path, or null for infrastructure/tooling findings."
+                      },
+                      "line": {
+                        "type": ["integer", "null"],
+                        "description": "Changed or relevant line number, or null when not applicable."
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "evidence": {
+                        "type": "string",
+                        "description": "Why this is a real bug, regression risk, review blocker, or repo-invariant architecture/style drift."
+                      },
+                      "suggested_fix": {
+                        "type": ["string", "null"]
+                      },
+                      "confidence": {
+                        "type": "string",
+                        "enum": ["high", "medium", "low"]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        env:
+          PULLFROG_AGENT: opencode
+          AWS_REGION: us-east-1
+          BEDROCK_MODEL_ID: ${{ inputs.model_id || 'us.anthropic.claude-sonnet-4-6' }}
+
+      - name: Render review result
+        if: ${{ always() && steps.review.outputs.result != '' }}
+        env:
+          REVIEW_RESULT: ${{ steps.review.outputs.result }}
+        run: |
+          node <<'NODE'
+          const result = JSON.parse(process.env.REVIEW_RESULT);
+          const findings = Array.isArray(result.findings) ? result.findings : [];
+          const lines = [`${result.verdict} ${result.summary}`];
+
+          if (findings.length > 0) {
+            lines.push("", "Findings:");
+            for (const finding of findings) {
+              const location = finding.file
+                ? `${finding.file}${finding.line === null ? "" : `:${finding.line}`}`
+                : "workflow";
+              const category = finding.category ? ` [${finding.category}]` : "";
+              lines.push(
+                `- ${finding.severity.toUpperCase()}${category} ${location} - ${finding.title}`,
+                `  Evidence: ${finding.evidence}`,
+              );
+              if (finding.suggested_fix) {
+                lines.push(`  Fix: ${finding.suggested_fix}`);
+              }
+              lines.push(`  Confidence: ${finding.confidence}`);
+            }
+          }
+
+          const summary = `${lines.join("\n")}\n`;
+          console.log(summary);
+          require("node:fs").appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+
+          if (result.verdict === "🚨") {
+            process.exitCode = 1;
+          }
+          NODE

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ output.wav
 .context/
 .worktrees/
 eval/results/
+
+!.agents/
+!.agents/reviewers/
+!.agents/reviewers/**


### PR DESCRIPTION
## Summary

- Add a manually dispatched Pullfrog workflow for review runs.
- Add a voice-specific reviewer rubric covering TTS/STT inference, G2P, streaming/daemon contracts, CLI/MCP behavior, packaging, and tests.
- Unignore `.agents/reviewers/**` locally so the rubric is tracked even when a global gitignore ignores `.agents`.

## Verification

- `actionlint .github/workflows/pullfrog.yml`
- `ruby -e 'require "yaml"; require "json"; workflow = YAML.load_file(".github/workflows/pullfrog.yml"); schema = workflow.fetch("jobs").fetch("pullfrog").fetch("steps").find { |step| step["id"] == "review" }.fetch("with").fetch("output_schema"); JSON.parse(schema); puts "workflow yaml and schema json ok"'`
- `git diff --check`

## Notes

This PR intentionally keeps the Pullfrog workflow draft-only/manual via `workflow_dispatch`; it does not add automatic PR review triggers.
