### PR TITLE
Add Voxtral per-frame benchmark metrics

### DIFF
--- a/crates/voice-cli/src/cli.rs
+++ b/crates/voice-cli/src/cli.rs
@@ -1643,13 +1643,18 @@ struct TtsBenchRunReport {
     voxtral_language_cache: Option<bool>,
     voxtral_stream_begin_frames: Option<usize>,
     voxtral_voice_cache_hit: Option<bool>,
+    voxtral_audio_frames: Option<usize>,
     voxtral_codec_chunks: Option<usize>,
     voxtral_codec_chunks_per_second: Option<f64>,
     voxtral_prompt_ms: Option<f64>,
     voxtral_language_ms: Option<f64>,
+    voxtral_language_ms_per_frame: Option<f64>,
     voxtral_acoustic_ms: Option<f64>,
+    voxtral_acoustic_ms_per_frame: Option<f64>,
     voxtral_decode_loop_ms: Option<f64>,
+    voxtral_decode_loop_ms_per_frame: Option<f64>,
     voxtral_codec_ms: Option<f64>,
+    voxtral_codec_ms_per_chunk: Option<f64>,
     daemon_response_ms: Option<f64>,
     daemon_started_ms: Option<f64>,
     daemon_first_pcm_ms: Option<f64>,
@@ -1816,13 +1821,18 @@ fn bench_kokoro_tts(args: &BenchTtsArgs, text: &str) -> Result<TtsBenchEngineRep
             voxtral_language_cache: None,
             voxtral_stream_begin_frames: None,
             voxtral_voice_cache_hit: None,
+            voxtral_audio_frames: None,
             voxtral_codec_chunks: None,
             voxtral_codec_chunks_per_second: None,
             voxtral_prompt_ms: None,
             voxtral_language_ms: None,
+            voxtral_language_ms_per_frame: None,
             voxtral_acoustic_ms: None,
+            voxtral_acoustic_ms_per_frame: None,
             voxtral_decode_loop_ms: None,
+            voxtral_decode_loop_ms_per_frame: None,
             voxtral_codec_ms: None,
+            voxtral_codec_ms_per_chunk: None,
             daemon_response_ms: None,
             daemon_started_ms: None,
             daemon_first_pcm_ms: None,
@@ -1885,6 +1895,10 @@ fn bench_voxtral_tts(args: &BenchTtsArgs, text: &str) -> Result<TtsBenchEngineRe
         let total_ms = duration_ms(total);
         let first_audio_ms = duration_ms(trace.first_audio_chunk.unwrap_or(total));
         let generated_audio_ms = audio_duration_ms(audio.samples.len(), audio.sample_rate);
+        let language_ms = duration_ms(trace.language);
+        let acoustic_ms = duration_ms(trace.acoustic);
+        let decode_loop_ms = duration_ms(trace.decode_loop);
+        let codec_ms = duration_ms(trace.codec);
         let output_wav = maybe_write_bench_wav(
             &args.output_dir,
             TtsEngine::Voxtral,
@@ -1917,13 +1931,18 @@ fn bench_voxtral_tts(args: &BenchTtsArgs, text: &str) -> Result<TtsBenchEngineRe
             voxtral_language_cache: Some(trace.language_cache),
             voxtral_stream_begin_frames: Some(voxtral_streaming_config(voxtral).chunk_frames_at_begin),
             voxtral_voice_cache_hit: Some(trace.voice_cache_hit),
+            voxtral_audio_frames: Some(audio.frames),
             voxtral_codec_chunks: Some(trace.codec_chunks),
             voxtral_codec_chunks_per_second: per_second(trace.codec_chunks, total_ms),
             voxtral_prompt_ms: Some(duration_ms(trace.prompt)),
-            voxtral_language_ms: Some(duration_ms(trace.language)),
-            voxtral_acoustic_ms: Some(duration_ms(trace.acoustic)),
-            voxtral_decode_loop_ms: Some(duration_ms(trace.decode_loop)),
-            voxtral_codec_ms: Some(duration_ms(trace.codec)),
+            voxtral_language_ms: Some(language_ms),
+            voxtral_language_ms_per_frame: per_unit(language_ms, audio.frames),
+            voxtral_acoustic_ms: Some(acoustic_ms),
+            voxtral_acoustic_ms_per_frame: per_unit(acoustic_ms, audio.frames),
+            voxtral_decode_loop_ms: Some(decode_loop_ms),
+            voxtral_decode_loop_ms_per_frame: per_unit(decode_loop_ms, audio.frames),
+            voxtral_codec_ms: Some(codec_ms),
+            voxtral_codec_ms_per_chunk: per_unit(codec_ms, trace.codec_chunks),
             daemon_response_ms: None,
             daemon_started_ms: None,
             daemon_first_pcm_ms: None,
@@ -2055,8 +2074,12 @@ fn bench_daemon_tts(
         let voxtral_codec_chunks = worker_result
             .as_ref()
             .and_then(|result| result.get("chunks"))
-            .and_then(|value| value.as_u64())
-            .and_then(|value| usize::try_from(value).ok())
+            .and_then(json_number_usize)
+            .filter(|_| engine == TtsEngine::Voxtral);
+        let voxtral_audio_frames = worker_result
+            .as_ref()
+            .and_then(|result| result.get("voxtral_frames"))
+            .and_then(json_number_usize)
             .filter(|_| engine == TtsEngine::Voxtral);
 
         let total = total_start.elapsed();
@@ -2088,14 +2111,19 @@ fn bench_daemon_tts(
             voxtral_stream_begin_frames: (engine == TtsEngine::Voxtral)
                 .then_some(voxtral_streaming_config(voxtral).chunk_frames_at_begin),
             voxtral_voice_cache_hit: None,
+            voxtral_audio_frames,
             voxtral_codec_chunks,
             voxtral_codec_chunks_per_second: voxtral_codec_chunks
                 .and_then(|chunks| per_second(chunks, total_ms)),
             voxtral_prompt_ms: None,
             voxtral_language_ms: None,
+            voxtral_language_ms_per_frame: None,
             voxtral_acoustic_ms: None,
+            voxtral_acoustic_ms_per_frame: None,
             voxtral_decode_loop_ms: None,
+            voxtral_decode_loop_ms_per_frame: None,
             voxtral_codec_ms: None,
+            voxtral_codec_ms_per_chunk: None,
             daemon_response_ms: response_at.map(duration_ms),
             daemon_started_ms: started_at.map(duration_ms),
             daemon_first_pcm_ms: Some(duration_ms(first_audio)),
@@ -2161,6 +2189,12 @@ fn daemon_recent_result_for_queue(
 
 fn json_number_ms(value: &serde_json::Value) -> Option<f64> {
     value.as_f64().or_else(|| value.as_u64().map(|value| value as f64))
+}
+
+fn json_number_usize(value: &serde_json::Value) -> Option<usize> {
+    value
+        .as_u64()
+        .and_then(|value| usize::try_from(value).ok())
 }
 
 fn voxtral_streaming_config(
@@ -2269,6 +2303,10 @@ fn per_second(count: usize, elapsed_ms: f64) -> Option<f64> {
     (elapsed_ms > 0.0).then_some(count as f64 / (elapsed_ms / 1_000.0))
 }
 
+fn per_unit(total_ms: f64, units: usize) -> Option<f64> {
+    (units > 0).then_some(total_ms / units as f64)
+}
+
 fn print_tts_bench_report(report: &TtsBenchReport) {
     println!("tts_bench.text={}", report.text);
     println!("tts_bench.mode={}", report.mode);
@@ -2288,7 +2326,7 @@ fn print_tts_bench_report(report: &TtsBenchReport) {
         );
         for run in &engine.runs {
             let mut line = format!(
-                "tts_bench.run engine={} run={} first_audio_ms={:.1} total_ms={:.1} synth_ms={:.1} audio_ms={:.1} realtime_factor={} first_audio_realtime_factor={} phoneme_ms={} first_code_frame_ms={} voxtral_realtime={} voxtral_max_frames={} voxtral_flow_steps={} voxtral_stream_begin_frames={} voxtral_codec_chunks={} voxtral_codec_chunks_per_second={} output_wav={}",
+                "tts_bench.run engine={} run={} first_audio_ms={:.1} total_ms={:.1} synth_ms={:.1} audio_ms={:.1} realtime_factor={} first_audio_realtime_factor={} phoneme_ms={} first_code_frame_ms={} voxtral_realtime={} voxtral_max_frames={} voxtral_flow_steps={} voxtral_stream_begin_frames={} voxtral_audio_frames={} voxtral_codec_chunks={} voxtral_codec_chunks_per_second={} voxtral_language_ms_per_frame={} voxtral_acoustic_ms_per_frame={} voxtral_decode_loop_ms_per_frame={} voxtral_codec_ms_per_chunk={} output_wav={}",
                 engine.engine,
                 run.run,
                 run.first_audio_ms,
@@ -2319,11 +2357,26 @@ fn print_tts_bench_report(report: &TtsBenchReport) {
                 run.voxtral_stream_begin_frames
                     .map(|value| value.to_string())
                     .unwrap_or_else(|| "-".to_string()),
+                run.voxtral_audio_frames
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "-".to_string()),
                 run.voxtral_codec_chunks
                     .map(|value| value.to_string())
                     .unwrap_or_else(|| "-".to_string()),
                 run.voxtral_codec_chunks_per_second
                     .map(|value| format!("{value:.2}"))
+                    .unwrap_or_else(|| "-".to_string()),
+                run.voxtral_language_ms_per_frame
+                    .map(|value| format!("{value:.1}"))
+                    .unwrap_or_else(|| "-".to_string()),
+                run.voxtral_acoustic_ms_per_frame
+                    .map(|value| format!("{value:.1}"))
+                    .unwrap_or_else(|| "-".to_string()),
+                run.voxtral_decode_loop_ms_per_frame
+                    .map(|value| format!("{value:.1}"))
+                    .unwrap_or_else(|| "-".to_string()),
+                run.voxtral_codec_ms_per_chunk
+                    .map(|value| format!("{value:.1}"))
                     .unwrap_or_else(|| "-".to_string()),
                 run.output_wav.as_deref().unwrap_or("")
             );

--- a/crates/voice-cli/src/cli.rs
+++ b/crates/voice-cli/src/cli.rs
@@ -478,11 +478,13 @@ fn voxtral_generation_options(
     max_frames: usize,
     flow_steps: usize,
     kv_cache: bool,
+    synchronize_trace: bool,
 ) -> voice_voxtral::VoxtralGenerationOptions {
     voice_voxtral::VoxtralGenerationOptions {
         max_frames,
         flow_steps,
         use_kv_cache: kv_cache,
+        synchronize_trace,
         ..Default::default()
     }
 }
@@ -749,6 +751,10 @@ struct BenchTtsArgs {
     /// Use the current opt-in low-latency Voxtral preset
     #[arg(long = "voxtral-realtime")]
     voxtral_realtime: bool,
+
+    /// Synchronize Metal around Voxtral trace sections for local benchmark profiling
+    #[arg(long = "voxtral-sync-trace")]
+    voxtral_sync_trace: bool,
 
     /// Override Voxtral's initial streaming codec chunk size for benchmarking
     #[arg(long = "voxtral-stream-begin-frames")]
@@ -1640,6 +1646,7 @@ struct TtsBenchRunReport {
     voxtral_max_frames: Option<usize>,
     voxtral_flow_steps: Option<usize>,
     voxtral_realtime: Option<bool>,
+    voxtral_sync_trace: Option<bool>,
     voxtral_language_cache: Option<bool>,
     voxtral_stream_begin_frames: Option<usize>,
     voxtral_voice_cache_hit: Option<bool>,
@@ -1818,6 +1825,7 @@ fn bench_kokoro_tts(args: &BenchTtsArgs, text: &str) -> Result<TtsBenchEngineRep
             voxtral_max_frames: None,
             voxtral_flow_steps: None,
             voxtral_realtime: None,
+            voxtral_sync_trace: None,
             voxtral_language_cache: None,
             voxtral_stream_begin_frames: None,
             voxtral_voice_cache_hit: None,
@@ -1881,6 +1889,7 @@ fn bench_voxtral_tts(args: &BenchTtsArgs, text: &str) -> Result<TtsBenchEngineRe
                     voxtral.max_frames,
                     voxtral.flow_steps,
                     voxtral.kv_cache,
+                    args.voxtral_sync_trace,
                 ),
                 voxtral_streaming_config(voxtral),
                 |chunk| {
@@ -1928,6 +1937,7 @@ fn bench_voxtral_tts(args: &BenchTtsArgs, text: &str) -> Result<TtsBenchEngineRe
             voxtral_max_frames: Some(voxtral.max_frames),
             voxtral_flow_steps: Some(voxtral.flow_steps),
             voxtral_realtime: Some(args.voxtral_realtime),
+            voxtral_sync_trace: Some(args.voxtral_sync_trace),
             voxtral_language_cache: Some(trace.language_cache),
             voxtral_stream_begin_frames: Some(voxtral_streaming_config(voxtral).chunk_frames_at_begin),
             voxtral_voice_cache_hit: Some(trace.voice_cache_hit),
@@ -2107,6 +2117,7 @@ fn bench_daemon_tts(
             voxtral_max_frames: (engine == TtsEngine::Voxtral).then_some(voxtral.max_frames),
             voxtral_flow_steps: (engine == TtsEngine::Voxtral).then_some(voxtral.flow_steps),
             voxtral_realtime: (engine == TtsEngine::Voxtral).then_some(args.voxtral_realtime),
+            voxtral_sync_trace: (engine == TtsEngine::Voxtral).then_some(false),
             voxtral_language_cache: (engine == TtsEngine::Voxtral).then_some(voxtral.kv_cache),
             voxtral_stream_begin_frames: (engine == TtsEngine::Voxtral)
                 .then_some(voxtral_streaming_config(voxtral).chunk_frames_at_begin),
@@ -2326,7 +2337,7 @@ fn print_tts_bench_report(report: &TtsBenchReport) {
         );
         for run in &engine.runs {
             let mut line = format!(
-                "tts_bench.run engine={} run={} first_audio_ms={:.1} total_ms={:.1} synth_ms={:.1} audio_ms={:.1} realtime_factor={} first_audio_realtime_factor={} phoneme_ms={} first_code_frame_ms={} voxtral_realtime={} voxtral_max_frames={} voxtral_flow_steps={} voxtral_stream_begin_frames={} voxtral_audio_frames={} voxtral_codec_chunks={} voxtral_codec_chunks_per_second={} voxtral_language_ms_per_frame={} voxtral_acoustic_ms_per_frame={} voxtral_decode_loop_ms_per_frame={} voxtral_codec_ms_per_chunk={} output_wav={}",
+                "tts_bench.run engine={} run={} first_audio_ms={:.1} total_ms={:.1} synth_ms={:.1} audio_ms={:.1} realtime_factor={} first_audio_realtime_factor={} phoneme_ms={} first_code_frame_ms={} voxtral_realtime={} voxtral_sync_trace={} voxtral_max_frames={} voxtral_flow_steps={} voxtral_stream_begin_frames={} voxtral_audio_frames={} voxtral_codec_chunks={} voxtral_codec_chunks_per_second={} voxtral_language_ms_per_frame={} voxtral_acoustic_ms_per_frame={} voxtral_decode_loop_ms_per_frame={} voxtral_codec_ms_per_chunk={} output_wav={}",
                 engine.engine,
                 run.run,
                 run.first_audio_ms,
@@ -2346,6 +2357,9 @@ fn print_tts_bench_report(report: &TtsBenchReport) {
                     .map(|value| format!("{value:.1}"))
                     .unwrap_or_else(|| "-".to_string()),
                 run.voxtral_realtime
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+                run.voxtral_sync_trace
                     .map(|value| value.to_string())
                     .unwrap_or_else(|| "-".to_string()),
                 run.voxtral_max_frames
@@ -2762,7 +2776,7 @@ fn run_voxtral_say(
     let audio = match runtime.generate_audio(
         &text,
         voice,
-        voxtral_generation_options(voxtral.max_frames, voxtral.flow_steps, voxtral.kv_cache),
+        voxtral_generation_options(voxtral.max_frames, voxtral.flow_steps, voxtral.kv_cache, false),
     ) {
         Ok(audio) => audio,
         Err(e) => {
@@ -3346,7 +3360,7 @@ fn run_converse(args: ConverseArgs) {
         let audio = match runtime.generate_audio(
             &text,
             &voice,
-            voxtral_generation_options(voxtral.max_frames, voxtral.flow_steps, voxtral.kv_cache),
+            voxtral_generation_options(voxtral.max_frames, voxtral.flow_steps, voxtral.kv_cache, false),
         ) {
             Ok(audio) => audio,
             Err(e) => {

--- a/crates/voice-voxtral/src/generation.rs
+++ b/crates/voice-voxtral/src/generation.rs
@@ -17,6 +17,7 @@ pub struct VoxtralGenerationOptions {
     pub flow_steps: usize,
     pub cfg_alpha: f32,
     pub use_kv_cache: bool,
+    pub synchronize_trace: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -77,6 +78,7 @@ impl Default for VoxtralGenerationOptions {
             flow_steps: 7,
             cfg_alpha: 1.2,
             use_kv_cache: false,
+            synchronize_trace: false,
         }
     }
 }
@@ -407,6 +409,7 @@ fn generate_audio_inner(
                 .narrow(1, last_pos, 1)
                 .and_then(|hidden| hidden.reshape((1, config.dim))),
         )?;
+        sync_trace(device, options.synchronize_trace)?;
         trace.language += language_start.elapsed();
 
         let acoustic_start = Instant::now();
@@ -424,6 +427,7 @@ fn generate_audio_inner(
             &timesteps,
             options.cfg_alpha,
         ))?;
+        sync_trace(device, options.synchronize_trace)?;
         trace.acoustic += acoustic_start.elapsed();
         trace
             .first_frame
@@ -466,6 +470,7 @@ fn generate_audio_inner(
     let codes = candle(codes.transpose(0, 1))?;
     let codes = candle(codes.unsqueeze(0))?;
     let waveform = candle(modules.codec.decode_codes_to_waveform(&codes))?;
+    sync_trace(device, options.synchronize_trace)?;
     let samples = candle(waveform.to_dtype(DType::F32))?
         .to_vec3::<f32>()
         .map_err(|e| VoxtralError::Candle(e.to_string()))?[0][0]
@@ -569,6 +574,7 @@ where
                 .narrow(1, last_pos, 1)
                 .and_then(|hidden| hidden.reshape((1, config.dim))),
         )?;
+        sync_trace(device, options.synchronize_trace)?;
         trace.language += language_start.elapsed();
 
         let acoustic_start = Instant::now();
@@ -586,6 +592,7 @@ where
             &timesteps,
             options.cfg_alpha,
         ))?;
+        sync_trace(device, options.synchronize_trace)?;
         trace.acoustic += acoustic_start.elapsed();
         trace
             .first_frame
@@ -608,6 +615,7 @@ where
             &mut emitted_frames,
             &mut emitted_samples,
             &mut trace,
+            options.synchronize_trace,
             total_start,
             &mut on_chunk,
         )?;
@@ -642,6 +650,7 @@ where
         &mut emitted_frames,
         &mut emitted_samples,
         &mut trace,
+        options.synchronize_trace,
         total_start,
         &mut on_chunk,
     )?;
@@ -670,6 +679,7 @@ fn maybe_emit_streaming_chunk<F>(
     emitted_frames: &mut usize,
     emitted_samples: &mut Vec<f32>,
     trace: &mut VoxtralGenerationTrace,
+    synchronize_trace: bool,
     total_start: Instant,
     on_chunk: &mut F,
 ) -> Result<()>
@@ -692,6 +702,7 @@ where
 
     let codec_start = Instant::now();
     let samples = decode_codec_chunk_samples(config, modules, device, &chunk)?;
+    sync_trace(device, synchronize_trace)?;
     trace.codec += codec_start.elapsed();
     trace.codec_chunks += 1;
     trace.first_audio_chunk.get_or_insert(total_start.elapsed());
@@ -799,6 +810,13 @@ fn deterministic_noise(
     }
     let noise = candle(Tensor::from_vec(values, (1, len), device))?;
     candle(noise.to_dtype(dtype))
+}
+
+fn sync_trace(device: &Device, synchronize_trace: bool) -> Result<()> {
+    if synchronize_trace {
+        candle(device.synchronize())?;
+    }
+    Ok(())
 }
 
 struct XorShift64 {


### PR DESCRIPTION
## Summary

- expose Voxtral audio-code frame count in `voice bench tts`
- add per-frame language/acoustic/decode-loop metrics for local Voxtral runs
- add codec milliseconds per chunk for local Voxtral runs
- surface daemon `voxtral_frames` as `voxtral_audio_frames`
- add opt-in `--voxtral-sync-trace` for local Metal-synchronized section timings

## Verification

```bash
cargo fmt --check
cargo check -p voice-voxtral -p voice --bins
cargo test -p voice-voxtral -p voice --bins
cargo clippy -p voice-voxtral -p voice --bins -- -D warnings
cargo run -p voice --bin voice -- bench tts --engine voxtral --runs 1 --voxtral-realtime --json "A fast reply should arrive naturally."
cargo run -p voice --bin voice -- bench tts --engine voxtral --runs 1 --voxtral-realtime --voxtral-sync-trace --json "A fast reply should arrive naturally."
cargo run -p voice --bin voice -- bench tts --daemon --engine voxtral --runs 1 --voxtral-realtime --json "A fast reply should arrive naturally."
cargo install --path crates/voice-cli --force --locked
voice bench tts --engine voxtral --runs 1 --voxtral-realtime --voxtral-sync-trace --json "Installed synchronized trace smoke."
voice bench tts --daemon --engine voxtral --runs 1 --voxtral-realtime --json "Installed warm daemon smoke after sync trace install."
```

## Profiling smoke

- Local dev profile: language `39.2 ms/frame`, acoustic `93.5 ms/frame`, decode loop `149.2 ms/frame`, codec `39.0 ms/chunk`
- Local synchronized dev profile: language `55.3 ms/frame`, acoustic `85.8 ms/frame`, decode loop `147.7 ms/frame`, codec `19.9 ms/chunk`
- Daemon stream: first PCM `385.6 ms`, total `5049.4 ms`, realtime factor `1.578`, `voxtral_audio_frames=40`, `voxtral_codec_chunks=14`
- Installed release synchronized profile: first PCM `308.1 ms`, total `3862.6 ms`, realtime factor `1.207`, language `51.6 ms/frame`, acoustic `41.6 ms/frame`, decode loop `95.9 ms/frame`, codec `7.1 ms/chunk`
- Installed warm daemon stream: first PCM `343.0 ms`, total `3915.9 ms`, realtime factor `1.224`, first code frame `11.0 ms`, codec chunks/sec `3.58`

## Quality/speed matrix

Installed `voice` + `voice-eval` on prompt `A fast reply should arrive naturally.`:

| Max frames | Flow steps | First PCM | Total | Realtime factor | Whisper transcript | WER |
| ---: | ---: | ---: | ---: | ---: | --- | ---: |
| 24 | 5 | `369.5 ms` | `3154.6 ms` | `1.643` | `a fast reply` | `0.500` |
| 24 | 7 | `513.0 ms` | `3642.1 ms` | `1.897` | `a fast reply` | `0.500` |
| 40 | 5 | `369.2 ms` | `4282.4 ms` | `1.338` | `A fast reply should arrive no.` | `0.167` |
| 40 | 7 | `395.7 ms` | `5955.4 ms` | `1.861` | `A fast reply should arrive naturally.` | `0.000` |

This PR is instrumentation-only; it does not change synthesis behavior or public defaults.
