### PR TITLE
Add Voxtral termination diagnostics

### DIFF
--- a/crates/voice-eval/src/main.rs
+++ b/crates/voice-eval/src/main.rs
@@ -114,6 +114,10 @@ struct Args {
     #[arg(long = "voxtral-sync-trace")]
     voxtral_sync_trace: bool,
 
+    /// Collect EOS rank/margin diagnostics for Voxtral semantic logits.
+    #[arg(long = "voxtral-eos-scores")]
+    voxtral_eos_scores: bool,
+
     /// Deterministic seed for Voxtral flow noise.
     #[arg(long, default_value_t = 0x5658_5452_414c)]
     seed: u64,
@@ -215,6 +219,7 @@ struct VoxtralMatrixReport {
     kv_cache: bool,
     sync_trace: bool,
     text_normalization: bool,
+    eos_scores: bool,
     seed: u64,
     output_dir: Option<PathBuf>,
     spectrogram_dir: Option<PathBuf>,
@@ -237,6 +242,15 @@ struct VoxtralMatrixRow {
     sample_rate: u32,
     audio_frames: usize,
     ended: bool,
+    eos_frame: Option<usize>,
+    semantic_code_count: usize,
+    semantic_tail_codes: Vec<u32>,
+    semantic_tail_unique_count: usize,
+    semantic_tail_repeat_count: usize,
+    semantic_eos_rank_tail: Vec<usize>,
+    semantic_eos_margin_tail: Vec<f32>,
+    semantic_best_eos_rank: Option<usize>,
+    semantic_best_eos_margin: Option<f32>,
     codec_chunks: usize,
     language_ms: f64,
     language_ms_per_frame: Option<f64>,
@@ -450,6 +464,7 @@ fn run_voxtral_matrix(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
                     flow_steps,
                     use_kv_cache: args.voxtral_kv_cache,
                     synchronize_trace: args.voxtral_sync_trace,
+                    trace_semantic_scores: args.voxtral_eos_scores,
                     ..Default::default()
                 };
 
@@ -492,6 +507,14 @@ fn run_voxtral_matrix(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
                 let acoustic_ms = duration_ms(trace.acoustic);
                 let decode_loop_ms = duration_ms(trace.decode_loop);
                 let codec_ms = duration_ms(trace.codec);
+                let semantic_tail_codes = tail_semantic_codes(&trace.semantic_codes, 8);
+                let semantic_tail_unique_count = unique_count(&semantic_tail_codes);
+                let semantic_tail_repeat_count = repeated_tail_count(&trace.semantic_codes);
+                let semantic_eos_rank_tail = tail_values(&trace.semantic_eos_ranks, 8);
+                let semantic_eos_margin_tail = tail_values(&trace.semantic_eos_margins, 8);
+                let semantic_best_eos_rank = trace.semantic_eos_ranks.iter().copied().min();
+                let semantic_best_eos_margin =
+                    trace.semantic_eos_margins.iter().copied().reduce(f32::min);
 
                 rows.push(VoxtralMatrixRow {
                     text_index,
@@ -508,6 +531,15 @@ fn run_voxtral_matrix(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
                     sample_rate: audio.sample_rate,
                     audio_frames: audio.frames,
                     ended: audio.ended,
+                    eos_frame: trace.eos_frame,
+                    semantic_code_count: trace.semantic_codes.len(),
+                    semantic_tail_codes,
+                    semantic_tail_unique_count,
+                    semantic_tail_repeat_count,
+                    semantic_eos_rank_tail,
+                    semantic_eos_margin_tail,
+                    semantic_best_eos_rank,
+                    semantic_best_eos_margin,
                     codec_chunks: trace.codec_chunks,
                     language_ms,
                     language_ms_per_frame: per_unit(language_ms, audio.frames),
@@ -544,6 +576,7 @@ fn run_voxtral_matrix(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
         kv_cache: args.voxtral_kv_cache,
         sync_trace: args.voxtral_sync_trace,
         text_normalization: args.voxtral_normalize_text,
+        eos_scores: args.voxtral_eos_scores,
         seed: args.seed,
         output_dir: args.output_dir.clone(),
         spectrogram_dir: args.spectrogram_dir.clone(),
@@ -980,13 +1013,14 @@ fn print_voxtral_matrix_report(report: &VoxtralMatrixReport) {
     );
     println!("voxtral_matrix.model_load_ms={:.1}", report.model_load_ms);
     println!(
-        "voxtral_matrix.max_frames={:?} flow_steps={:?} stream_begin_frames={} kv_cache={} sync_trace={} text_normalization={}",
+        "voxtral_matrix.max_frames={:?} flow_steps={:?} stream_begin_frames={} kv_cache={} sync_trace={} text_normalization={} eos_scores={}",
         report.matrix_max_frames,
         report.matrix_flow_steps,
         report.stream_begin_frames,
         report.kv_cache,
         report.sync_trace,
-        report.text_normalization
+        report.text_normalization,
+        report.eos_scores
     );
     if let Some(output_dir) = &report.output_dir {
         println!("voxtral_matrix.output_dir={}", output_dir.display());
@@ -1004,6 +1038,10 @@ fn print_voxtral_matrix_report(report: &VoxtralMatrixReport) {
                 "reference_text={:?} synthesis_text={:?} ",
                 "first_audio_ms={} total_ms={:.1} audio_ms={:.1} rtf={} ",
                 "wer={} errors={}/{} frames={} ended={} chunks={} ",
+                "eos_frame={} semantic_count={} semantic_tail={:?} ",
+                "semantic_tail_unique={} semantic_tail_repeat={} ",
+                "eos_rank_tail={:?} eos_margin_tail={:?} ",
+                "best_eos_rank={} best_eos_margin={} ",
                 "segments={} long_gaps={} longest_gap_s={:.3} active_ratio={} ",
                 "lead_frag_s={} trail_frag_s={} spectrogram={} transcript={:?}"
             ),
@@ -1022,6 +1060,15 @@ fn print_voxtral_matrix_report(report: &VoxtralMatrixReport) {
             row.audio_frames,
             row.ended,
             row.codec_chunks,
+            format_optional_usize(row.eos_frame),
+            row.semantic_code_count,
+            row.semantic_tail_codes,
+            row.semantic_tail_unique_count,
+            row.semantic_tail_repeat_count,
+            row.semantic_eos_rank_tail,
+            row.semantic_eos_margin_tail,
+            format_optional_usize(row.semantic_best_eos_rank),
+            format_optional_f32(row.semantic_best_eos_margin),
             row.audio_diagnostics.active_segment_count,
             row.audio_diagnostics.long_gap_count,
             row.audio_diagnostics.longest_internal_gap_seconds,
@@ -1054,6 +1101,30 @@ fn per_unit(total_ms: f64, units: usize) -> Option<f64> {
     (units > 0).then_some(total_ms / units as f64)
 }
 
+fn tail_semantic_codes(codes: &[u32], max_len: usize) -> Vec<u32> {
+    let start = codes.len().saturating_sub(max_len);
+    codes[start..].to_vec()
+}
+
+fn tail_values<T: Clone>(values: &[T], max_len: usize) -> Vec<T> {
+    let start = values.len().saturating_sub(max_len);
+    values[start..].to_vec()
+}
+
+fn unique_count(codes: &[u32]) -> usize {
+    let mut sorted = codes.to_vec();
+    sorted.sort_unstable();
+    sorted.dedup();
+    sorted.len()
+}
+
+fn repeated_tail_count(codes: &[u32]) -> usize {
+    let Some(&last) = codes.last() else {
+        return 0;
+    };
+    codes.iter().rev().take_while(|&&code| code == last).count()
+}
+
 fn format_optional_f64(value: Option<f64>) -> String {
     value
         .map(|value| format!("{value:.3}"))
@@ -1063,6 +1134,12 @@ fn format_optional_f64(value: Option<f64>) -> String {
 fn format_optional_f32(value: Option<f32>) -> String {
     value
         .map(|value| format!("{value:.3}"))
+        .unwrap_or_else(|| "n/a".to_string())
+}
+
+fn format_optional_usize(value: Option<usize>) -> String {
+    value
+        .map(|value| value.to_string())
         .unwrap_or_else(|| "n/a".to_string())
 }
 
@@ -1276,6 +1353,7 @@ mod tests {
             "--matrix-flow-steps",
             "5,6,7",
             "--voxtral-kv-cache",
+            "--voxtral-eos-scores",
             "--voxtral-stream-begin-frames",
             "2",
             "--output-dir",
@@ -1303,6 +1381,7 @@ mod tests {
         assert_eq!(args.matrix_max_frames, vec![32, 40]);
         assert_eq!(args.matrix_flow_steps, vec![5, 6, 7]);
         assert!(args.voxtral_kv_cache);
+        assert!(args.voxtral_eos_scores);
         assert_eq!(args.voxtral_stream_begin_frames, 2);
         assert_eq!(args.output_dir, Some(PathBuf::from("/tmp/voxtral-matrix")));
         assert_eq!(
@@ -1430,6 +1509,17 @@ mod tests {
         assert!(
             err.contains("--matrix-synthesis-text count (1) must match --matrix-text count (2)")
         );
+    }
+
+    #[test]
+    fn semantic_tail_helpers_summarize_generation_codes() {
+        let codes = vec![10, 11, 12, 12, 12];
+
+        assert_eq!(tail_semantic_codes(&codes, 3), vec![12, 12, 12]);
+        assert_eq!(tail_values(&codes, 2), vec![12, 12]);
+        assert_eq!(unique_count(&tail_semantic_codes(&codes, 4)), 2);
+        assert_eq!(repeated_tail_count(&codes), 3);
+        assert_eq!(repeated_tail_count(&[]), 0);
     }
 
     #[test]

--- a/crates/voice-voxtral/src/generation.rs
+++ b/crates/voice-voxtral/src/generation.rs
@@ -18,6 +18,7 @@ pub struct VoxtralGenerationOptions {
     pub cfg_alpha: f32,
     pub use_kv_cache: bool,
     pub synchronize_trace: bool,
+    pub trace_semantic_scores: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -43,6 +44,10 @@ pub struct VoxtralGeneratedAudioChunk {
 pub struct VoxtralGenerationTrace {
     pub language_cache: bool,
     pub voice_cache_hit: bool,
+    pub semantic_codes: Vec<u32>,
+    pub eos_frame: Option<usize>,
+    pub semantic_eos_ranks: Vec<usize>,
+    pub semantic_eos_margins: Vec<f32>,
     pub voice_load: Duration,
     pub prompt: Duration,
     pub language: Duration,
@@ -79,6 +84,7 @@ impl Default for VoxtralGenerationOptions {
             cfg_alpha: 1.2,
             use_kv_cache: false,
             synchronize_trace: false,
+            trace_semantic_scores: false,
         }
     }
 }
@@ -434,10 +440,19 @@ fn generate_audio_inner(
             .get_or_insert_with(|| loop_start.elapsed());
 
         let frame = candle(frame_codes.to_vec2::<u32>())?.remove(0);
-        if frame[0] == 1 {
+        let semantic_code = frame[0];
+        if options.trace_semantic_scores {
+            let (rank, margin) =
+                semantic_eos_rank_and_margin(config, modules, &last_hidden, semantic_code)?;
+            trace.semantic_eos_ranks.push(rank);
+            trace.semantic_eos_margins.push(margin);
+        }
+        if semantic_code == 1 {
+            trace.eos_frame = Some(frame_idx);
             ended = true;
             break;
         }
+        trace.semantic_codes.push(semantic_code);
         code_frames.extend_from_slice(&frame);
 
         let next_embedding = candle(
@@ -599,10 +614,19 @@ where
             .get_or_insert_with(|| loop_start.elapsed());
 
         let frame = candle(frame_codes.to_vec2::<u32>())?.remove(0);
-        if frame[0] == 1 {
+        let semantic_code = frame[0];
+        if options.trace_semantic_scores {
+            let (rank, margin) =
+                semantic_eos_rank_and_margin(config, modules, &last_hidden, semantic_code)?;
+            trace.semantic_eos_ranks.push(rank);
+            trace.semantic_eos_margins.push(margin);
+        }
+        if semantic_code == 1 {
+            trace.eos_frame = Some(frame_idx);
             ended = true;
             break;
         }
+        trace.semantic_codes.push(semantic_code);
         frame_history.push(frame.clone());
 
         maybe_emit_streaming_chunk(
@@ -778,6 +802,33 @@ fn decode_codec_chunk_samples(
         )));
     }
     Ok(samples[start..end].to_vec())
+}
+
+fn semantic_eos_rank_and_margin(
+    config: &crate::VoxtralConfig,
+    modules: &VoxtralInferenceModules,
+    llm_hidden: &Tensor,
+    selected_code: u32,
+) -> Result<(usize, f32)> {
+    let logits = candle(modules.acoustic.semantic_logits(config, llm_hidden))?;
+    let row = candle(logits.to_dtype(DType::F32))?
+        .to_vec2::<f32>()
+        .map_err(|e| VoxtralError::Candle(e.to_string()))?
+        .remove(0);
+    let eos_logit = *row
+        .get(1)
+        .ok_or_else(|| VoxtralError::InvalidConfig("semantic logits missing EOS index".into()))?;
+    let selected_idx = usize::try_from(selected_code).map_err(|_| {
+        VoxtralError::InvalidConfig(format!("semantic code {selected_code} does not fit usize"))
+    })?;
+    let selected_logit = *row.get(selected_idx).ok_or_else(|| {
+        VoxtralError::InvalidConfig(format!(
+            "selected semantic code {selected_code} exceeds semantic logits length {}",
+            row.len()
+        ))
+    })?;
+    let rank = 1 + row.iter().filter(|&&logit| logit > eos_logit).count();
+    Ok((rank, selected_logit - eos_logit))
 }
 
 fn flow_timesteps(steps: usize) -> Result<Vec<f32>> {


### PR DESCRIPTION
## Summary

- Adds semantic-code and EOS-frame fields to `VoxtralGenerationTrace`.
- Surfaces compact termination diagnostics in `voice-eval --voxtral-matrix` rows:
  - `eos_frame`
  - `semantic_code_count`
  - `semantic_tail_codes`
  - `semantic_tail_unique_count`
  - `semantic_tail_repeat_count`
  - `semantic_eos_rank_tail`
  - `semantic_eos_margin_tail`
  - `semantic_best_eos_rank`
  - `semantic_best_eos_margin`
- Uses the diagnostics to rule out a repeated-code tail stop policy for the current normalized numeric failures.

This is stacked on #276.

## Focused Eval

```bash
cargo run --release -p voice-eval -- \
  --tts-backend voxtral \
  --voxtral-matrix \
  --voxtral-kv-cache \
  --voxtral-normalize-text \
  --voxtral-eos-scores \
  --voxtral-stream-begin-frames 2 \
  --matrix-max-frames 40,48,56 \
  --matrix-flow-steps 7 \
  --matrix-text "Read ticket A17, version 2.4.1, at 9:30 PM." \
  --matrix-text "Use API on CPU at 12:05 AM." \
  --output-dir /tmp/voxtral-termination-diagnostics/wavs \
  --spectrogram-dir /tmp/voxtral-termination-diagnostics/spectrograms \
  --json > .context/voxtral-termination-diagnostics-2026-06-24.json
```

| Prompt | Max Frames | WER | Ended | Best EOS Rank | Best EOS Margin | Tail Repeat | Semantic Tail |
| --- | ---: | ---: | --- | ---: | ---: | ---: | --- |
| `Read ticket A17...` | 40 | `0.273` | false | 117 | `9.014` | 1 | `[1821,7019,8024,8024,6114,7973,10,2046]` |
| `Read ticket A17...` | 48 | `0.273` | false | 75 | `9.014` | 1 | `[10,1465,1381,1381,2881,7860,3118,7860]` |
| `Read ticket A17...` | 56 | `0.182` | false | 2 | `0.250` | 1 | `[1544,7019,744,744,2460,4349,1795,44]` |
| `Use API on CPU...` | 40 | `0.250` | false | 23 | `5.586` | 1 | `[50,4723,7086,58,1526,3643,799,1704]` |
| `Use API on CPU...` | 48 | `0.375` | false | 23 | `5.586` | 1 | `[1704,7019,7019,6114,2297,2297,1544,10]` |
| `Use API on CPU...` | 56 | `0.375` | false | 17 | `5.586` | 1 | `[7019,855,7517,744,2460,4349,4349,5246]` |

Follow-up on the longer version/time prompt:

```bash
cargo run --release -p voice-eval -- \
  --tts-backend voxtral \
  --voxtral-matrix \
  --voxtral-kv-cache \
  --voxtral-normalize-text \
  --voxtral-eos-scores \
  --voxtral-stream-begin-frames 2 \
  --matrix-max-frames 64,72 \
  --matrix-flow-steps 7 \
  --matrix-text "Read ticket A17, version 2.4.1, at 9:30 PM." \
  --output-dir /tmp/voxtral-eos-followup/wavs \
  --spectrogram-dir /tmp/voxtral-eos-followup/spectrograms \
  --json > .context/voxtral-eos-followup-2026-06-24.json
```

| Max Frames | WER | Ended | EOS Frame | Audio Frames | Best EOS Rank | Best EOS Margin |
| ---: | ---: | --- | ---: | ---: | ---: | ---: |
| 64 | `0.182` | true | 56 | 56 | 1 | `0.000` |
| 72 | `0.182` | true | 56 | 56 | 1 | `0.000` |

Artifacts are local only:

- `.context/voxtral-termination-diagnostics-2026-06-24.json`
- `.context/voxtral-eos-followup-2026-06-24.json`
- `/tmp/voxtral-termination-diagnostics/wavs`
- `/tmp/voxtral-termination-diagnostics/spectrograms`
- `/tmp/voxtral-eos-followup/wavs`
- `/tmp/voxtral-eos-followup/spectrograms`

## Interpretation

The capped rows are not looping on a repeated semantic code. Their tails remain varied. EOS rank/margin is useful: the longer version/time prompt was exactly one predicted EOS frame short at `max_frames=56`, while the shorter API/time prompt was not close to EOS and got worse with larger caps. A safe termination slice should therefore target prompt-aware frame budgeting or an EOS-near-cap guard rather than a repeated-tail stop rule or blanket higher cap.

## Verification

```bash
cargo fmt --check
cargo test -p voice-voxtral --lib
cargo test -p voice-eval
cargo clippy -p voice-voxtral -p voice-eval -- -D warnings
```
