### PR TITLE
Add Voxtral EOS guard

### DIFF
--- a/crates/voice-eval/src/main.rs
+++ b/crates/voice-eval/src/main.rs
@@ -118,6 +118,18 @@ struct Args {
     #[arg(long = "voxtral-eos-scores")]
     voxtral_eos_scores: bool,
 
+    /// Extra frames to allow after --max-frames when EOS is close at the cap.
+    #[arg(long = "voxtral-eos-guard-frames", default_value_t = 0)]
+    voxtral_eos_guard_frames: usize,
+
+    /// Maximum EOS rank that can activate --voxtral-eos-guard-frames.
+    #[arg(long = "voxtral-eos-guard-rank", default_value_t = 2)]
+    voxtral_eos_guard_rank: usize,
+
+    /// Maximum selected-minus-EOS logit margin that can activate the EOS guard.
+    #[arg(long = "voxtral-eos-guard-margin", default_value_t = 0.5)]
+    voxtral_eos_guard_margin: f32,
+
     /// Deterministic seed for Voxtral flow noise.
     #[arg(long, default_value_t = 0x5658_5452_414c)]
     seed: u64,
@@ -220,6 +232,9 @@ struct VoxtralMatrixReport {
     sync_trace: bool,
     text_normalization: bool,
     eos_scores: bool,
+    eos_guard_frames: usize,
+    eos_guard_rank: usize,
+    eos_guard_margin: f32,
     seed: u64,
     output_dir: Option<PathBuf>,
     spectrogram_dir: Option<PathBuf>,
@@ -465,6 +480,9 @@ fn run_voxtral_matrix(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
                     use_kv_cache: args.voxtral_kv_cache,
                     synchronize_trace: args.voxtral_sync_trace,
                     trace_semantic_scores: args.voxtral_eos_scores,
+                    eos_guard_frames: args.voxtral_eos_guard_frames,
+                    eos_guard_max_rank: args.voxtral_eos_guard_rank,
+                    eos_guard_max_margin: args.voxtral_eos_guard_margin,
                     ..Default::default()
                 };
 
@@ -577,6 +595,9 @@ fn run_voxtral_matrix(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
         sync_trace: args.voxtral_sync_trace,
         text_normalization: args.voxtral_normalize_text,
         eos_scores: args.voxtral_eos_scores,
+        eos_guard_frames: args.voxtral_eos_guard_frames,
+        eos_guard_rank: args.voxtral_eos_guard_rank,
+        eos_guard_margin: args.voxtral_eos_guard_margin,
         seed: args.seed,
         output_dir: args.output_dir.clone(),
         spectrogram_dir: args.spectrogram_dir.clone(),
@@ -706,6 +727,10 @@ fn synthesize_voxtral(
             flow_steps: args.flow_steps,
             use_kv_cache: args.voxtral_kv_cache,
             synchronize_trace: args.voxtral_sync_trace,
+            trace_semantic_scores: args.voxtral_eos_scores,
+            eos_guard_frames: args.voxtral_eos_guard_frames,
+            eos_guard_max_rank: args.voxtral_eos_guard_rank,
+            eos_guard_max_margin: args.voxtral_eos_guard_margin,
             ..Default::default()
         },
     )?;
@@ -1013,14 +1038,17 @@ fn print_voxtral_matrix_report(report: &VoxtralMatrixReport) {
     );
     println!("voxtral_matrix.model_load_ms={:.1}", report.model_load_ms);
     println!(
-        "voxtral_matrix.max_frames={:?} flow_steps={:?} stream_begin_frames={} kv_cache={} sync_trace={} text_normalization={} eos_scores={}",
+        "voxtral_matrix.max_frames={:?} flow_steps={:?} stream_begin_frames={} kv_cache={} sync_trace={} text_normalization={} eos_scores={} eos_guard_frames={} eos_guard_rank={} eos_guard_margin={:.3}",
         report.matrix_max_frames,
         report.matrix_flow_steps,
         report.stream_begin_frames,
         report.kv_cache,
         report.sync_trace,
         report.text_normalization,
-        report.eos_scores
+        report.eos_scores,
+        report.eos_guard_frames,
+        report.eos_guard_rank,
+        report.eos_guard_margin
     );
     if let Some(output_dir) = &report.output_dir {
         println!("voxtral_matrix.output_dir={}", output_dir.display());
@@ -1354,6 +1382,12 @@ mod tests {
             "5,6,7",
             "--voxtral-kv-cache",
             "--voxtral-eos-scores",
+            "--voxtral-eos-guard-frames",
+            "8",
+            "--voxtral-eos-guard-rank",
+            "3",
+            "--voxtral-eos-guard-margin",
+            "0.75",
             "--voxtral-stream-begin-frames",
             "2",
             "--output-dir",
@@ -1382,6 +1416,9 @@ mod tests {
         assert_eq!(args.matrix_flow_steps, vec![5, 6, 7]);
         assert!(args.voxtral_kv_cache);
         assert!(args.voxtral_eos_scores);
+        assert_eq!(args.voxtral_eos_guard_frames, 8);
+        assert_eq!(args.voxtral_eos_guard_rank, 3);
+        assert_eq!(args.voxtral_eos_guard_margin, 0.75);
         assert_eq!(args.voxtral_stream_begin_frames, 2);
         assert_eq!(args.output_dir, Some(PathBuf::from("/tmp/voxtral-matrix")));
         assert_eq!(

--- a/crates/voice-eval/src/main.rs
+++ b/crates/voice-eval/src/main.rs
@@ -233,8 +233,8 @@ struct VoxtralMatrixReport {
     text_normalization: bool,
     eos_scores: bool,
     eos_guard_frames: usize,
-    eos_guard_rank: usize,
-    eos_guard_margin: f32,
+    eos_guard_max_rank: usize,
+    eos_guard_max_margin: f32,
     seed: u64,
     output_dir: Option<PathBuf>,
     spectrogram_dir: Option<PathBuf>,
@@ -596,8 +596,8 @@ fn run_voxtral_matrix(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
         text_normalization: args.voxtral_normalize_text,
         eos_scores: args.voxtral_eos_scores,
         eos_guard_frames: args.voxtral_eos_guard_frames,
-        eos_guard_rank: args.voxtral_eos_guard_rank,
-        eos_guard_margin: args.voxtral_eos_guard_margin,
+        eos_guard_max_rank: args.voxtral_eos_guard_rank,
+        eos_guard_max_margin: args.voxtral_eos_guard_margin,
         seed: args.seed,
         output_dir: args.output_dir.clone(),
         spectrogram_dir: args.spectrogram_dir.clone(),
@@ -1038,7 +1038,7 @@ fn print_voxtral_matrix_report(report: &VoxtralMatrixReport) {
     );
     println!("voxtral_matrix.model_load_ms={:.1}", report.model_load_ms);
     println!(
-        "voxtral_matrix.max_frames={:?} flow_steps={:?} stream_begin_frames={} kv_cache={} sync_trace={} text_normalization={} eos_scores={} eos_guard_frames={} eos_guard_rank={} eos_guard_margin={:.3}",
+        "voxtral_matrix.max_frames={:?} flow_steps={:?} stream_begin_frames={} kv_cache={} sync_trace={} text_normalization={} eos_scores={} eos_guard_frames={} eos_guard_max_rank={} eos_guard_max_margin={:.3}",
         report.matrix_max_frames,
         report.matrix_flow_steps,
         report.stream_begin_frames,
@@ -1047,8 +1047,8 @@ fn print_voxtral_matrix_report(report: &VoxtralMatrixReport) {
         report.text_normalization,
         report.eos_scores,
         report.eos_guard_frames,
-        report.eos_guard_rank,
-        report.eos_guard_margin
+        report.eos_guard_max_rank,
+        report.eos_guard_max_margin
     );
     if let Some(output_dir) = &report.output_dir {
         println!("voxtral_matrix.output_dir={}", output_dir.display());

--- a/crates/voice-voxtral/src/generation.rs
+++ b/crates/voice-voxtral/src/generation.rs
@@ -19,6 +19,9 @@ pub struct VoxtralGenerationOptions {
     pub use_kv_cache: bool,
     pub synchronize_trace: bool,
     pub trace_semantic_scores: bool,
+    pub eos_guard_frames: usize,
+    pub eos_guard_max_rank: usize,
+    pub eos_guard_max_margin: f32,
 }
 
 #[derive(Debug, Clone)]
@@ -85,6 +88,9 @@ impl Default for VoxtralGenerationOptions {
             use_kv_cache: false,
             synchronize_trace: false,
             trace_semantic_scores: false,
+            eos_guard_frames: 0,
+            eos_guard_max_rank: 2,
+            eos_guard_max_margin: 0.5,
         }
     }
 }
@@ -391,8 +397,15 @@ fn generate_audio_inner(
     let loop_start = Instant::now();
     let mut code_frames = Vec::with_capacity(options.max_frames * config.num_codebooks());
     let mut ended = false;
+    let mut eos_guard_active = false;
+    let max_decode_frames = options.max_frames.saturating_add(options.eos_guard_frames);
 
-    for frame_idx in 0..options.max_frames {
+    for frame_idx in 0..max_decode_frames {
+        if frame_idx >= options.max_frames && !eos_guard_active {
+            break;
+        }
+        eos_guard_active = false;
+
         let language_start = Instant::now();
         let hidden = if let Some(cache) = language_cache.as_mut() {
             let start_pos = cache.len();
@@ -441,11 +454,24 @@ fn generate_audio_inner(
 
         let frame = candle(frame_codes.to_vec2::<u32>())?.remove(0);
         let semantic_code = frame[0];
-        if options.trace_semantic_scores {
-            let (rank, margin) =
-                semantic_eos_rank_and_margin(config, modules, &last_hidden, semantic_code)?;
-            trace.semantic_eos_ranks.push(rank);
-            trace.semantic_eos_margins.push(margin);
+        let should_check_guard =
+            options.eos_guard_frames > 0 && frame_idx + 1 >= options.max_frames;
+        let semantic_score = if options.trace_semantic_scores || should_check_guard {
+            Some(semantic_eos_rank_and_margin(
+                config,
+                modules,
+                &last_hidden,
+                semantic_code,
+            )?)
+        } else {
+            None
+        };
+        if let Some((rank, margin)) = semantic_score {
+            if options.trace_semantic_scores {
+                trace.semantic_eos_ranks.push(rank);
+                trace.semantic_eos_margins.push(margin);
+            }
+            eos_guard_active = should_extend_eos_guard(&options, should_check_guard, rank, margin);
         }
         if semantic_code == 1 {
             trace.eos_frame = Some(frame_idx);
@@ -565,8 +591,15 @@ where
     let mut emitted_frames = 0usize;
     let mut emitted_samples = Vec::new();
     let mut ended = false;
+    let mut eos_guard_active = false;
+    let max_decode_frames = options.max_frames.saturating_add(options.eos_guard_frames);
 
-    for frame_idx in 0..options.max_frames {
+    for frame_idx in 0..max_decode_frames {
+        if frame_idx >= options.max_frames && !eos_guard_active {
+            break;
+        }
+        eos_guard_active = false;
+
         let language_start = Instant::now();
         let hidden = if let Some(cache) = language_cache.as_mut() {
             let start_pos = cache.len();
@@ -615,11 +648,24 @@ where
 
         let frame = candle(frame_codes.to_vec2::<u32>())?.remove(0);
         let semantic_code = frame[0];
-        if options.trace_semantic_scores {
-            let (rank, margin) =
-                semantic_eos_rank_and_margin(config, modules, &last_hidden, semantic_code)?;
-            trace.semantic_eos_ranks.push(rank);
-            trace.semantic_eos_margins.push(margin);
+        let should_check_guard =
+            options.eos_guard_frames > 0 && frame_idx + 1 >= options.max_frames;
+        let semantic_score = if options.trace_semantic_scores || should_check_guard {
+            Some(semantic_eos_rank_and_margin(
+                config,
+                modules,
+                &last_hidden,
+                semantic_code,
+            )?)
+        } else {
+            None
+        };
+        if let Some((rank, margin)) = semantic_score {
+            if options.trace_semantic_scores {
+                trace.semantic_eos_ranks.push(rank);
+                trace.semantic_eos_margins.push(margin);
+            }
+            eos_guard_active = should_extend_eos_guard(&options, should_check_guard, rank, margin);
         }
         if semantic_code == 1 {
             trace.eos_frame = Some(frame_idx);
@@ -831,6 +877,18 @@ fn semantic_eos_rank_and_margin(
     Ok((rank, selected_logit - eos_logit))
 }
 
+fn should_extend_eos_guard(
+    options: &VoxtralGenerationOptions,
+    should_check_guard: bool,
+    eos_rank: usize,
+    eos_margin: f32,
+) -> bool {
+    should_check_guard
+        && options.eos_guard_frames > 0
+        && eos_rank <= options.eos_guard_max_rank
+        && eos_margin <= options.eos_guard_max_margin
+}
+
 fn flow_timesteps(steps: usize) -> Result<Vec<f32>> {
     if steps == 0 {
         return Err(VoxtralError::InvalidConfig(
@@ -897,4 +955,30 @@ impl XorShift64 {
 
 fn candle<T>(result: candle_core::Result<T>) -> Result<T> {
     result.map_err(|e| VoxtralError::Candle(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{should_extend_eos_guard, VoxtralGenerationOptions};
+
+    #[test]
+    fn eos_guard_extends_only_near_cap_when_eos_is_close() {
+        let options = VoxtralGenerationOptions {
+            eos_guard_frames: 8,
+            eos_guard_max_rank: 2,
+            eos_guard_max_margin: 0.5,
+            ..Default::default()
+        };
+
+        assert!(should_extend_eos_guard(&options, true, 2, 0.25));
+        assert!(!should_extend_eos_guard(&options, false, 2, 0.25));
+        assert!(!should_extend_eos_guard(&options, true, 3, 0.25));
+        assert!(!should_extend_eos_guard(&options, true, 2, 0.75));
+        assert!(!should_extend_eos_guard(
+            &VoxtralGenerationOptions::default(),
+            true,
+            1,
+            0.0
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

- adds disabled-by-default Voxtral EOS guard controls for allowing a small number of extra frames only when EOS is close at the configured frame cap
- wires the guard through `voice-eval` single synthesis and matrix runs
- records guard settings in the matrix JSON/text report so quality experiments can be reproduced

## Why

The termination diagnostics in #277 showed that a blanket higher frame cap is not safe. The normalized version/time prompt improved when allowed to reach frame 56 and predicted EOS immediately after the cap, while the shorter API/time prompt got worse at larger caps and never had a close EOS score. This PR makes that distinction measurable and opt-in instead of changing public defaults.

## Local Eval

Command:

```bash
cargo run --release -p voice-eval -- \
  --tts-backend voxtral \
  --voxtral-matrix \
  --voxtral-kv-cache \
  --voxtral-normalize-text \
  --voxtral-eos-scores \
  --voxtral-eos-guard-frames 8 \
  --voxtral-eos-guard-rank 2 \
  --voxtral-eos-guard-margin 0.5 \
  --voxtral-stream-begin-frames 2 \
  --matrix-max-frames 56 \
  --matrix-flow-steps 7 \
  --matrix-text "Read ticket A17, version 2.4.1, at 9:30 PM." \
  --matrix-text "Use API on CPU at 12:05 AM." \
  --output-dir /tmp/voxtral-eos-guard/wavs \
  --spectrogram-dir /tmp/voxtral-eos-guard/spectrograms \
  --json > .context/voxtral-eos-guard-2026-06-24.json
```

Result:

- version/time: WER `0.182`, `ended=true`, `eos_frame=56`, `audio_frames=56`, `best_eos_rank=1`, `best_eos_margin=0.0`
- API/time: WER `0.375`, `ended=false`, `audio_frames=56`, `best_eos_rank=17`, `best_eos_margin=5.586`

Interpretation:

- the guard activates for a near-EOS cap boundary and lets the generation terminate naturally
- the guard does not extend the API/time prompt because EOS was not close, matching the evidence that larger frame caps hurt that prompt
- this is still not a full default policy; it is a reusable measurement/control knob for the next prompt-aware frame-budget slice

Artifacts:

- JSON: `.context/voxtral-eos-guard-2026-06-24.json`
- WAVs: `/tmp/voxtral-eos-guard/wavs`
- spectrograms: `/tmp/voxtral-eos-guard/spectrograms`

## Verification

```bash
cargo fmt --check
cargo test -p voice-voxtral --lib
cargo test -p voice-eval
cargo clippy -p voice-voxtral -p voice-eval -- -D warnings
```
