### PR TITLE
Add opt-in Voxtral text normalization

### DIFF
--- a/crates/voice-cli/src/cli.rs
+++ b/crates/voice-cli/src/cli.rs
@@ -638,6 +638,10 @@ struct ConverseArgs {
     #[arg(long = "voxtral-realtime")]
     voxtral_realtime: bool,
 
+    // Deliberately no --voxtral-normalize-text yet: converse has separate
+    // turn-taking and daemon queue behavior that should be validated in its
+    // own slice before changing the spoken prompt.
+
     /// Override Voxtral's initial streaming codec chunk size for daemon playback
     #[arg(long = "voxtral-stream-begin-frames")]
     voxtral_stream_begin_frames: Option<usize>,

--- a/crates/voice-cli/src/cli.rs
+++ b/crates/voice-cli/src/cli.rs
@@ -187,6 +187,10 @@ struct SayArgs {
     #[arg(long = "voxtral-realtime")]
     voxtral_realtime: bool,
 
+    /// Normalize compact Voxtral numeric forms such as versions and times before synthesis
+    #[arg(long = "voxtral-normalize-text")]
+    voxtral_normalize_text: bool,
+
     /// Override Voxtral's initial streaming codec chunk size for daemon playback
     #[arg(long = "voxtral-stream-begin-frames")]
     voxtral_stream_begin_frames: Option<usize>,
@@ -527,6 +531,10 @@ struct StreamArgs {
     #[arg(long = "voxtral-realtime")]
     voxtral_realtime: bool,
 
+    /// Normalize compact Voxtral numeric forms such as versions and times before synthesis
+    #[arg(long = "voxtral-normalize-text")]
+    voxtral_normalize_text: bool,
+
     /// Override Voxtral's initial streaming codec chunk size
     #[arg(long = "voxtral-stream-begin-frames")]
     voxtral_stream_begin_frames: Option<usize>,
@@ -755,6 +763,10 @@ struct BenchTtsArgs {
     /// Synchronize Metal around Voxtral trace sections for local benchmark profiling
     #[arg(long = "voxtral-sync-trace")]
     voxtral_sync_trace: bool,
+
+    /// Normalize compact Voxtral numeric forms such as versions and times before synthesis
+    #[arg(long = "voxtral-normalize-text")]
+    voxtral_normalize_text: bool,
 
     /// Override Voxtral's initial streaming codec chunk size for benchmarking
     #[arg(long = "voxtral-stream-begin-frames")]
@@ -1237,9 +1249,11 @@ fn collect_subs(
 
 fn preprocess_daemon_text(
     text: String,
+    engine: TtsEngine,
     markdown: bool,
     cli_subs: &[String],
     sub_file: Option<PathBuf>,
+    voxtral_normalize_text: bool,
 ) -> String {
     let text = if markdown {
         strip_markdown(&text)
@@ -1249,10 +1263,15 @@ fn preprocess_daemon_text(
     let text = apply_tech_subs(&text);
     let sub_file = sub_file.or_else(find_sub_file);
     let (subs, _phoneme_overrides) = collect_subs(cli_subs, sub_file.as_deref());
-    if subs.is_empty() {
+    let text = if subs.is_empty() {
         text
     } else {
         apply_substitutions(&text, &subs)
+    };
+    if engine == TtsEngine::Voxtral && voxtral_normalize_text {
+        voice_voxtral::normalize_tts_text(&text)
+    } else {
+        text
     }
 }
 
@@ -1351,6 +1370,7 @@ fn main() {
                     voxtral_flow_steps: 7,
                     voxtral_kv_cache: false,
                     voxtral_realtime: false,
+                    voxtral_normalize_text: false,
                     voxtral_stream_begin_frames: None,
                     output: None,
                     format: None,
@@ -1761,7 +1781,7 @@ fn bench_kokoro_tts(args: &BenchTtsArgs, text: &str) -> Result<TtsBenchEngineRep
     for run_idx in 0..args.runs {
         let total_start = Instant::now();
         let text_prep_start = Instant::now();
-        let (prepared, phoneme_overrides) = prepare_bench_text(text, args);
+        let (prepared, phoneme_overrides) = prepare_bench_text(text, args, TtsEngine::Kokoro);
         let text_prep = text_prep_start.elapsed();
 
         let phoneme_start = Instant::now();
@@ -1876,7 +1896,7 @@ fn bench_voxtral_tts(args: &BenchTtsArgs, text: &str) -> Result<TtsBenchEngineRe
     for run_idx in 0..args.runs {
         let total_start = Instant::now();
         let text_prep_start = Instant::now();
-        let (prepared, _phoneme_overrides) = prepare_bench_text(text, args);
+        let (prepared, _phoneme_overrides) = prepare_bench_text(text, args, TtsEngine::Voxtral);
         let text_prep = text_prep_start.elapsed();
 
         let synth_start = Instant::now();
@@ -2003,7 +2023,7 @@ fn bench_daemon_tts(
     for run_idx in 0..args.runs {
         let total_start = Instant::now();
         let text_prep_start = Instant::now();
-        let (prepared, _phoneme_overrides) = prepare_bench_text(text, args);
+        let (prepared, _phoneme_overrides) = prepare_bench_text(text, args, engine);
         let text_prep = text_prep_start.elapsed();
 
         let mut response_at = None;
@@ -2245,7 +2265,11 @@ fn resolve_bench_text(args: &BenchTtsArgs) -> Result<String, String> {
     }
 }
 
-fn prepare_bench_text(text: &str, args: &BenchTtsArgs) -> (String, HashMap<String, String>) {
+fn prepare_bench_text(
+    text: &str,
+    args: &BenchTtsArgs,
+    engine: TtsEngine,
+) -> (String, HashMap<String, String>) {
     let text = if args.markdown {
         strip_markdown(text)
     } else {
@@ -2258,6 +2282,11 @@ fn prepare_bench_text(text: &str, args: &BenchTtsArgs) -> (String, HashMap<Strin
         text
     } else {
         apply_substitutions(&text, &subs)
+    };
+    let text = if engine == TtsEngine::Voxtral && args.voxtral_normalize_text {
+        voice_voxtral::normalize_tts_text(&text)
+    } else {
+        text
     };
     (text, phoneme_overrides)
 }
@@ -2565,9 +2594,11 @@ fn run_say(say_args: SayArgs) {
                 };
                 let text = preprocess_daemon_text(
                     text,
+                    say_args.engine,
                     say_args.markdown,
                     &say_args.subs,
                     say_args.sub_file.clone(),
+                    say_args.voxtral_normalize_text,
                 );
                 let tts_options =
                     daemon_tts_options(say_args.engine, &say_args.voxtral_model, voxtral);
@@ -2750,9 +2781,11 @@ fn run_voxtral_say(
     };
     let text = preprocess_daemon_text(
         text,
+        say_args.engine,
         say_args.markdown,
         &say_args.subs,
         say_args.sub_file.clone(),
+        say_args.voxtral_normalize_text,
     );
 
     if (say_args.speed - 1.0).abs() > f32::EPSILON {
@@ -2823,9 +2856,11 @@ fn run_stream(stream_args: StreamArgs) {
     };
     let text = preprocess_daemon_text(
         text,
+        stream_args.engine,
         stream_args.markdown,
         &stream_args.subs,
         stream_args.sub_file.clone(),
+        stream_args.voxtral_normalize_text,
     );
 
     validate_stream_frame_params(stream_args.sample_rate, stream_args.frame_ms).unwrap_or_else(
@@ -4069,6 +4104,122 @@ mod tests {
             Some(Command::Say(args)) => assert_eq!(args.engine, TtsEngine::Kokoro),
             other => panic!("expected say command, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parses_voxtral_text_normalization_for_say_stream_and_bench() {
+        let say = Args::parse_from([
+            "voice",
+            "say",
+            "--engine",
+            "voxtral",
+            "--voxtral-normalize-text",
+            "Read ticket A17.",
+        ]);
+        match say.command {
+            Some(Command::Say(args)) => assert!(args.voxtral_normalize_text),
+            other => panic!("expected say command, got {other:?}"),
+        }
+
+        let stream = Args::parse_from([
+            "voice",
+            "stream",
+            "--engine",
+            "voxtral",
+            "--voxtral-normalize-text",
+            "Read ticket A17.",
+        ]);
+        match stream.command {
+            Some(Command::Stream(args)) => assert!(args.voxtral_normalize_text),
+            other => panic!("expected stream command, got {other:?}"),
+        }
+
+        let bench = Args::parse_from([
+            "voice",
+            "bench",
+            "tts",
+            "--engine",
+            "voxtral",
+            "--voxtral-normalize-text",
+            "Read ticket A17.",
+        ]);
+        match bench.command {
+            Some(Command::Bench(BenchArgs {
+                command: BenchCommand::Tts(args),
+            })) => assert!(args.voxtral_normalize_text),
+            other => panic!("expected bench tts command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn preprocess_voxtral_text_normalization_is_opt_in() {
+        let text = "Read ticket A17, version 2.4.1, at 9:30 PM.".to_string();
+
+        assert_eq!(
+            preprocess_daemon_text(
+                text.clone(),
+                TtsEngine::Voxtral,
+                false,
+                &[],
+                None,
+                false
+            ),
+            text
+        );
+        assert_eq!(
+            preprocess_daemon_text(
+                text.clone(),
+                TtsEngine::Kokoro,
+                false,
+                &[],
+                None,
+                true
+            ),
+            text
+        );
+        assert_eq!(
+            preprocess_daemon_text(text, TtsEngine::Voxtral, false, &[], None, true),
+            "Read ticket A seventeen, version two point four point one, at nine thirty PM."
+        );
+    }
+
+    #[test]
+    fn prepare_bench_text_normalizes_only_voxtral_engine() {
+        let args = BenchTtsArgs {
+            text: vec![],
+            input_file: None,
+            engines: vec![],
+            kokoro_voice: KOKORO_DEFAULT_VOICE.to_string(),
+            voxtral_voice: VOXTRAL_DEFAULT_VOICE.to_string(),
+            voxtral_model: DEFAULT_VOXTRAL_MODEL.to_string(),
+            voxtral_max_frames: VOXTRAL_DEFAULT_MAX_FRAMES,
+            voxtral_flow_steps: 7,
+            voxtral_kv_cache: false,
+            voxtral_realtime: false,
+            voxtral_sync_trace: false,
+            voxtral_normalize_text: true,
+            voxtral_stream_begin_frames: None,
+            daemon: false,
+            stream_sample_rate: 24_000,
+            stream_frame_ms: 20,
+            runs: 1,
+            deterministic: false,
+            markdown: false,
+            subs: vec![],
+            sub_file: None,
+            output_dir: None,
+            json: false,
+        };
+
+        let text = "Read ticket A17.";
+        assert_eq!(
+            prepare_bench_text(text, &args, TtsEngine::Kokoro).0,
+            "Read ticket A17."
+        );
+        assert_eq!(
+            prepare_bench_text(text, &args, TtsEngine::Voxtral).0,
+            "Read ticket A seventeen."
+        );
     }
 
     #[test]

--- a/crates/voice-eval/src/main.rs
+++ b/crates/voice-eval/src/main.rs
@@ -102,6 +102,10 @@ struct Args {
     #[arg(long = "voxtral-kv-cache")]
     voxtral_kv_cache: bool,
 
+    /// Normalize compact Voxtral numeric synthesis text forms such as versions and times.
+    #[arg(long = "voxtral-normalize-text")]
+    voxtral_normalize_text: bool,
+
     /// Initial streaming codec chunk size for Voxtral matrix timing.
     #[arg(long = "voxtral-stream-begin-frames", default_value_t = 2)]
     voxtral_stream_begin_frames: usize,
@@ -179,6 +183,7 @@ struct EvalReport {
     stt_backend: String,
     stt_model: String,
     synthesis_mode: &'static str,
+    voxtral_text_normalization: bool,
     sample_rate: u32,
     sample_count: usize,
     duration_seconds: f32,
@@ -209,6 +214,7 @@ struct VoxtralMatrixReport {
     stream_begin_frames: usize,
     kv_cache: bool,
     sync_trace: bool,
+    text_normalization: bool,
     seed: u64,
     output_dir: Option<PathBuf>,
     spectrogram_dir: Option<PathBuf>,
@@ -264,6 +270,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if args.input_wav.is_some() && args.synthesis_text.is_some() {
         return Err("--synthesis-text cannot be used with --input-wav".into());
     }
+    if args.input_wav.is_some() && args.voxtral_normalize_text {
+        return Err("--voxtral-normalize-text cannot be used with --input-wav".into());
+    }
     let reference_text = args
         .expected_text
         .clone()
@@ -272,6 +281,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .synthesis_text
         .clone()
         .unwrap_or_else(|| args.text.clone());
+    let synthesis_text = maybe_normalize_voxtral_text(&args, synthesis_text);
     let (samples, sample_rate, phoneme_chunks, synthesis_mode) = if let Some(input_wav) =
         &args.input_wav
     {
@@ -346,6 +356,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         stt_backend: stt_backend.as_str().to_string(),
         stt_model: stt_model_path,
         synthesis_mode,
+        voxtral_text_normalization: args.tts_backend == "voxtral" && args.voxtral_normalize_text,
         sample_rate,
         sample_count: samples.len(),
         duration_seconds,
@@ -532,6 +543,7 @@ fn run_voxtral_matrix(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
         stream_begin_frames: args.voxtral_stream_begin_frames,
         kv_cache: args.voxtral_kv_cache,
         sync_trace: args.voxtral_sync_trace,
+        text_normalization: args.voxtral_normalize_text,
         seed: args.seed,
         output_dir: args.output_dir.clone(),
         spectrogram_dir: args.spectrogram_dir.clone(),
@@ -603,9 +615,17 @@ fn matrix_cases(args: &Args) -> Result<Vec<MatrixCase>, Box<dyn std::error::Erro
         .zip(synthesis_texts)
         .map(|(reference_text, synthesis_text)| MatrixCase {
             reference_text,
-            synthesis_text,
+            synthesis_text: maybe_normalize_voxtral_text(args, synthesis_text),
         })
         .collect())
+}
+
+fn maybe_normalize_voxtral_text(args: &Args, text: String) -> String {
+    if args.tts_backend == "voxtral" && args.voxtral_normalize_text {
+        voice_voxtral::normalize_tts_text(&text)
+    } else {
+        text
+    }
 }
 
 fn synthesize_kokoro(
@@ -960,12 +980,13 @@ fn print_voxtral_matrix_report(report: &VoxtralMatrixReport) {
     );
     println!("voxtral_matrix.model_load_ms={:.1}", report.model_load_ms);
     println!(
-        "voxtral_matrix.max_frames={:?} flow_steps={:?} stream_begin_frames={} kv_cache={} sync_trace={}",
+        "voxtral_matrix.max_frames={:?} flow_steps={:?} stream_begin_frames={} kv_cache={} sync_trace={} text_normalization={}",
         report.matrix_max_frames,
         report.matrix_flow_steps,
         report.stream_begin_frames,
         report.kv_cache,
-        report.sync_trace
+        report.sync_trace,
+        report.text_normalization
     );
     if let Some(output_dir) = &report.output_dir {
         println!("voxtral_matrix.output_dir={}", output_dir.display());
@@ -1054,6 +1075,9 @@ fn print_text_report(report: &EvalReport) {
     println!("reference: {}", report.text);
     if report.synthesis_text != report.text {
         println!("synthesis text: {}", report.synthesis_text);
+    }
+    if report.voxtral_text_normalization {
+        println!("voxtral text normalization: enabled");
     }
     println!("hypothesis: {}", report.transcription);
     println!("normalized reference: {}", report.normalized_reference);
@@ -1220,6 +1244,7 @@ mod tests {
             "Voxtral should sound clear.",
             "--synthesis-text",
             "Vox trahl should sound clear.",
+            "--voxtral-normalize-text",
         ])
         .unwrap();
 
@@ -1228,6 +1253,7 @@ mod tests {
             args.synthesis_text.as_deref(),
             Some("Vox trahl should sound clear.")
         );
+        assert!(args.voxtral_normalize_text);
     }
 
     #[test]
@@ -1333,6 +1359,8 @@ mod tests {
     fn matrix_cases_pair_reference_and_synthesis_texts() {
         let args = Args::try_parse_from([
             "voice-eval",
+            "--tts-backend",
+            "voxtral",
             "--voxtral-matrix",
             "--matrix-text",
             "Voxtral sounds clear.",
@@ -1357,6 +1385,30 @@ mod tests {
                     synthesis_text: "Read ticket A seventeen.".to_string(),
                 }
             ]
+        );
+    }
+
+    #[test]
+    fn matrix_cases_apply_opt_in_voxtral_text_normalization() {
+        let args = Args::try_parse_from([
+            "voice-eval",
+            "--tts-backend",
+            "voxtral",
+            "--voxtral-matrix",
+            "--voxtral-normalize-text",
+            "--matrix-text",
+            "Read ticket A17, version 2.4.1, at 9:30 PM.",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            matrix_cases(&args).unwrap(),
+            vec![MatrixCase {
+                reference_text: "Read ticket A17, version 2.4.1, at 9:30 PM.".to_string(),
+                synthesis_text:
+                    "Read ticket A seventeen, version two point four point one, at nine thirty PM."
+                        .to_string(),
+            }]
         );
     }
 

--- a/crates/voice-voxtral/src/lib.rs
+++ b/crates/voice-voxtral/src/lib.rs
@@ -16,6 +16,7 @@ mod realtime;
 mod realtime_audio;
 mod realtime_inference;
 mod streaming;
+mod text;
 mod tokenizer;
 mod transformer;
 mod voice_embedding;
@@ -80,6 +81,7 @@ pub use streaming::{
     plan_codec_chunk, VoxtralCodecChunk, VoxtralStreamingConfig, DEFAULT_CODEC_CHUNK_FRAMES,
     DEFAULT_CODEC_CHUNK_FRAMES_AT_BEGIN, DEFAULT_CODEC_LEFT_CONTEXT_FRAMES,
 };
+pub use text::normalize_tts_text;
 pub use tokenizer::{
     TekkenAudioEncodingConfig, TekkenAudioMetadata, TekkenConfig, TekkenSpecialToken,
     TekkenVocabToken, VoxtralTekkenDecoder, VoxtralTekkenEncoder, VoxtralTokenizerMetadata,

--- a/crates/voice-voxtral/src/text.rs
+++ b/crates/voice-voxtral/src/text.rs
@@ -1,0 +1,300 @@
+/// Normalize numeric text forms that Voxtral currently handles poorly when
+/// they are left as compact written forms.
+pub fn normalize_tts_text(text: &str) -> String {
+    let mut output = String::with_capacity(text.len());
+    let mut index = 0;
+    let bytes = text.as_bytes();
+
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if byte.is_ascii_digit() {
+            if let Some((replacement, end)) = parse_time(text, index) {
+                output.push_str(&replacement);
+                index = end;
+                continue;
+            }
+            if let Some((replacement, end)) = parse_dotted_number(text, index) {
+                output.push_str(&replacement);
+                index = end;
+                continue;
+            }
+            let number = parse_ascii_digits(text, index);
+            output.push_str(&number_to_words_for_token(number.value, number.digits));
+            index = number.end;
+            continue;
+        }
+
+        if is_ascii_uppercase(byte) {
+            if let Some((replacement, end)) = parse_letter_number(text, index) {
+                output.push_str(&replacement);
+                index = end;
+                continue;
+            }
+        }
+
+        let ch = text[index..]
+            .chars()
+            .next()
+            .expect("index is inside a valid UTF-8 string");
+        output.push(ch);
+        index += ch.len_utf8();
+    }
+
+    output
+}
+
+fn parse_time(text: &str, start: usize) -> Option<(String, usize)> {
+    let bytes = text.as_bytes();
+    let hour = parse_ascii_digits(text, start);
+    if hour.value == 0 || hour.value > 23 || bytes.get(hour.end) != Some(&b':') {
+        return None;
+    }
+    let minute_start = hour.end + 1;
+    if !bytes.get(minute_start).is_some_and(u8::is_ascii_digit)
+        || !bytes.get(minute_start + 1).is_some_and(u8::is_ascii_digit)
+    {
+        return None;
+    }
+    if bytes.get(minute_start + 2).is_some_and(u8::is_ascii_digit) {
+        return None;
+    }
+    let minute =
+        ((bytes[minute_start] - b'0') as u32) * 10 + (bytes[minute_start + 1] - b'0') as u32;
+    if minute > 59 {
+        return None;
+    }
+
+    let mut parts = Vec::new();
+    parts.push(number_to_words_for_token(hour.value, hour.digits));
+    if minute == 0 {
+        parts.push("o'clock".to_string());
+    } else if minute < 10 {
+        parts.push(format!("oh {}", number_to_words(minute)));
+    } else {
+        parts.push(number_to_words(minute));
+    }
+
+    Some((parts.join(" "), minute_start + 2))
+}
+
+fn parse_dotted_number(text: &str, start: usize) -> Option<(String, usize)> {
+    let bytes = text.as_bytes();
+    let first = parse_ascii_digits(text, start);
+    let mut end = first.end;
+    if bytes.get(end) != Some(&b'.') || !bytes.get(end + 1).is_some_and(u8::is_ascii_digit) {
+        return None;
+    }
+
+    let mut parts = vec![number_to_words_for_token(first.value, first.digits)];
+    while bytes.get(end) == Some(&b'.') && bytes.get(end + 1).is_some_and(u8::is_ascii_digit) {
+        let number = parse_ascii_digits(text, end + 1);
+        parts.push("point".to_string());
+        parts.push(number_to_words_for_token(number.value, number.digits));
+        end = number.end;
+    }
+
+    Some((parts.join(" "), end))
+}
+
+fn parse_letter_number(text: &str, start: usize) -> Option<(String, usize)> {
+    let bytes = text.as_bytes();
+    if start > 0 && is_ascii_alphanumeric(bytes[start - 1]) {
+        return None;
+    }
+    if !is_ascii_uppercase(bytes[start]) || !bytes.get(start + 1).is_some_and(u8::is_ascii_digit) {
+        return None;
+    }
+    let letter = bytes[start] as char;
+    let number = parse_ascii_digits(text, start + 1);
+    let end = number.end;
+    if bytes
+        .get(end)
+        .is_some_and(|byte| is_ascii_alphanumeric(*byte))
+    {
+        return None;
+    }
+    Some((
+        format!(
+            "{} {}",
+            letter,
+            number_to_words_for_token(number.value, number.digits)
+        ),
+        end,
+    ))
+}
+
+struct NumberToken<'a> {
+    value: u32,
+    end: usize,
+    digits: &'a str,
+}
+
+fn parse_ascii_digits(text: &str, start: usize) -> NumberToken<'_> {
+    let bytes = text.as_bytes();
+    let mut end = start;
+    let mut value = 0u32;
+    while let Some(byte) = bytes.get(end).filter(|byte| byte.is_ascii_digit()) {
+        value = value
+            .saturating_mul(10)
+            .saturating_add((*byte - b'0') as u32);
+        end += 1;
+    }
+    NumberToken {
+        value,
+        end,
+        digits: &text[start..end],
+    }
+}
+
+fn number_to_words_for_token(number: u32, digits: &str) -> String {
+    if digits.len() > 1 && digits.as_bytes()[0] == b'0' {
+        return digit_words(digits.as_bytes());
+    }
+    number_to_words(number)
+}
+
+fn number_to_words(number: u32) -> String {
+    match number {
+        0 => "zero".to_string(),
+        1..=19 => small_number_word(number).to_string(),
+        20..=99 => {
+            let tens = number / 10;
+            let ones = number % 10;
+            if ones == 0 {
+                tens_word(tens).to_string()
+            } else {
+                format!("{} {}", tens_word(tens), small_number_word(ones))
+            }
+        }
+        100..=999 => {
+            let hundreds = number / 100;
+            let rest = number % 100;
+            if rest == 0 {
+                format!("{} hundred", small_number_word(hundreds))
+            } else {
+                format!(
+                    "{} hundred {}",
+                    small_number_word(hundreds),
+                    number_to_words(rest)
+                )
+            }
+        }
+        1000..=9999 => {
+            let thousands = number / 1000;
+            let rest = number % 1000;
+            if rest == 0 {
+                format!("{} thousand", small_number_word(thousands))
+            } else {
+                format!(
+                    "{} thousand {}",
+                    small_number_word(thousands),
+                    number_to_words(rest)
+                )
+            }
+        }
+        _ => digit_words(number.to_string().as_bytes()),
+    }
+}
+
+fn digit_words(digits: &[u8]) -> String {
+    digits
+        .iter()
+        .filter_map(|digit| digit.is_ascii_digit().then_some((*digit - b'0') as u32))
+        .map(number_to_words)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn small_number_word(number: u32) -> &'static str {
+    match number {
+        0 => "zero",
+        1 => "one",
+        2 => "two",
+        3 => "three",
+        4 => "four",
+        5 => "five",
+        6 => "six",
+        7 => "seven",
+        8 => "eight",
+        9 => "nine",
+        10 => "ten",
+        11 => "eleven",
+        12 => "twelve",
+        13 => "thirteen",
+        14 => "fourteen",
+        15 => "fifteen",
+        16 => "sixteen",
+        17 => "seventeen",
+        18 => "eighteen",
+        19 => "nineteen",
+        _ => unreachable!("small number out of range"),
+    }
+}
+
+fn tens_word(tens: u32) -> &'static str {
+    match tens {
+        2 => "twenty",
+        3 => "thirty",
+        4 => "forty",
+        5 => "fifty",
+        6 => "sixty",
+        7 => "seventy",
+        8 => "eighty",
+        9 => "ninety",
+        _ => unreachable!("tens out of range"),
+    }
+}
+
+fn is_ascii_uppercase(byte: u8) -> bool {
+    byte.is_ascii_uppercase()
+}
+
+fn is_ascii_alphanumeric(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_tts_text;
+
+    #[test]
+    fn leaves_plain_prompt_unchanged() {
+        assert_eq!(normalize_tts_text("hello world"), "hello world");
+        assert_eq!(
+            normalize_tts_text("Voxtral should sound clear."),
+            "Voxtral should sound clear."
+        );
+    }
+
+    #[test]
+    fn expands_ticket_version_and_time() {
+        assert_eq!(
+            normalize_tts_text("Read ticket A17, version 2.4.1, at 9:30 PM."),
+            "Read ticket A seventeen, version two point four point one, at nine thirty PM."
+        );
+    }
+
+    #[test]
+    fn preserves_acronyms_while_expanding_time() {
+        assert_eq!(
+            normalize_tts_text("Use API on CPU at 12:05 AM."),
+            "Use API on CPU at twelve oh five AM."
+        );
+    }
+
+    #[test]
+    fn preserves_trailing_sentence_period_after_dotted_number() {
+        assert_eq!(
+            normalize_tts_text("Ship version 10.2."),
+            "Ship version ten point two."
+        );
+    }
+
+    #[test]
+    fn spells_general_leading_zero_tokens_digit_by_digit() {
+        assert_eq!(
+            normalize_tts_text("Use code 007."),
+            "Use code zero zero seven."
+        );
+    }
+}

--- a/crates/voice-voxtral/src/text.rs
+++ b/crates/voice-voxtral/src/text.rs
@@ -24,7 +24,7 @@ pub fn normalize_tts_text(text: &str) -> String {
             continue;
         }
 
-        if is_ascii_uppercase(byte) {
+        if byte.is_ascii_uppercase() {
             if let Some((replacement, end)) = parse_letter_number(text, index) {
                 output.push_str(&replacement);
                 index = end;
@@ -98,10 +98,10 @@ fn parse_dotted_number(text: &str, start: usize) -> Option<(String, usize)> {
 
 fn parse_letter_number(text: &str, start: usize) -> Option<(String, usize)> {
     let bytes = text.as_bytes();
-    if start > 0 && is_ascii_alphanumeric(bytes[start - 1]) {
+    if start > 0 && bytes[start - 1].is_ascii_alphanumeric() {
         return None;
     }
-    if !is_ascii_uppercase(bytes[start]) || !bytes.get(start + 1).is_some_and(u8::is_ascii_digit) {
+    if !bytes[start].is_ascii_uppercase() || !bytes.get(start + 1).is_some_and(u8::is_ascii_digit) {
         return None;
     }
     let letter = bytes[start] as char;
@@ -109,7 +109,7 @@ fn parse_letter_number(text: &str, start: usize) -> Option<(String, usize)> {
     let end = number.end;
     if bytes
         .get(end)
-        .is_some_and(|byte| is_ascii_alphanumeric(*byte))
+        .is_some_and(|byte| byte.is_ascii_alphanumeric())
     {
         return None;
     }
@@ -243,14 +243,6 @@ fn tens_word(tens: u32) -> &'static str {
         9 => "ninety",
         _ => unreachable!("tens out of range"),
     }
-}
-
-fn is_ascii_uppercase(byte: u8) -> bool {
-    byte.is_ascii_uppercase()
-}
-
-fn is_ascii_alphanumeric(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Adds `voice_voxtral::normalize_tts_text()` for opt-in numeric prompt normalization.
- Wires `--voxtral-normalize-text` into `voice-eval`, `voice say` / `voxtral say`, `voice stream` / `voxtral stream`, and `voice bench tts`.
- Keeps defaults unchanged; normalization is only applied when the new Voxtral-specific flag is set.

This is stacked on #275. The harness PR added reference/synthesis text pairs; this PR uses that lane to add a narrow, evidence-backed normalization affordance.

## Normalized Forms

- `A17` -> `A seventeen`
- `2.4.1` -> `two point four point one`
- `9:30` -> `nine thirty`
- `12:05` -> `twelve oh five`
- standalone numbers, including leading-zero codes

Acronym spelling was tested and intentionally not shipped: expanding `API` / `CPU` made the focused eval row worse.

## Focused Eval

Raw:

```bash
cargo run --release -p voice-eval -- \
  --tts-backend voxtral \
  --voxtral-matrix \
  --voxtral-kv-cache \
  --voxtral-stream-begin-frames 2 \
  --matrix-max-frames 40 \
  --matrix-flow-steps 7 \
  --matrix-text "hello world" \
  --matrix-text "Voxtral should pronounce its own made-up name clearly." \
  --matrix-text "Read ticket A17, version 2.4.1, at 9:30 PM." \
  --matrix-text "Use API on CPU at 12:05 AM." \
  --output-dir /tmp/voxtral-text-normalization/raw-wavs \
  --spectrogram-dir /tmp/voxtral-text-normalization/raw-spectrograms \
  --json > .context/voxtral-text-normalization-raw-2026-06-24.json
```

Normalized:

```bash
cargo run --release -p voice-eval -- \
  --tts-backend voxtral \
  --voxtral-matrix \
  --voxtral-kv-cache \
  --voxtral-normalize-text \
  --voxtral-stream-begin-frames 2 \
  --matrix-max-frames 40 \
  --matrix-flow-steps 7 \
  --matrix-text "hello world" \
  --matrix-text "Voxtral should pronounce its own made-up name clearly." \
  --matrix-text "Read ticket A17, version 2.4.1, at 9:30 PM." \
  --matrix-text "Use API on CPU at 12:05 AM." \
  --output-dir /tmp/voxtral-text-normalization/normalized-wavs \
  --spectrogram-dir /tmp/voxtral-text-normalization/normalized-spectrograms \
  --json > .context/voxtral-text-normalization-normalized-2026-06-24.json
```

| Prompt | Raw WER | Normalized WER | Artifact Change |
| --- | ---: | ---: | --- |
| `hello world` | `0.000` | `0.000` | unchanged clean row |
| `Voxtral should...` | `0.111` | `0.111` | unchanged; pronunciation still unresolved |
| `Read ticket A17, version 2.4.1, at 9:30 PM.` | `0.727` | `0.273` | no new artifact flags |
| `Use API on CPU at 12:05 AM.` | `0.375` | `0.250` | removed two-segment/trailing-fragment flag |

Artifacts are local only:

- `.context/voxtral-text-normalization-raw-2026-06-24.json`
- `.context/voxtral-text-normalization-normalized-2026-06-24.json`
- `/tmp/voxtral-text-normalization`

## Verification

```bash
cargo fmt --check
cargo test -p voice-voxtral text --lib
cargo test -p voice-eval
cargo test -p voice
cargo clippy -p voice-voxtral -p voice-eval -p voice -- -D warnings
```

Installed smoke:

```bash
cargo install --path crates/voice-cli --force --locked
voice bench tts \
  --engine voxtral \
  --runs 1 \
  --voxtral-kv-cache \
  --voxtral-normalize-text \
  --voxtral-max-frames 40 \
  --voxtral-flow-steps 7 \
  --json \
  "Read ticket A17, version 2.4.1, at 9:30 PM." \
  > .context/voxtral-installed-normalize-smoke-2026-06-24.json
```

Installed result: first audio `570.4 ms`, total `3773.5 ms`, RTF `1.179`, frames `40`, ended `false`.
