### PR TITLE
Add Voxtral pronunciation aliases

### DIFF
--- a/crates/voice-cli/src/cli.rs
+++ b/crates/voice-cli/src/cli.rs
@@ -191,6 +191,10 @@ struct SayArgs {
     #[arg(long = "voxtral-normalize-text")]
     voxtral_normalize_text: bool,
 
+    /// Apply known Voxtral pronunciation aliases before synthesis
+    #[arg(long = "voxtral-pronunciation-aliases")]
+    voxtral_pronunciation_aliases: bool,
+
     /// Override Voxtral's initial streaming codec chunk size for daemon playback
     #[arg(long = "voxtral-stream-begin-frames")]
     voxtral_stream_begin_frames: Option<usize>,
@@ -535,6 +539,10 @@ struct StreamArgs {
     #[arg(long = "voxtral-normalize-text")]
     voxtral_normalize_text: bool,
 
+    /// Apply known Voxtral pronunciation aliases before synthesis
+    #[arg(long = "voxtral-pronunciation-aliases")]
+    voxtral_pronunciation_aliases: bool,
+
     /// Override Voxtral's initial streaming codec chunk size
     #[arg(long = "voxtral-stream-begin-frames")]
     voxtral_stream_begin_frames: Option<usize>,
@@ -771,6 +779,10 @@ struct BenchTtsArgs {
     /// Normalize compact Voxtral numeric forms such as versions and times before synthesis
     #[arg(long = "voxtral-normalize-text")]
     voxtral_normalize_text: bool,
+
+    /// Apply known Voxtral pronunciation aliases before synthesis
+    #[arg(long = "voxtral-pronunciation-aliases")]
+    voxtral_pronunciation_aliases: bool,
 
     /// Override Voxtral's initial streaming codec chunk size for benchmarking
     #[arg(long = "voxtral-stream-begin-frames")]
@@ -1258,6 +1270,7 @@ fn preprocess_daemon_text(
     cli_subs: &[String],
     sub_file: Option<PathBuf>,
     voxtral_normalize_text: bool,
+    voxtral_pronunciation_aliases: bool,
 ) -> String {
     let text = if markdown {
         strip_markdown(&text)
@@ -1272,8 +1285,30 @@ fn preprocess_daemon_text(
     } else {
         apply_substitutions(&text, &subs)
     };
-    if engine == TtsEngine::Voxtral && voxtral_normalize_text {
-        voice_voxtral::normalize_tts_text(&text)
+    if engine == TtsEngine::Voxtral {
+        apply_voxtral_text_options(
+            text,
+            voxtral_normalize_text,
+            voxtral_pronunciation_aliases,
+        )
+    } else {
+        text
+    }
+}
+
+fn apply_voxtral_text_options(
+    text: String,
+    normalize_numbers: bool,
+    pronunciation_aliases: bool,
+) -> String {
+    if normalize_numbers || pronunciation_aliases {
+        voice_voxtral::normalize_tts_text_with_options(
+            &text,
+            voice_voxtral::VoxtralTextNormalizationOptions {
+                numeric: normalize_numbers,
+                pronunciation_aliases,
+            },
+        )
     } else {
         text
     }
@@ -1375,6 +1410,7 @@ fn main() {
                     voxtral_kv_cache: false,
                     voxtral_realtime: false,
                     voxtral_normalize_text: false,
+                    voxtral_pronunciation_aliases: false,
                     voxtral_stream_begin_frames: None,
                     output: None,
                     format: None,
@@ -2287,8 +2323,12 @@ fn prepare_bench_text(
     } else {
         apply_substitutions(&text, &subs)
     };
-    let text = if engine == TtsEngine::Voxtral && args.voxtral_normalize_text {
-        voice_voxtral::normalize_tts_text(&text)
+    let text = if engine == TtsEngine::Voxtral {
+        apply_voxtral_text_options(
+            text,
+            args.voxtral_normalize_text,
+            args.voxtral_pronunciation_aliases,
+        )
     } else {
         text
     };
@@ -2603,6 +2643,7 @@ fn run_say(say_args: SayArgs) {
                     &say_args.subs,
                     say_args.sub_file.clone(),
                     say_args.voxtral_normalize_text,
+                    say_args.voxtral_pronunciation_aliases,
                 );
                 let tts_options =
                     daemon_tts_options(say_args.engine, &say_args.voxtral_model, voxtral);
@@ -2790,6 +2831,7 @@ fn run_voxtral_say(
         &say_args.subs,
         say_args.sub_file.clone(),
         say_args.voxtral_normalize_text,
+        say_args.voxtral_pronunciation_aliases,
     );
 
     if (say_args.speed - 1.0).abs() > f32::EPSILON {
@@ -2865,6 +2907,7 @@ fn run_stream(stream_args: StreamArgs) {
         &stream_args.subs,
         stream_args.sub_file.clone(),
         stream_args.voxtral_normalize_text,
+        stream_args.voxtral_pronunciation_aliases,
     );
 
     validate_stream_frame_params(stream_args.sample_rate, stream_args.frame_ms).unwrap_or_else(
@@ -4111,17 +4154,21 @@ mod tests {
     }
 
     #[test]
-    fn parses_voxtral_text_normalization_for_say_stream_and_bench() {
+    fn parses_voxtral_text_options_for_say_stream_and_bench() {
         let say = Args::parse_from([
             "voice",
             "say",
             "--engine",
             "voxtral",
             "--voxtral-normalize-text",
+            "--voxtral-pronunciation-aliases",
             "Read ticket A17.",
         ]);
         match say.command {
-            Some(Command::Say(args)) => assert!(args.voxtral_normalize_text),
+            Some(Command::Say(args)) => {
+                assert!(args.voxtral_normalize_text);
+                assert!(args.voxtral_pronunciation_aliases);
+            }
             other => panic!("expected say command, got {other:?}"),
         }
 
@@ -4131,10 +4178,14 @@ mod tests {
             "--engine",
             "voxtral",
             "--voxtral-normalize-text",
+            "--voxtral-pronunciation-aliases",
             "Read ticket A17.",
         ]);
         match stream.command {
-            Some(Command::Stream(args)) => assert!(args.voxtral_normalize_text),
+            Some(Command::Stream(args)) => {
+                assert!(args.voxtral_normalize_text);
+                assert!(args.voxtral_pronunciation_aliases);
+            }
             other => panic!("expected stream command, got {other:?}"),
         }
 
@@ -4145,12 +4196,16 @@ mod tests {
             "--engine",
             "voxtral",
             "--voxtral-normalize-text",
+            "--voxtral-pronunciation-aliases",
             "Read ticket A17.",
         ]);
         match bench.command {
             Some(Command::Bench(BenchArgs {
                 command: BenchCommand::Tts(args),
-            })) => assert!(args.voxtral_normalize_text),
+            })) => {
+                assert!(args.voxtral_normalize_text);
+                assert!(args.voxtral_pronunciation_aliases);
+            }
             other => panic!("expected bench tts command, got {other:?}"),
         }
     }
@@ -4166,6 +4221,7 @@ mod tests {
                 false,
                 &[],
                 None,
+                false,
                 false
             ),
             text
@@ -4177,13 +4233,27 @@ mod tests {
                 false,
                 &[],
                 None,
+                true,
                 true
             ),
             text
         );
         assert_eq!(
-            preprocess_daemon_text(text, TtsEngine::Voxtral, false, &[], None, true),
+            preprocess_daemon_text(text, TtsEngine::Voxtral, false, &[], None, true, false),
             "Read ticket A seventeen, version two point four point one, at nine thirty PM."
+        );
+
+        assert_eq!(
+            preprocess_daemon_text(
+                "Voxtral reads A17.".to_string(),
+                TtsEngine::Voxtral,
+                false,
+                &[],
+                None,
+                true,
+                true
+            ),
+            "Vox trell reads A seventeen."
         );
     }
 
@@ -4202,6 +4272,7 @@ mod tests {
             voxtral_realtime: false,
             voxtral_sync_trace: false,
             voxtral_normalize_text: true,
+            voxtral_pronunciation_aliases: false,
             voxtral_stream_begin_frames: None,
             daemon: false,
             stream_sample_rate: 24_000,

--- a/crates/voice-eval/src/main.rs
+++ b/crates/voice-eval/src/main.rs
@@ -106,6 +106,10 @@ struct Args {
     #[arg(long = "voxtral-normalize-text")]
     voxtral_normalize_text: bool,
 
+    /// Apply known Voxtral pronunciation aliases before synthesis.
+    #[arg(long = "voxtral-pronunciation-aliases")]
+    voxtral_pronunciation_aliases: bool,
+
     /// Initial streaming codec chunk size for Voxtral matrix timing.
     #[arg(long = "voxtral-stream-begin-frames", default_value_t = 2)]
     voxtral_stream_begin_frames: usize,
@@ -200,6 +204,7 @@ struct EvalReport {
     stt_model: String,
     synthesis_mode: &'static str,
     voxtral_text_normalization: bool,
+    voxtral_pronunciation_aliases: bool,
     sample_rate: u32,
     sample_count: usize,
     duration_seconds: f32,
@@ -231,6 +236,7 @@ struct VoxtralMatrixReport {
     kv_cache: bool,
     sync_trace: bool,
     text_normalization: bool,
+    pronunciation_aliases: bool,
     eos_scores: bool,
     eos_guard_frames: usize,
     eos_guard_max_rank: usize,
@@ -386,6 +392,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         stt_model: stt_model_path,
         synthesis_mode,
         voxtral_text_normalization: args.tts_backend == "voxtral" && args.voxtral_normalize_text,
+        voxtral_pronunciation_aliases: args.tts_backend == "voxtral"
+            && args.voxtral_pronunciation_aliases,
         sample_rate,
         sample_count: samples.len(),
         duration_seconds,
@@ -594,6 +602,7 @@ fn run_voxtral_matrix(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
         kv_cache: args.voxtral_kv_cache,
         sync_trace: args.voxtral_sync_trace,
         text_normalization: args.voxtral_normalize_text,
+        pronunciation_aliases: args.voxtral_pronunciation_aliases,
         eos_scores: args.voxtral_eos_scores,
         eos_guard_frames: args.voxtral_eos_guard_frames,
         eos_guard_max_rank: args.voxtral_eos_guard_rank,
@@ -675,8 +684,16 @@ fn matrix_cases(args: &Args) -> Result<Vec<MatrixCase>, Box<dyn std::error::Erro
 }
 
 fn maybe_normalize_voxtral_text(args: &Args, text: String) -> String {
-    if args.tts_backend == "voxtral" && args.voxtral_normalize_text {
-        voice_voxtral::normalize_tts_text(&text)
+    if args.tts_backend == "voxtral"
+        && (args.voxtral_normalize_text || args.voxtral_pronunciation_aliases)
+    {
+        voice_voxtral::normalize_tts_text_with_options(
+            &text,
+            voice_voxtral::VoxtralTextNormalizationOptions {
+                numeric: args.voxtral_normalize_text,
+                pronunciation_aliases: args.voxtral_pronunciation_aliases,
+            },
+        )
     } else {
         text
     }
@@ -1038,13 +1055,14 @@ fn print_voxtral_matrix_report(report: &VoxtralMatrixReport) {
     );
     println!("voxtral_matrix.model_load_ms={:.1}", report.model_load_ms);
     println!(
-        "voxtral_matrix.max_frames={:?} flow_steps={:?} stream_begin_frames={} kv_cache={} sync_trace={} text_normalization={} eos_scores={} eos_guard_frames={} eos_guard_max_rank={} eos_guard_max_margin={:.3}",
+        "voxtral_matrix.max_frames={:?} flow_steps={:?} stream_begin_frames={} kv_cache={} sync_trace={} text_normalization={} pronunciation_aliases={} eos_scores={} eos_guard_frames={} eos_guard_max_rank={} eos_guard_max_margin={:.3}",
         report.matrix_max_frames,
         report.matrix_flow_steps,
         report.stream_begin_frames,
         report.kv_cache,
         report.sync_trace,
         report.text_normalization,
+        report.pronunciation_aliases,
         report.eos_scores,
         report.eos_guard_frames,
         report.eos_guard_max_rank,
@@ -1183,6 +1201,9 @@ fn print_text_report(report: &EvalReport) {
     }
     if report.voxtral_text_normalization {
         println!("voxtral text normalization: enabled");
+    }
+    if report.voxtral_pronunciation_aliases {
+        println!("voxtral pronunciation aliases: enabled");
     }
     println!("hypothesis: {}", report.transcription);
     println!("normalized reference: {}", report.normalized_reference);
@@ -1350,6 +1371,7 @@ mod tests {
             "--synthesis-text",
             "Vox trahl should sound clear.",
             "--voxtral-normalize-text",
+            "--voxtral-pronunciation-aliases",
         ])
         .unwrap();
 
@@ -1359,6 +1381,7 @@ mod tests {
             Some("Vox trahl should sound clear.")
         );
         assert!(args.voxtral_normalize_text);
+        assert!(args.voxtral_pronunciation_aliases);
     }
 
     #[test]
@@ -1381,6 +1404,7 @@ mod tests {
             "--matrix-flow-steps",
             "5,6,7",
             "--voxtral-kv-cache",
+            "--voxtral-pronunciation-aliases",
             "--voxtral-eos-scores",
             "--voxtral-eos-guard-frames",
             "8",
@@ -1415,6 +1439,7 @@ mod tests {
         assert_eq!(args.matrix_max_frames, vec![32, 40]);
         assert_eq!(args.matrix_flow_steps, vec![5, 6, 7]);
         assert!(args.voxtral_kv_cache);
+        assert!(args.voxtral_pronunciation_aliases);
         assert!(args.voxtral_eos_scores);
         assert_eq!(args.voxtral_eos_guard_frames, 8);
         assert_eq!(args.voxtral_eos_guard_rank, 3);
@@ -1525,6 +1550,36 @@ mod tests {
                     "Read ticket A seventeen, version two point four point one, at nine thirty PM."
                         .to_string(),
             }]
+        );
+    }
+
+    #[test]
+    fn matrix_cases_apply_opt_in_voxtral_pronunciation_aliases() {
+        let args = Args::try_parse_from([
+            "voice-eval",
+            "--tts-backend",
+            "voxtral",
+            "--voxtral-matrix",
+            "--voxtral-pronunciation-aliases",
+            "--matrix-text",
+            "Voxtral reads A17.",
+            "--matrix-text",
+            "Kokoro should stay unchanged.",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            matrix_cases(&args).unwrap(),
+            vec![
+                MatrixCase {
+                    reference_text: "Voxtral reads A17.".to_string(),
+                    synthesis_text: "Vox trell reads A17.".to_string(),
+                },
+                MatrixCase {
+                    reference_text: "Kokoro should stay unchanged.".to_string(),
+                    synthesis_text: "Kokoro should stay unchanged.".to_string(),
+                }
+            ]
         );
     }
 

--- a/crates/voice-voxtral/src/lib.rs
+++ b/crates/voice-voxtral/src/lib.rs
@@ -81,7 +81,9 @@ pub use streaming::{
     plan_codec_chunk, VoxtralCodecChunk, VoxtralStreamingConfig, DEFAULT_CODEC_CHUNK_FRAMES,
     DEFAULT_CODEC_CHUNK_FRAMES_AT_BEGIN, DEFAULT_CODEC_LEFT_CONTEXT_FRAMES,
 };
-pub use text::normalize_tts_text;
+pub use text::{
+    normalize_tts_text, normalize_tts_text_with_options, VoxtralTextNormalizationOptions,
+};
 pub use tokenizer::{
     TekkenAudioEncodingConfig, TekkenAudioMetadata, TekkenConfig, TekkenSpecialToken,
     TekkenVocabToken, VoxtralTekkenDecoder, VoxtralTekkenEncoder, VoxtralTokenizerMetadata,

--- a/crates/voice-voxtral/src/text.rs
+++ b/crates/voice-voxtral/src/text.rs
@@ -110,10 +110,10 @@ fn replace_ascii_word(text: &str, word: &str, replacement: &str) -> String {
 
 fn is_word_boundary(text: &str, start: usize, end: usize) -> bool {
     let bytes = text.as_bytes();
-    let before = start == 0 || !is_ascii_alphanumeric(bytes[start - 1]);
+    let before = start == 0 || !bytes[start - 1].is_ascii_alphanumeric();
     let after = bytes
         .get(end)
-        .is_none_or(|byte| !is_ascii_alphanumeric(*byte));
+        .is_none_or(|byte| !byte.is_ascii_alphanumeric());
     before && after
 }
 

--- a/crates/voice-voxtral/src/text.rs
+++ b/crates/voice-voxtral/src/text.rs
@@ -1,6 +1,41 @@
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct VoxtralTextNormalizationOptions {
+    /// Expand compact numeric forms that Voxtral currently handles poorly.
+    pub numeric: bool,
+    /// Rewrite known hard-to-pronounce project names into pronounceable hints.
+    pub pronunciation_aliases: bool,
+}
+
 /// Normalize numeric text forms that Voxtral currently handles poorly when
 /// they are left as compact written forms.
 pub fn normalize_tts_text(text: &str) -> String {
+    normalize_tts_text_with_options(
+        text,
+        VoxtralTextNormalizationOptions {
+            numeric: true,
+            pronunciation_aliases: false,
+        },
+    )
+}
+
+pub fn normalize_tts_text_with_options(
+    text: &str,
+    options: VoxtralTextNormalizationOptions,
+) -> String {
+    let text = if options.numeric {
+        normalize_numeric_tts_text(text)
+    } else {
+        text.to_string()
+    };
+
+    if options.pronunciation_aliases {
+        apply_pronunciation_aliases(&text)
+    } else {
+        text
+    }
+}
+
+fn normalize_numeric_tts_text(text: &str) -> String {
     let mut output = String::with_capacity(text.len());
     let mut index = 0;
     let bytes = text.as_bytes();
@@ -41,6 +76,45 @@ pub fn normalize_tts_text(text: &str) -> String {
     }
 
     output
+}
+
+fn apply_pronunciation_aliases(text: &str) -> String {
+    replace_ascii_word(text, "Voxtral", "Vox trell")
+}
+
+fn replace_ascii_word(text: &str, word: &str, replacement: &str) -> String {
+    let mut output = String::with_capacity(text.len());
+    let mut index = 0;
+
+    while index < text.len() {
+        let candidate_end = index.saturating_add(word.len());
+        if candidate_end <= text.len()
+            && text[index..candidate_end].eq_ignore_ascii_case(word)
+            && is_word_boundary(text, index, candidate_end)
+        {
+            output.push_str(replacement);
+            index = candidate_end;
+            continue;
+        }
+
+        let ch = text[index..]
+            .chars()
+            .next()
+            .expect("index is inside a valid UTF-8 string");
+        output.push(ch);
+        index += ch.len_utf8();
+    }
+
+    output
+}
+
+fn is_word_boundary(text: &str, start: usize, end: usize) -> bool {
+    let bytes = text.as_bytes();
+    let before = start == 0 || !is_ascii_alphanumeric(bytes[start - 1]);
+    let after = bytes
+        .get(end)
+        .is_none_or(|byte| !is_ascii_alphanumeric(*byte));
+    before && after
 }
 
 fn parse_time(text: &str, start: usize) -> Option<(String, usize)> {
@@ -247,7 +321,9 @@ fn tens_word(tens: u32) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_tts_text;
+    use super::{
+        normalize_tts_text, normalize_tts_text_with_options, VoxtralTextNormalizationOptions,
+    };
 
     #[test]
     fn leaves_plain_prompt_unchanged() {
@@ -287,6 +363,54 @@ mod tests {
         assert_eq!(
             normalize_tts_text("Use code 007."),
             "Use code zero zero seven."
+        );
+    }
+
+    #[test]
+    fn pronunciation_aliases_are_opt_in_and_word_bounded() {
+        assert_eq!(
+            normalize_tts_text_with_options(
+                "Voxtral should say voxtral clearly.",
+                VoxtralTextNormalizationOptions {
+                    numeric: false,
+                    pronunciation_aliases: false,
+                }
+            ),
+            "Voxtral should say voxtral clearly."
+        );
+        assert_eq!(
+            normalize_tts_text_with_options(
+                "Voxtral should say voxtral clearly.",
+                VoxtralTextNormalizationOptions {
+                    numeric: false,
+                    pronunciation_aliases: true,
+                }
+            ),
+            "Vox trell should say Vox trell clearly."
+        );
+        assert_eq!(
+            normalize_tts_text_with_options(
+                "Voxtralized text should not change.",
+                VoxtralTextNormalizationOptions {
+                    numeric: false,
+                    pronunciation_aliases: true,
+                }
+            ),
+            "Voxtralized text should not change."
+        );
+    }
+
+    #[test]
+    fn text_normalization_options_can_combine_numeric_and_pronunciation_rewrites() {
+        assert_eq!(
+            normalize_tts_text_with_options(
+                "Voxtral reads A17 at 9:30 PM.",
+                VoxtralTextNormalizationOptions {
+                    numeric: true,
+                    pronunciation_aliases: true,
+                }
+            ),
+            "Vox trell reads A seventeen at nine thirty PM."
         );
     }
 }

--- a/crates/voice-voxtral/src/text.rs
+++ b/crates/voice-voxtral/src/text.rs
@@ -84,14 +84,16 @@ fn apply_pronunciation_aliases(text: &str) -> String {
 
 fn replace_ascii_word(text: &str, word: &str, replacement: &str) -> String {
     let mut output = String::with_capacity(text.len());
+    let bytes = text.as_bytes();
+    let word_bytes = word.as_bytes();
     let mut index = 0;
 
     while index < text.len() {
         let candidate_end = index.saturating_add(word.len());
-        if candidate_end <= text.len()
-            && text[index..candidate_end].eq_ignore_ascii_case(word)
-            && is_word_boundary(text, index, candidate_end)
-        {
+        let matches_word = bytes
+            .get(index..candidate_end)
+            .is_some_and(|candidate| candidate.eq_ignore_ascii_case(word_bytes));
+        if matches_word && is_word_boundary(text, index, candidate_end) {
             output.push_str(replacement);
             index = candidate_end;
             continue;
@@ -397,6 +399,20 @@ mod tests {
                 }
             ),
             "Voxtralized text should not change."
+        );
+    }
+
+    #[test]
+    fn pronunciation_aliases_do_not_panic_on_utf8_boundary_overlap() {
+        assert_eq!(
+            normalize_tts_text_with_options(
+                "Voxtraé should remain unchanged.",
+                VoxtralTextNormalizationOptions {
+                    numeric: false,
+                    pronunciation_aliases: true,
+                }
+            ),
+            "Voxtraé should remain unchanged."
         );
     }
 


### PR DESCRIPTION
## Summary

- adds `VoxtralTextNormalizationOptions` so numeric normalization and pronunciation aliases can be controlled independently
- adds an opt-in `Voxtral -> Vox trell` pronunciation alias
- wires `--voxtral-pronunciation-aliases` through `voice-eval`, `voice say`, `voice stream`, and `voice bench tts`

## Why

The expanded Voxtral matrix showed that the `Voxtral` prompt is not primarily a frame-cap or EOS problem. Raw synthesis produced transcripts like `the astral should pronounce voxtrel clearly in a short answer`, even at 56 frames. A paired-synthesis probe found that `Vox trell` is a measurable improvement while still not exact enough to become a public default.

## Local Eval

Probe command shape:

```bash
cargo run --release -p voice-eval -- \
  --tts-backend voxtral \
  --voxtral-matrix \
  --voxtral-kv-cache \
  --voxtral-pronunciation-aliases \
  --voxtral-eos-scores \
  --voxtral-eos-guard-frames 8 \
  --voxtral-eos-guard-rank 2 \
  --voxtral-eos-guard-margin 0.5 \
  --voxtral-stream-begin-frames 2 \
  --matrix-max-frames 56 \
  --matrix-flow-steps 7 \
  --matrix-text "Voxtral should pronounce Voxtral clearly in a short answer." \
  --output-dir /tmp/voxtral-alias-smoke/wavs \
  --spectrogram-dir /tmp/voxtral-alias-smoke/spectrograms \
  --json > .context/voxtral-pronunciation-alias-smoke-2026-06-24.json
```

Result:

- synthesis text: `Vox trell should pronounce Vox trell clearly in a short answer.`
- transcript: `Voxtrell should pronounce Voxtrell clearly in a short answer.`
- WER: `0.222`
- ended: `true`
- EOS frame: `51`

Baseline from the same prompt without aliases:

- transcript: `the astral should pronounce voxtrel clearly in a short answer`
- WER: `0.333`
- ended: `false`

Interpretation:

- the alias improves the known proper-noun failure and helps generation terminate
- it is still explicit and opt-in because `Voxtrell` is closer but not exact

Artifacts:

- Probe JSON: `.context/voxtral-pronunciation-probe-2026-06-24.json`
- Flag smoke JSON: `.context/voxtral-pronunciation-alias-smoke-2026-06-24.json`
- Alias matrix JSON: `.context/voxtral-alias-matrix-2026-06-24.json`
- WAVs: `/tmp/voxtral-pronunciation-probe/wavs`, `/tmp/voxtral-alias-smoke/wavs`
- Spectrograms: `/tmp/voxtral-pronunciation-probe/spectrograms`, `/tmp/voxtral-alias-smoke/spectrograms`

Alias regression matrix:

```bash
cargo run --release -p voice-eval -- \
  --tts-backend voxtral \
  --voxtral-matrix \
  --voxtral-kv-cache \
  --voxtral-normalize-text \
  --voxtral-pronunciation-aliases \
  --voxtral-eos-scores \
  --voxtral-eos-guard-frames 8 \
  --voxtral-eos-guard-rank 2 \
  --voxtral-eos-guard-margin 0.5 \
  --voxtral-stream-begin-frames 2 \
  --matrix-max-frames 40,56 \
  --matrix-flow-steps 7 \
  --matrix-text "hello world" \
  --matrix-text "A fast reply should arrive naturally." \
  --matrix-text "Voxtral should pronounce Voxtral clearly in a short answer." \
  --matrix-text "Read ticket A17, version 2.4.1, at 9:30 PM." \
  --output-dir /tmp/voxtral-alias-matrix/wavs \
  --spectrogram-dir /tmp/voxtral-alias-matrix/spectrograms \
  --json > .context/voxtral-alias-matrix-2026-06-24.json
```

Observed comparison against the earlier raw expanded matrix:

- `hello world`: unchanged, WER `0.000`, ended at frame `26`
- `A fast reply should arrive naturally.`: unchanged, WER `0.000`
- `Read ticket A17, version 2.4.1, at 9:30 PM.`: unchanged, WER `0.273` at 40 and `0.182` at 56
- `Voxtral should pronounce Voxtral clearly in a short answer.`: improved from WER `0.778` to `0.556` at 40 frames, and from WER `0.333` to `0.222` at 56 frames

## Verification

```bash
cargo fmt --check
cargo test -p voice-voxtral --lib
cargo test -p voice-eval
cargo test -p voice --bin voice
cargo clippy -p voice-voxtral -p voice-eval -p voice -- -D warnings
```
