### PR TITLE
Add Voxtral auto frame budget

### DIFF
--- a/crates/voice-cli/src/cli.rs
+++ b/crates/voice-cli/src/cli.rs
@@ -195,6 +195,10 @@ struct SayArgs {
     #[arg(long = "voxtral-pronunciation-aliases")]
     voxtral_pronunciation_aliases: bool,
 
+    /// Choose Voxtral max frames from the post-normalization synthesis text
+    #[arg(long = "voxtral-auto-max-frames")]
+    voxtral_auto_max_frames: bool,
+
     /// Override Voxtral's initial streaming codec chunk size for daemon playback
     #[arg(long = "voxtral-stream-begin-frames")]
     voxtral_stream_begin_frames: Option<usize>,
@@ -397,6 +401,22 @@ fn validate_effective_voxtral_options(options: EffectiveVoxtralOptions) -> Resul
     validate_voxtral_stream_begin_frames(options.stream_begin_frames)
 }
 
+fn apply_auto_voxtral_max_frames(
+    mut options: EffectiveVoxtralOptions,
+    text: &str,
+    enabled: bool,
+) -> EffectiveVoxtralOptions {
+    if enabled {
+        let suggested = voice_voxtral::suggest_max_frames_for_text(text);
+        options.max_frames = if options.max_frames == VOXTRAL_DEFAULT_MAX_FRAMES {
+            suggested
+        } else {
+            options.max_frames.max(suggested)
+        };
+    }
+    options
+}
+
 impl SayArgs {
     fn effective_voxtral_options(&self) -> EffectiveVoxtralOptions {
         effective_voxtral_options(
@@ -542,6 +562,10 @@ struct StreamArgs {
     /// Apply known Voxtral pronunciation aliases before synthesis
     #[arg(long = "voxtral-pronunciation-aliases")]
     voxtral_pronunciation_aliases: bool,
+
+    /// Choose Voxtral max frames from the post-normalization synthesis text
+    #[arg(long = "voxtral-auto-max-frames")]
+    voxtral_auto_max_frames: bool,
 
     /// Override Voxtral's initial streaming codec chunk size
     #[arg(long = "voxtral-stream-begin-frames")]
@@ -783,6 +807,10 @@ struct BenchTtsArgs {
     /// Apply known Voxtral pronunciation aliases before synthesis
     #[arg(long = "voxtral-pronunciation-aliases")]
     voxtral_pronunciation_aliases: bool,
+
+    /// Choose Voxtral max frames from the post-normalization synthesis text
+    #[arg(long = "voxtral-auto-max-frames")]
+    voxtral_auto_max_frames: bool,
 
     /// Override Voxtral's initial streaming codec chunk size for benchmarking
     #[arg(long = "voxtral-stream-begin-frames")]
@@ -1411,6 +1439,7 @@ fn main() {
                     voxtral_realtime: false,
                     voxtral_normalize_text: false,
                     voxtral_pronunciation_aliases: false,
+                    voxtral_auto_max_frames: false,
                     voxtral_stream_begin_frames: None,
                     output: None,
                     format: None,
@@ -1937,6 +1966,11 @@ fn bench_voxtral_tts(args: &BenchTtsArgs, text: &str) -> Result<TtsBenchEngineRe
         let total_start = Instant::now();
         let text_prep_start = Instant::now();
         let (prepared, _phoneme_overrides) = prepare_bench_text(text, args, TtsEngine::Voxtral);
+        let voxtral = apply_auto_voxtral_max_frames(
+            voxtral,
+            &prepared,
+            args.voxtral_auto_max_frames,
+        );
         let text_prep = text_prep_start.elapsed();
 
         let synth_start = Instant::now();
@@ -2064,6 +2098,15 @@ fn bench_daemon_tts(
         let total_start = Instant::now();
         let text_prep_start = Instant::now();
         let (prepared, _phoneme_overrides) = prepare_bench_text(text, args, engine);
+        let voxtral = if engine == TtsEngine::Voxtral {
+            apply_auto_voxtral_max_frames(
+                voxtral,
+                &prepared,
+                args.voxtral_auto_max_frames,
+            )
+        } else {
+            voxtral
+        };
         let text_prep = text_prep_start.elapsed();
 
         let mut response_at = None;
@@ -2645,6 +2688,11 @@ fn run_say(say_args: SayArgs) {
                     say_args.voxtral_normalize_text,
                     say_args.voxtral_pronunciation_aliases,
                 );
+                let voxtral = apply_auto_voxtral_max_frames(
+                    voxtral,
+                    &text,
+                    say_args.voxtral_auto_max_frames,
+                );
                 let tts_options =
                     daemon_tts_options(say_args.engine, &say_args.voxtral_model, voxtral);
 
@@ -2833,11 +2881,19 @@ fn run_voxtral_say(
         say_args.voxtral_normalize_text,
         say_args.voxtral_pronunciation_aliases,
     );
+    let voxtral = apply_auto_voxtral_max_frames(
+        say_args.effective_voxtral_options(),
+        &text,
+        say_args.voxtral_auto_max_frames,
+    );
+    if let Err(message) = validate_effective_voxtral_options(voxtral) {
+        eprintln!("Error: {message}");
+        std::process::exit(1);
+    }
 
     if (say_args.speed - 1.0).abs() > f32::EPSILON {
         info!("Voxtral does not support --speed yet; generating at model speed");
     }
-    let voxtral = say_args.effective_voxtral_options();
 
     info!("Loading Voxtral TTS model ({})...", say_args.voxtral_model);
     let mut runtime = match voice_voxtral::VoxtralTtsRuntime::load_default(&say_args.voxtral_model)
@@ -2908,6 +2964,11 @@ fn run_stream(stream_args: StreamArgs) {
         stream_args.sub_file.clone(),
         stream_args.voxtral_normalize_text,
         stream_args.voxtral_pronunciation_aliases,
+    );
+    let voxtral = apply_auto_voxtral_max_frames(
+        voxtral,
+        &text,
+        stream_args.voxtral_auto_max_frames,
     );
 
     validate_stream_frame_params(stream_args.sample_rate, stream_args.frame_ms).unwrap_or_else(
@@ -4060,6 +4121,38 @@ mod tests {
     }
 
     #[test]
+    fn auto_voxtral_max_frames_uses_text_estimate_without_lowering_explicit_caps() {
+        let default_options =
+            effective_voxtral_options(VOXTRAL_DEFAULT_MAX_FRAMES, 7, false, None, false);
+        assert_eq!(
+            apply_auto_voxtral_max_frames(
+                default_options,
+                "Vox trell should pronounce Vox trell clearly in a short answer.",
+                true,
+            )
+            .max_frames,
+            56
+        );
+
+        let explicit_high = effective_voxtral_options(80, 7, false, None, false);
+        assert_eq!(
+            apply_auto_voxtral_max_frames(explicit_high, "hello world", true).max_frames,
+            80
+        );
+
+        let realtime = effective_voxtral_options(VOXTRAL_DEFAULT_MAX_FRAMES, 7, false, None, true);
+        assert_eq!(
+            apply_auto_voxtral_max_frames(
+                realtime,
+                "Vox trell should pronounce Vox trell clearly in a short answer.",
+                true,
+            )
+            .max_frames,
+            56
+        );
+    }
+
+    #[test]
     fn pcm_s16le_bytes_to_frames_decodes_little_endian_samples() {
         let bytes = [
             0x00, 0x00, // 0
@@ -4162,12 +4255,14 @@ mod tests {
             "voxtral",
             "--voxtral-normalize-text",
             "--voxtral-pronunciation-aliases",
+            "--voxtral-auto-max-frames",
             "Read ticket A17.",
         ]);
         match say.command {
             Some(Command::Say(args)) => {
                 assert!(args.voxtral_normalize_text);
                 assert!(args.voxtral_pronunciation_aliases);
+                assert!(args.voxtral_auto_max_frames);
             }
             other => panic!("expected say command, got {other:?}"),
         }
@@ -4179,12 +4274,14 @@ mod tests {
             "voxtral",
             "--voxtral-normalize-text",
             "--voxtral-pronunciation-aliases",
+            "--voxtral-auto-max-frames",
             "Read ticket A17.",
         ]);
         match stream.command {
             Some(Command::Stream(args)) => {
                 assert!(args.voxtral_normalize_text);
                 assert!(args.voxtral_pronunciation_aliases);
+                assert!(args.voxtral_auto_max_frames);
             }
             other => panic!("expected stream command, got {other:?}"),
         }
@@ -4197,6 +4294,7 @@ mod tests {
             "voxtral",
             "--voxtral-normalize-text",
             "--voxtral-pronunciation-aliases",
+            "--voxtral-auto-max-frames",
             "Read ticket A17.",
         ]);
         match bench.command {
@@ -4205,6 +4303,7 @@ mod tests {
             })) => {
                 assert!(args.voxtral_normalize_text);
                 assert!(args.voxtral_pronunciation_aliases);
+                assert!(args.voxtral_auto_max_frames);
             }
             other => panic!("expected bench tts command, got {other:?}"),
         }
@@ -4273,6 +4372,7 @@ mod tests {
             voxtral_sync_trace: false,
             voxtral_normalize_text: true,
             voxtral_pronunciation_aliases: false,
+            voxtral_auto_max_frames: false,
             voxtral_stream_begin_frames: None,
             daemon: false,
             stream_sample_rate: 24_000,

--- a/crates/voice-eval/src/main.rs
+++ b/crates/voice-eval/src/main.rs
@@ -711,7 +711,7 @@ fn maybe_normalize_voxtral_text(args: &Args, text: String) -> String {
 
 fn effective_voxtral_max_frames(args: &Args, synthesis_text: &str, configured: usize) -> usize {
     if args.voxtral_auto_max_frames {
-        voice_voxtral::suggest_max_frames_for_text(synthesis_text)
+        configured.max(voice_voxtral::suggest_max_frames_for_text(synthesis_text))
     } else {
         configured
     }
@@ -1610,7 +1610,7 @@ mod tests {
     }
 
     #[test]
-    fn auto_voxtral_max_frames_uses_synthesis_text_estimate() {
+    fn auto_voxtral_max_frames_uses_synthesis_text_estimate_without_lowering_explicit_caps() {
         let args = Args::try_parse_from([
             "voice-eval",
             "--tts-backend",
@@ -1628,6 +1628,20 @@ mod tests {
                 args.max_frames,
             ),
             56
+        );
+
+        let explicit_high = Args::try_parse_from([
+            "voice-eval",
+            "--tts-backend",
+            "voxtral",
+            "--voxtral-auto-max-frames",
+            "--max-frames",
+            "200",
+        ])
+        .unwrap();
+        assert_eq!(
+            effective_voxtral_max_frames(&explicit_high, "hello world", explicit_high.max_frames),
+            200
         );
 
         let fixed = Args::try_parse_from([

--- a/crates/voice-eval/src/main.rs
+++ b/crates/voice-eval/src/main.rs
@@ -110,6 +110,10 @@ struct Args {
     #[arg(long = "voxtral-pronunciation-aliases")]
     voxtral_pronunciation_aliases: bool,
 
+    /// Choose Voxtral max frames from the post-normalization synthesis text.
+    #[arg(long = "voxtral-auto-max-frames")]
+    voxtral_auto_max_frames: bool,
+
     /// Initial streaming codec chunk size for Voxtral matrix timing.
     #[arg(long = "voxtral-stream-begin-frames", default_value_t = 2)]
     voxtral_stream_begin_frames: usize,
@@ -205,6 +209,7 @@ struct EvalReport {
     synthesis_mode: &'static str,
     voxtral_text_normalization: bool,
     voxtral_pronunciation_aliases: bool,
+    voxtral_auto_max_frames: bool,
     sample_rate: u32,
     sample_count: usize,
     duration_seconds: f32,
@@ -237,6 +242,7 @@ struct VoxtralMatrixReport {
     sync_trace: bool,
     text_normalization: bool,
     pronunciation_aliases: bool,
+    auto_max_frames: bool,
     eos_scores: bool,
     eos_guard_frames: usize,
     eos_guard_max_rank: usize,
@@ -394,6 +400,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         voxtral_text_normalization: args.tts_backend == "voxtral" && args.voxtral_normalize_text,
         voxtral_pronunciation_aliases: args.tts_backend == "voxtral"
             && args.voxtral_pronunciation_aliases,
+        voxtral_auto_max_frames: args.tts_backend == "voxtral" && args.voxtral_auto_max_frames,
         sample_rate,
         sample_count: samples.len(),
         duration_seconds,
@@ -475,8 +482,10 @@ fn run_voxtral_matrix(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
 
     let mut rows = Vec::new();
     for (text_index, case) in cases.iter().enumerate() {
-        for &max_frames in &args.matrix_max_frames {
+        for &configured_max_frames in &args.matrix_max_frames {
             for &flow_steps in &args.matrix_flow_steps {
+                let max_frames =
+                    effective_voxtral_max_frames(args, &case.synthesis_text, configured_max_frames);
                 let streaming = voice_voxtral::VoxtralStreamingConfig {
                     chunk_frames_at_begin: args.voxtral_stream_begin_frames,
                     ..Default::default()
@@ -603,6 +612,7 @@ fn run_voxtral_matrix(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
         sync_trace: args.voxtral_sync_trace,
         text_normalization: args.voxtral_normalize_text,
         pronunciation_aliases: args.voxtral_pronunciation_aliases,
+        auto_max_frames: args.voxtral_auto_max_frames,
         eos_scores: args.voxtral_eos_scores,
         eos_guard_frames: args.voxtral_eos_guard_frames,
         eos_guard_max_rank: args.voxtral_eos_guard_rank,
@@ -699,6 +709,14 @@ fn maybe_normalize_voxtral_text(args: &Args, text: String) -> String {
     }
 }
 
+fn effective_voxtral_max_frames(args: &Args, synthesis_text: &str, configured: usize) -> usize {
+    if args.voxtral_auto_max_frames {
+        voice_voxtral::suggest_max_frames_for_text(synthesis_text)
+    } else {
+        configured
+    }
+}
+
 fn synthesize_kokoro(
     args: &Args,
     phoneme_chunks: &[String],
@@ -739,7 +757,7 @@ fn synthesize_voxtral(
         text,
         voice_name,
         voice_voxtral::VoxtralGenerationOptions {
-            max_frames: args.max_frames,
+            max_frames: effective_voxtral_max_frames(args, text, args.max_frames),
             seed: args.seed,
             flow_steps: args.flow_steps,
             use_kv_cache: args.voxtral_kv_cache,
@@ -1055,7 +1073,7 @@ fn print_voxtral_matrix_report(report: &VoxtralMatrixReport) {
     );
     println!("voxtral_matrix.model_load_ms={:.1}", report.model_load_ms);
     println!(
-        "voxtral_matrix.max_frames={:?} flow_steps={:?} stream_begin_frames={} kv_cache={} sync_trace={} text_normalization={} pronunciation_aliases={} eos_scores={} eos_guard_frames={} eos_guard_max_rank={} eos_guard_max_margin={:.3}",
+        "voxtral_matrix.max_frames={:?} flow_steps={:?} stream_begin_frames={} kv_cache={} sync_trace={} text_normalization={} pronunciation_aliases={} auto_max_frames={} eos_scores={} eos_guard_frames={} eos_guard_max_rank={} eos_guard_max_margin={:.3}",
         report.matrix_max_frames,
         report.matrix_flow_steps,
         report.stream_begin_frames,
@@ -1063,6 +1081,7 @@ fn print_voxtral_matrix_report(report: &VoxtralMatrixReport) {
         report.sync_trace,
         report.text_normalization,
         report.pronunciation_aliases,
+        report.auto_max_frames,
         report.eos_scores,
         report.eos_guard_frames,
         report.eos_guard_max_rank,
@@ -1204,6 +1223,9 @@ fn print_text_report(report: &EvalReport) {
     }
     if report.voxtral_pronunciation_aliases {
         println!("voxtral pronunciation aliases: enabled");
+    }
+    if report.voxtral_auto_max_frames {
+        println!("voxtral auto max frames: enabled");
     }
     println!("hypothesis: {}", report.transcription);
     println!("normalized reference: {}", report.normalized_reference);
@@ -1372,6 +1394,7 @@ mod tests {
             "Vox trahl should sound clear.",
             "--voxtral-normalize-text",
             "--voxtral-pronunciation-aliases",
+            "--voxtral-auto-max-frames",
         ])
         .unwrap();
 
@@ -1382,6 +1405,7 @@ mod tests {
         );
         assert!(args.voxtral_normalize_text);
         assert!(args.voxtral_pronunciation_aliases);
+        assert!(args.voxtral_auto_max_frames);
     }
 
     #[test]
@@ -1405,6 +1429,7 @@ mod tests {
             "5,6,7",
             "--voxtral-kv-cache",
             "--voxtral-pronunciation-aliases",
+            "--voxtral-auto-max-frames",
             "--voxtral-eos-scores",
             "--voxtral-eos-guard-frames",
             "8",
@@ -1440,6 +1465,7 @@ mod tests {
         assert_eq!(args.matrix_flow_steps, vec![5, 6, 7]);
         assert!(args.voxtral_kv_cache);
         assert!(args.voxtral_pronunciation_aliases);
+        assert!(args.voxtral_auto_max_frames);
         assert!(args.voxtral_eos_scores);
         assert_eq!(args.voxtral_eos_guard_frames, 8);
         assert_eq!(args.voxtral_eos_guard_rank, 3);
@@ -1580,6 +1606,41 @@ mod tests {
                     synthesis_text: "Kokoro should stay unchanged.".to_string(),
                 }
             ]
+        );
+    }
+
+    #[test]
+    fn auto_voxtral_max_frames_uses_synthesis_text_estimate() {
+        let args = Args::try_parse_from([
+            "voice-eval",
+            "--tts-backend",
+            "voxtral",
+            "--voxtral-auto-max-frames",
+            "--max-frames",
+            "40",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            effective_voxtral_max_frames(
+                &args,
+                "Vox trell should pronounce Vox trell clearly in a short answer.",
+                args.max_frames,
+            ),
+            56
+        );
+
+        let fixed = Args::try_parse_from([
+            "voice-eval",
+            "--tts-backend",
+            "voxtral",
+            "--max-frames",
+            "40",
+        ])
+        .unwrap();
+        assert_eq!(
+            effective_voxtral_max_frames(&fixed, "hello world", fixed.max_frames),
+            40
         );
     }
 

--- a/crates/voice-voxtral/src/lib.rs
+++ b/crates/voice-voxtral/src/lib.rs
@@ -82,7 +82,8 @@ pub use streaming::{
     DEFAULT_CODEC_CHUNK_FRAMES_AT_BEGIN, DEFAULT_CODEC_LEFT_CONTEXT_FRAMES,
 };
 pub use text::{
-    normalize_tts_text, normalize_tts_text_with_options, VoxtralTextNormalizationOptions,
+    normalize_tts_text, normalize_tts_text_with_options, suggest_max_frames_for_text,
+    VoxtralTextNormalizationOptions, DEFAULT_SUGGESTED_MAX_FRAMES, SUGGESTED_MAX_FRAMES_CAP,
 };
 pub use tokenizer::{
     TekkenAudioEncodingConfig, TekkenAudioMetadata, TekkenConfig, TekkenSpecialToken,

--- a/crates/voice-voxtral/src/text.rs
+++ b/crates/voice-voxtral/src/text.rs
@@ -6,6 +6,9 @@ pub struct VoxtralTextNormalizationOptions {
     pub pronunciation_aliases: bool,
 }
 
+pub const DEFAULT_SUGGESTED_MAX_FRAMES: usize = 32;
+pub const SUGGESTED_MAX_FRAMES_CAP: usize = 64;
+
 /// Normalize numeric text forms that Voxtral currently handles poorly when
 /// they are left as compact written forms.
 pub fn normalize_tts_text(text: &str) -> String {
@@ -32,6 +35,42 @@ pub fn normalize_tts_text_with_options(
         apply_pronunciation_aliases(&text)
     } else {
         text
+    }
+}
+
+pub fn suggest_max_frames_for_text(text: &str) -> usize {
+    let word_count = count_speech_tokens(text);
+    let raw_frames = if word_count <= 4 {
+        DEFAULT_SUGGESTED_MAX_FRAMES
+    } else {
+        DEFAULT_SUGGESTED_MAX_FRAMES + (word_count - 4) * 3
+    };
+    round_up_to_multiple(raw_frames, 8)
+        .clamp(DEFAULT_SUGGESTED_MAX_FRAMES, SUGGESTED_MAX_FRAMES_CAP)
+}
+
+fn count_speech_tokens(text: &str) -> usize {
+    let mut count = 0;
+    let mut in_token = false;
+    for ch in text.chars() {
+        if ch.is_alphanumeric() {
+            if !in_token {
+                count += 1;
+                in_token = true;
+            }
+        } else {
+            in_token = false;
+        }
+    }
+    count
+}
+
+fn round_up_to_multiple(value: usize, multiple: usize) -> usize {
+    debug_assert!(multiple > 0);
+    if value == 0 {
+        0
+    } else {
+        value.div_ceil(multiple) * multiple
     }
 }
 
@@ -324,7 +363,8 @@ fn tens_word(tens: u32) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::{
-        normalize_tts_text, normalize_tts_text_with_options, VoxtralTextNormalizationOptions,
+        normalize_tts_text, normalize_tts_text_with_options, suggest_max_frames_for_text,
+        VoxtralTextNormalizationOptions,
     };
 
     #[test]
@@ -427,6 +467,31 @@ mod tests {
                 }
             ),
             "Vox trell reads A seventeen at nine thirty PM."
+        );
+    }
+
+    #[test]
+    fn suggested_frame_budget_scales_with_preprocessed_text_length() {
+        assert_eq!(suggest_max_frames_for_text("hello world"), 32);
+        assert_eq!(
+            suggest_max_frames_for_text("A fast reply should arrive naturally."),
+            40
+        );
+        assert_eq!(
+            suggest_max_frames_for_text(
+                "Vox trell should pronounce Vox trell clearly in a short answer."
+            ),
+            56
+        );
+        assert_eq!(
+            suggest_max_frames_for_text(
+                "Read ticket A seventeen, version two point four point one, at nine thirty PM."
+            ),
+            64
+        );
+        assert_eq!(
+            suggest_max_frames_for_text("one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen"),
+            64
         );
     }
 }


### PR DESCRIPTION
## Summary

- adds `voice_voxtral::suggest_max_frames_for_text()` as a small prompt-length frame-budget estimator
- adds opt-in `--voxtral-auto-max-frames` to `voice-eval`, `voice say`, `voice stream`, and `voice bench tts`
- applies the estimate after text preprocessing, so numeric normalization and pronunciation aliases affect the budget

## Why

The expanded Voxtral matrix showed that a single fixed cap is not quality-preserving:

- `hello world` ends cleanly at 26 frames
- short conversational text is fine at 40 frames
- the aliased `Voxtral` prompt needs 56 frames
- normalized version/time prompts can need more room but should still stop on EOS

This PR keeps public defaults unchanged and makes frame budgeting explicit/opt-in.

## Policy

- `voice-eval --voxtral-auto-max-frames` uses the estimator as the effective per-row cap.
- CLI `--voxtral-auto-max-frames` uses the estimator after preprocessing.
- For CLI defaults, the default 256-frame non-realtime cap becomes the estimate when auto is enabled.
- For realtime or explicit smaller caps, auto can raise the cap to the estimate.
- Explicit larger caps are not lowered in the CLI path.

## Local Eval

Command:

```bash
cargo run --release -p voice-eval -- \
  --tts-backend voxtral \
  --voxtral-matrix \
  --voxtral-kv-cache \
  --voxtral-normalize-text \
  --voxtral-pronunciation-aliases \
  --voxtral-auto-max-frames \
  --voxtral-eos-scores \
  --voxtral-eos-guard-frames 8 \
  --voxtral-eos-guard-rank 2 \
  --voxtral-eos-guard-margin 0.5 \
  --voxtral-stream-begin-frames 2 \
  --matrix-max-frames 40 \
  --matrix-flow-steps 7 \
  --matrix-text "hello world" \
  --matrix-text "A fast reply should arrive naturally." \
  --matrix-text "Voxtral should pronounce Voxtral clearly in a short answer." \
  --matrix-text "Read ticket A17, version 2.4.1, at 9:30 PM." \
  --output-dir /tmp/voxtral-auto-frame-budget/wavs \
  --spectrogram-dir /tmp/voxtral-auto-frame-budget/spectrograms \
  --json > .context/voxtral-auto-frame-budget-2026-06-24.json
```

Observed rows:

| Prompt | Effective max frames | WER | Ended |
| --- | ---: | ---: | --- |
| `hello world` | 32 | `0.000` | yes at 26 |
| `A fast reply should arrive naturally.` | 40 | `0.000` | no |
| `Voxtral should pronounce Voxtral clearly in a short answer.` | 56 | `0.222` | yes at 51 |
| `Read ticket A17, version 2.4.1, at 9:30 PM.` | 64 | `0.182` | yes at 56 |

Artifacts:

- JSON: `.context/voxtral-auto-frame-budget-2026-06-24.json`
- WAVs: `/tmp/voxtral-auto-frame-budget/wavs`
- Spectrograms: `/tmp/voxtral-auto-frame-budget/spectrograms`

Broader flow matrix:

```bash
cargo run --release -p voice-eval -- \
  --tts-backend voxtral \
  --voxtral-matrix \
  --voxtral-kv-cache \
  --voxtral-normalize-text \
  --voxtral-pronunciation-aliases \
  --voxtral-auto-max-frames \
  --voxtral-eos-scores \
  --voxtral-eos-guard-frames 8 \
  --voxtral-eos-guard-rank 2 \
  --voxtral-eos-guard-margin 0.5 \
  --voxtral-stream-begin-frames 2 \
  --matrix-max-frames 40 \
  --matrix-flow-steps 5,6,7 \
  --matrix-text "hello world" \
  --matrix-text "A fast reply should arrive naturally." \
  --matrix-text "Please answer the question, then pause before the next sentence." \
  --matrix-text "Voxtral should pronounce Voxtral clearly in a short answer." \
  --matrix-text "Read ticket A17, version 2.4.1, at 9:30 PM." \
  --matrix-text "Use API on CPU at 12:05 AM." \
  --matrix-text "Can you repeat that more slowly? Yes, I can repeat it more slowly." \
  --output-dir /tmp/voxtral-auto-frame-budget-flow-matrix/wavs \
  --spectrogram-dir /tmp/voxtral-auto-frame-budget-flow-matrix/spectrograms \
  --json > .context/voxtral-auto-frame-budget-flow-matrix-2026-06-24.json
```

Best observed rows:

| Prompt | Effective max frames | Flow steps | WER | Ended | Note |
| --- | ---: | ---: | ---: | --- | --- |
| `hello world` | 32 | 6 | `0.000` | yes at 22 | All flow settings scored cleanly. |
| `A fast reply should arrive naturally.` | 40 | 7 | `0.000` | no | Lower flow steps changed the final words. |
| `Please answer...next sentence.` | 56 | 5 | `0.000` | yes at 53 | Flow 6/7 scored cleanly too, but had extra active segments. |
| `Voxtral should pronounce...` | 56 | 7 | `0.222` | yes at 51 | Alias helps, but still transcribes as `Voxtrell`. |
| `Read ticket A17...9:30 PM.` | 64 | 5 or 7 | `0.182` | yes | EOS stops before using the full cap. |
| `Use API on CPU at 12:05 AM.` | 48 | 5/6/7 | `0.375` | no | Still unresolved; Whisper renders `1205`/`a.m.` and the current WER normalizer scores it poorly. |
| `Can you repeat...` | 64 | 5 | `0.154` | yes at 50 | Flow 6/7 repeat the second sentence. |

Additional artifacts:

- JSON: `.context/voxtral-auto-frame-budget-flow-matrix-2026-06-24.json`
- WAVs: `/tmp/voxtral-auto-frame-budget-flow-matrix/wavs`
- Spectrograms: `/tmp/voxtral-auto-frame-budget-flow-matrix/spectrograms`

Caveat: this flag is still an opt-in measurement/control knob. It improves the base-cap choice for several prompts, but the API/time prompt needs a separate scoring/listening pass before claiming it as a quality win.

## Verification

```bash
cargo fmt --check
cargo test -p voice-voxtral --lib
cargo test -p voice-eval
cargo test -p voice --bin voice
cargo clippy -p voice-voxtral -p voice-eval -p voice -- -D warnings
cargo install --path crates/voice-cli --force --locked
voice bench tts --engine voxtral --runs 1 --voxtral-kv-cache --voxtral-realtime --voxtral-normalize-text --voxtral-pronunciation-aliases --voxtral-auto-max-frames --output-dir /tmp/voxtral-installed-auto-smoke --json "Voxtral should pronounce Voxtral clearly in a short answer."
```

Installed smoke result:

- installed binaries: `/Users/kylekelley/.cargo/bin/voice`, `/Users/kylekelley/.cargo/bin/voxtral`
- JSON: `.context/voxtral-installed-auto-smoke-2026-06-24.json`
- effective max frames: `56`
- generated frames: `51`
- ended: `true`
- first audio: `481.0 ms`
- total: `8358.6 ms`
- saved WAV: `/tmp/voxtral-installed-auto-smoke/voxtral-casual_male-run1.wav`
- saved WAV layout: stereo L/R, 24 kHz Float32 interleaved
