### PR TITLE
Stream Voxtral codec chunks

### DIFF
--- a/crates/voice-cli/src/cli.rs
+++ b/crates/voice-cli/src/cli.rs
@@ -1500,6 +1500,7 @@ struct TtsBenchRunReport {
     ended: Option<bool>,
     voxtral_language_cache: Option<bool>,
     voxtral_voice_cache_hit: Option<bool>,
+    voxtral_codec_chunks: Option<usize>,
     voxtral_prompt_ms: Option<f64>,
     voxtral_language_ms: Option<f64>,
     voxtral_acoustic_ms: Option<f64>,
@@ -1648,6 +1649,7 @@ fn bench_kokoro_tts(args: &BenchTtsArgs, text: &str) -> Result<TtsBenchEngineRep
             ended: None,
             voxtral_language_cache: None,
             voxtral_voice_cache_hit: None,
+            voxtral_codec_chunks: None,
             voxtral_prompt_ms: None,
             voxtral_language_ms: None,
             voxtral_acoustic_ms: None,
@@ -1685,8 +1687,9 @@ fn bench_voxtral_tts(args: &BenchTtsArgs, text: &str) -> Result<TtsBenchEngineRe
         let text_prep = text_prep_start.elapsed();
 
         let synth_start = Instant::now();
+        let mut streamed_samples = 0usize;
         let (audio, trace) = runtime
-            .generate_audio_with_trace(
+            .generate_audio_streaming_with_trace(
                 &prepared,
                 &args.voxtral_voice,
                 voxtral_generation_options(
@@ -1694,9 +1697,15 @@ fn bench_voxtral_tts(args: &BenchTtsArgs, text: &str) -> Result<TtsBenchEngineRe
                     args.voxtral_flow_steps,
                     args.voxtral_kv_cache,
                 ),
+                voice_voxtral::VoxtralStreamingConfig::default(),
+                |chunk| {
+                    streamed_samples += chunk.samples.len();
+                    Ok(())
+                },
             )
             .map_err(|e| format!("voxtral synthesis failed: {e}"))?;
         let synth = synth_start.elapsed();
+        debug_assert_eq!(streamed_samples, audio.samples.len());
         let total = total_start.elapsed();
         let output_wav = maybe_write_bench_wav(
             &args.output_dir,
@@ -1714,7 +1723,7 @@ fn bench_voxtral_tts(args: &BenchTtsArgs, text: &str) -> Result<TtsBenchEngineRe
             voice_load_ms: Some(duration_ms(trace.voice_load)),
             synth_ms: duration_ms(synth),
             first_code_frame_ms: trace.first_frame.map(duration_ms),
-            first_audio_ms: duration_ms(total),
+            first_audio_ms: duration_ms(trace.first_audio_chunk.unwrap_or(total)),
             total_ms: duration_ms(total),
             audio_duration_ms: audio_duration_ms(audio.samples.len(), audio.sample_rate),
             samples: audio.samples.len(),
@@ -1724,6 +1733,7 @@ fn bench_voxtral_tts(args: &BenchTtsArgs, text: &str) -> Result<TtsBenchEngineRe
             ended: Some(audio.ended),
             voxtral_language_cache: Some(trace.language_cache),
             voxtral_voice_cache_hit: Some(trace.voice_cache_hit),
+            voxtral_codec_chunks: Some(trace.codec_chunks),
             voxtral_prompt_ms: Some(duration_ms(trace.prompt)),
             voxtral_language_ms: Some(duration_ms(trace.language)),
             voxtral_acoustic_ms: Some(duration_ms(trace.acoustic)),
@@ -1854,7 +1864,7 @@ fn print_tts_bench_report(report: &TtsBenchReport) {
         );
         for run in &engine.runs {
             println!(
-                "tts_bench.run engine={} run={} first_audio_ms={:.1} total_ms={:.1} synth_ms={:.1} audio_ms={:.1} phoneme_ms={} first_code_frame_ms={} output_wav={}",
+                "tts_bench.run engine={} run={} first_audio_ms={:.1} total_ms={:.1} synth_ms={:.1} audio_ms={:.1} phoneme_ms={} first_code_frame_ms={} voxtral_codec_chunks={} output_wav={}",
                 engine.engine,
                 run.run,
                 run.first_audio_ms,
@@ -1866,6 +1876,9 @@ fn print_tts_bench_report(report: &TtsBenchReport) {
                     .unwrap_or_else(|| "-".to_string()),
                 run.first_code_frame_ms
                     .map(|value| format!("{value:.1}"))
+                    .unwrap_or_else(|| "-".to_string()),
+                run.voxtral_codec_chunks
+                    .map(|value| value.to_string())
                     .unwrap_or_else(|| "-".to_string()),
                 run.output_wav.as_deref().unwrap_or("")
             );

--- a/crates/voice-cli/src/cli.rs
+++ b/crates/voice-cli/src/cli.rs
@@ -2737,64 +2737,10 @@ fn run_converse(args: ConverseArgs) {
         std::process::exit(1);
     }
 
-    let text = args.text.join(" ");
-
-    // Delegate to daemon if available
-    if let Some(mut daemon) = voice_protocol::client::DaemonClient::connect() {
-        if !daemon_supports_engine(&mut daemon, args.engine) {
-            eprintln!(
-                "Daemon does not advertise {} support, falling back to local",
-                args.engine.as_str()
-            );
-        } else {
-            match daemon.converse_with_options_and_duration(
-                &text,
-                Some(&voice),
-                daemon_tts_options(
-                    args.engine,
-                    &args.voxtral_model,
-                    args.voxtral_max_frames,
-                    args.voxtral_flow_steps,
-                    args.voxtral_kv_cache,
-                ),
-                Some(args.duration * 1_000),
-            ) {
-                Ok(resp) => {
-                    if interrupted() {
-                        std::process::exit(130);
-                    }
-                    // Extract and print the heard text from the worker's JSON result.
-                    if let Some(result) = resp.result {
-                        if let Some(r) = result.get("result").and_then(|v| v.as_str()) {
-                            if let Ok(value) = serde_json::from_str::<serde_json::Value>(r) {
-                                if let Some(text) = value
-                                    .get("heard")
-                                    .and_then(|heard| heard.get("text"))
-                                    .and_then(|text| text.as_str())
-                                {
-                                    println!("{text}");
-                                } else {
-                                    println!("{r}");
-                                }
-                            } else {
-                                println!("{r}");
-                            }
-                        }
-                    } else if let Some(err) = resp.error {
-                        eprintln!("Daemon error: {}", err.message);
-                    }
-                    return;
-                }
-                Err(e) => {
-                    eprintln!("Daemon error: {e}, falling back to local");
-                }
-            }
-        }
-    }
-
     let sub_file = args.sub_file.clone().or_else(find_sub_file);
     let (subs, phoneme_overrides) = collect_subs(&args.subs, sub_file.as_deref());
 
+    let text = args.text.join(" ");
     let text = if args.markdown {
         strip_markdown(&text)
     } else {
@@ -2807,14 +2753,69 @@ fn run_converse(args: ConverseArgs) {
         apply_substitutions(&text, &subs)
     };
 
+    // Delegate TTS playback to daemon if available, but keep microphone capture
+    // in the foreground CLI process. Background daemon mic capture can wedge in
+    // CoreAudio on macOS, while daemon TTS is the fast queued path we want.
+    if let Some(mut daemon) = voice_protocol::client::DaemonClient::connect() {
+        if !daemon_supports_engine(&mut daemon, args.engine) {
+            eprintln!(
+                "Daemon does not advertise {} support, falling back to local",
+                args.engine.as_str()
+            );
+        } else {
+            let stt_handle = std::thread::spawn(listen::load_stt);
+            match daemon.speak_with_options_and_wait(
+                &text,
+                Some(&voice),
+                Some(args.speed as f64),
+                daemon_tts_options(
+                    args.engine,
+                    &args.voxtral_model,
+                    args.voxtral_max_frames,
+                    args.voxtral_flow_steps,
+                    args.voxtral_kv_cache,
+                ),
+                true,
+            ) {
+                Ok(resp) if resp.error.is_none() => {
+                    let failed = resp
+                        .result
+                        .as_ref()
+                        .and_then(|r| r.get("status"))
+                        .and_then(|s| s.as_str())
+                        == Some("failed");
+                    if failed {
+                        let _ = stt_handle.join();
+                        eprintln!("Daemon speak failed, falling back to local");
+                    } else {
+                        if interrupted() {
+                            std::process::exit(130);
+                        }
+                        finish_converse_listen(stt_handle, args.duration);
+                        return;
+                    }
+                }
+                Ok(resp) => {
+                    let _ = stt_handle.join();
+                    if let Some(err) = resp.error {
+                        eprintln!("Daemon error: {}, falling back to local", err.message);
+                    }
+                }
+                Err(e) => {
+                    let _ = stt_handle.join();
+                    eprintln!("Daemon error: {e}, falling back to local");
+                }
+            }
+        }
+    }
+
     if args.engine == TtsEngine::Voxtral {
         if (args.speed - 1.0).abs() > f32::EPSILON {
             info!("Voxtral does not support --speed yet; generating at model speed");
         }
         let stt_handle = std::thread::spawn(listen::load_stt);
         info!("Loading Voxtral TTS model ({})...", args.voxtral_model);
-        let mut runtime = match voice_voxtral::VoxtralTtsRuntime::load_default(&args.voxtral_model)
-        {
+        let mut runtime = match voice_voxtral::VoxtralTtsRuntime::load_default(&args.voxtral_model) {
             Ok(runtime) => runtime,
             Err(e) => {
                 eprintln!("Failed to load Voxtral model '{}': {e}", args.voxtral_model);

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -25,13 +25,15 @@ use std::path::Path;
 use std::sync::atomic::Ordering;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use rodio::microphone::MicrophoneBuilder;
 use rodio::{buffer::SamplesBuffer, DeviceSinkBuilder, Player};
 use voice_stream::InterleavedMonoMixer;
 
 use crate::{INTERRUPTED, QUIET};
+
+const MIC_OPEN_TIMEOUT_MS: u64 = 8_000;
 
 // ── Sound configuration ───────────────────────────────────────────────
 
@@ -486,6 +488,39 @@ impl Drop for WarmMic {
 /// Uses the default input device. Rodio handles sample format conversion
 /// and multi-channel mixing internally.
 fn open_mic() -> Result<(String, u32, rodio::microphone::Microphone), String> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(open_mic_inner());
+    });
+
+    let timeout = Duration::from_millis(MIC_OPEN_TIMEOUT_MS);
+    let started = Instant::now();
+    loop {
+        if INTERRUPTED.load(Ordering::Relaxed) {
+            return Err("Interrupted".to_string());
+        }
+
+        let elapsed = started.elapsed();
+        if elapsed >= timeout {
+            return Err(format!(
+                "Opening microphone timed out after {}ms",
+                timeout.as_millis()
+            ));
+        }
+
+        let remaining = timeout.saturating_sub(elapsed);
+        let poll = remaining.min(Duration::from_millis(100));
+        match rx.recv_timeout(poll) {
+            Ok(result) => return result,
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return Err("Microphone open worker exited without a result".to_string());
+            }
+        }
+    }
+}
+
+fn open_mic_inner() -> Result<(String, u32, rodio::microphone::Microphone), String> {
     let mic = MicrophoneBuilder::new()
         .default_device()
         .map_err(|e| format!("No input device: {e}"))?

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::num::NonZero;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use voice_audio::AudioOutputFormat;
 use voice_stream::{
     resample_linear, AudioEncoding, InterleavedMonoMixer, Packetizer, StreamEnded, StreamMetadata,
@@ -27,6 +27,7 @@ const STT_REPO: &str = "distil-whisper/distil-large-v3";
 const KOKORO_ENGINE: &str = "kokoro";
 const VOXTRAL_ENGINE: &str = "voxtral";
 const KOKORO_DEFAULT_VOICE: &str = "af_heart";
+const LISTEN_OPEN_GRACE_MS: u64 = 8_000;
 
 // -- TTS state ---------------------------------------------------------------
 
@@ -346,10 +347,12 @@ pub async fn run(
                     let max_ms = *max_duration_ms;
                     let stt = stt.clone();
                     let queue_id = entry.id.clone();
+                    let cancelled = entry.cancelled.clone();
 
-                    let result =
-                        tokio::task::spawn_blocking(move || listen(&stt, max_ms, Some(&queue_id)))
-                            .await;
+                    let result = tokio::task::spawn_blocking(move || {
+                        listen_bounded(&stt, max_ms, Some(&queue_id), &cancelled)
+                    })
+                    .await;
 
                     match result {
                         Ok(Ok(msg)) => {
@@ -393,9 +396,24 @@ pub async fn run(
 
                     // Speak then listen, return combined JSON
                     let speak_result = tokio::task::spawn_blocking(move || {
-                        let spoke_json = speak(&tts, &text, resolved, Some(&queue_id), &cancelled)?;
-                        let heard_json = listen(&stt, max_duration_ms, Some(&queue_id))?; // Pass queue_id for answer recording
-                                                                                          // Parse both results and combine into the converse format
+                        let stt_warmup = {
+                            let stt = stt.clone();
+                            std::thread::spawn(move || ensure_stt(&stt))
+                        };
+                        let spoke_json =
+                            match speak(&tts, &text, resolved, Some(&queue_id), &cancelled) {
+                                Ok(spoke_json) => spoke_json,
+                                Err(err) => {
+                                    let _ = stt_warmup.join();
+                                    return Err(err);
+                                }
+                            };
+                        stt_warmup
+                            .join()
+                            .map_err(|_| "stt warmup panicked".to_string())??;
+                        let heard_json =
+                            listen_bounded(&stt, max_duration_ms, Some(&queue_id), &cancelled)?; // Pass queue_id for answer recording
+                                                                                                 // Parse both results and combine into the converse format
                         let spoke: serde_json::Value =
                             serde_json::from_str(&spoke_json).unwrap_or_default();
                         let heard: serde_json::Value =
@@ -1063,10 +1081,58 @@ fn ensure_stt(stt: &Arc<Mutex<Option<voice_stt::WhisperModel>>>) -> Result<(), S
     Ok(())
 }
 
+fn listen_bounded(
+    stt: &Arc<Mutex<Option<voice_stt::WhisperModel>>>,
+    max_duration_ms: Option<u64>,
+    queue_id: Option<&str>,
+    cancelled: &Arc<AtomicBool>,
+) -> Result<String, String> {
+    let max_ms = max_duration_ms.unwrap_or(60000);
+    let timeout = Duration::from_millis(max_ms.saturating_add(LISTEN_OPEN_GRACE_MS));
+    let started = Instant::now();
+    let (tx, rx) = std::sync::mpsc::channel();
+    let stt = stt.clone();
+    let queue_id = queue_id.map(ToOwned::to_owned);
+    let cancelled_for_thread = cancelled.clone();
+
+    std::thread::spawn(move || {
+        let result = listen(
+            &stt,
+            max_duration_ms,
+            queue_id.as_deref(),
+            &cancelled_for_thread,
+        );
+        let _ = tx.send(result);
+    });
+
+    loop {
+        if cancelled.load(Ordering::SeqCst) {
+            return Err("Cancelled by user".to_string());
+        }
+
+        let elapsed = started.elapsed();
+        if elapsed >= timeout {
+            cancelled.store(true, Ordering::SeqCst);
+            return Err(format!("listen timed out after {}ms", timeout.as_millis()));
+        }
+
+        let remaining = timeout.saturating_sub(elapsed);
+        let poll = remaining.min(Duration::from_millis(100));
+        match rx.recv_timeout(poll) {
+            Ok(result) => return result,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                return Err("listen worker exited without a result".to_string());
+            }
+        }
+    }
+}
+
 fn listen(
     stt: &Arc<Mutex<Option<voice_stt::WhisperModel>>>,
     max_duration_ms: Option<u64>,
     queue_id: Option<&str>,
+    cancelled: &Arc<AtomicBool>,
 ) -> Result<String, String> {
     ensure_stt(stt)?;
 
@@ -1074,10 +1140,18 @@ fn listen(
 
     eprintln!("voice daemon: listening (max {}ms)...", max_ms);
 
+    if cancelled.load(Ordering::SeqCst) {
+        return Err("Cancelled by user".to_string());
+    }
+
     // Play a ding to signal recording start
     play_tone(880.0, 0.15);
     // Brief pause so the ding finishes before mic opens
-    std::thread::sleep(std::time::Duration::from_millis(100));
+    std::thread::sleep(Duration::from_millis(100));
+
+    if cancelled.load(Ordering::SeqCst) {
+        return Err("Cancelled by user".to_string());
+    }
 
     // Open mic
     let mic = MicrophoneBuilder::new()
@@ -1129,7 +1203,15 @@ fn listen(
 
     // Calibrate noise floor — sample peak amplitude over 500ms.
     // The mic may take a moment to warm up (especially Bluetooth).
-    std::thread::sleep(std::time::Duration::from_millis(500));
+    let calibration_started = Instant::now();
+    while calibration_started.elapsed() < Duration::from_millis(500) {
+        if cancelled.load(Ordering::SeqCst) {
+            stop.store(true, Ordering::Relaxed);
+            let _ = mic_thread.join();
+            return Err("Cancelled by user".to_string());
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
     let noise_floor = f32::from_bits(recent_peak.swap(0f32.to_bits(), Ordering::Relaxed));
     // Threshold must be well above noise to avoid false positives.
     // Use the same heuristic as the CLI: max(noise * 3, 0.01)
@@ -1142,17 +1224,22 @@ fn listen(
     // VAD state machine: wait for speech, then stop after 2s of silence.
     let started = Instant::now();
     let max_dur = std::time::Duration::from_millis(max_ms);
-    let silence_timeout = std::time::Duration::from_millis(2000);
+    let silence_timeout = Duration::from_millis(2000);
     let mut speech_detected = false;
     let mut last_speech = Instant::now();
+    let mut was_cancelled = false;
 
     loop {
+        if cancelled.load(Ordering::SeqCst) {
+            was_cancelled = true;
+            break;
+        }
         if started.elapsed() > max_dur {
             eprintln!("voice daemon: max duration reached");
             break;
         }
 
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        std::thread::sleep(Duration::from_millis(50));
         let peak = f32::from_bits(recent_peak.swap(0f32.to_bits(), Ordering::Relaxed));
 
         if peak > threshold {
@@ -1172,6 +1259,10 @@ fn listen(
 
     stop.store(true, Ordering::Relaxed);
     let _ = mic_thread.join();
+
+    if was_cancelled {
+        return Err("Cancelled by user".to_string());
+    }
 
     // Play stop tone
     play_tone(440.0, 0.1);

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -548,37 +548,44 @@ fn speak(
         }
 
         let started = Instant::now();
-        let audio = {
-            let mut state = tts.lock().map_err(|e| format!("lock: {}", e))?;
-            generate_voxtral_audio(
-                &mut state,
-                text,
-                &resolved.voice,
-                &resolved.voxtral_model,
-                resolved.voxtral_options.clone(),
-            )?
-        };
-
-        if cancelled.load(Ordering::SeqCst) {
-            return Err("Cancelled by user".to_string());
-        }
-
         let mut stream =
             DeviceSinkBuilder::open_default_sink().map_err(|e| format!("audio: {}", e))?;
         stream.log_on_drop(false);
         let player = Player::connect_new(stream.mixer());
         let channels = NonZero::new(1u16).unwrap();
-        let rate = NonZero::new(audio.sample_rate).unwrap();
-        player.append(SamplesBuffer::new(channels, rate, audio.samples.clone()));
+        let rate = NonZero::new(voice_voxtral::SAMPLE_RATE).unwrap();
+        let mut accumulated_audio = Vec::new();
+        let (audio, trace) = {
+            let mut state = tts.lock().map_err(|e| format!("lock: {}", e))?;
+            let runtime = state.get_voxtral_runtime(&resolved.voxtral_model)?;
+            runtime
+                .generate_audio_streaming_with_trace(
+                    text,
+                    &resolved.voice,
+                    resolved.voxtral_options.clone(),
+                    VoxtralStreamingConfig::default(),
+                    |chunk| {
+                        if cancelled.load(Ordering::SeqCst) {
+                            return Err(voice_voxtral::VoxtralError::Unsupported(
+                                "Cancelled by user".to_string(),
+                            ));
+                        }
+                        accumulated_audio.extend_from_slice(&chunk.samples);
+                        player.append(SamplesBuffer::new(channels, rate, chunk.samples.clone()));
+                        Ok(())
+                    },
+                )
+                .map_err(|e| format!("generate Voxtral audio: {e}"))?
+        };
 
         while !player.empty() {
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
 
         if let Some(qid) = queue_id {
-            if !audio.samples.is_empty() {
+            if !accumulated_audio.is_empty() {
                 let path = audio_recorder::question_path(qid);
-                audio_recorder::save_wav(&path, &audio.samples, audio.sample_rate)?;
+                audio_recorder::save_wav(&path, &accumulated_audio, audio.sample_rate)?;
             }
         }
 
@@ -586,11 +593,13 @@ fn speak(
             "engine": resolved.engine,
             "voice": resolved.voice,
             "duration_ms": started.elapsed().as_millis() as u64,
-            "chunks": 1,
+            "chunks": trace.codec_chunks,
             "samples": audio.samples.len(),
             "sample_rate": audio.sample_rate,
             "frames": audio.frames,
             "ended": audio.ended,
+            "first_code_frame_ms": trace.first_frame.map(|duration| duration.as_millis() as u64),
+            "first_audio_chunk_ms": trace.first_audio_chunk.map(|duration| duration.as_millis() as u64),
         })
         .to_string());
     }

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -18,7 +18,7 @@ use voice_stream::{
     TtsStreamEvent,
 };
 use voice_tts::KokoroModel;
-use voice_voxtral::{VoxtralGenerationOptions, VoxtralTtsRuntime};
+use voice_voxtral::{VoxtralGenerationOptions, VoxtralStreamingConfig, VoxtralTtsRuntime};
 
 use crate::audio_recorder;
 
@@ -793,31 +793,9 @@ fn stream_speak(tts: &Arc<Mutex<TtsState>>, job: StreamSpeakJob) -> Result<Strin
     let started = Instant::now();
 
     if resolved.engine == VOXTRAL_ENGINE {
-        let audio = {
-            let mut state = tts.lock().map_err(|e| format!("lock: {}", e))?;
-            generate_voxtral_audio(
-                &mut state,
-                &text,
-                &resolved.voice,
-                &resolved.voxtral_model,
-                resolved.voxtral_options.clone(),
-            )
-        };
-        let audio = match audio {
-            Ok(audio) => audio,
-            Err(e) => {
-                let _ = send_stream_event(
-                    &event_tx,
-                    TtsStreamEvent::error(stream_id.clone(), e.clone()),
-                    &cancelled,
-                );
-                return Err(e);
-            }
-        };
-
         let output_sample_rate = sample_rate.max(1);
         let frame_ms = frame_ms.max(1);
-        let source_sample_rate = audio.sample_rate;
+        let source_sample_rate = voice_voxtral::SAMPLE_RATE;
         let metadata = StreamMetadata {
             stream_id: stream_id.clone(),
             sample_rate: output_sample_rate,
@@ -832,14 +810,45 @@ fn stream_speak(tts: &Arc<Mutex<TtsState>>, job: StreamSpeakJob) -> Result<Strin
         send_stream_event(&event_tx, TtsStreamEvent::Started { metadata }, &cancelled)?;
 
         let mut packetizer = Packetizer::new(stream_id.clone(), output_sample_rate, frame_ms);
-        let samples = if output_sample_rate == source_sample_rate {
-            audio.samples
-        } else {
-            resample_linear(&audio.samples, source_sample_rate, output_sample_rate)
+        let generation = {
+            let mut state = tts.lock().map_err(|e| format!("lock: {}", e))?;
+            let runtime = state.get_voxtral_runtime(&resolved.voxtral_model)?;
+            runtime.generate_audio_streaming_with_trace(
+                &text,
+                &resolved.voice,
+                resolved.voxtral_options.clone(),
+                VoxtralStreamingConfig::default(),
+                |chunk| {
+                    if cancelled.load(Ordering::SeqCst) {
+                        return Err(voice_voxtral::VoxtralError::Unsupported(
+                            "Cancelled by user".to_string(),
+                        ));
+                    }
+                    let samples = if output_sample_rate == chunk.sample_rate {
+                        chunk.samples.clone()
+                    } else {
+                        resample_linear(&chunk.samples, chunk.sample_rate, output_sample_rate)
+                    };
+                    for frame in packetizer.push_samples(chunk.chunk_index as u32, &samples) {
+                        send_stream_event(&event_tx, TtsStreamEvent::Audio { frame }, &cancelled)
+                            .map_err(voice_voxtral::VoxtralError::Unsupported)?;
+                    }
+                    Ok(())
+                },
+            )
         };
-        for frame in packetizer.push_samples(0, &samples) {
-            send_stream_event(&event_tx, TtsStreamEvent::Audio { frame }, &cancelled)?;
-        }
+        let (audio, trace) = match generation {
+            Ok(result) => result,
+            Err(e) => {
+                let msg = format!("generate Voxtral audio: {e}");
+                let _ = send_stream_event(
+                    &event_tx,
+                    TtsStreamEvent::error(stream_id.clone(), msg.clone()),
+                    &cancelled,
+                );
+                return Err(msg);
+            }
+        };
         if let Some(frame) = packetizer.finish(0) {
             send_stream_event(&event_tx, TtsStreamEvent::Audio { frame }, &cancelled)?;
         }
@@ -860,7 +869,7 @@ fn stream_speak(tts: &Arc<Mutex<TtsState>>, job: StreamSpeakJob) -> Result<Strin
             "engine": resolved.engine,
             "duration_ms": duration_ms,
             "elapsed_ms": started.elapsed().as_millis() as u64,
-            "chunks": 1,
+            "chunks": trace.codec_chunks,
             "frames": packetizer.frames_emitted(),
             "samples": samples,
             "sample_rate": output_sample_rate,
@@ -868,6 +877,10 @@ fn stream_speak(tts: &Arc<Mutex<TtsState>>, job: StreamSpeakJob) -> Result<Strin
             "frame_ms": frame_ms,
             "voice": resolved.voice,
             "speed": resolved.speed,
+            "voxtral_frames": audio.frames,
+            "voxtral_ended": audio.ended,
+            "first_code_frame_ms": trace.first_frame.map(|duration| duration.as_millis() as u64),
+            "first_audio_chunk_ms": trace.first_audio_chunk.map(|duration| duration.as_millis() as u64),
         })
         .to_string());
     }

--- a/crates/voice-protocol/src/client.rs
+++ b/crates/voice-protocol/src/client.rs
@@ -142,7 +142,22 @@ impl DaemonClient {
         speed: Option<f64>,
         options: TtsRequestOptions<'_>,
     ) -> Result<Response, String> {
-        let mut params = serde_json::json!({"text": text, "wait": false});
+        self.speak_with_options_and_wait(text, voice, speed, options, false)
+    }
+
+    /// Convenience: send a speak request and optionally wait for playback completion.
+    pub fn speak_with_options_and_wait(
+        &mut self,
+        text: &str,
+        voice: Option<&str>,
+        speed: Option<f64>,
+        options: TtsRequestOptions<'_>,
+        wait: bool,
+    ) -> Result<Response, String> {
+        let read_timeout = wait
+            .then(|| read_timeout_for_tts_options(&options))
+            .flatten();
+        let mut params = serde_json::json!({"text": text, "wait": wait});
         if let Some(v) = voice {
             params["voice"] = Value::String(v.to_string());
         }
@@ -150,7 +165,7 @@ impl DaemonClient {
             params["speed"] = serde_json::json!(s);
         }
         insert_tts_options(&mut params, options);
-        self.call("speak", params)
+        self.call_with_read_timeout("speak", params, read_timeout)
     }
 
     /// Convenience: synthesize text to an audio file via the daemon and wait for completion.
@@ -725,6 +740,71 @@ mod tests {
         let mut client = DaemonClient::connect().unwrap();
         let response = client
             .converse_with_duration("hello", Some("af_heart"), Some(1500))
+            .unwrap();
+
+        assert!(response.error.is_none());
+
+        match old {
+            Some(value) => std::env::set_var(SOCKET_ENV, value),
+            None => std::env::remove_var(SOCKET_ENV),
+        }
+        let _ = std::fs::remove_file(path);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn speak_with_options_and_wait_sends_wait_true() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "voice-protocol-speak-wait-test-{}.sock",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).unwrap();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let frame = read_frame_sync(&mut stream).unwrap().unwrap();
+            let request = frame.json::<Request>().unwrap();
+            assert_eq!(request.method, "speak");
+            assert_eq!(request.params["text"], "hello");
+            assert_eq!(request.params["voice"], "casual_male");
+            assert_eq!(request.params["wait"], true);
+            assert_eq!(request.params["engine"], "voxtral");
+            assert_eq!(request.params["voxtral_kv_cache"], true);
+
+            let response = Response::success(
+                Some(1.into()),
+                serde_json::json!({
+                    "queue_id": "q",
+                    "status": "completed",
+                    "result": "{\"engine\":\"voxtral\"}",
+                }),
+            );
+            write_frame_sync(
+                &mut stream,
+                &Frame::response(&serde_json::to_vec(&response).unwrap()),
+            )
+            .unwrap();
+        });
+
+        let old = std::env::var(SOCKET_ENV).ok();
+        std::env::set_var(SOCKET_ENV, &path);
+
+        let mut client = DaemonClient::connect().unwrap();
+        let response = client
+            .speak_with_options_and_wait(
+                "hello",
+                Some("casual_male"),
+                Some(1.0),
+                TtsRequestOptions {
+                    engine: Some("voxtral"),
+                    voxtral_kv_cache: true,
+                    ..TtsRequestOptions::default()
+                },
+                true,
+            )
             .unwrap();
 
         assert!(response.error.is_none());

--- a/crates/voice-voxtral/src/generation.rs
+++ b/crates/voice-voxtral/src/generation.rs
@@ -5,8 +5,9 @@ use std::time::{Duration, Instant};
 use candle_core::{DType, Device, Tensor};
 
 use crate::{
-    build_prompt_embeddings, build_prompt_token_ids, load_voice_embedding, Result, VoxtralError,
-    VoxtralInferenceModules, VoxtralModel, VoxtralTokenizerMetadata,
+    build_prompt_embeddings, build_prompt_token_ids, load_voice_embedding, plan_codec_chunk,
+    Result, VoxtralCodecChunk, VoxtralError, VoxtralInferenceModules, VoxtralModel,
+    VoxtralStreamingConfig, VoxtralTokenizerMetadata,
 };
 
 #[derive(Debug, Clone)]
@@ -26,6 +27,17 @@ pub struct VoxtralGeneratedAudio {
     pub ended: bool,
 }
 
+#[derive(Debug, Clone)]
+pub struct VoxtralGeneratedAudioChunk {
+    pub samples: Vec<f32>,
+    pub sample_rate: u32,
+    pub chunk_index: usize,
+    pub context_frames: usize,
+    pub chunk_frames: usize,
+    pub generated_frames: usize,
+    pub finished: bool,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct VoxtralGenerationTrace {
     pub language_cache: bool,
@@ -36,7 +48,9 @@ pub struct VoxtralGenerationTrace {
     pub acoustic: Duration,
     pub decode_loop: Duration,
     pub codec: Duration,
+    pub codec_chunks: usize,
     pub first_frame: Option<Duration>,
+    pub first_audio_chunk: Option<Duration>,
     pub total: Duration,
 }
 
@@ -199,6 +213,42 @@ impl VoxtralTtsRuntime {
             device: &self.device,
             options,
         })?;
+        trace.voice_cache_hit = voice_cache_hit;
+        trace.voice_load = voice_load;
+        trace.total = total_start.elapsed();
+        Ok((audio, trace))
+    }
+
+    pub fn generate_audio_streaming_with_trace<F>(
+        &mut self,
+        text: &str,
+        voice: &str,
+        options: VoxtralGenerationOptions,
+        streaming: VoxtralStreamingConfig,
+        on_chunk: F,
+    ) -> Result<(VoxtralGeneratedAudio, VoxtralGenerationTrace)>
+    where
+        F: FnMut(&VoxtralGeneratedAudioChunk) -> Result<()>,
+    {
+        let total_start = Instant::now();
+        let (voice_embeddings, voice_cache_hit, voice_load) = self.voice_embedding(voice)?;
+        let (audio, mut trace) = generate_audio_inner_streaming(
+            GenerateAudioInner {
+                config: self.model.config(),
+                tokenizer: self
+                    .model
+                    .tokenizer()
+                    .ok_or_else(|| VoxtralError::InvalidTokenizer("missing tekken.json".into()))?,
+                modules: &self.modules,
+                text,
+                voice,
+                voice_embeddings: &voice_embeddings,
+                device: &self.device,
+                options,
+            },
+            streaming,
+            on_chunk,
+        )?;
         trace.voice_cache_hit = voice_cache_hit;
         trace.voice_load = voice_load;
         trace.total = total_start.elapsed();
@@ -432,6 +482,291 @@ fn generate_audio_inner(
         },
         trace,
     ))
+}
+
+fn generate_audio_inner_streaming<F>(
+    request: GenerateAudioInner<'_>,
+    streaming: VoxtralStreamingConfig,
+    mut on_chunk: F,
+) -> Result<(VoxtralGeneratedAudio, VoxtralGenerationTrace)>
+where
+    F: FnMut(&VoxtralGeneratedAudioChunk) -> Result<()>,
+{
+    let GenerateAudioInner {
+        config,
+        tokenizer,
+        modules,
+        text,
+        voice,
+        voice_embeddings,
+        device,
+        options,
+    } = request;
+    let total_start = Instant::now();
+    let mut trace = VoxtralGenerationTrace::default();
+    let dtype = voice_embeddings.dtype();
+
+    let prompt_start = Instant::now();
+    let encoder = tokenizer.encoder()?;
+    let text_token_ids = encoder.encode(text)?;
+    let voice_frames = candle(voice_embeddings.dim(0))?;
+    if let Some(expected_voice_frames) = tokenizer.voice_audio_tokens(voice) {
+        if expected_voice_frames != voice_frames {
+            return Err(VoxtralError::InvalidCheckpoint(format!(
+                "voice {voice:?} has {voice_frames} rows but tekken metadata expects {expected_voice_frames}"
+            )));
+        }
+    }
+
+    let prompt = build_prompt_token_ids(config, tokenizer, voice_frames, &text_token_ids)?;
+    let prompt_embeddings =
+        build_prompt_embeddings(&modules.embeddings, &prompt, voice_embeddings, device)?;
+    let audio_token_id = usize::try_from(config.multimodal.audio_model_args.audio_token_id)
+        .map_err(|_| {
+            VoxtralError::InvalidConfig(format!(
+                "audio_token_id must be non-negative, got {}",
+                config.multimodal.audio_model_args.audio_token_id
+            ))
+        })?;
+    let audio_embedding = candle(
+        modules
+            .embeddings
+            .token_embeddings(&[audio_token_id], device),
+    )?;
+    let mut decode_embeddings = candle(Tensor::cat(&[prompt_embeddings, audio_embedding], 1))?;
+    let mut decode_input = decode_embeddings.clone();
+    let mut language_cache = options.use_kv_cache.then(|| modules.language.new_cache());
+    let timesteps = flow_timesteps(options.flow_steps)?;
+    trace.language_cache = options.use_kv_cache;
+    trace.prompt = prompt_start.elapsed();
+
+    let loop_start = Instant::now();
+    let mut frame_history: Vec<Vec<u32>> = Vec::with_capacity(options.max_frames);
+    let mut emitted_frames = 0usize;
+    let mut emitted_samples = Vec::new();
+    let mut ended = false;
+
+    for frame_idx in 0..options.max_frames {
+        let language_start = Instant::now();
+        let hidden = if let Some(cache) = language_cache.as_mut() {
+            let start_pos = cache.len();
+            candle(modules.language.forward_causal_cached(
+                &decode_input,
+                start_pos,
+                config.rope_theta,
+                cache,
+            ))?
+        } else {
+            candle(
+                modules
+                    .language
+                    .forward_causal(&decode_embeddings, 0, config.rope_theta),
+            )?
+        };
+        let last_pos = candle(hidden.dim(1))? - 1;
+        let last_hidden = candle(
+            hidden
+                .narrow(1, last_pos, 1)
+                .and_then(|hidden| hidden.reshape((1, config.dim))),
+        )?;
+        trace.language += language_start.elapsed();
+
+        let acoustic_start = Instant::now();
+        let initial_noise = deterministic_noise(
+            options.seed,
+            frame_idx,
+            config.multimodal.audio_model_args.n_acoustic_codebook,
+            dtype,
+            device,
+        )?;
+        let frame_codes = candle(modules.acoustic.predict_frame_codes_from_noise(
+            config,
+            &last_hidden,
+            &initial_noise,
+            &timesteps,
+            options.cfg_alpha,
+        ))?;
+        trace.acoustic += acoustic_start.elapsed();
+        trace
+            .first_frame
+            .get_or_insert_with(|| loop_start.elapsed());
+
+        let frame = candle(frame_codes.to_vec2::<u32>())?.remove(0);
+        if frame[0] == 1 {
+            ended = true;
+            break;
+        }
+        frame_history.push(frame.clone());
+
+        maybe_emit_streaming_chunk(
+            config,
+            modules,
+            device,
+            streaming,
+            false,
+            &frame_history,
+            &mut emitted_frames,
+            &mut emitted_samples,
+            &mut trace,
+            total_start,
+            &mut on_chunk,
+        )?;
+
+        let next_embedding = candle(
+            modules
+                .embeddings
+                .audio_codes_embedding(config, &frame_codes),
+        )?;
+        let next_embedding = candle(next_embedding.unsqueeze(1))?;
+        if language_cache.is_some() {
+            decode_input = next_embedding;
+        } else {
+            decode_embeddings = candle(Tensor::cat(&[decode_embeddings, next_embedding], 1))?;
+        }
+    }
+    trace.decode_loop = loop_start.elapsed();
+
+    if frame_history.is_empty() {
+        return Err(VoxtralError::Unsupported(
+            "generation produced no audio frames".into(),
+        ));
+    }
+
+    maybe_emit_streaming_chunk(
+        config,
+        modules,
+        device,
+        streaming,
+        true,
+        &frame_history,
+        &mut emitted_frames,
+        &mut emitted_samples,
+        &mut trace,
+        total_start,
+        &mut on_chunk,
+    )?;
+
+    trace.total = total_start.elapsed();
+
+    Ok((
+        VoxtralGeneratedAudio {
+            samples: emitted_samples,
+            sample_rate: config.sample_rate(),
+            frames: emitted_frames,
+            ended,
+        },
+        trace,
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn maybe_emit_streaming_chunk<F>(
+    config: &crate::VoxtralConfig,
+    modules: &VoxtralInferenceModules,
+    device: &Device,
+    streaming: VoxtralStreamingConfig,
+    finished: bool,
+    frame_history: &[Vec<u32>],
+    emitted_frames: &mut usize,
+    emitted_samples: &mut Vec<f32>,
+    trace: &mut VoxtralGenerationTrace,
+    total_start: Instant,
+    on_chunk: &mut F,
+) -> Result<()>
+where
+    F: FnMut(&VoxtralGeneratedAudioChunk) -> Result<()>,
+{
+    let Some(chunk) = plan_codec_chunk(frame_history, streaming, finished)? else {
+        return Ok(());
+    };
+    if chunk.chunk_frames == 0 || *emitted_frames >= frame_history.len() {
+        return Ok(());
+    }
+    let new_frames = frame_history.len() - *emitted_frames;
+    if chunk.chunk_frames != new_frames {
+        return Err(VoxtralError::Unsupported(format!(
+            "streaming codec chunk mismatch: planned {} new frames but {} remain",
+            chunk.chunk_frames, new_frames
+        )));
+    }
+
+    let codec_start = Instant::now();
+    let samples = decode_codec_chunk_samples(config, modules, device, &chunk)?;
+    trace.codec += codec_start.elapsed();
+    trace.codec_chunks += 1;
+    trace.first_audio_chunk.get_or_insert(total_start.elapsed());
+
+    let audio_chunk = VoxtralGeneratedAudioChunk {
+        samples,
+        sample_rate: config.sample_rate(),
+        chunk_index: trace.codec_chunks - 1,
+        context_frames: chunk.context_frames,
+        chunk_frames: chunk.chunk_frames,
+        generated_frames: frame_history.len(),
+        finished: chunk.finished,
+    };
+    on_chunk(&audio_chunk)?;
+    emitted_samples.extend_from_slice(&audio_chunk.samples);
+    *emitted_frames += audio_chunk.chunk_frames;
+    Ok(())
+}
+
+fn decode_codec_chunk_samples(
+    config: &crate::VoxtralConfig,
+    modules: &VoxtralInferenceModules,
+    device: &Device,
+    chunk: &VoxtralCodecChunk,
+) -> Result<Vec<f32>> {
+    let num_codebooks = config.num_codebooks();
+    if chunk.frames.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut code_frames = Vec::with_capacity(chunk.frames.len() * num_codebooks);
+    for frame in &chunk.frames {
+        if frame.len() != num_codebooks {
+            return Err(VoxtralError::InvalidConfig(format!(
+                "codec frame has {} codebooks but config expects {num_codebooks}",
+                frame.len()
+            )));
+        }
+        code_frames.extend_from_slice(frame);
+    }
+
+    let codes = candle(Tensor::from_vec(
+        code_frames,
+        (chunk.frames.len(), num_codebooks),
+        device,
+    ))?;
+    let codes = candle(codes.transpose(0, 1))?;
+    let codes = candle(codes.unsqueeze(0))?;
+    let waveform = candle(modules.codec.decode_codes_to_waveform(&codes))?;
+    let samples = candle(waveform.to_dtype(DType::F32))?
+        .to_vec3::<f32>()
+        .map_err(|e| VoxtralError::Candle(e.to_string()))?[0][0]
+        .clone();
+
+    if samples.is_empty() {
+        return Ok(samples);
+    }
+    if samples.len() % chunk.frames.len() != 0 {
+        return Err(VoxtralError::Unsupported(format!(
+            "codec chunk produced {} samples for {} frames",
+            samples.len(),
+            chunk.frames.len()
+        )));
+    }
+    let samples_per_frame = samples.len() / chunk.frames.len();
+    let start = chunk.context_frames * samples_per_frame;
+    let len = chunk.chunk_frames * samples_per_frame;
+    let end = start + len;
+    if end > samples.len() {
+        return Err(VoxtralError::Unsupported(format!(
+            "codec chunk sample window {start}..{end} exceeds {} samples",
+            samples.len()
+        )));
+    }
+    Ok(samples[start..end].to_vec())
 }
 
 fn flow_timesteps(steps: usize) -> Result<Vec<f32>> {

--- a/crates/voice-voxtral/src/lib.rs
+++ b/crates/voice-voxtral/src/lib.rs
@@ -36,8 +36,8 @@ pub use config::{
 };
 pub use error::{Result, VoxtralError};
 pub use generation::{
-    VoxtralGeneratedAudio, VoxtralGenerationOptions, VoxtralGenerationTrace,
-    VoxtralRuntimeLoadTrace, VoxtralTtsRuntime,
+    VoxtralGeneratedAudio, VoxtralGeneratedAudioChunk, VoxtralGenerationOptions,
+    VoxtralGenerationTrace, VoxtralRuntimeLoadTrace, VoxtralTtsRuntime,
 };
 pub use model::VoxtralModel;
 pub use prompt::{


### PR DESCRIPTION
## Summary

- adds a streamable Voxtral generation API that decodes planned codec chunks during generation
- switches daemon `stream_speak` for Voxtral to emit PCM frames as each codec chunk becomes available
- switches normal daemon `speak` playback, used by `voice converse`, to append Voxtral codec chunks as soon as they decode
- routes CLI `voice converse` through daemon TTS plus foreground local listen, and bounds mic-open failures so CoreAudio input issues do not hang the command or daemon queue
- updates `voice bench tts` so Voxtral `first_audio_ms` is first playable chunk availability, not full-buffer completion

## Benchmark Evidence

Command:

```bash
cargo run --release -p voice --bin voice -- bench tts \
  --engine voxtral \
  --runs 2 \
  --voxtral-max-frames 80 \
  --voxtral-kv-cache \
  --json \
  "Voxtral should respond quickly."
```

Observed on the local Mac:

| Engine | Options | Model load | Cold first audio | Run 1 first audio | Run 2 first audio | Run 2 first code frame | Codec chunks | Total |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Voxtral `casual_male` | `--voxtral-kv-cache` + streaming codec | 1225.9 ms | 1799.5 ms | 573.5 ms | 568.4 ms | 10.9 ms | 6 | 2959.0 ms |

Compared with PR #267's full-buffer Voxtral baseline, warm first playable audio moves from roughly 3.0 s full-buffer availability to roughly 568 ms first chunk availability on this prompt. Total generation remains around 3.0 s.

## Installed Daemon Smoke

Stream command:

```bash
voice stream --engine voxtral -v casual_male \
  --voxtral-max-frames 80 \
  --voxtral-kv-cache \
  --raw-output /tmp/voxtral-streaming-latency-smoke80.pcm \
  "The streaming smoke test is complete."
```

Daemon result included:

- `chunks`: 6
- `first_code_frame_ms`: 15
- `first_audio_chunk_ms`: 584
- `elapsed_ms`: 4499
- `duration_ms`: 3760
- `voxtral_frames`: 47
- `voxtral_ended`: true

The raw PCM output had 188 fixed 20 ms frames, 90,240 samples, and 180,480 bytes.

Normal daemon playback path used by `voice converse`:

```bash
voice say --engine voxtral -v casual_male \
  --voxtral-max-frames 40 \
  --voxtral-kv-cache \
  "The prompt should start quickly."
```

Daemon result included:

- `chunks`: 6
- `first_code_frame_ms`: 19
- `first_audio_chunk_ms`: 600
- `duration_ms`: 4462
- `frames`: 26
- `voxtral_ended`: true

Installed `voice converse` now uses daemon TTS playback with local foreground listen:

```bash
voice converse --engine voxtral -v casual_male \
  --voxtral-max-frames 40 \
  --voxtral-kv-cache \
  --duration 1 \
  "The converse prompt should start quickly."
```

On this Mac, CoreAudio input open is currently unhealthy, so the foreground listen failed bounded instead of hanging:

- CLI output: `Recording failed: Opening microphone timed out after 8000ms`
- daemon status after command: `idle`
- daemon `speak` result:
  - `chunks`: 6
  - `first_code_frame_ms`: 16
  - `first_audio_chunk_ms`: 653
  - `duration_ms`: 5329
  - `frames`: 40
  - `ended`: false

Direct daemon `converse`/`listen` paths are also bounded now; the same CoreAudio input-open failure returns `listen timed out after 9000ms` instead of wedging the daemon worker.

Installed `voxtral` binary smoke:

```bash
voxtral say -v casual_male \
  --voxtral-max-frames 20 \
  --voxtral-kv-cache \
  -o /tmp/voxtral-cli-smoke.wav \
  "Voxtral binary smoke."
```

`ffprobe` metadata:

- codec: `pcm_f32le`
- sample rate: `24000`
- channels: `1`
- duration: `1.600000`
- size: `153668`

## Whisper Self-Eval

```bash
ffmpeg -y -f s16le -ar 24000 -ac 1 \
  -i /tmp/voxtral-streaming-latency-smoke80.pcm \
  /tmp/voxtral-streaming-latency-smoke80.wav

cargo run -p voice-eval -- \
  --input-wav /tmp/voxtral-streaming-latency-smoke80.wav \
  --expected-text "The streaming smoke test is complete." \
  --json
```

Result: transcription matched after normalization, WER `0.0`.

## Verification

```bash
cargo fmt --check
cargo check -p voice-voxtral -p voice-daemon -p voice --bins
cargo check -p voice-protocol -p voice-daemon -p voice --bins
cargo test -p voice-voxtral -p voice-daemon
cargo test -p voice-voxtral -p voice-daemon -p voice --bins
cargo test -p voice-protocol -p voice-daemon
cargo test -p voice --bins
cargo clippy --workspace -- -D warnings
cargo run --release -p voice --bin voice -- bench tts --engine voxtral --runs 2 --voxtral-max-frames 80 --voxtral-kv-cache --json "Voxtral should respond quickly."
```
