### PR TITLE
Explore Voxtral initial stream chunks

### DIFF
--- a/crates/voice-cli/src/cli.rs
+++ b/crates/voice-cli/src/cli.rs
@@ -345,6 +345,7 @@ fn daemon_tts_options<'a>(
     voxtral_model: &'a str,
     max_frames: usize,
     flow_steps: usize,
+    stream_begin_frames: Option<usize>,
     kv_cache: bool,
 ) -> voice_protocol::client::TtsRequestOptions<'a> {
     voice_protocol::client::TtsRequestOptions {
@@ -352,6 +353,9 @@ fn daemon_tts_options<'a>(
         voxtral_model: (engine == TtsEngine::Voxtral).then_some(voxtral_model),
         voxtral_max_frames: (engine == TtsEngine::Voxtral).then_some(max_frames),
         voxtral_flow_steps: (engine == TtsEngine::Voxtral).then_some(flow_steps),
+        voxtral_stream_begin_frames: (engine == TtsEngine::Voxtral)
+            .then_some(stream_begin_frames)
+            .flatten(),
         voxtral_kv_cache: engine == TtsEngine::Voxtral && kv_cache,
     }
 }
@@ -631,6 +635,10 @@ struct BenchTtsArgs {
     /// Enable Voxtral language KV cache
     #[arg(long = "voxtral-kv-cache")]
     voxtral_kv_cache: bool,
+
+    /// Override Voxtral's initial streaming codec chunk size for benchmarking
+    #[arg(long = "voxtral-stream-begin-frames")]
+    voxtral_stream_begin_frames: Option<usize>,
 
     /// Benchmark daemon streaming instead of local in-process synthesis
     #[arg(long)]
@@ -1512,6 +1520,7 @@ struct TtsBenchRunReport {
     frames: Option<usize>,
     ended: Option<bool>,
     voxtral_language_cache: Option<bool>,
+    voxtral_stream_begin_frames: Option<usize>,
     voxtral_voice_cache_hit: Option<bool>,
     voxtral_codec_chunks: Option<usize>,
     voxtral_prompt_ms: Option<f64>,
@@ -1545,6 +1554,10 @@ fn run_bench_tts(args: BenchTtsArgs) {
     }
     if args.voxtral_flow_steps == 0 {
         eprintln!("Error: --voxtral-flow-steps must be greater than zero");
+        std::process::exit(1);
+    }
+    if args.voxtral_stream_begin_frames == Some(0) {
+        eprintln!("Error: --voxtral-stream-begin-frames must be greater than zero");
         std::process::exit(1);
     }
     if args.daemon {
@@ -1679,6 +1692,7 @@ fn bench_kokoro_tts(args: &BenchTtsArgs, text: &str) -> Result<TtsBenchEngineRep
             frames: None,
             ended: None,
             voxtral_language_cache: None,
+            voxtral_stream_begin_frames: None,
             voxtral_voice_cache_hit: None,
             voxtral_codec_chunks: None,
             voxtral_prompt_ms: None,
@@ -1734,7 +1748,7 @@ fn bench_voxtral_tts(args: &BenchTtsArgs, text: &str) -> Result<TtsBenchEngineRe
                     args.voxtral_flow_steps,
                     args.voxtral_kv_cache,
                 ),
-                voice_voxtral::VoxtralStreamingConfig::default(),
+                voxtral_streaming_config(args),
                 |chunk| {
                     streamed_samples += chunk.samples.len();
                     Ok(())
@@ -1769,6 +1783,9 @@ fn bench_voxtral_tts(args: &BenchTtsArgs, text: &str) -> Result<TtsBenchEngineRe
             frames: Some(audio.frames),
             ended: Some(audio.ended),
             voxtral_language_cache: Some(trace.language_cache),
+            voxtral_stream_begin_frames: Some(
+                voxtral_streaming_config(args).chunk_frames_at_begin,
+            ),
             voxtral_voice_cache_hit: Some(trace.voice_cache_hit),
             voxtral_codec_chunks: Some(trace.codec_chunks),
             voxtral_prompt_ms: Some(duration_ms(trace.prompt)),
@@ -1852,6 +1869,7 @@ fn bench_daemon_tts(
                     &args.voxtral_model,
                     args.voxtral_max_frames,
                     args.voxtral_flow_steps,
+                    args.voxtral_stream_begin_frames,
                     args.voxtral_kv_cache,
                 ),
             },
@@ -1934,6 +1952,8 @@ fn bench_daemon_tts(
             frames: Some(frames as usize),
             ended: Some(true),
             voxtral_language_cache: (engine == TtsEngine::Voxtral).then_some(args.voxtral_kv_cache),
+            voxtral_stream_begin_frames: (engine == TtsEngine::Voxtral)
+                .then_some(voxtral_streaming_config(args).chunk_frames_at_begin),
             voxtral_voice_cache_hit: None,
             voxtral_codec_chunks,
             voxtral_prompt_ms: None,
@@ -2006,6 +2026,14 @@ fn daemon_recent_result_for_queue(
 
 fn json_number_ms(value: &serde_json::Value) -> Option<f64> {
     value.as_f64().or_else(|| value.as_u64().map(|value| value as f64))
+}
+
+fn voxtral_streaming_config(args: &BenchTtsArgs) -> voice_voxtral::VoxtralStreamingConfig {
+    let mut config = voice_voxtral::VoxtralStreamingConfig::default();
+    if let Some(stream_begin_frames) = args.voxtral_stream_begin_frames {
+        config.chunk_frames_at_begin = stream_begin_frames;
+    }
+    config
 }
 
 fn resolve_bench_text(args: &BenchTtsArgs) -> Result<String, String> {
@@ -2115,7 +2143,7 @@ fn print_tts_bench_report(report: &TtsBenchReport) {
         );
         for run in &engine.runs {
             let mut line = format!(
-                "tts_bench.run engine={} run={} first_audio_ms={:.1} total_ms={:.1} synth_ms={:.1} audio_ms={:.1} phoneme_ms={} first_code_frame_ms={} voxtral_codec_chunks={} output_wav={}",
+                "tts_bench.run engine={} run={} first_audio_ms={:.1} total_ms={:.1} synth_ms={:.1} audio_ms={:.1} phoneme_ms={} first_code_frame_ms={} voxtral_stream_begin_frames={} voxtral_codec_chunks={} output_wav={}",
                 engine.engine,
                 run.run,
                 run.first_audio_ms,
@@ -2127,6 +2155,9 @@ fn print_tts_bench_report(report: &TtsBenchReport) {
                     .unwrap_or_else(|| "-".to_string()),
                 run.first_code_frame_ms
                     .map(|value| format!("{value:.1}"))
+                    .unwrap_or_else(|| "-".to_string()),
+                run.voxtral_stream_begin_frames
+                    .map(|value| value.to_string())
                     .unwrap_or_else(|| "-".to_string()),
                 run.voxtral_codec_chunks
                     .map(|value| value.to_string())
@@ -2308,6 +2339,7 @@ fn run_say(say_args: SayArgs) {
                     &say_args.voxtral_model,
                     say_args.voxtral_max_frames,
                     say_args.voxtral_flow_steps,
+                    None,
                     say_args.voxtral_kv_cache,
                 );
 
@@ -2656,6 +2688,7 @@ fn run_stream(stream_args: StreamArgs) {
                 &stream_args.voxtral_model,
                 stream_args.voxtral_max_frames,
                 stream_args.voxtral_flow_steps,
+                None,
                 stream_args.voxtral_kv_cache,
             ),
         },
@@ -3041,6 +3074,7 @@ fn run_converse(args: ConverseArgs) {
                     &args.voxtral_model,
                     args.voxtral_max_frames,
                     args.voxtral_flow_steps,
+                    None,
                     args.voxtral_kv_cache,
                 ),
                 true,

--- a/crates/voice-daemon/src/queue.rs
+++ b/crates/voice-daemon/src/queue.rs
@@ -18,6 +18,7 @@ pub struct TtsOptions {
     pub voxtral_model: Option<String>,
     pub voxtral_max_frames: Option<usize>,
     pub voxtral_flow_steps: Option<usize>,
+    pub voxtral_stream_begin_frames: Option<usize>,
     pub voxtral_kv_cache: bool,
 }
 

--- a/crates/voice-daemon/src/socket.rs
+++ b/crates/voice-daemon/src/socket.rs
@@ -971,6 +971,8 @@ fn optional_tts_options(req: &rpc::Request, default_engine: &str) -> Result<TtsO
 
     let voxtral_max_frames = optional_usize_param(req, "voxtral_max_frames", 1, 16_384)?;
     let voxtral_flow_steps = optional_usize_param(req, "voxtral_flow_steps", 1, 256)?;
+    let voxtral_stream_begin_frames =
+        optional_usize_param(req, "voxtral_stream_begin_frames", 1, 1_024)?;
     let voxtral_kv_cache = match req.params.get("voxtral_kv_cache") {
         Some(value) => value.as_bool().ok_or_else(|| {
             Response::error(
@@ -998,6 +1000,7 @@ fn optional_tts_options(req: &rpc::Request, default_engine: &str) -> Result<TtsO
         voxtral_model,
         voxtral_max_frames,
         voxtral_flow_steps,
+        voxtral_stream_begin_frames,
         voxtral_kv_cache,
     })
 }

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -481,6 +481,7 @@ struct ResolvedTtsRequest {
     speed: f32,
     voxtral_model: String,
     voxtral_options: VoxtralGenerationOptions,
+    voxtral_streaming: VoxtralStreamingConfig,
 }
 
 fn resolve_tts_request(
@@ -512,6 +513,10 @@ fn resolve_tts_request(
         voxtral_options.flow_steps = flow_steps;
     }
     voxtral_options.use_kv_cache = options.voxtral_kv_cache;
+    let mut voxtral_streaming = VoxtralStreamingConfig::default();
+    if let Some(stream_begin_frames) = options.voxtral_stream_begin_frames {
+        voxtral_streaming.chunk_frames_at_begin = stream_begin_frames;
+    }
 
     Ok(ResolvedTtsRequest {
         engine,
@@ -524,6 +529,7 @@ fn resolve_tts_request(
             .clone()
             .unwrap_or_else(|| config.get_voxtral_model()),
         voxtral_options,
+        voxtral_streaming,
     })
 }
 
@@ -581,7 +587,7 @@ fn speak(
                     text,
                     &resolved.voice,
                     resolved.voxtral_options.clone(),
-                    VoxtralStreamingConfig::default(),
+                    resolved.voxtral_streaming,
                     |chunk| {
                         if cancelled.load(Ordering::SeqCst) {
                             return Err(voice_voxtral::VoxtralError::Unsupported(
@@ -844,7 +850,7 @@ fn stream_speak(tts: &Arc<Mutex<TtsState>>, job: StreamSpeakJob) -> Result<Strin
                 &text,
                 &resolved.voice,
                 resolved.voxtral_options.clone(),
-                VoxtralStreamingConfig::default(),
+                resolved.voxtral_streaming,
                 |chunk| {
                     if cancelled.load(Ordering::SeqCst) {
                         return Err(voice_voxtral::VoxtralError::Unsupported(

--- a/crates/voice-protocol/src/client.rs
+++ b/crates/voice-protocol/src/client.rs
@@ -23,6 +23,7 @@ pub struct TtsRequestOptions<'a> {
     pub voxtral_model: Option<&'a str>,
     pub voxtral_max_frames: Option<usize>,
     pub voxtral_flow_steps: Option<usize>,
+    pub voxtral_stream_begin_frames: Option<usize>,
     pub voxtral_kv_cache: bool,
 }
 
@@ -619,6 +620,9 @@ fn insert_tts_options(params: &mut Value, options: TtsRequestOptions<'_>) {
     if let Some(flow_steps) = options.voxtral_flow_steps {
         params["voxtral_flow_steps"] = serde_json::json!(flow_steps);
     }
+    if let Some(stream_begin_frames) = options.voxtral_stream_begin_frames {
+        params["voxtral_stream_begin_frames"] = serde_json::json!(stream_begin_frames);
+    }
     if options.voxtral_kv_cache {
         params["voxtral_kv_cache"] = Value::Bool(true);
     }
@@ -789,6 +793,7 @@ mod tests {
             assert_eq!(request.params["wait"], true);
             assert_eq!(request.params["engine"], "voxtral");
             assert_eq!(request.params["voxtral_kv_cache"], true);
+            assert_eq!(request.params["voxtral_stream_begin_frames"], 3);
 
             let response = Response::success(
                 Some(1.into()),
@@ -816,6 +821,7 @@ mod tests {
                 Some(1.0),
                 TtsRequestOptions {
                     engine: Some("voxtral"),
+                    voxtral_stream_begin_frames: Some(3),
                     voxtral_kv_cache: true,
                     ..TtsRequestOptions::default()
                 },

--- a/crates/voice-voxtral/src/generation.rs
+++ b/crates/voice-voxtral/src/generation.rs
@@ -676,7 +676,7 @@ fn maybe_emit_streaming_chunk<F>(
 where
     F: FnMut(&VoxtralGeneratedAudioChunk) -> Result<()>,
 {
-    let Some(chunk) = plan_codec_chunk(frame_history, streaming, finished)? else {
+    let Some(chunk) = plan_codec_chunk(frame_history, *emitted_frames, streaming, finished)? else {
         return Ok(());
     };
     if chunk.chunk_frames == 0 || *emitted_frames >= frame_history.len() {

--- a/crates/voice-voxtral/src/streaming.rs
+++ b/crates/voice-voxtral/src/streaming.rs
@@ -44,14 +44,6 @@ impl VoxtralStreamingConfig {
         }
         Ok(())
     }
-
-    fn current_chunk_frames(&self, generated_frames: usize) -> usize {
-        if generated_frames <= self.chunk_frames {
-            self.chunk_frames_at_begin
-        } else {
-            self.chunk_frames
-        }
-    }
 }
 
 /// One generator-to-codec streaming payload.
@@ -88,12 +80,18 @@ impl VoxtralCodecChunk {
 /// finished chunk when the request ends before producing audio frames.
 pub fn plan_codec_chunk(
     frames: &[Vec<u32>],
+    emitted_frames: usize,
     config: VoxtralStreamingConfig,
     finished: bool,
 ) -> Result<Option<VoxtralCodecChunk>> {
     config.validate()?;
 
     let generated_frames = frames.len();
+    if emitted_frames > generated_frames {
+        return Err(VoxtralError::InvalidConfig(format!(
+            "emitted_frames {emitted_frames} exceeds generated_frames {generated_frames}"
+        )));
+    }
     if generated_frames == 0 {
         if finished {
             return Ok(Some(VoxtralCodecChunk {
@@ -105,26 +103,33 @@ pub fn plan_codec_chunk(
         }
         return Ok(None);
     }
-
-    let chunk_frames = config.current_chunk_frames(generated_frames);
-    let partial_chunk_frames = generated_frames % chunk_frames;
-    if partial_chunk_frames != 0 && !finished {
+    if emitted_frames == generated_frames {
         return Ok(None);
     }
 
-    let current_chunk_frames = if partial_chunk_frames == 0 {
-        chunk_frames
+    let chunk_frames = if emitted_frames < config.chunk_frames {
+        let remaining_initial_frames = config.chunk_frames - emitted_frames;
+        config
+            .chunk_frames_at_begin
+            .min(remaining_initial_frames)
+            .max(1)
     } else {
-        partial_chunk_frames
+        config.chunk_frames
     };
-    let window_frames = generated_frames.min(config.left_context_frames + current_chunk_frames);
-    let context_frames = window_frames.saturating_sub(current_chunk_frames);
-    let start = generated_frames - window_frames;
+    let available_frames = generated_frames - emitted_frames;
+    if available_frames < chunk_frames && !finished {
+        return Ok(None);
+    }
+
+    let current_chunk_frames = available_frames.min(chunk_frames);
+    let end = emitted_frames + current_chunk_frames;
+    let start = emitted_frames.saturating_sub(config.left_context_frames);
+    let context_frames = emitted_frames - start;
 
     Ok(Some(VoxtralCodecChunk {
         context_frames,
         chunk_frames: current_chunk_frames,
-        frames: frames[start..].to_vec(),
+        frames: frames[start..end].to_vec(),
         finished,
     }))
 }
@@ -143,9 +148,12 @@ mod tests {
     fn waits_for_the_first_streaming_boundary() {
         let config = VoxtralStreamingConfig::default();
 
-        assert_eq!(plan_codec_chunk(&frames(4), config, false).unwrap(), None);
+        assert_eq!(
+            plan_codec_chunk(&frames(4), 0, config, false).unwrap(),
+            None
+        );
 
-        let chunk = plan_codec_chunk(&frames(5), config, false)
+        let chunk = plan_codec_chunk(&frames(5), 0, config, false)
             .unwrap()
             .unwrap();
         assert_eq!(chunk.context_frames, 0);
@@ -157,7 +165,7 @@ mod tests {
     fn includes_left_context_for_followup_chunks() {
         let config = VoxtralStreamingConfig::default();
 
-        let chunk = plan_codec_chunk(&frames(50), config, false)
+        let chunk = plan_codec_chunk(&frames(50), 25, config, false)
             .unwrap()
             .unwrap();
 
@@ -172,7 +180,9 @@ mod tests {
     fn flushes_partial_final_chunks_with_context() {
         let config = VoxtralStreamingConfig::default();
 
-        let chunk = plan_codec_chunk(&frames(7), config, true).unwrap().unwrap();
+        let chunk = plan_codec_chunk(&frames(7), 5, config, true)
+            .unwrap()
+            .unwrap();
 
         assert_eq!(chunk.context_frames, 5);
         assert_eq!(chunk.chunk_frames, 2);
@@ -184,7 +194,7 @@ mod tests {
     fn emits_empty_finished_marker() {
         let config = VoxtralStreamingConfig::default();
 
-        let chunk = plan_codec_chunk(&[], config, true).unwrap().unwrap();
+        let chunk = plan_codec_chunk(&[], 0, config, true).unwrap().unwrap();
 
         assert_eq!(chunk.context_frames, 0);
         assert_eq!(chunk.chunk_frames, 0);
@@ -195,7 +205,7 @@ mod tests {
     #[test]
     fn flattens_prompt_codes_with_header() {
         let config = VoxtralStreamingConfig::default();
-        let chunk = plan_codec_chunk(&frames(5), config, false)
+        let chunk = plan_codec_chunk(&frames(5), 0, config, false)
             .unwrap()
             .unwrap();
 
@@ -212,6 +222,40 @@ mod tests {
             ..VoxtralStreamingConfig::default()
         };
 
-        assert!(plan_codec_chunk(&frames(1), config, false).is_err());
+        assert!(plan_codec_chunk(&frames(1), 0, config, false).is_err());
+    }
+
+    #[test]
+    fn finishes_non_divisor_begin_chunks_at_normal_boundary() {
+        let config = VoxtralStreamingConfig {
+            chunk_frames_at_begin: 3,
+            ..VoxtralStreamingConfig::default()
+        };
+
+        let chunk = plan_codec_chunk(&frames(25), 24, config, false)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(chunk.context_frames, 24);
+        assert_eq!(chunk.chunk_frames, 1);
+        assert_eq!(chunk.frames.len(), 25);
+        assert!(!chunk.finished);
+    }
+
+    #[test]
+    fn flushes_final_non_divisor_begin_chunk_without_mismatch() {
+        let config = VoxtralStreamingConfig {
+            chunk_frames_at_begin: 3,
+            ..VoxtralStreamingConfig::default()
+        };
+
+        let chunk = plan_codec_chunk(&frames(40), 25, config, true)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(chunk.context_frames, 25);
+        assert_eq!(chunk.chunk_frames, 15);
+        assert_eq!(chunk.frames.len(), 40);
+        assert!(chunk.finished);
     }
 }


### PR DESCRIPTION
## Summary

- adds benchmark-only `--voxtral-stream-begin-frames` for exploring Voxtral's initial streaming codec chunk size
- threads the option through daemon stream requests without changing normal `voice say`, `voice stream`, or `voice converse` defaults
- fixes the streaming chunk planner so non-divisor beginning chunks, such as 2 or 3 frames, flush correctly at the 25-frame normal chunk boundary

## Benchmark Evidence

After installing this branch and restarting the local voice daemon, warm daemon-stream results on the same prompt:

```bash
voice bench tts \
  --daemon \
  --engine voxtral \
  --runs 1 \
  --voxtral-max-frames 40 \
  --voxtral-kv-cache \
  --voxtral-stream-begin-frames <N> \
  --json \
  "Chunk size affects first playable audio."
```

| Begin frames | First PCM | First code frame | Codec chunks | Total stream |
| ---: | ---: | ---: | ---: | ---: |
| 5 | 663.1 ms | 14.0 ms | 6 | 4302.9 ms |
| 3 | 462.5 ms | 16.0 ms | 10 | 4310.5 ms |
| 2 | 370.9 ms | 13.0 ms | 14 | 4337.6 ms |
| 1 | 367.9 ms | 14.0 ms | 26 | 4547.3 ms |

Interpretation: begin-2 is the best current candidate, matching Kokoro-like first PCM without begin-1's chunk-count and total-time penalty. This PR does not change the public default; it keeps the benchmark knob available for review and further evaluation.

## Quality Smoke

```bash
voice bench tts \
  --engine voxtral \
  --runs 1 \
  --voxtral-max-frames 40 \
  --voxtral-kv-cache \
  --voxtral-stream-begin-frames 2 \
  --output-dir /tmp/voxtral-begin2-eval \
  --json \
  "Chunk size affects first playable audio."

cargo run -p voice-eval -- \
  --input-wav /tmp/voxtral-begin2-eval/voxtral-casual_male-run1.wav \
  --expected-text "Chunk size affects first playable audio." \
  --json
```

Result:

- WAV metadata: mono, 24000 Hz, 3.2 s, `pcm_f32le`
- Whisper normalized transcription matched, WER `0.0`

## Verification

```bash
cargo fmt --check
cargo check -p voice-voxtral -p voice-protocol -p voice-daemon -p voice --bins
cargo test -p voice-voxtral streaming
cargo test -p voice-protocol -p voice-daemon
cargo test -p voice-protocol -p voice-daemon -p voice --bins
cargo clippy -p voice-voxtral -p voice-protocol -p voice-daemon -p voice --bins -- -D warnings
```
