### PR TITLE
Add Voxtral artifact-aware eval diagnostics

### DIFF
--- a/crates/voice-audio/src/lib.rs
+++ b/crates/voice-audio/src/lib.rs
@@ -106,7 +106,7 @@ pub fn save_wav(samples: &[f32], path: &Path, sample_rate: u32) -> Result<(), St
     ensure_parent_dir(path)?;
 
     let spec = WavSpec {
-        channels: 1,
+        channels: 2,
         sample_rate,
         bits_per_sample: 32,
         sample_format: hound::SampleFormat::Float,
@@ -116,6 +116,9 @@ pub fn save_wav(samples: &[f32], path: &Path, sample_rate: u32) -> Result<(), St
         WavWriter::create(path, spec).map_err(|e| format!("create WAV {}: {e}", path.display()))?;
 
     for &sample in samples {
+        writer
+            .write_sample(sample)
+            .map_err(|e| format!("write WAV sample: {e}"))?;
         writer
             .write_sample(sample)
             .map_err(|e| format!("write WAV sample: {e}"))?;
@@ -467,7 +470,7 @@ mod tests {
 
         let mut reader = hound::WavReader::open(&path).expect("read saved wav");
         let spec = reader.spec();
-        assert_eq!(spec.channels, 1);
+        assert_eq!(spec.channels, 2);
         assert_eq!(spec.sample_rate, 24_000);
         assert_eq!(spec.bits_per_sample, 32);
         assert_eq!(spec.sample_format, hound::SampleFormat::Float);
@@ -476,7 +479,11 @@ mod tests {
             .samples::<f32>()
             .collect::<Result<Vec<_>, _>>()
             .expect("decode saved wav samples");
-        assert_eq!(decoded.len(), samples.len());
+        assert_eq!(decoded.len(), samples.len() * 2);
+        for (frame, expected) in decoded.chunks_exact(2).zip(samples.iter().copied()) {
+            assert_eq!(frame[0], expected);
+            assert_eq!(frame[1], expected);
+        }
         let rms = (decoded.iter().map(|sample| sample * sample).sum::<f32>()
             / decoded.len() as f32)
             .sqrt();

--- a/crates/voice-eval/src/main.rs
+++ b/crates/voice-eval/src/main.rs
@@ -1,4 +1,7 @@
-use std::path::PathBuf;
+use std::f64::consts::PI;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use clap::Parser;
 use serde::Serialize;
@@ -6,6 +9,8 @@ use serde::Serialize;
 const DEFAULT_TTS_MODEL: &str = "prince-canuma/Kokoro-82M";
 const DEFAULT_TTS_BACKEND: &str = "kokoro";
 const DEFAULT_STT_BACKEND: &str = "whisper";
+const DEFAULT_KOKORO_VOICE: &str = "af_heart";
+const DEFAULT_VOXTRAL_VOICE: &str = "casual_male";
 
 #[derive(Debug, Parser)]
 #[command(
@@ -30,12 +35,12 @@ struct Args {
     tts_backend: String,
 
     /// TTS voice name.
-    #[arg(short, long, default_value = "af_heart")]
-    voice: String,
+    #[arg(short, long)]
+    voice: Option<String>,
 
-    /// TTS model repo or local directory.
-    #[arg(long = "tts-model", default_value = DEFAULT_TTS_MODEL)]
-    tts_model: String,
+    /// TTS model repo or local directory. Defaults to the backend's known model.
+    #[arg(long = "tts-model")]
+    tts_model: Option<String>,
 
     /// STT backend to transcribe with.
     #[arg(long = "stt-backend", default_value = DEFAULT_STT_BACKEND)]
@@ -61,6 +66,42 @@ struct Args {
     #[arg(long = "max-frames", default_value_t = 256)]
     max_frames: usize,
 
+    /// Run a Voxtral quality/speed matrix instead of a single evaluation.
+    #[arg(long = "voxtral-matrix")]
+    voxtral_matrix: bool,
+
+    /// Additional prompt for --voxtral-matrix. Repeat for multiple prompts.
+    #[arg(long = "matrix-text", value_name = "TEXT")]
+    matrix_texts: Vec<String>,
+
+    /// Comma-separated max-frame values for --voxtral-matrix.
+    #[arg(
+        long = "matrix-max-frames",
+        value_delimiter = ',',
+        default_value = "32,40"
+    )]
+    matrix_max_frames: Vec<usize>,
+
+    /// Comma-separated flow-step values for --voxtral-matrix.
+    #[arg(
+        long = "matrix-flow-steps",
+        value_delimiter = ',',
+        default_value = "5,6,7"
+    )]
+    matrix_flow_steps: Vec<usize>,
+
+    /// Enable Voxtral language KV cache for Voxtral synthesis.
+    #[arg(long = "voxtral-kv-cache")]
+    voxtral_kv_cache: bool,
+
+    /// Initial streaming codec chunk size for Voxtral matrix timing.
+    #[arg(long = "voxtral-stream-begin-frames", default_value_t = 2)]
+    voxtral_stream_begin_frames: usize,
+
+    /// Synchronize Metal around Voxtral trace sections for profiling.
+    #[arg(long = "voxtral-sync-trace")]
+    voxtral_sync_trace: bool,
+
     /// Deterministic seed for Voxtral flow noise.
     #[arg(long, default_value_t = 0x5658_5452_414c)]
     seed: u64,
@@ -73,9 +114,46 @@ struct Args {
     #[arg(long = "output-wav")]
     output_wav: Option<PathBuf>,
 
+    /// Directory for generated WAVs when --voxtral-matrix is set.
+    #[arg(long = "output-dir")]
+    output_dir: Option<PathBuf>,
+
+    /// Directory for grayscale PGM spectrograms.
+    #[arg(long = "spectrogram-dir")]
+    spectrogram_dir: Option<PathBuf>,
+
     /// Print the report as pretty JSON.
     #[arg(long)]
     json: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AudioSegment {
+    start_seconds: f64,
+    end_seconds: f64,
+    duration_seconds: f64,
+    peak_dbfs: f64,
+    rms_dbfs: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AudioDiagnostics {
+    duration_seconds: f64,
+    peak_dbfs: f64,
+    rms_dbfs: f64,
+    active_threshold_dbfs: f64,
+    active_duration_seconds: f64,
+    active_span_seconds: f64,
+    active_ratio: Option<f64>,
+    active_segment_count: usize,
+    long_gap_count: usize,
+    longest_internal_gap_seconds: f64,
+    gap_seconds: Vec<f64>,
+    leading_silence_seconds: f64,
+    trailing_silence_seconds: f64,
+    leading_fragment_seconds: Option<f64>,
+    trailing_fragment_seconds: Option<f64>,
+    segments: Vec<AudioSegment>,
 }
 
 #[derive(Debug, Serialize)]
@@ -98,49 +176,112 @@ struct EvalReport {
     word_error_rate: Option<f32>,
     stt_token_count: usize,
     stt_sample_rate: u32,
+    audio_diagnostics: AudioDiagnostics,
     input_wav: Option<PathBuf>,
     output_wav: Option<PathBuf>,
+    spectrogram_pgm: Option<PathBuf>,
+}
+
+#[derive(Debug, Serialize)]
+struct VoxtralMatrixReport {
+    voice: String,
+    tts_model: String,
+    stt_backend: String,
+    stt_model: String,
+    model_load_ms: f64,
+    matrix_max_frames: Vec<usize>,
+    matrix_flow_steps: Vec<usize>,
+    stream_begin_frames: usize,
+    kv_cache: bool,
+    sync_trace: bool,
+    seed: u64,
+    output_dir: Option<PathBuf>,
+    spectrogram_dir: Option<PathBuf>,
+    rows: Vec<VoxtralMatrixRow>,
+}
+
+#[derive(Debug, Serialize)]
+struct VoxtralMatrixRow {
+    text_index: usize,
+    text: String,
+    max_frames: usize,
+    flow_steps: usize,
+    first_code_frame_ms: Option<f64>,
+    first_audio_ms: Option<f64>,
+    total_ms: f64,
+    audio_duration_ms: f64,
+    realtime_factor: Option<f64>,
+    samples: usize,
+    sample_rate: u32,
+    audio_frames: usize,
+    ended: bool,
+    codec_chunks: usize,
+    language_ms: f64,
+    language_ms_per_frame: Option<f64>,
+    acoustic_ms: f64,
+    acoustic_ms_per_frame: Option<f64>,
+    decode_loop_ms: f64,
+    decode_loop_ms_per_frame: Option<f64>,
+    codec_ms: f64,
+    codec_ms_per_chunk: Option<f64>,
+    transcription: String,
+    normalized_reference: String,
+    normalized_hypothesis: String,
+    reference_word_count: usize,
+    word_error_count: usize,
+    word_error_rate: Option<f32>,
+    stt_token_count: usize,
+    audio_diagnostics: AudioDiagnostics,
+    output_wav: Option<PathBuf>,
+    spectrogram_pgm: Option<PathBuf>,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
+    if args.voxtral_matrix {
+        return run_voxtral_matrix(&args);
+    }
+
+    let tts_model_path = tts_model_path(&args);
+    let tts_voice = tts_voice(&args);
     let reference_text = args
         .expected_text
         .clone()
         .unwrap_or_else(|| args.text.clone());
-    let (samples, sample_rate, phoneme_chunks, synthesis_mode) =
-        if let Some(input_wav) = &args.input_wav {
-            let audio = voice_stt::load_audio_file(input_wav)?;
-            (audio.samples, audio.sample_rate, Vec::new(), "input-wav")
-        } else if args.tts_backend == "voxtral" {
-            let (samples, sample_rate) = synthesize_voxtral(&args)?;
-            (samples, sample_rate, Vec::new(), "voxtral-native")
-        } else if args.tts_backend == "kokoro" {
-            let phoneme_chunks = voice_g2p::text_to_phoneme_chunks(&args.text)?;
-            let mode = if args.stochastic {
-                voice_tts::SynthesisMode::Stochastic
-            } else {
-                voice_tts::SynthesisMode::Deterministic
-            };
-            let (samples, sample_rate) = synthesize_kokoro(&args, &phoneme_chunks, mode)?;
-            (
-                samples,
-                sample_rate,
-                phoneme_chunks,
-                if args.stochastic {
-                    "stochastic"
-                } else {
-                    "deterministic"
-                },
-            )
+    let (samples, sample_rate, phoneme_chunks, synthesis_mode) = if let Some(input_wav) =
+        &args.input_wav
+    {
+        let audio = voice_stt::load_audio_file(input_wav)?;
+        (audio.samples, audio.sample_rate, Vec::new(), "input-wav")
+    } else if args.tts_backend == "voxtral" {
+        let (samples, sample_rate) = synthesize_voxtral(&args, &tts_voice)?;
+        (samples, sample_rate, Vec::new(), "voxtral-native")
+    } else if args.tts_backend == "kokoro" {
+        let phoneme_chunks = voice_g2p::text_to_phoneme_chunks(&args.text)?;
+        let mode = if args.stochastic {
+            voice_tts::SynthesisMode::Stochastic
         } else {
-            return Err(format!(
-                "unsupported --tts-backend {:?}; expected kokoro or voxtral",
-                args.tts_backend
-            )
-            .into());
+            voice_tts::SynthesisMode::Deterministic
         };
+        let (samples, sample_rate) = synthesize_kokoro(&args, &phoneme_chunks, mode, &tts_voice)?;
+        (
+            samples,
+            sample_rate,
+            phoneme_chunks,
+            if args.stochastic {
+                "stochastic"
+            } else {
+                "deterministic"
+            },
+        )
+    } else {
+        return Err(format!(
+            "unsupported --tts-backend {:?}; expected kokoro or voxtral",
+            args.tts_backend
+        )
+        .into());
+    };
 
     if args.input_wav.is_some() && args.output_wav.is_some() {
         return Err("--output-wav cannot be used with --input-wav".into());
@@ -166,11 +307,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         samples.len() as f32 / sample_rate as f32
     };
+    let audio_diagnostics = analyze_audio(&samples, sample_rate);
+    let spectrogram_pgm = maybe_write_spectrogram_pgm(
+        args.spectrogram_dir.as_deref(),
+        "eval.pgm",
+        &samples,
+        sample_rate,
+    )?;
 
     let report = EvalReport {
         text: reference_text,
-        voice: args.voice,
-        tts_model: args.tts_model,
+        voice: tts_voice,
+        tts_model: tts_model_path,
         stt_backend: stt_backend.as_str().to_string(),
         stt_model: stt_model_path,
         synthesis_mode,
@@ -186,8 +334,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         word_error_rate: wer.rate,
         stt_token_count: transcription.tokens.len(),
         stt_sample_rate: transcription.sample_rate,
-        input_wav: args.input_wav,
-        output_wav: args.output_wav,
+        audio_diagnostics,
+        input_wav: args.input_wav.clone(),
+        output_wav: args.output_wav.clone(),
+        spectrogram_pgm,
     };
 
     if args.json {
@@ -199,14 +349,215 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+fn run_voxtral_matrix(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
+    if args.input_wav.is_some() {
+        return Err("--voxtral-matrix cannot be used with --input-wav".into());
+    }
+    if args.output_wav.is_some() {
+        return Err("--output-wav cannot be used with --voxtral-matrix; use --output-dir".into());
+    }
+    if args.expected_text.is_some() {
+        return Err("--expected-text cannot be used with --voxtral-matrix".into());
+    }
+    if args.tts_backend != "voxtral" {
+        return Err("--voxtral-matrix requires --tts-backend voxtral".into());
+    }
+    if args.matrix_max_frames.is_empty() {
+        return Err("--matrix-max-frames must include at least one value".into());
+    }
+    if args.matrix_flow_steps.is_empty() {
+        return Err("--matrix-flow-steps must include at least one value".into());
+    }
+    if args.matrix_max_frames.contains(&0) {
+        return Err("--matrix-max-frames values must be greater than zero".into());
+    }
+    if args.matrix_flow_steps.contains(&0) {
+        return Err("--matrix-flow-steps values must be greater than zero".into());
+    }
+    if args.voxtral_stream_begin_frames == 0 {
+        return Err("--voxtral-stream-begin-frames must be greater than zero".into());
+    }
+
+    let texts = matrix_texts(args)?;
+    let tts_model_path = tts_model_path(args);
+    let tts_voice = tts_voice(args);
+    let (mut runtime, load_trace) =
+        voice_voxtral::VoxtralTtsRuntime::load_default_with_trace(&tts_model_path)?;
+    runtime.preload_voice(&tts_voice)?;
+
+    let stt_backend = voice_stt::SttBackend::parse(&args.stt_backend)?;
+    let stt_model_path = args
+        .stt_model
+        .clone()
+        .unwrap_or_else(|| voice_stt::default_model_for_backend(stt_backend).to_string());
+    let mut stt_model = voice_stt::load_backend_model(stt_backend, &stt_model_path)?;
+    if let Some(max_new_tokens) = args.stt_max_tokens {
+        stt_model.set_max_new_tokens(max_new_tokens);
+    }
+
+    let mut rows = Vec::new();
+    for (text_index, text) in texts.iter().enumerate() {
+        for &max_frames in &args.matrix_max_frames {
+            for &flow_steps in &args.matrix_flow_steps {
+                let streaming = voice_voxtral::VoxtralStreamingConfig {
+                    chunk_frames_at_begin: args.voxtral_stream_begin_frames,
+                    ..Default::default()
+                };
+                let options = voice_voxtral::VoxtralGenerationOptions {
+                    max_frames,
+                    seed: args.seed,
+                    flow_steps,
+                    use_kv_cache: args.voxtral_kv_cache,
+                    synchronize_trace: args.voxtral_sync_trace,
+                    ..Default::default()
+                };
+
+                let run_start = Instant::now();
+                let (audio, trace) = runtime.generate_audio_streaming_with_trace(
+                    text,
+                    &tts_voice,
+                    options,
+                    streaming,
+                    |_| Ok(()),
+                )?;
+                let total = run_start.elapsed();
+                let output_wav = maybe_write_matrix_wav(
+                    args.output_dir.as_deref(),
+                    text_index,
+                    max_frames,
+                    flow_steps,
+                    &audio.samples,
+                    audio.sample_rate,
+                )?;
+                let spectrogram_pgm = maybe_write_spectrogram_pgm(
+                    args.spectrogram_dir.as_deref(),
+                    &format!(
+                        "voxtral-text{}-max{}-flow{}.pgm",
+                        text_index + 1,
+                        max_frames,
+                        flow_steps
+                    ),
+                    &audio.samples,
+                    audio.sample_rate,
+                )?;
+
+                let transcription =
+                    stt_model.transcribe_audio(&audio.samples, audio.sample_rate)?;
+                let wer = word_error_rate(text, &transcription.text);
+                let audio_diagnostics = analyze_audio(&audio.samples, audio.sample_rate);
+                let total_ms = duration_ms(total);
+                let audio_duration_ms = audio_duration_ms(audio.samples.len(), audio.sample_rate);
+                let language_ms = duration_ms(trace.language);
+                let acoustic_ms = duration_ms(trace.acoustic);
+                let decode_loop_ms = duration_ms(trace.decode_loop);
+                let codec_ms = duration_ms(trace.codec);
+
+                rows.push(VoxtralMatrixRow {
+                    text_index,
+                    text: text.clone(),
+                    max_frames,
+                    flow_steps,
+                    first_code_frame_ms: trace.first_frame.map(duration_ms),
+                    first_audio_ms: trace.first_audio_chunk.map(duration_ms),
+                    total_ms,
+                    audio_duration_ms,
+                    realtime_factor: ratio_ms(total_ms, audio_duration_ms),
+                    samples: audio.samples.len(),
+                    sample_rate: audio.sample_rate,
+                    audio_frames: audio.frames,
+                    ended: audio.ended,
+                    codec_chunks: trace.codec_chunks,
+                    language_ms,
+                    language_ms_per_frame: per_unit(language_ms, audio.frames),
+                    acoustic_ms,
+                    acoustic_ms_per_frame: per_unit(acoustic_ms, audio.frames),
+                    decode_loop_ms,
+                    decode_loop_ms_per_frame: per_unit(decode_loop_ms, audio.frames),
+                    codec_ms,
+                    codec_ms_per_chunk: per_unit(codec_ms, trace.codec_chunks),
+                    transcription: transcription.text,
+                    normalized_reference: wer.reference_words.join(" "),
+                    normalized_hypothesis: wer.hypothesis_words.join(" "),
+                    reference_word_count: wer.reference_words.len(),
+                    word_error_count: wer.distance,
+                    word_error_rate: wer.rate,
+                    stt_token_count: transcription.tokens.len(),
+                    audio_diagnostics,
+                    output_wav,
+                    spectrogram_pgm,
+                });
+            }
+        }
+    }
+
+    let report = VoxtralMatrixReport {
+        voice: tts_voice,
+        tts_model: tts_model_path,
+        stt_backend: stt_backend.as_str().to_string(),
+        stt_model: stt_model_path,
+        model_load_ms: duration_ms(load_trace.total),
+        matrix_max_frames: args.matrix_max_frames.clone(),
+        matrix_flow_steps: args.matrix_flow_steps.clone(),
+        stream_begin_frames: args.voxtral_stream_begin_frames,
+        kv_cache: args.voxtral_kv_cache,
+        sync_trace: args.voxtral_sync_trace,
+        seed: args.seed,
+        output_dir: args.output_dir.clone(),
+        spectrogram_dir: args.spectrogram_dir.clone(),
+        rows,
+    };
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_voxtral_matrix_report(&report);
+    }
+
+    Ok(())
+}
+
+fn tts_model_path(args: &Args) -> String {
+    args.tts_model.clone().unwrap_or_else(|| {
+        if args.tts_backend == "voxtral" {
+            voice_voxtral::DEFAULT_REPO.to_string()
+        } else {
+            DEFAULT_TTS_MODEL.to_string()
+        }
+    })
+}
+
+fn tts_voice(args: &Args) -> String {
+    args.voice.clone().unwrap_or_else(|| {
+        if args.tts_backend == "voxtral" {
+            DEFAULT_VOXTRAL_VOICE.to_string()
+        } else {
+            DEFAULT_KOKORO_VOICE.to_string()
+        }
+    })
+}
+
+fn matrix_texts(args: &Args) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let texts = if args.matrix_texts.is_empty() {
+        vec![args.text.clone()]
+    } else {
+        args.matrix_texts.clone()
+    };
+    if texts.iter().any(|text| text.trim().is_empty()) {
+        return Err("--matrix-text values must not be empty".into());
+    }
+    Ok(texts)
+}
+
 fn synthesize_kokoro(
     args: &Args,
     phoneme_chunks: &[String],
     synthesis_mode: voice_tts::SynthesisMode,
+    voice_name: &str,
 ) -> Result<(Vec<f32>, u32), Box<dyn std::error::Error>> {
-    let mut model = voice_tts::load_model(&args.tts_model)?;
+    let tts_model_path = tts_model_path(args);
+    let mut model = voice_tts::load_model(&tts_model_path)?;
     let sample_rate = model.sample_rate;
-    let voice = model.load_voice(&args.voice, Some(&args.tts_model))?;
+    let voice = model.load_voice(voice_name, Some(&tts_model_path))?;
     let mut samples = Vec::new();
 
     for phonemes in phoneme_chunks {
@@ -226,19 +577,413 @@ fn synthesize_kokoro(
     Ok((samples, sample_rate))
 }
 
-fn synthesize_voxtral(args: &Args) -> Result<(Vec<f32>, u32), Box<dyn std::error::Error>> {
-    let model = voice_voxtral::VoxtralModel::load(&args.tts_model)?;
+fn synthesize_voxtral(
+    args: &Args,
+    voice_name: &str,
+) -> Result<(Vec<f32>, u32), Box<dyn std::error::Error>> {
+    let tts_model_path = tts_model_path(args);
+    let model = voice_voxtral::VoxtralModel::load(&tts_model_path)?;
     let audio = model.generate_audio_default(
         &args.text,
-        &args.voice,
+        voice_name,
         voice_voxtral::VoxtralGenerationOptions {
             max_frames: args.max_frames,
             seed: args.seed,
             flow_steps: args.flow_steps,
+            use_kv_cache: args.voxtral_kv_cache,
+            synchronize_trace: args.voxtral_sync_trace,
             ..Default::default()
         },
     )?;
     Ok((audio.samples, audio.sample_rate))
+}
+
+fn maybe_write_matrix_wav(
+    output_dir: Option<&Path>,
+    text_index: usize,
+    max_frames: usize,
+    flow_steps: usize,
+    samples: &[f32],
+    sample_rate: u32,
+) -> Result<Option<PathBuf>, Box<dyn std::error::Error>> {
+    let Some(output_dir) = output_dir else {
+        return Ok(None);
+    };
+    std::fs::create_dir_all(output_dir)?;
+    let path = output_dir.join(format!(
+        "voxtral-text{}-max{}-flow{}.wav",
+        text_index + 1,
+        max_frames,
+        flow_steps
+    ));
+    voice_tts::save_wav(samples, &path, sample_rate)?;
+    Ok(Some(path))
+}
+
+fn maybe_write_spectrogram_pgm(
+    spectrogram_dir: Option<&Path>,
+    file_name: &str,
+    samples: &[f32],
+    sample_rate: u32,
+) -> Result<Option<PathBuf>, Box<dyn std::error::Error>> {
+    let Some(spectrogram_dir) = spectrogram_dir else {
+        return Ok(None);
+    };
+    std::fs::create_dir_all(spectrogram_dir)?;
+    let path = spectrogram_dir.join(file_name);
+    let image = spectrogram_pgm(samples, sample_rate);
+    let mut file = std::fs::File::create(&path)?;
+    file.write_all(&image)?;
+    Ok(Some(path))
+}
+
+fn spectrogram_pgm(samples: &[f32], sample_rate: u32) -> Vec<u8> {
+    const WINDOW_SIZE: usize = 256;
+    const HOP_SIZE: usize = 128;
+    const BINS: usize = 96;
+    const DB_RANGE: f64 = 80.0;
+
+    let frame_count = if samples.is_empty() {
+        1
+    } else {
+        ((samples.len().saturating_sub(1)) / HOP_SIZE) + 1
+    };
+    let mut magnitudes = vec![0.0_f64; frame_count * BINS];
+    let mut max_db = -120.0_f64;
+
+    for frame in 0..frame_count {
+        let start = frame * HOP_SIZE;
+        for bin in 0..BINS {
+            let mut real = 0.0_f64;
+            let mut imag = 0.0_f64;
+            for n in 0..WINDOW_SIZE {
+                let sample = samples.get(start + n).copied().unwrap_or(0.0) as f64;
+                let window = 0.5 - 0.5 * ((2.0 * PI * n as f64) / (WINDOW_SIZE - 1) as f64).cos();
+                let angle = 2.0 * PI * bin as f64 * n as f64 / WINDOW_SIZE as f64;
+                real += sample * window * angle.cos();
+                imag -= sample * window * angle.sin();
+            }
+            let magnitude = (real.mul_add(real, imag * imag)).sqrt();
+            let db = dbfs_amplitude(magnitude.max(1.0e-12));
+            magnitudes[frame * BINS + bin] = db;
+            max_db = max_db.max(db);
+        }
+    }
+
+    let floor_db = max_db - DB_RANGE;
+    let mut image = Vec::new();
+    image.extend_from_slice(
+        format!("P5\n# sample_rate {sample_rate}\n{frame_count} {BINS}\n255\n").as_bytes(),
+    );
+    for display_bin in (0..BINS).rev() {
+        for frame in 0..frame_count {
+            let db = magnitudes[frame * BINS + display_bin];
+            let normalized = ((db - floor_db) / DB_RANGE).clamp(0.0, 1.0);
+            image.push((normalized * 255.0).round() as u8);
+        }
+    }
+    image
+}
+
+fn analyze_audio(samples: &[f32], sample_rate: u32) -> AudioDiagnostics {
+    const FRAME_MS: u32 = 20;
+    const HOP_MS: u32 = 10;
+    const MERGE_GAP_SECONDS: f64 = 0.10;
+    const MIN_SEGMENT_SECONDS: f64 = 0.03;
+    const LONG_GAP_SECONDS: f64 = 0.25;
+    const FRAGMENT_SECONDS: f64 = 0.25;
+
+    let duration_seconds = seconds(samples.len(), sample_rate);
+    let peak = peak_amplitude(samples);
+    let rms = rms_amplitude(samples);
+    let peak_dbfs = dbfs_amplitude(peak);
+    let rms_dbfs = dbfs_amplitude(rms);
+    let active_threshold_dbfs = (peak_dbfs - 35.0).max(-55.0);
+
+    if samples.is_empty() || sample_rate == 0 {
+        return AudioDiagnostics {
+            duration_seconds,
+            peak_dbfs,
+            rms_dbfs,
+            active_threshold_dbfs,
+            active_duration_seconds: 0.0,
+            active_span_seconds: 0.0,
+            active_ratio: None,
+            active_segment_count: 0,
+            long_gap_count: 0,
+            longest_internal_gap_seconds: 0.0,
+            gap_seconds: Vec::new(),
+            leading_silence_seconds: duration_seconds,
+            trailing_silence_seconds: 0.0,
+            leading_fragment_seconds: None,
+            trailing_fragment_seconds: None,
+            segments: Vec::new(),
+        };
+    }
+
+    let frame_len = samples_for_duration(sample_rate, FRAME_MS as f64 / 1_000.0);
+    let hop_len = samples_for_duration(sample_rate, HOP_MS as f64 / 1_000.0);
+    let merge_gap_samples = samples_for_duration(sample_rate, MERGE_GAP_SECONDS);
+    let min_segment_samples = samples_for_duration(sample_rate, MIN_SEGMENT_SECONDS);
+
+    let mut raw_segments = Vec::new();
+    let mut current: Option<(usize, usize)> = None;
+    let mut start = 0;
+    while start < samples.len() {
+        let end = (start + frame_len).min(samples.len());
+        let frame_rms_dbfs = dbfs_amplitude(rms_amplitude(&samples[start..end]));
+        let is_active = frame_rms_dbfs >= active_threshold_dbfs && frame_rms_dbfs > -90.0;
+        if is_active {
+            match current {
+                Some((segment_start, segment_end)) => {
+                    if start.saturating_sub(segment_end) <= merge_gap_samples {
+                        current = Some((segment_start, end));
+                    } else {
+                        push_raw_segment(
+                            &mut raw_segments,
+                            segment_start,
+                            segment_end,
+                            min_segment_samples,
+                        );
+                        current = Some((start, end));
+                    }
+                }
+                None => current = Some((start, end)),
+            }
+        }
+        start += hop_len;
+    }
+    if let Some((segment_start, segment_end)) = current {
+        push_raw_segment(
+            &mut raw_segments,
+            segment_start,
+            segment_end,
+            min_segment_samples,
+        );
+    }
+
+    let segments: Vec<AudioSegment> = raw_segments
+        .into_iter()
+        .map(|(start, end)| {
+            let segment_samples = &samples[start..end];
+            let start_seconds = seconds(start, sample_rate);
+            let end_seconds = seconds(end, sample_rate);
+            AudioSegment {
+                start_seconds,
+                end_seconds,
+                duration_seconds: end_seconds - start_seconds,
+                peak_dbfs: dbfs_amplitude(peak_amplitude(segment_samples)),
+                rms_dbfs: dbfs_amplitude(rms_amplitude(segment_samples)),
+            }
+        })
+        .collect();
+
+    let active_duration_seconds: f64 = segments
+        .iter()
+        .map(|segment| segment.duration_seconds)
+        .sum();
+    let active_span_seconds = match (segments.first(), segments.last()) {
+        (Some(first), Some(last)) => last.end_seconds - first.start_seconds,
+        _ => 0.0,
+    };
+    let active_ratio =
+        (active_span_seconds > 0.0).then_some(active_duration_seconds / active_span_seconds);
+    let gap_seconds: Vec<f64> = segments
+        .windows(2)
+        .map(|pair| pair[1].start_seconds - pair[0].end_seconds)
+        .collect();
+    let longest_internal_gap_seconds = gap_seconds.iter().copied().fold(0.0, f64::max);
+    let long_gap_count = gap_seconds
+        .iter()
+        .filter(|gap_seconds| **gap_seconds >= LONG_GAP_SECONDS)
+        .count();
+    let leading_silence_seconds = segments
+        .first()
+        .map(|segment| segment.start_seconds)
+        .unwrap_or(duration_seconds);
+    let trailing_silence_seconds = segments
+        .last()
+        .map(|segment| (duration_seconds - segment.end_seconds).max(0.0))
+        .unwrap_or(0.0);
+    let leading_fragment_seconds = (segments.len() > 1)
+        .then(|| segments.first())
+        .flatten()
+        .and_then(|segment| {
+            (segment.duration_seconds < FRAGMENT_SECONDS).then_some(segment.duration_seconds)
+        });
+    let trailing_fragment_seconds = (segments.len() > 1)
+        .then(|| segments.last())
+        .flatten()
+        .and_then(|segment| {
+            (segment.duration_seconds < FRAGMENT_SECONDS).then_some(segment.duration_seconds)
+        });
+
+    AudioDiagnostics {
+        duration_seconds,
+        peak_dbfs,
+        rms_dbfs,
+        active_threshold_dbfs,
+        active_duration_seconds,
+        active_span_seconds,
+        active_ratio,
+        active_segment_count: segments.len(),
+        long_gap_count,
+        longest_internal_gap_seconds,
+        gap_seconds,
+        leading_silence_seconds,
+        trailing_silence_seconds,
+        leading_fragment_seconds,
+        trailing_fragment_seconds,
+        segments,
+    }
+}
+
+fn push_raw_segment(
+    segments: &mut Vec<(usize, usize)>,
+    start: usize,
+    end: usize,
+    min_segment_samples: usize,
+) {
+    if end.saturating_sub(start) >= min_segment_samples {
+        segments.push((start, end));
+    }
+}
+
+fn samples_for_duration(sample_rate: u32, duration_seconds: f64) -> usize {
+    ((sample_rate as f64 * duration_seconds).round() as usize).max(1)
+}
+
+fn seconds(samples: usize, sample_rate: u32) -> f64 {
+    if sample_rate == 0 {
+        0.0
+    } else {
+        samples as f64 / sample_rate as f64
+    }
+}
+
+fn peak_amplitude(samples: &[f32]) -> f64 {
+    samples
+        .iter()
+        .map(|sample| sample.abs() as f64)
+        .fold(0.0, f64::max)
+}
+
+fn rms_amplitude(samples: &[f32]) -> f64 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let sum_squares: f64 = samples
+        .iter()
+        .map(|sample| {
+            let sample = *sample as f64;
+            sample * sample
+        })
+        .sum();
+    (sum_squares / samples.len() as f64).sqrt()
+}
+
+fn dbfs_amplitude(amplitude: f64) -> f64 {
+    if amplitude <= 0.0 {
+        -120.0
+    } else {
+        20.0 * amplitude.log10()
+    }
+}
+
+fn print_voxtral_matrix_report(report: &VoxtralMatrixReport) {
+    println!("voxtral_matrix.voice={}", report.voice);
+    println!("voxtral_matrix.model={}", report.tts_model);
+    println!(
+        "voxtral_matrix.stt={} model={}",
+        report.stt_backend, report.stt_model
+    );
+    println!("voxtral_matrix.model_load_ms={:.1}", report.model_load_ms);
+    println!(
+        "voxtral_matrix.max_frames={:?} flow_steps={:?} stream_begin_frames={} kv_cache={} sync_trace={}",
+        report.matrix_max_frames,
+        report.matrix_flow_steps,
+        report.stream_begin_frames,
+        report.kv_cache,
+        report.sync_trace
+    );
+    if let Some(output_dir) = &report.output_dir {
+        println!("voxtral_matrix.output_dir={}", output_dir.display());
+    }
+    if let Some(spectrogram_dir) = &report.spectrogram_dir {
+        println!(
+            "voxtral_matrix.spectrogram_dir={}",
+            spectrogram_dir.display()
+        );
+    }
+    for row in &report.rows {
+        println!(
+            concat!(
+                "voxtral_matrix.row text_index={} max_frames={} flow_steps={} ",
+                "first_audio_ms={} total_ms={:.1} audio_ms={:.1} rtf={} ",
+                "wer={} errors={}/{} frames={} ended={} chunks={} ",
+                "segments={} long_gaps={} longest_gap_s={:.3} active_ratio={} ",
+                "lead_frag_s={} trail_frag_s={} spectrogram={} transcript={:?}"
+            ),
+            row.text_index,
+            row.max_frames,
+            row.flow_steps,
+            format_optional_f64(row.first_audio_ms),
+            row.total_ms,
+            row.audio_duration_ms,
+            format_optional_f64(row.realtime_factor),
+            format_optional_f32(row.word_error_rate),
+            row.word_error_count,
+            row.reference_word_count,
+            row.audio_frames,
+            row.ended,
+            row.codec_chunks,
+            row.audio_diagnostics.active_segment_count,
+            row.audio_diagnostics.long_gap_count,
+            row.audio_diagnostics.longest_internal_gap_seconds,
+            format_optional_f64(row.audio_diagnostics.active_ratio),
+            format_optional_f64(row.audio_diagnostics.leading_fragment_seconds),
+            format_optional_f64(row.audio_diagnostics.trailing_fragment_seconds),
+            format_optional_path(row.spectrogram_pgm.as_ref()),
+            row.transcription
+        );
+    }
+}
+
+fn duration_ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}
+
+fn audio_duration_ms(samples: usize, sample_rate: u32) -> f64 {
+    if sample_rate == 0 {
+        0.0
+    } else {
+        samples as f64 / sample_rate as f64 * 1_000.0
+    }
+}
+
+fn ratio_ms(numerator_ms: f64, denominator_ms: f64) -> Option<f64> {
+    (denominator_ms > 0.0).then_some(numerator_ms / denominator_ms)
+}
+
+fn per_unit(total_ms: f64, units: usize) -> Option<f64> {
+    (units > 0).then_some(total_ms / units as f64)
+}
+
+fn format_optional_f64(value: Option<f64>) -> String {
+    value
+        .map(|value| format!("{value:.3}"))
+        .unwrap_or_else(|| "n/a".to_string())
+}
+
+fn format_optional_f32(value: Option<f32>) -> String {
+    value
+        .map(|value| format!("{value:.3}"))
+        .unwrap_or_else(|| "n/a".to_string())
+}
+
+fn format_optional_path(path: Option<&PathBuf>) -> String {
+    path.map(|path| path.display().to_string())
+        .unwrap_or_else(|| "n/a".to_string())
 }
 
 fn print_text_report(report: &EvalReport) {
@@ -260,6 +1005,25 @@ fn print_text_report(report: &EvalReport) {
         report.duration_seconds, report.sample_rate, report.sample_count
     );
     println!(
+        concat!(
+            "audio diagnostics: peak={:.1} dBFS rms={:.1} dBFS threshold={:.1} dBFS ",
+            "segments={} active_ratio={} long_gaps={} longest_gap_s={:.3} ",
+            "leading_silence_s={:.3} trailing_silence_s={:.3} ",
+            "lead_frag_s={} trail_frag_s={}"
+        ),
+        report.audio_diagnostics.peak_dbfs,
+        report.audio_diagnostics.rms_dbfs,
+        report.audio_diagnostics.active_threshold_dbfs,
+        report.audio_diagnostics.active_segment_count,
+        format_optional_f64(report.audio_diagnostics.active_ratio),
+        report.audio_diagnostics.long_gap_count,
+        report.audio_diagnostics.longest_internal_gap_seconds,
+        report.audio_diagnostics.leading_silence_seconds,
+        report.audio_diagnostics.trailing_silence_seconds,
+        format_optional_f64(report.audio_diagnostics.leading_fragment_seconds),
+        format_optional_f64(report.audio_diagnostics.trailing_fragment_seconds)
+    );
+    println!(
         "stt: {} ({} Hz) using {}",
         report.stt_backend, report.stt_sample_rate, report.stt_model
     );
@@ -268,6 +1032,9 @@ fn print_text_report(report: &EvalReport) {
     }
     if let Some(path) = &report.input_wav {
         println!("input wav: {}", path.display());
+    }
+    if let Some(path) = &report.spectrogram_pgm {
+        println!("spectrogram: {}", path.display());
     }
 }
 
@@ -374,5 +1141,142 @@ mod tests {
         assert_eq!(args.stt_model.as_deref(), Some("/tmp/voxtral-realtime"));
         assert_eq!(args.stt_max_tokens, Some(4));
         assert_eq!(args.input_wav, Some(PathBuf::from("/tmp/known.wav")));
+    }
+
+    #[test]
+    fn parses_voxtral_matrix_args() {
+        let args = Args::try_parse_from([
+            "voice-eval",
+            "--tts-backend",
+            "voxtral",
+            "--voxtral-matrix",
+            "--matrix-text",
+            "A fast reply should arrive naturally.",
+            "--matrix-text",
+            "Voxtral pronunciation should stay clear.",
+            "--matrix-max-frames",
+            "32,40",
+            "--matrix-flow-steps",
+            "5,6,7",
+            "--voxtral-kv-cache",
+            "--voxtral-stream-begin-frames",
+            "2",
+            "--output-dir",
+            "/tmp/voxtral-matrix",
+            "--spectrogram-dir",
+            "/tmp/voxtral-spectrograms",
+        ])
+        .unwrap();
+
+        assert!(args.voxtral_matrix);
+        assert_eq!(
+            args.matrix_texts,
+            vec![
+                "A fast reply should arrive naturally.",
+                "Voxtral pronunciation should stay clear."
+            ]
+        );
+        assert_eq!(args.matrix_max_frames, vec![32, 40]);
+        assert_eq!(args.matrix_flow_steps, vec![5, 6, 7]);
+        assert!(args.voxtral_kv_cache);
+        assert_eq!(args.voxtral_stream_begin_frames, 2);
+        assert_eq!(args.output_dir, Some(PathBuf::from("/tmp/voxtral-matrix")));
+        assert_eq!(
+            args.spectrogram_dir,
+            Some(PathBuf::from("/tmp/voxtral-spectrograms"))
+        );
+    }
+
+    #[test]
+    fn defaults_tts_model_from_backend() {
+        let kokoro_args = Args::try_parse_from(["voice-eval"]).unwrap();
+        assert_eq!(tts_model_path(&kokoro_args), DEFAULT_TTS_MODEL);
+
+        let voxtral_args =
+            Args::try_parse_from(["voice-eval", "--tts-backend", "voxtral"]).unwrap();
+        assert_eq!(tts_model_path(&voxtral_args), voice_voxtral::DEFAULT_REPO);
+    }
+
+    #[test]
+    fn defaults_tts_voice_from_backend() {
+        let kokoro_args = Args::try_parse_from(["voice-eval"]).unwrap();
+        assert_eq!(tts_voice(&kokoro_args), DEFAULT_KOKORO_VOICE);
+
+        let voxtral_args =
+            Args::try_parse_from(["voice-eval", "--tts-backend", "voxtral"]).unwrap();
+        assert_eq!(tts_voice(&voxtral_args), DEFAULT_VOXTRAL_VOICE);
+
+        let explicit_voxtral_args = Args::try_parse_from([
+            "voice-eval",
+            "--tts-backend",
+            "voxtral",
+            "--voice",
+            "neutral_female",
+        ])
+        .unwrap();
+        assert_eq!(tts_voice(&explicit_voxtral_args), "neutral_female");
+    }
+
+    #[test]
+    fn matrix_texts_falls_back_to_primary_text() {
+        let args =
+            Args::try_parse_from(["voice-eval", "--voxtral-matrix", "--text", "hello"]).unwrap();
+
+        assert_eq!(matrix_texts(&args).unwrap(), vec!["hello"]);
+    }
+
+    #[test]
+    fn audio_diagnostics_keep_continuous_audio_in_one_segment() {
+        let sample_rate = 1_000;
+        let samples = tone_samples(sample_rate, 1.0, 0.5);
+
+        let diagnostics = analyze_audio(&samples, sample_rate);
+
+        assert_eq!(diagnostics.active_segment_count, 1);
+        assert_eq!(diagnostics.long_gap_count, 0);
+        assert!(diagnostics.longest_internal_gap_seconds < 0.01);
+        assert!(diagnostics.leading_fragment_seconds.is_none());
+        assert!(diagnostics.trailing_fragment_seconds.is_none());
+    }
+
+    #[test]
+    fn audio_diagnostics_flag_islands_and_long_internal_gaps() {
+        let sample_rate = 1_000;
+        let mut samples = Vec::new();
+        samples.extend(tone_samples(sample_rate, 0.08, 0.5));
+        samples.extend(silence_samples(sample_rate, 0.40));
+        samples.extend(tone_samples(sample_rate, 0.50, 0.5));
+        samples.extend(silence_samples(sample_rate, 0.30));
+        samples.extend(tone_samples(sample_rate, 0.10, 0.5));
+
+        let diagnostics = analyze_audio(&samples, sample_rate);
+
+        assert_eq!(diagnostics.active_segment_count, 3);
+        assert_eq!(diagnostics.long_gap_count, 2);
+        assert!(diagnostics.longest_internal_gap_seconds > 0.25);
+        assert!(diagnostics.leading_fragment_seconds.is_some());
+        assert!(diagnostics.trailing_fragment_seconds.is_some());
+    }
+
+    #[test]
+    fn spectrogram_pgm_has_a_valid_grayscale_header() {
+        let image = spectrogram_pgm(&tone_samples(1_000, 0.10, 0.5), 1_000);
+
+        assert!(image.starts_with(b"P5\n# sample_rate 1000\n"));
+        assert!(image.len() > b"P5\n# sample_rate 1000\n1 96\n255\n".len());
+    }
+
+    fn tone_samples(sample_rate: u32, duration_seconds: f64, amplitude: f32) -> Vec<f32> {
+        let sample_count = (sample_rate as f64 * duration_seconds).round() as usize;
+        (0..sample_count)
+            .map(|index| {
+                let phase = 2.0 * PI * 120.0 * index as f64 / sample_rate as f64;
+                amplitude * phase.sin() as f32
+            })
+            .collect()
+    }
+
+    fn silence_samples(sample_rate: u32, duration_seconds: f64) -> Vec<f32> {
+        vec![0.0; (sample_rate as f64 * duration_seconds).round() as usize]
     }
 }

--- a/crates/voice-tts/src/lib.rs
+++ b/crates/voice-tts/src/lib.rs
@@ -225,10 +225,10 @@ pub fn generate_with_mode(
     Ok(samples)
 }
 
-/// Save audio samples to a WAV file (24kHz, 32-bit float).
+/// Save mono audio samples to a stereo WAV file (24kHz, 32-bit float).
 pub fn save_wav(samples: &[f32], path: &Path, sample_rate: u32) -> Result<()> {
     let spec = hound::WavSpec {
-        channels: 1,
+        channels: 2,
         sample_rate,
         bits_per_sample: 32,
         sample_format: hound::SampleFormat::Float,
@@ -236,6 +236,9 @@ pub fn save_wav(samples: &[f32], path: &Path, sample_rate: u32) -> Result<()> {
     let mut writer = hound::WavWriter::create(path, spec)
         .map_err(|e| VoicersError::Io(std::io::Error::other(e)))?;
     for &sample in samples {
+        writer
+            .write_sample(sample)
+            .map_err(|e| VoicersError::Io(std::io::Error::other(e)))?;
         writer
             .write_sample(sample)
             .map_err(|e| VoicersError::Io(std::io::Error::other(e)))?;
@@ -272,14 +275,14 @@ mod tests {
     }
 
     #[test]
-    fn save_wav_writes_mono_float_samples() {
+    fn save_wav_writes_stereo_float_samples() {
         let path = temp_path("wav");
         let samples = vec![0.0, 0.25, -0.25, 0.5, -0.5];
         save_wav(&samples, &path, 24_000).expect("save wav");
 
         let mut reader = hound::WavReader::open(&path).expect("read saved wav");
         let spec = reader.spec();
-        assert_eq!(spec.channels, 1);
+        assert_eq!(spec.channels, 2);
         assert_eq!(spec.sample_rate, 24_000);
         assert_eq!(spec.bits_per_sample, 32);
         assert_eq!(spec.sample_format, hound::SampleFormat::Float);
@@ -288,7 +291,11 @@ mod tests {
             .samples::<f32>()
             .collect::<std::result::Result<Vec<_>, _>>()
             .expect("decode saved wav samples");
-        assert_eq!(decoded, samples);
+        assert_eq!(decoded.len(), samples.len() * 2);
+        for (frame, expected) in decoded.chunks_exact(2).zip(samples) {
+            assert_eq!(frame[0], expected);
+            assert_eq!(frame[1], expected);
+        }
 
         let _ = std::fs::remove_file(path);
     }


### PR DESCRIPTION
## Summary

- add `voice-eval --voxtral-matrix` for reusable Voxtral prompt/settings sweeps
- add artifact-aware audio diagnostics alongside Whisper WER: active segment count, internal gaps, leading/trailing fragments, peak/RMS, and optional PGM spectrograms
- default `voice-eval --tts-backend voxtral` to Voxtral's `casual_male` voice when `--voice` is omitted
- write saved generated TTS WAVs as stereo Float32 by duplicating mono samples into left and right channels

## Verification

- `cargo fmt --check`
- `cargo check -p voice-tts -p voice-audio -p voice-eval`
- `cargo test -p voice-tts -p voice-audio -p voice-eval`
- `cargo clippy -p voice-tts -p voice-audio -p voice-eval -- -D warnings`
- GitHub CI passed: `check`, `python-helpers`, `sidecar-python`
- real Voxtral eval smoke:

```bash
cargo run -p voice-eval -- \
  --tts-backend voxtral \
  --text "hello world" \
  --max-frames 40 \
  --flow-steps 7 \
  --voxtral-kv-cache \
  --output-wav /tmp/voxtral-quality-throughput/wavs/hello-world.wav \
  --spectrogram-dir /tmp/voxtral-quality-throughput/spectrograms \
  --json
```

Observed: Whisper WER `0.0`, one active segment, zero long gaps, no leading/trailing fragment.

Saved WAV channel check:

```text
Data format:     2 ch,  24000 Hz, Float32, interleaved
Channel layout: Stereo (L R)
```

## Local Matrix Evidence

- prompt dataset: `.context/voxtral-prompt-dataset.txt`
- full matrix JSON: `.context/voxtral-matrix-2026-06-24.json`
- executive briefing: `.context/voxtral-executive-briefing.md`
- technical study: `.context/voxtral-technical-study.md`
- matrix WAVs: `/tmp/voxtral-quality-throughput/matrix-wavs`
- matrix spectrograms: `/tmp/voxtral-quality-throughput/matrix-spectrograms`
- voice sample WAVs: `/tmp/voxtral-quality-throughput/voice-samples`

Current recommendation from the matrix: keep `max_frames=40`, `flow_steps=7`, and KV cache for quality-sensitive short prompts. The Q/A prompt produced rows with WER `0.0` but extra active segments/fragments, so the new diagnostics are catching transcript-correct audio that still needs listening review.

## Installed Smoke

Installed globally from this branch:

```text
/Users/kylekelley/.cargo/bin/voice
/Users/kylekelley/.cargo/bin/voxtral
```

Installed no-playback smoke:

```bash
voice bench tts --engine voxtral --runs 1 \
  --voxtral-kv-cache \
  --voxtral-realtime \
  --output-dir /tmp/voxtral-quality-throughput/installed-bench \
  --json \
  "hello world"
```

Observed: first audio `291.9 ms`, total `2494.9 ms`, ended `true`, output WAV `Stereo (L R)`.

Installed `voice say --output` smoke:

```bash
voice say --engine voxtral -v casual_male \
  --voxtral-max-frames 40 \
  --voxtral-flow-steps 7 \
  --output /tmp/voxtral-quality-throughput/installed-say-output.wav \
  "hello world"
```

Observed output WAV: `2 ch, 24000 Hz, Float32, interleaved`, `Stereo (L R)`.
