### PR TITLE
Add daemon-backed Voice UI bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +331,61 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2666,6 +2754,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2688,6 +2782,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -3339,6 +3434,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
@@ -5355,6 +5456,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_plain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6660,6 +6772,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6698,6 +6811,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -7094,10 +7208,13 @@ dependencies = [
 name = "voice-daemon"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "automerge",
  "automorph",
+ "axum",
  "candle-core",
  "dirs 6.0.0",
+ "futures-core",
  "hound",
  "rodio",
  "serde",
@@ -7110,6 +7227,7 @@ dependencies = [
  "voice-stream",
  "voice-stt",
  "voice-tts",
+ "voice-ui",
  "voice-voxtral",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7220,6 +7220,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tower",
  "uuid",
  "voice-audio",
  "voice-g2p",

--- a/crates/voice-cli/src/mcp.rs
+++ b/crates/voice-cli/src/mcp.rs
@@ -376,14 +376,15 @@ fn handle_tools_list() -> Result<Value, RpcErr> {
         "tools": [
             {
                 "name": "speak",
-                "description": "Speak text aloud using text-to-speech. Plays audio through the default output device.",
+                "description": "Queue text for voice playback in the daemon UI. Set immediate=true to play through the daemon now.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
                         "text": { "type": "string", "description": "Text to speak" },
                         "voice": { "type": "string", "description": "Voice name override for this utterance" },
                         "speed": { "type": "number", "description": "Speed override for this utterance" },
-                        "markdown": { "type": "boolean", "description": "Strip markdown formatting before speaking" }
+                        "markdown": { "type": "boolean", "description": "Strip markdown formatting before speaking" },
+                        "immediate": { "type": "boolean", "description": "Play immediately instead of leaving a UI playlist item" }
                     },
                     "required": ["text"]
                 }
@@ -408,7 +409,7 @@ fn handle_tools_list() -> Result<Value, RpcErr> {
             // },
             {
                 "name": "converse",
-                "description": "Speak text aloud, then immediately listen for a response. Combines speak and listen into a single turn-based exchange, reducing round trips.",
+                "description": "Queue a voice prompt that needs a user response in the daemon UI. Set immediate=true to speak and listen in one blocking turn.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -420,7 +421,8 @@ fn handle_tools_list() -> Result<Value, RpcErr> {
                         "silence_timeout_ms": { "type": "number", "description": "Stop listening after this many ms of silence following speech (default: 2000)" },
                         "silence_threshold": { "type": "number", "description": "Minimum amplitude for voice activity detection (default: 0.01)" },
                         "noise_multiplier": { "type": "number", "description": "Multiplier for calibrated noise floor (default: 3.0)" },
-                        "calibration_ms": { "type": "number", "description": "Duration in ms to calibrate noise floor (default: 500)" }
+                        "calibration_ms": { "type": "number", "description": "Duration in ms to calibrate noise floor (default: 500)" },
+                        "immediate": { "type": "boolean", "description": "Speak and listen immediately instead of leaving a UI playlist item" }
                     },
                     "required": ["text"]
                 }
@@ -524,11 +526,24 @@ fn handle_tools_call(
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
                 let text = preprocess_for_daemon(raw, markdown, &session.subs);
-                Some(daemon.speak(
-                    &text,
-                    arguments.get("voice").and_then(|v| v.as_str()),
-                    arguments.get("speed").and_then(|v| v.as_f64()),
-                ))
+                let immediate = arguments
+                    .get("immediate")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                if immediate {
+                    Some(daemon.speak(
+                        &text,
+                        arguments.get("voice").and_then(|v| v.as_str()),
+                        arguments.get("speed").and_then(|v| v.as_f64()),
+                    ))
+                } else {
+                    Some(daemon.speak_with_options_held_for_ui(
+                        &text,
+                        arguments.get("voice").and_then(|v| v.as_str()),
+                        arguments.get("speed").and_then(|v| v.as_f64()),
+                        voice_protocol::client::TtsRequestOptions::default(),
+                    ))
+                }
             }
             "listen" => {
                 Some(daemon.listen(arguments.get("max_duration_ms").and_then(|v| v.as_u64())))
@@ -540,11 +555,23 @@ fn handle_tools_call(
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
                 let text = preprocess_for_daemon(raw, markdown, &session.subs);
-                Some(daemon.converse_with_duration(
-                    &text,
-                    arguments.get("voice").and_then(|v| v.as_str()),
-                    arguments.get("max_duration_ms").and_then(|v| v.as_u64()),
-                ))
+                let immediate = arguments
+                    .get("immediate")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                if immediate {
+                    Some(daemon.converse_with_duration(
+                        &text,
+                        arguments.get("voice").and_then(|v| v.as_str()),
+                        arguments.get("max_duration_ms").and_then(|v| v.as_u64()),
+                    ))
+                } else {
+                    Some(daemon.converse_held_for_ui(
+                        &text,
+                        arguments.get("voice").and_then(|v| v.as_str()),
+                        arguments.get("max_duration_ms").and_then(|v| v.as_u64()),
+                    ))
+                }
             }
             _ => None,
         };

--- a/crates/voice-daemon/Cargo.toml
+++ b/crates/voice-daemon/Cargo.toml
@@ -29,3 +29,6 @@ rodio = { version = "0.22", features = ["experimental"] }
 hound = { workspace = true }
 automerge = "0.7"
 automorph = "0.2"
+
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }

--- a/crates/voice-daemon/Cargo.toml
+++ b/crates/voice-daemon/Cargo.toml
@@ -9,11 +9,15 @@ repository = "https://github.com/rgbkrk/voice"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
+axum = "0.7"
+async-stream = "0.3"
+futures-core = "0.3"
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"
 voice-protocol = { path = "../voice-protocol" }
+voice-ui = { path = "../voice-ui" }
 voice-tts = { path = "../voice-tts" }
 voice-voxtral = { path = "../voice-voxtral" }
 voice-stt = { path = "../voice-stt" }

--- a/crates/voice-daemon/src/audio_recorder.rs
+++ b/crates/voice-daemon/src/audio_recorder.rs
@@ -5,6 +5,12 @@ use std::path::{Path, PathBuf};
 
 /// Audio storage directory.
 pub fn audio_dir() -> PathBuf {
+    if let Ok(path) = std::env::var("VOICE_AUDIO_DIR") {
+        if !path.trim().is_empty() {
+            return PathBuf::from(path);
+        }
+    }
+
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".voice")

--- a/crates/voice-daemon/src/lib.rs
+++ b/crates/voice-daemon/src/lib.rs
@@ -9,6 +9,8 @@ mod cleanup;
 mod config;
 mod queue;
 mod socket;
+mod ui_server;
+mod ui_state;
 mod worker;
 
 use automerge_state::AutomergeState;
@@ -103,6 +105,11 @@ pub async fn run(options: DaemonOptions) {
     let cleanup_automerge = automerge.clone();
     tokio::spawn(async move {
         cleanup::run(cleanup_queue, cleanup_automerge).await;
+    });
+
+    let ui_queue = queue.clone();
+    tokio::spawn(async move {
+        ui_server::serve(ui_queue).await;
     });
 
     socket::serve(queue, config, automerge).await;

--- a/crates/voice-daemon/src/queue.rs
+++ b/crates/voice-daemon/src/queue.rs
@@ -137,6 +137,7 @@ pub struct QueueEntry {
     pub client_id: String,
     pub request: VoiceRequest,
     pub status: ItemStatus,
+    pub held_for_ui: bool,
     pub created_at: u64,
     pub result: Option<String>,
     pub completed_at: Option<u64>,
@@ -152,6 +153,7 @@ impl QueueEntry {
             client_id: self.client_id.clone(),
             method: self.request.method().to_string(),
             status: self.status.clone(),
+            held_for_ui: self.held_for_ui,
             created_at: self.created_at,
             text_preview: self.request.text_preview(),
             result: self.result.clone(),
@@ -269,6 +271,7 @@ impl RequestQueue {
             client_id,
             request,
             status: ItemStatus::Queued,
+            held_for_ui: false,
             created_at: now_secs(),
             result: None,
             completed_at: None,
@@ -300,6 +303,7 @@ impl RequestQueue {
             client_id,
             request,
             status: ItemStatus::Queued,
+            held_for_ui: false,
             created_at: now_secs(),
             result: None,
             completed_at: None,
@@ -314,14 +318,55 @@ impl RequestQueue {
 
     pub async fn dequeue(&self) -> Option<QueueEntry> {
         let mut items = self.items.lock().await;
-        if let Some(mut entry) = items.pop_front() {
-            entry.status = ItemStatus::Processing;
-            *self.current.lock().await = Some(entry.clone());
-            self.notify.notify_waiters();
-            Some(entry)
-        } else {
-            None
-        }
+        let position = items.iter().position(|entry| !entry.held_for_ui)?;
+        let mut entry = items.remove(position)?;
+        entry.status = ItemStatus::Processing;
+        *self.current.lock().await = Some(entry.clone());
+        self.notify.notify_waiters();
+        Some(entry)
+    }
+
+    /// Add a playlist/mailbox item that is visible to the UI but not consumed
+    /// by the worker until a later compatibility path explicitly releases it.
+    pub async fn enqueue_ui_held(&self, client_id: String, request: VoiceRequest) -> String {
+        let id = Uuid::new_v4().to_string()[..8].to_string();
+        let entry = QueueEntry {
+            id: id.clone(),
+            client_id,
+            request,
+            status: ItemStatus::Queued,
+            held_for_ui: true,
+            created_at: now_secs(),
+            result: None,
+            completed_at: None,
+            repo: None,
+            auto_clear_at: None,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+        self.items.lock().await.push_back(entry);
+        self.notify.notify_waiters();
+        id
+    }
+
+    pub async fn complete_held_item(&self, queue_id: &str, result: Option<String>) -> bool {
+        let entry = {
+            let mut items = self.items.lock().await;
+            items
+                .iter()
+                .position(|entry| entry.id == queue_id && entry.held_for_ui)
+                .and_then(|position| items.remove(position))
+        };
+
+        let Some(mut entry) = entry else {
+            return false;
+        };
+
+        entry.status = ItemStatus::Completed;
+        entry.result = result;
+        entry.completed_at = Some(now_secs());
+        self.push_recent(entry).await;
+        self.notify.notify_waiters();
+        true
     }
 
     pub async fn complete(&self, result: Option<String>, auto_clear_secs: Option<u64>) {
@@ -599,5 +644,66 @@ mod tests {
         let result = rx.await.unwrap();
         assert_eq!(result.status, ItemStatus::Failed);
         assert_eq!(result.result.as_deref(), Some(CANCELLED_MESSAGE));
+    }
+
+    #[tokio::test]
+    async fn dequeue_skips_ui_held_items() {
+        let queue = RequestQueue::new();
+        let held_id = queue
+            .enqueue_ui_held(
+                "agent-a".to_string(),
+                VoiceRequest::Speak {
+                    text: "hold this".to_string(),
+                    voice: None,
+                    speed: None,
+                    options: TtsOptions::default(),
+                },
+            )
+            .await;
+        let live_id = queue
+            .enqueue_speak(
+                "cli".to_string(),
+                "play this".to_string(),
+                None,
+                None,
+                TtsOptions::default(),
+            )
+            .await;
+
+        let entry = queue.dequeue().await.expect("worker item");
+        assert_eq!(entry.id, live_id);
+
+        let snapshot = queue.snapshot().await;
+        assert_eq!(snapshot.pending.len(), 1);
+        assert_eq!(snapshot.pending[0].id, held_id);
+        assert!(snapshot.pending[0].held_for_ui);
+    }
+
+    #[tokio::test]
+    async fn complete_held_item_moves_it_to_recent() {
+        let queue = RequestQueue::new();
+        let held_id = queue
+            .enqueue_ui_held(
+                "agent-a".to_string(),
+                VoiceRequest::Converse {
+                    text: "need your response".to_string(),
+                    voice: None,
+                    max_duration_ms: None,
+                    options: TtsOptions::default(),
+                },
+            )
+            .await;
+
+        assert!(
+            queue
+                .complete_held_item(&held_id, Some(r#"{"heard":{"text":"yes"}}"#.to_string()))
+                .await
+        );
+
+        let snapshot = queue.snapshot().await;
+        assert!(snapshot.pending.is_empty());
+        assert_eq!(snapshot.recent.len(), 1);
+        assert_eq!(snapshot.recent[0].id, held_id);
+        assert_eq!(snapshot.recent[0].status, ItemStatus::Completed);
     }
 }

--- a/crates/voice-daemon/src/queue.rs
+++ b/crates/voice-daemon/src/queue.rs
@@ -349,6 +349,21 @@ impl RequestQueue {
     }
 
     pub async fn complete_held_item(&self, queue_id: &str, result: Option<String>) -> bool {
+        self.finish_held_item(queue_id, ItemStatus::Completed, result)
+            .await
+    }
+
+    pub async fn fail_held_item(&self, queue_id: &str, result: Option<String>) -> bool {
+        self.finish_held_item(queue_id, ItemStatus::Failed, result)
+            .await
+    }
+
+    async fn finish_held_item(
+        &self,
+        queue_id: &str,
+        status: ItemStatus,
+        result: Option<String>,
+    ) -> bool {
         let entry = {
             let mut items = self.items.lock().await;
             items
@@ -361,7 +376,7 @@ impl RequestQueue {
             return false;
         };
 
-        entry.status = ItemStatus::Completed;
+        entry.status = status;
         entry.result = result;
         entry.completed_at = Some(now_secs());
         self.push_recent(entry).await;

--- a/crates/voice-daemon/src/queue.rs
+++ b/crates/voice-daemon/src/queue.rs
@@ -317,6 +317,7 @@ impl RequestQueue {
         if let Some(mut entry) = items.pop_front() {
             entry.status = ItemStatus::Processing;
             *self.current.lock().await = Some(entry.clone());
+            self.notify.notify_waiters();
             Some(entry)
         } else {
             None
@@ -345,6 +346,7 @@ impl RequestQueue {
                 },
             )
             .await;
+            self.notify.notify_waiters();
         }
     }
 
@@ -362,6 +364,7 @@ impl RequestQueue {
                 },
             )
             .await;
+            self.notify.notify_waiters();
         }
     }
 
@@ -504,11 +507,13 @@ impl RequestQueue {
             },
         )
         .await;
+        self.notify.notify_waiters();
     }
 
     /// Remove a completed item from the recent list by ID.
     pub async fn remove_recent(&self, id: &str) {
         self.recent.lock().await.retain(|item| item.id != id);
+        self.notify.notify_waiters();
     }
 }
 

--- a/crates/voice-daemon/src/socket.rs
+++ b/crates/voice-daemon/src/socket.rs
@@ -474,6 +474,10 @@ async fn dispatch(
         Ok(wait) => wait,
         Err(resp) => return resp,
     };
+    let ui_hold = match ui_hold_param(&req) {
+        Ok(ui_hold) => ui_hold,
+        Err(resp) => return resp,
+    };
 
     // Build the voice request from params
     let voice_req = match req.method.as_str() {
@@ -768,6 +772,23 @@ async fn dispatch(
 
     if !wait {
         // Fire-and-forget: enqueue and return immediately
+        let can_hold_for_ui = matches!(
+            voice_req,
+            VoiceRequest::Speak { .. }
+                | VoiceRequest::Listen { .. }
+                | VoiceRequest::Converse { .. }
+        );
+        if ui_hold && can_hold_for_ui {
+            let queue_id = queue
+                .enqueue_ui_held(client_id.to_string(), voice_req)
+                .await;
+            sync_automerge(queue, automerge).await;
+            return Response::success(
+                req.id,
+                serde_json::json!({ "queue_id": queue_id, "status": "held" }),
+            );
+        }
+
         let queue_id = match voice_req {
             VoiceRequest::Speak {
                 text,
@@ -859,6 +880,19 @@ fn wait_param(req: &rpc::Request) -> Result<bool, Response> {
             )
         }),
         None => Ok(req.method == "synthesize"),
+    }
+}
+
+fn ui_hold_param(req: &rpc::Request) -> Result<bool, Response> {
+    match req.params.get("ui_hold") {
+        Some(value) => value.as_bool().ok_or_else(|| {
+            Response::error(
+                req.id.clone(),
+                rpc::INVALID_PARAMS,
+                "param 'ui_hold' must be a boolean",
+            )
+        }),
+        None => Ok(false),
     }
 }
 
@@ -1263,6 +1297,43 @@ mod tests {
 
         let err = parse_stt_audio_samples(&data, "stream-1", 48_000).unwrap_err();
         assert!(err.contains("stream_id"));
+    }
+
+    #[tokio::test]
+    async fn ui_hold_request_stays_out_of_worker_queue() {
+        let queue = Arc::new(RequestQueue::new());
+        let automerge = Arc::new(tokio::sync::Mutex::new(AutomergeState::new()));
+        let request = rpc::Request::new(
+            "speak",
+            serde_json::json!({
+                "text": "Hold this for the playlist.",
+                "wait": false,
+                "ui_hold": true
+            }),
+        )
+        .with_id(1);
+
+        let response = dispatch(
+            request,
+            &queue,
+            &Arc::new(DaemonConfig::new()),
+            "agent-a",
+            &automerge,
+        )
+        .await;
+
+        assert!(response.error.is_none());
+        let result = response.result.expect("response result");
+        assert_eq!(result["status"], "held");
+
+        assert!(queue.dequeue().await.is_none());
+        let snapshot = queue.snapshot().await;
+        assert_eq!(snapshot.pending.len(), 1);
+        assert!(snapshot.pending[0].held_for_ui);
+        assert_eq!(
+            snapshot.pending[0].text_preview.as_deref(),
+            Some("Hold this for the playlist.")
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/voice-daemon/src/socket.rs
+++ b/crates/voice-daemon/src/socket.rs
@@ -8,6 +8,7 @@ use crate::queue::{
     RequestQueue, StreamSpeakRequest, StreamTranscribeRequest, SynthesizeRequest, TtsOptions,
     VoiceRequest,
 };
+use crate::ui_state::UI_INTERNAL_CLIENT_ID;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
@@ -779,9 +780,18 @@ async fn dispatch(
                 | VoiceRequest::Converse { .. }
         );
         if ui_hold && can_hold_for_ui {
+            let prompt_request = held_prompt_request(&voice_req);
             let queue_id = queue
                 .enqueue_ui_held(client_id.to_string(), voice_req)
                 .await;
+            if let Some(mut request) = prompt_request {
+                request.output_path = crate::audio_recorder::question_path(&queue_id)
+                    .to_string_lossy()
+                    .into_owned();
+                queue
+                    .enqueue_synthesize(UI_INTERNAL_CLIENT_ID.to_string(), request)
+                    .await;
+            }
             sync_automerge(queue, automerge).await;
             return Response::success(
                 req.id,
@@ -893,6 +903,38 @@ fn ui_hold_param(req: &rpc::Request) -> Result<bool, Response> {
             )
         }),
         None => Ok(false),
+    }
+}
+
+fn held_prompt_request(request: &VoiceRequest) -> Option<SynthesizeRequest> {
+    match request {
+        VoiceRequest::Speak {
+            text,
+            voice,
+            speed,
+            options,
+        } => Some(SynthesizeRequest {
+            text: text.clone(),
+            output_path: String::new(),
+            output_format: Some(AudioOutputFormat::Wav),
+            voice: voice.clone(),
+            speed: *speed,
+            options: options.clone(),
+        }),
+        VoiceRequest::Converse {
+            text,
+            voice,
+            options,
+            ..
+        } => Some(SynthesizeRequest {
+            text: text.clone(),
+            output_path: String::new(),
+            output_format: Some(AudioOutputFormat::Wav),
+            voice: voice.clone(),
+            speed: None,
+            options: options.clone(),
+        }),
+        _ => None,
     }
 }
 
@@ -1326,7 +1368,18 @@ mod tests {
         let result = response.result.expect("response result");
         assert_eq!(result["status"], "held");
 
-        assert!(queue.dequeue().await.is_none());
+        let synth = queue.dequeue().await.expect("hidden synth job");
+        assert_eq!(synth.client_id, UI_INTERNAL_CLIENT_ID);
+        match synth.request {
+            VoiceRequest::Synthesize {
+                output_path, text, ..
+            } => {
+                assert_eq!(text, "Hold this for the playlist.");
+                assert!(output_path.ends_with("-q.wav"));
+            }
+            other => panic!("expected hidden synth job, got {other:?}"),
+        }
+
         let snapshot = queue.snapshot().await;
         assert_eq!(snapshot.pending.len(), 1);
         assert!(snapshot.pending[0].held_for_ui);

--- a/crates/voice-daemon/src/ui_server.rs
+++ b/crates/voice-daemon/src/ui_server.rs
@@ -1,7 +1,8 @@
 use crate::audio_recorder;
-use crate::queue::RequestQueue;
+use crate::queue::{RequestQueue, VoiceRequest};
 use crate::ui_state::{
     snapshot_from_daemon, UiCommandResult, UiEvent, UiSnapshot, UiTransport, UiTransportState,
+    UI_INTERNAL_CLIENT_ID,
 };
 use axum::body::Body;
 use axum::extract::{Path, State};
@@ -17,6 +18,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::sync::{broadcast, Mutex};
+use voice_protocol::rpc::ItemStatus;
 
 #[derive(Clone)]
 struct UiServerState {
@@ -283,9 +285,11 @@ impl UiServerState {
         };
 
         let Ok(text) = std::env::var("VOICE_UI_TEST_RESPONSE_TEXT") else {
+            self.start_microphone_response(track_id.clone()).await;
             return result;
         };
         if text.trim().is_empty() {
+            self.start_microphone_response(track_id.clone()).await;
             return result;
         }
 
@@ -330,6 +334,57 @@ impl UiServerState {
             track_id: Some(track_id),
             message: (!completed).then(|| "track is not a held UI item".to_string()),
         }
+    }
+
+    async fn start_microphone_response(&self, track_id: String) {
+        let state = self.clone();
+        tokio::spawn(async move {
+            let (listen_id, completion_rx) = state
+                .queue
+                .enqueue_and_wait(
+                    UI_INTERNAL_CLIENT_ID.to_string(),
+                    VoiceRequest::Listen {
+                        max_duration_ms: ui_response_max_duration_ms(),
+                    },
+                )
+                .await;
+            state.broadcast_snapshot().await;
+
+            let finish = match completion_rx.await {
+                Ok(completion) => {
+                    if completion.status == ItemStatus::Completed {
+                        let _ = copy_answer_audio(&listen_id, &track_id).await;
+                        state
+                            .queue
+                            .complete_held_item(&track_id, completion.result)
+                            .await
+                    } else {
+                        state
+                            .queue
+                            .fail_held_item(&track_id, completion.result)
+                            .await
+                    }
+                }
+                Err(_) => {
+                    state
+                        .queue
+                        .fail_held_item(
+                            &track_id,
+                            Some("internal listen worker dropped".to_string()),
+                        )
+                        .await
+                }
+            };
+
+            if finish {
+                *state.transport.lock().await = UiTransport {
+                    state: UiTransportState::Idle,
+                    paused: true,
+                    position_seconds: 0,
+                };
+                state.broadcast_snapshot().await;
+            }
+        });
     }
 
     async fn set_transport(
@@ -435,6 +490,30 @@ fn write_synthetic_answer_audio(track_id: &str) -> Result<(), String> {
         &samples,
         sample_rate,
     )
+}
+
+fn ui_response_max_duration_ms() -> Option<u64> {
+    std::env::var("VOICE_UI_RESPONSE_MAX_DURATION_MS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .or(Some(30_000))
+}
+
+async fn copy_answer_audio(from_id: &str, to_id: &str) -> Result<(), String> {
+    let from = audio_recorder::answer_path(from_id);
+    let to = audio_recorder::answer_path(to_id);
+    if !from.exists() {
+        return Ok(());
+    }
+    if let Some(parent) = to.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|err| format!("mkdir {}: {err}", parent.display()))?;
+    }
+    tokio::fs::copy(&from, &to)
+        .await
+        .map(|_| ())
+        .map_err(|err| format!("copy answer audio: {err}"))
 }
 
 #[cfg(test)]

--- a/crates/voice-daemon/src/ui_server.rs
+++ b/crates/voice-daemon/src/ui_server.rs
@@ -1,0 +1,377 @@
+use crate::audio_recorder;
+use crate::queue::RequestQueue;
+use crate::ui_state::{
+    snapshot_from_daemon, UiCommandResult, UiEvent, UiSnapshot, UiTransport, UiTransportState,
+};
+use axum::body::Body;
+use axum::extract::{Path, State};
+use axum::http::{header, StatusCode, Uri};
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::Deserialize;
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::sync::{broadcast, Mutex};
+
+#[derive(Clone)]
+struct UiServerState {
+    queue: Arc<RequestQueue>,
+    active_track_id: Arc<Mutex<Option<String>>>,
+    transport: Arc<Mutex<UiTransport>>,
+    events: broadcast::Sender<UiEvent>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CommandBody {
+    track_id: Option<String>,
+}
+
+pub async fn serve(queue: Arc<RequestQueue>) {
+    let addr = ui_addr();
+    let listener = match TcpListener::bind(addr).await {
+        Ok(listener) => listener,
+        Err(err) => {
+            eprintln!("voice daemon: failed to bind UI server at {addr}: {err}");
+            return;
+        }
+    };
+
+    let (event_tx, _) = broadcast::channel(64);
+    let state = UiServerState {
+        queue,
+        active_track_id: Arc::new(Mutex::new(None)),
+        transport: Arc::new(Mutex::new(UiTransport {
+            state: UiTransportState::Idle,
+            paused: true,
+            position_seconds: 0,
+        })),
+        events: event_tx,
+    };
+
+    tokio::spawn(queue_event_pump(state.clone()));
+
+    let app = Router::new()
+        .route("/api/ui/snapshot", get(snapshot))
+        .route("/api/ui/events", get(event_stream))
+        .route("/api/ui/commands/:command", post(command))
+        .route("/api/ui/audio/:track_id/:part", get(audio))
+        .fallback(get(asset))
+        .with_state(state);
+
+    eprintln!("voice daemon: UI listening on http://{addr}");
+    if let Err(err) = axum::serve(listener, app).await {
+        eprintln!("voice daemon: UI server stopped: {err}");
+    }
+}
+
+fn ui_addr() -> SocketAddr {
+    std::env::var("VOICE_UI_ADDR")
+        .ok()
+        .and_then(|addr| addr.parse().ok())
+        .unwrap_or_else(|| SocketAddr::from(([127, 0, 0, 1], 8767)))
+}
+
+async fn queue_event_pump(state: UiServerState) {
+    loop {
+        state.queue.notify.notified().await;
+        state.broadcast_snapshot().await;
+    }
+}
+
+async fn snapshot(State(state): State<UiServerState>) -> Json<UiSnapshot> {
+    Json(state.snapshot().await)
+}
+
+async fn event_stream(
+    State(state): State<UiServerState>,
+) -> Sse<impl futures_core::Stream<Item = Result<Event, Infallible>>> {
+    let mut receiver = state.events.subscribe();
+
+    let stream = async_stream::stream! {
+        if let Some(event) = sse_json("snapshot", &UiEvent::Snapshot(state.snapshot().await)) {
+            yield Ok(event);
+        }
+
+        loop {
+            match receiver.recv().await {
+                Ok(event) => {
+                    let name = event_name(&event);
+                    if let Some(event) = sse_json(name, &event) {
+                        yield Ok(event);
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => {
+                    if let Some(event) = sse_json("snapshot", &UiEvent::Snapshot(state.snapshot().await)) {
+                        yield Ok(event);
+                    }
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    };
+
+    Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(15))
+            .text("keepalive"),
+    )
+}
+
+async fn command(
+    State(state): State<UiServerState>,
+    Path(command): Path<String>,
+    body: Option<Json<CommandBody>>,
+) -> Json<UiCommandResult> {
+    let track_id = body.and_then(|body| body.track_id.clone());
+    let result = match command.as_str() {
+        "play" => {
+            state
+                .set_active("play", track_id, UiTransportState::Playing, false)
+                .await
+        }
+        "pause" => state.set_transport(UiTransportState::Paused, true).await,
+        "next" => state.step(1).await,
+        "previous" => state.step(-1).await,
+        "respond" => {
+            state
+                .set_active("respond", track_id, UiTransportState::Listening, false)
+                .await
+        }
+        "cancel" => state.cancel(track_id).await,
+        "clear-recent" => state.clear_recent(track_id).await,
+        other => UiCommandResult {
+            command: other.to_string(),
+            ok: false,
+            track_id: None,
+            message: Some(format!("unknown command: {other}")),
+        },
+    };
+
+    let _ = state.events.send(UiEvent::CommandResult(result.clone()));
+    state.broadcast_snapshot().await;
+    Json(result)
+}
+
+async fn audio(Path((track_id, part)): Path<(String, String)>) -> Response {
+    let path = match part.as_str() {
+        "prompt" | "question" => audio_recorder::question_path(&track_id),
+        "answer" => audio_recorder::answer_path(&track_id),
+        _ => return StatusCode::NOT_FOUND.into_response(),
+    };
+
+    match tokio::fs::read(path).await {
+        Ok(bytes) => (
+            [(header::CONTENT_TYPE, "audio/wav")],
+            axum::body::Bytes::from(bytes),
+        )
+            .into_response(),
+        Err(_) => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+async fn asset(uri: Uri) -> Response {
+    let path = uri.path().trim_start_matches('/');
+    let candidate = if path.is_empty() { "index.html" } else { path };
+    let asset = voice_ui::get(candidate).or_else(|| {
+        if path.starts_with("api/") {
+            None
+        } else {
+            voice_ui::index_html()
+        }
+    });
+
+    match asset {
+        Some(asset) => Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, asset.mime)
+            .body(Body::from(asset.bytes))
+            .unwrap(),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+fn sse_json(name: &str, event: &UiEvent) -> Option<Event> {
+    Event::default()
+        .event(name)
+        .json_data(event)
+        .map_err(|err| {
+            eprintln!("voice daemon: failed to serialize UI event: {err}");
+        })
+        .ok()
+}
+
+fn event_name(event: &UiEvent) -> &'static str {
+    match event {
+        UiEvent::Snapshot(_) => "snapshot",
+        UiEvent::TrackUpserted(_) => "track_upserted",
+        UiEvent::TrackRemoved { .. } => "track_removed",
+        UiEvent::ActiveChanged { .. } => "active_changed",
+        UiEvent::TransportChanged(_) => "transport_changed",
+        UiEvent::CommandResult(_) => "command_result",
+        UiEvent::Error { .. } => "error",
+    }
+}
+
+impl UiServerState {
+    async fn snapshot(&self) -> UiSnapshot {
+        snapshot_from_daemon(
+            &self.queue.snapshot().await,
+            self.active_track_id.lock().await.clone(),
+            self.transport.lock().await.clone(),
+        )
+    }
+
+    async fn broadcast_snapshot(&self) {
+        let snapshot = self.snapshot().await;
+        let _ = self.events.send(UiEvent::Snapshot(snapshot));
+    }
+
+    async fn set_active(
+        &self,
+        command: &str,
+        requested_id: Option<String>,
+        transport_state: UiTransportState,
+        paused: bool,
+    ) -> UiCommandResult {
+        let snapshot = self.snapshot().await;
+        let next_id = requested_id.or(snapshot.active_track_id).or_else(|| {
+            snapshot
+                .queue_ids
+                .first()
+                .cloned()
+                .or_else(|| snapshot.recent_ids.first().cloned())
+        });
+
+        *self.active_track_id.lock().await = next_id.clone();
+        *self.transport.lock().await = UiTransport {
+            state: transport_state,
+            paused,
+            position_seconds: 0,
+        };
+
+        let _ = self.events.send(UiEvent::ActiveChanged {
+            active_track_id: next_id.clone(),
+        });
+        let _ = self.events.send(UiEvent::TransportChanged(
+            self.transport.lock().await.clone(),
+        ));
+
+        UiCommandResult {
+            command: command.to_string(),
+            ok: next_id.is_some(),
+            track_id: next_id,
+            message: None,
+        }
+    }
+
+    async fn set_transport(
+        &self,
+        transport_state: UiTransportState,
+        paused: bool,
+    ) -> UiCommandResult {
+        let active_track_id = self.active_track_id.lock().await.clone();
+        let mut transport = self.transport.lock().await;
+        transport.state = transport_state;
+        transport.paused = paused;
+        let _ = self
+            .events
+            .send(UiEvent::TransportChanged(transport.clone()));
+
+        UiCommandResult {
+            command: "pause".to_string(),
+            ok: true,
+            track_id: active_track_id,
+            message: None,
+        }
+    }
+
+    async fn step(&self, direction: isize) -> UiCommandResult {
+        let snapshot = self.snapshot().await;
+        let mut ids = snapshot.queue_ids.clone();
+        ids.extend(snapshot.recent_ids.iter().cloned());
+        if ids.is_empty() {
+            return UiCommandResult {
+                command: if direction > 0 { "next" } else { "previous" }.to_string(),
+                ok: false,
+                track_id: None,
+                message: Some("no tracks available".to_string()),
+            };
+        }
+
+        let current_index = snapshot
+            .active_track_id
+            .as_ref()
+            .and_then(|id| ids.iter().position(|candidate| candidate == id))
+            .unwrap_or(0);
+        let next_index = (current_index as isize + direction)
+            .clamp(0, ids.len().saturating_sub(1) as isize) as usize;
+        self.set_active(
+            if direction > 0 { "next" } else { "previous" },
+            Some(ids[next_index].clone()),
+            UiTransportState::Playing,
+            false,
+        )
+        .await
+    }
+
+    async fn cancel(&self, track_id: Option<String>) -> UiCommandResult {
+        let track_id = track_id.or_else(|| {
+            self.active_track_id
+                .try_lock()
+                .ok()
+                .and_then(|id| id.clone())
+        });
+        let Some(track_id) = track_id else {
+            return UiCommandResult {
+                command: "cancel".to_string(),
+                ok: false,
+                track_id: None,
+                message: Some("no active track".to_string()),
+            };
+        };
+
+        let ok = self.queue.cancel_item(&track_id).await;
+        UiCommandResult {
+            command: "cancel".to_string(),
+            ok,
+            track_id: Some(track_id),
+            message: None,
+        }
+    }
+
+    async fn clear_recent(&self, track_id: Option<String>) -> UiCommandResult {
+        let Some(track_id) = track_id else {
+            return UiCommandResult {
+                command: "clear-recent".to_string(),
+                ok: false,
+                track_id: None,
+                message: Some("track_id is required".to_string()),
+            };
+        };
+
+        self.queue.remove_recent(&track_id).await;
+        UiCommandResult {
+            command: "clear-recent".to_string(),
+            ok: true,
+            track_id: Some(track_id),
+            message: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn missing_static_asset_returns_not_found_for_api_path() {
+        let response = asset("/api/missing".parse().unwrap()).await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/voice-daemon/src/ui_server.rs
+++ b/crates/voice-daemon/src/ui_server.rs
@@ -56,18 +56,22 @@ pub async fn serve(queue: Arc<RequestQueue>) {
 
     tokio::spawn(queue_event_pump(state.clone()));
 
-    let app = Router::new()
-        .route("/api/ui/snapshot", get(snapshot))
-        .route("/api/ui/events", get(event_stream))
-        .route("/api/ui/commands/:command", post(command))
-        .route("/api/ui/audio/:track_id/:part", get(audio))
-        .fallback(get(asset))
-        .with_state(state);
+    let app = router(state);
 
     eprintln!("voice daemon: UI listening on http://{addr}");
     if let Err(err) = axum::serve(listener, app).await {
         eprintln!("voice daemon: UI server stopped: {err}");
     }
+}
+
+fn router(state: UiServerState) -> Router {
+    Router::new()
+        .route("/api/ui/snapshot", get(snapshot))
+        .route("/api/ui/events", get(event_stream))
+        .route("/api/ui/commands/:command", post(command))
+        .route("/api/ui/audio/:track_id/:part", get(audio))
+        .fallback(get(asset))
+        .with_state(state)
 }
 
 fn ui_addr() -> SocketAddr {
@@ -138,11 +142,7 @@ async fn command(
         "pause" => state.set_transport(UiTransportState::Paused, true).await,
         "next" => state.step(1).await,
         "previous" => state.step(-1).await,
-        "respond" => {
-            state
-                .set_active("respond", track_id, UiTransportState::Listening, false)
-                .await
-        }
+        "respond" => state.respond(track_id).await,
         "cancel" => state.cancel(track_id).await,
         "clear-recent" => state.clear_recent(track_id).await,
         other => UiCommandResult {
@@ -270,6 +270,68 @@ impl UiServerState {
         }
     }
 
+    async fn respond(&self, requested_id: Option<String>) -> UiCommandResult {
+        let result = self
+            .set_active("respond", requested_id, UiTransportState::Listening, false)
+            .await;
+        if !result.ok {
+            return result;
+        }
+
+        let Some(track_id) = result.track_id.clone() else {
+            return result;
+        };
+
+        let Ok(text) = std::env::var("VOICE_UI_TEST_RESPONSE_TEXT") else {
+            return result;
+        };
+        if text.trim().is_empty() {
+            return result;
+        }
+
+        if let Err(err) = write_synthetic_answer_audio(&track_id) {
+            return UiCommandResult {
+                command: "respond".to_string(),
+                ok: false,
+                track_id: Some(track_id),
+                message: Some(err),
+            };
+        }
+
+        let completed = self
+            .queue
+            .complete_held_item(
+                &track_id,
+                Some(
+                    serde_json::json!({
+                        "heard": {
+                            "text": text,
+                            "sample_rate": 16_000,
+                            "audio_duration_ms": 250,
+                        },
+                        "source": "ui-test-response",
+                    })
+                    .to_string(),
+                ),
+            )
+            .await;
+        if completed {
+            *self.transport.lock().await = UiTransport {
+                state: UiTransportState::Idle,
+                paused: true,
+                position_seconds: 0,
+            };
+            self.broadcast_snapshot().await;
+        }
+
+        UiCommandResult {
+            command: "respond".to_string(),
+            ok: completed,
+            track_id: Some(track_id),
+            message: (!completed).then(|| "track is not a held UI item".to_string()),
+        }
+    }
+
     async fn set_transport(
         &self,
         transport_state: UiTransportState,
@@ -365,13 +427,218 @@ impl UiServerState {
     }
 }
 
+fn write_synthetic_answer_audio(track_id: &str) -> Result<(), String> {
+    let sample_rate = 16_000_u32;
+    let samples = vec![0.0; sample_rate as usize / 4];
+    audio_recorder::save_wav(
+        &audio_recorder::answer_path(track_id),
+        &samples,
+        sample_rate,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::queue::{TtsOptions, VoiceRequest};
+    use axum::body::{to_bytes, Body};
+    use axum::http::{Method, Request};
+    use tower::ServiceExt;
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     #[tokio::test]
     async fn missing_static_asset_returns_not_found_for_api_path() {
         let response = asset("/api/missing".parse().unwrap()).await;
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_response_completes_held_track_without_microphone() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let audio_dir = std::env::temp_dir().join(format!(
+            "voice-ui-response-test-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let old_audio_dir = std::env::var("VOICE_AUDIO_DIR").ok();
+        let old_response = std::env::var("VOICE_UI_TEST_RESPONSE_TEXT").ok();
+        std::env::set_var("VOICE_AUDIO_DIR", &audio_dir);
+        std::env::set_var("VOICE_UI_TEST_RESPONSE_TEXT", "Run the regression suite.");
+
+        let queue = Arc::new(RequestQueue::new());
+        let (event_tx, _) = broadcast::channel(8);
+        let state = UiServerState {
+            queue: queue.clone(),
+            active_track_id: Arc::new(Mutex::new(None)),
+            transport: Arc::new(Mutex::new(UiTransport {
+                state: UiTransportState::Idle,
+                paused: true,
+                position_seconds: 0,
+            })),
+            events: event_tx,
+        };
+        let track_id = queue
+            .enqueue_ui_held(
+                "codex".to_string(),
+                VoiceRequest::Converse {
+                    text: "Should I run tests?".to_string(),
+                    voice: None,
+                    max_duration_ms: None,
+                    options: TtsOptions::default(),
+                },
+            )
+            .await;
+
+        let result = state.respond(Some(track_id.clone())).await;
+        assert!(result.ok, "{result:?}");
+
+        let snapshot = state.snapshot().await;
+        assert!(snapshot.queue_ids.is_empty());
+        assert_eq!(snapshot.recent_ids, vec![track_id.clone()]);
+        let track = &snapshot.tracks[&track_id];
+        assert_eq!(track.answer.as_deref(), Some("Run the regression suite."));
+        assert_eq!(
+            track.audio.answer_url,
+            Some(format!("/api/ui/audio/{track_id}/answer"))
+        );
+
+        match old_audio_dir {
+            Some(value) => std::env::set_var("VOICE_AUDIO_DIR", value),
+            None => std::env::remove_var("VOICE_AUDIO_DIR"),
+        }
+        match old_response {
+            Some(value) => std::env::set_var("VOICE_UI_TEST_RESPONSE_TEXT", value),
+            None => std::env::remove_var("VOICE_UI_TEST_RESPONSE_TEXT"),
+        }
+        let _ = std::fs::remove_dir_all(audio_dir);
+    }
+
+    #[tokio::test]
+    async fn http_snapshot_command_and_audio_round_trip_without_microphone() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let audio_dir = std::env::temp_dir().join(format!(
+            "voice-ui-http-test-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let old_audio_dir = std::env::var("VOICE_AUDIO_DIR").ok();
+        let old_response = std::env::var("VOICE_UI_TEST_RESPONSE_TEXT").ok();
+        std::env::set_var("VOICE_AUDIO_DIR", &audio_dir);
+        std::env::set_var("VOICE_UI_TEST_RESPONSE_TEXT", "Please open the PR.");
+
+        let queue = Arc::new(RequestQueue::new());
+        let (event_tx, _) = broadcast::channel(8);
+        let state = UiServerState {
+            queue: queue.clone(),
+            active_track_id: Arc::new(Mutex::new(None)),
+            transport: Arc::new(Mutex::new(UiTransport {
+                state: UiTransportState::Idle,
+                paused: true,
+                position_seconds: 0,
+            })),
+            events: event_tx,
+        };
+        let track_id = queue
+            .enqueue_ui_held(
+                "codex".to_string(),
+                VoiceRequest::Converse {
+                    text: "Should I open the PR?".to_string(),
+                    voice: None,
+                    max_duration_ms: None,
+                    options: TtsOptions::default(),
+                },
+            )
+            .await;
+        let app = router(state);
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/api/ui/snapshot")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let snapshot = serde_json::from_slice::<UiSnapshot>(
+            &to_bytes(response.into_body(), usize::MAX).await.unwrap(),
+        )
+        .unwrap();
+        assert_eq!(snapshot.queue_ids, vec![track_id.clone()]);
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/ui/commands/respond")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(format!(r#"{{"trackId":"{track_id}"}}"#)))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let result = serde_json::from_slice::<UiCommandResult>(
+            &to_bytes(response.into_body(), usize::MAX).await.unwrap(),
+        )
+        .unwrap();
+        assert!(result.ok, "{result:?}");
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/api/ui/snapshot")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let snapshot = serde_json::from_slice::<UiSnapshot>(
+            &to_bytes(response.into_body(), usize::MAX).await.unwrap(),
+        )
+        .unwrap();
+        assert!(snapshot.queue_ids.is_empty());
+        assert_eq!(snapshot.recent_ids, vec![track_id.clone()]);
+        assert_eq!(
+            snapshot.tracks[&track_id].answer.as_deref(),
+            Some("Please open the PR.")
+        );
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(format!("/api/ui/audio/{track_id}/answer"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "audio/wav"
+        );
+        assert!(!to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap()
+            .is_empty());
+
+        match old_audio_dir {
+            Some(value) => std::env::set_var("VOICE_AUDIO_DIR", value),
+            None => std::env::remove_var("VOICE_AUDIO_DIR"),
+        }
+        match old_response {
+            Some(value) => std::env::set_var("VOICE_UI_TEST_RESPONSE_TEXT", value),
+            None => std::env::remove_var("VOICE_UI_TEST_RESPONSE_TEXT"),
+        }
+        let _ = std::fs::remove_dir_all(audio_dir);
     }
 }

--- a/crates/voice-daemon/src/ui_state.rs
+++ b/crates/voice-daemon/src/ui_state.rs
@@ -1,0 +1,305 @@
+use crate::audio_recorder;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+use voice_protocol::rpc::{DaemonState, ItemStatus, QueueItem};
+
+const DEFAULT_COLORS: [&str; 5] = ["#82aaff", "#f0b878", "#e89a6a", "#9ad7c2", "#b58cff"];
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiSnapshot {
+    pub connected: bool,
+    pub ready: bool,
+    pub daemon_status: String,
+    pub transport: UiTransport,
+    pub active_track_id: Option<String>,
+    pub queue_ids: Vec<String>,
+    pub recent_ids: Vec<String>,
+    pub tracks: BTreeMap<String, UiTrack>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiTransport {
+    pub state: UiTransportState,
+    pub paused: bool,
+    pub position_seconds: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum UiTransportState {
+    Idle,
+    Playing,
+    Paused,
+    Listening,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiTrack {
+    pub id: String,
+    pub agent: UiAgent,
+    pub intent: UiIntent,
+    pub lifecycle: UiLifecycle,
+    pub prompt: String,
+    pub answer: Option<String>,
+    pub audio: UiAudio,
+    pub created_at: u64,
+    pub completed_at: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiAgent {
+    pub name: String,
+    pub initial: String,
+    pub color: String,
+    pub repo: String,
+    pub branch: String,
+    pub model: String,
+    pub session: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum UiIntent {
+    Play,
+    Respond,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum UiLifecycle {
+    Queued,
+    Preparing,
+    Ready,
+    Active,
+    Listening,
+    Completed,
+    Failed,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct UiAudio {
+    pub prompt_url: Option<String>,
+    pub answer_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", tag = "type", content = "payload")]
+pub enum UiEvent {
+    Snapshot(UiSnapshot),
+    TrackUpserted(UiTrack),
+    TrackRemoved { id: String },
+    ActiveChanged { active_track_id: Option<String> },
+    TransportChanged(UiTransport),
+    CommandResult(UiCommandResult),
+    Error { message: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiCommandResult {
+    pub command: String,
+    pub ok: bool,
+    pub track_id: Option<String>,
+    pub message: Option<String>,
+}
+
+pub fn snapshot_from_daemon(
+    daemon: &DaemonState,
+    active_track_id: Option<String>,
+    transport: UiTransport,
+) -> UiSnapshot {
+    let mut tracks = BTreeMap::new();
+    let mut queue_ids = Vec::new();
+    let mut recent_ids = Vec::new();
+
+    let mut ordered_items = Vec::new();
+    if let Some(current) = &daemon.current {
+        ordered_items.push(current.clone());
+    }
+    ordered_items.extend(daemon.pending.iter().cloned());
+    ordered_items.extend(daemon.recent.iter().cloned());
+
+    for (index, item) in ordered_items.iter().enumerate() {
+        let track = track_from_item(item, index, active_track_id.as_deref());
+        if daemon.recent.iter().any(|recent| recent.id == item.id) {
+            recent_ids.push(item.id.clone());
+        } else {
+            queue_ids.push(item.id.clone());
+        }
+        tracks.insert(track.id.clone(), track);
+    }
+
+    UiSnapshot {
+        connected: true,
+        ready: true,
+        daemon_status: daemon.status.clone(),
+        transport,
+        active_track_id,
+        queue_ids,
+        recent_ids,
+        tracks,
+    }
+}
+
+fn track_from_item(item: &QueueItem, index: usize, active_track_id: Option<&str>) -> UiTrack {
+    let intent = intent_for_method(&item.method);
+    let lifecycle = lifecycle_for_item(item, &intent, active_track_id);
+    let prompt = item
+        .text_preview
+        .clone()
+        .or_else(|| item.result.clone())
+        .unwrap_or_else(|| item.method.replace('_', " "));
+    let answer = answer_from_result(item.result.as_deref());
+    let client_id = item.client_id.trim();
+
+    UiTrack {
+        id: item.id.clone(),
+        agent: UiAgent {
+            name: agent_name(client_id),
+            initial: agent_initial(client_id),
+            color: DEFAULT_COLORS[index % DEFAULT_COLORS.len()].to_string(),
+            repo: item
+                .repo
+                .clone()
+                .unwrap_or_else(|| "voice daemon".to_string()),
+            branch: item.method.clone(),
+            model: client_id.to_string(),
+            session: client_id.to_string(),
+        },
+        intent,
+        lifecycle,
+        prompt,
+        answer,
+        audio: audio_for_item(&item.id),
+        created_at: item.created_at,
+        completed_at: item.completed_at,
+    }
+}
+
+fn lifecycle_for_item(
+    item: &QueueItem,
+    intent: &UiIntent,
+    active_track_id: Option<&str>,
+) -> UiLifecycle {
+    if active_track_id == Some(item.id.as_str()) {
+        return match intent {
+            UiIntent::Respond => UiLifecycle::Listening,
+            UiIntent::Play => UiLifecycle::Active,
+        };
+    }
+
+    match item.status {
+        ItemStatus::Queued => {
+            if audio_recorder::question_path(&item.id).exists() {
+                UiLifecycle::Ready
+            } else {
+                UiLifecycle::Queued
+            }
+        }
+        ItemStatus::Processing => UiLifecycle::Preparing,
+        ItemStatus::Completed => UiLifecycle::Completed,
+        ItemStatus::Failed => UiLifecycle::Failed,
+    }
+}
+
+fn intent_for_method(method: &str) -> UiIntent {
+    match method {
+        "converse" | "listen" | "stream_transcribe" => UiIntent::Respond,
+        _ => UiIntent::Play,
+    }
+}
+
+fn audio_for_item(id: &str) -> UiAudio {
+    UiAudio {
+        prompt_url: audio_url_if_exists(id, "prompt", &audio_recorder::question_path(id)),
+        answer_url: audio_url_if_exists(id, "answer", &audio_recorder::answer_path(id)),
+    }
+}
+
+fn audio_url_if_exists(id: &str, part: &str, path: &Path) -> Option<String> {
+    path.exists().then(|| format!("/api/ui/audio/{id}/{part}"))
+}
+
+fn answer_from_result(result: Option<&str>) -> Option<String> {
+    let result = result?;
+    let value = serde_json::from_str::<serde_json::Value>(result).ok()?;
+    value
+        .pointer("/heard/text")
+        .and_then(|text| text.as_str())
+        .or_else(|| value.get("text").and_then(|text| text.as_str()))
+        .map(ToOwned::to_owned)
+}
+
+fn agent_name(client_id: &str) -> String {
+    let first = client_id
+        .split(['.', '_', ':', '-'])
+        .find(|part| !part.is_empty())
+        .unwrap_or("daemon");
+    let mut chars = first.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().chain(chars).collect(),
+        None => "Daemon".to_string(),
+    }
+}
+
+fn agent_initial(client_id: &str) -> String {
+    client_id
+        .chars()
+        .find(|c| c.is_ascii_alphanumeric())
+        .unwrap_or('D')
+        .to_ascii_uppercase()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(id: &str, method: &str, status: ItemStatus) -> QueueItem {
+        QueueItem {
+            id: id.to_string(),
+            client_id: "codex.repo.main.gpt-5".to_string(),
+            method: method.to_string(),
+            status,
+            created_at: 10,
+            text_preview: Some("Need your decision.".to_string()),
+            result: None,
+            repo: Some("rgbkrk/voice".to_string()),
+            completed_at: None,
+            auto_clear_at: None,
+        }
+    }
+
+    #[test]
+    fn snapshot_projects_pending_and_recent_tracks() {
+        let daemon = DaemonState {
+            status: "queued".to_string(),
+            current: None,
+            pending: vec![item("one", "converse", ItemStatus::Queued)],
+            recent: vec![item("two", "speak", ItemStatus::Completed)],
+        };
+
+        let snapshot = snapshot_from_daemon(
+            &daemon,
+            Some("one".to_string()),
+            UiTransport {
+                state: UiTransportState::Listening,
+                paused: false,
+                position_seconds: 0,
+            },
+        );
+
+        assert_eq!(snapshot.queue_ids, vec!["one"]);
+        assert_eq!(snapshot.recent_ids, vec!["two"]);
+        assert_eq!(snapshot.tracks["one"].intent, UiIntent::Respond);
+        assert_eq!(snapshot.tracks["one"].lifecycle, UiLifecycle::Listening);
+        assert_eq!(snapshot.tracks["two"].lifecycle, UiLifecycle::Completed);
+    }
+}

--- a/crates/voice-daemon/src/ui_state.rs
+++ b/crates/voice-daemon/src/ui_state.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use voice_protocol::rpc::{DaemonState, ItemStatus, QueueItem};
 
 const DEFAULT_COLORS: [&str; 5] = ["#82aaff", "#f0b878", "#e89a6a", "#9ad7c2", "#b58cff"];
+pub const UI_INTERNAL_CLIENT_ID: &str = "__voice_ui_internal";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -126,7 +127,11 @@ pub fn snapshot_from_daemon(
     ordered_items.extend(daemon.pending.iter().cloned());
     ordered_items.extend(daemon.recent.iter().cloned());
 
-    for (index, item) in ordered_items.iter().enumerate() {
+    for (index, item) in ordered_items
+        .iter()
+        .filter(|item| item.client_id != UI_INTERNAL_CLIENT_ID)
+        .enumerate()
+    {
         let track = track_from_item(item, index, active_track_id.as_deref());
         if daemon.recent.iter().any(|recent| recent.id == item.id) {
             recent_ids.push(item.id.clone());
@@ -302,5 +307,31 @@ mod tests {
         assert_eq!(snapshot.tracks["one"].intent, UiIntent::Respond);
         assert_eq!(snapshot.tracks["one"].lifecycle, UiLifecycle::Listening);
         assert_eq!(snapshot.tracks["two"].lifecycle, UiLifecycle::Completed);
+    }
+
+    #[test]
+    fn snapshot_hides_internal_ui_worker_items() {
+        let mut hidden = item("hidden", "listen", ItemStatus::Processing);
+        hidden.client_id = UI_INTERNAL_CLIENT_ID.to_string();
+        let visible = item("visible", "converse", ItemStatus::Queued);
+        let daemon = DaemonState {
+            status: "listening".to_string(),
+            current: Some(hidden),
+            pending: vec![visible],
+            recent: vec![],
+        };
+
+        let snapshot = snapshot_from_daemon(
+            &daemon,
+            Some("visible".to_string()),
+            UiTransport {
+                state: UiTransportState::Listening,
+                paused: false,
+                position_seconds: 0,
+            },
+        );
+
+        assert_eq!(snapshot.queue_ids, vec!["visible"]);
+        assert!(!snapshot.tracks.contains_key("hidden"));
     }
 }

--- a/crates/voice-daemon/src/ui_state.rs
+++ b/crates/voice-daemon/src/ui_state.rs
@@ -268,6 +268,7 @@ mod tests {
             client_id: "codex.repo.main.gpt-5".to_string(),
             method: method.to_string(),
             status,
+            held_for_ui: false,
             created_at: 10,
             text_preview: Some("Need your decision.".to_string()),
             result: None,

--- a/crates/voice-protocol/src/client.rs
+++ b/crates/voice-protocol/src/client.rs
@@ -146,6 +146,30 @@ impl DaemonClient {
         self.speak_with_options_and_wait(text, voice, speed, options, false)
     }
 
+    /// Convenience: add a speak request to the daemon UI playlist without
+    /// immediate daemon playback.
+    pub fn speak_with_options_held_for_ui(
+        &mut self,
+        text: &str,
+        voice: Option<&str>,
+        speed: Option<f64>,
+        options: TtsRequestOptions<'_>,
+    ) -> Result<Response, String> {
+        let mut params = serde_json::json!({
+            "text": text,
+            "wait": false,
+            "ui_hold": true,
+        });
+        if let Some(v) = voice {
+            params["voice"] = Value::String(v.to_string());
+        }
+        if let Some(s) = speed {
+            params["speed"] = serde_json::json!(s);
+        }
+        insert_tts_options(&mut params, options);
+        self.call("speak", params)
+    }
+
     /// Convenience: send a speak request and optionally wait for playback completion.
     pub fn speak_with_options_and_wait(
         &mut self,
@@ -527,6 +551,28 @@ impl DaemonClient {
         self.call_with_read_timeout("converse", params, read_timeout)
     }
 
+    /// Convenience: add a converse request to the daemon UI playlist without
+    /// speaking or opening the microphone immediately.
+    pub fn converse_held_for_ui(
+        &mut self,
+        text: &str,
+        voice: Option<&str>,
+        max_duration_ms: Option<u64>,
+    ) -> Result<Response, String> {
+        let mut params = serde_json::json!({
+            "text": text,
+            "wait": false,
+            "ui_hold": true,
+        });
+        if let Some(v) = voice {
+            params["voice"] = Value::String(v.to_string());
+        }
+        if let Some(ms) = max_duration_ms {
+            params["max_duration_ms"] = serde_json::json!(ms);
+        }
+        self.call("converse", params)
+    }
+
     /// Convenience: cancel all pending requests from this client.
     pub fn cancel(&mut self) -> Result<Response, String> {
         self.call("cancel", serde_json::json!({}))
@@ -773,6 +819,55 @@ mod tests {
     }
 
     #[test]
+    fn converse_held_for_ui_sends_ui_hold_without_waiting() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let path = std::env::temp_dir().join(format!(
+            "voice-protocol-converse-ui-hold-test-{}.sock",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).unwrap();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let frame = read_frame_sync(&mut stream).unwrap().unwrap();
+            let request = frame.json::<Request>().unwrap();
+            assert_eq!(request.method, "converse");
+            assert_eq!(request.params["text"], "question");
+            assert_eq!(request.params["max_duration_ms"], 1500);
+            assert_eq!(request.params["wait"], false);
+            assert_eq!(request.params["ui_hold"], true);
+
+            let response = Response::success(
+                Some(1.into()),
+                serde_json::json!({"queue_id": "q", "status": "held"}),
+            );
+            write_frame_sync(
+                &mut stream,
+                &Frame::response(&serde_json::to_vec(&response).unwrap()),
+            )
+            .unwrap();
+        });
+
+        let old = std::env::var(SOCKET_ENV).ok();
+        std::env::set_var(SOCKET_ENV, &path);
+
+        let mut client = DaemonClient::connect().unwrap();
+        let response = client
+            .converse_held_for_ui("question", None, Some(1500))
+            .unwrap();
+
+        assert!(response.error.is_none());
+
+        match old {
+            Some(value) => std::env::set_var(SOCKET_ENV, value),
+            None => std::env::remove_var(SOCKET_ENV),
+        }
+        let _ = std::fs::remove_file(path);
+        server.join().unwrap();
+    }
+
+    #[test]
     fn speak_with_options_and_wait_sends_wait_true() {
         let _guard = ENV_LOCK.lock().unwrap();
         let dir = std::env::temp_dir();
@@ -829,6 +924,52 @@ mod tests {
             )
             .unwrap();
 
+        assert!(response.error.is_none());
+
+        match old {
+            Some(value) => std::env::set_var(SOCKET_ENV, value),
+            None => std::env::remove_var(SOCKET_ENV),
+        }
+        let _ = std::fs::remove_file(path);
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn speak_held_for_ui_sends_ui_hold_without_waiting() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let path = std::env::temp_dir().join(format!(
+            "voice-protocol-speak-ui-hold-test-{}.sock",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).unwrap();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let frame = read_frame_sync(&mut stream).unwrap().unwrap();
+            let request = frame.json::<Request>().unwrap();
+            assert_eq!(request.method, "speak");
+            assert_eq!(request.params["text"], "hello");
+            assert_eq!(request.params["wait"], false);
+            assert_eq!(request.params["ui_hold"], true);
+
+            let response = Response::success(
+                Some(1.into()),
+                serde_json::json!({"queue_id": "q", "status": "held"}),
+            );
+            write_frame_sync(
+                &mut stream,
+                &Frame::response(&serde_json::to_vec(&response).unwrap()),
+            )
+            .unwrap();
+        });
+
+        let old = std::env::var(SOCKET_ENV).ok();
+        std::env::set_var(SOCKET_ENV, &path);
+        let mut client = DaemonClient::connect().unwrap();
+        let response = client
+            .speak_with_options_held_for_ui("hello", None, None, TtsRequestOptions::default())
+            .unwrap();
         assert!(response.error.is_none());
 
         match old {

--- a/crates/voice-protocol/src/rpc.rs
+++ b/crates/voice-protocol/src/rpc.rs
@@ -130,6 +130,8 @@ pub struct QueueItem {
     pub client_id: String,
     pub method: String,
     pub status: ItemStatus,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub held_for_ui: bool,
     pub created_at: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text_preview: Option<String>,
@@ -141,6 +143,10 @@ pub struct QueueItem {
     pub completed_at: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auto_clear_at: Option<u64>,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 /// Snapshot of daemon state — returned by the `status` method.

--- a/crates/voice-ui/package-lock.json
+++ b/crates/voice-ui/package-lock.json
@@ -15,6 +15,7 @@
         "lucide-react": "^0.468.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "rxjs": "^7.8.2",
         "tailwind-merge": "^2.5.5"
       },
       "devDependencies": {
@@ -2680,6 +2681,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -2883,6 +2893,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/crates/voice-ui/package.json
+++ b/crates/voice-ui/package.json
@@ -18,6 +18,7 @@
     "lucide-react": "^0.468.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "rxjs": "^7.8.2",
     "tailwind-merge": "^2.5.5"
   },
   "devDependencies": {

--- a/crates/voice-ui/web/src/App.tsx
+++ b/crates/voice-ui/web/src/App.tsx
@@ -1,125 +1,75 @@
-import { useEffect, useMemo, useState } from "react";
-import { voiceMessages } from "@/data";
-import { fetchDaemonMessages } from "@/lib/daemon";
-import type { VoiceMessage } from "@/types";
+import { useEffect } from "react";
 import { MiniTransport } from "@/components/voice/mini-transport";
 import { NowPlaying } from "@/components/voice/now-playing";
 import { VoiceHeader } from "@/components/voice/voice-header";
 import { VoiceQueue } from "@/components/voice/voice-queue";
+import { voiceActions, voiceBridge } from "@/state/voice-bridge";
+import { useVoiceSelector } from "@/state/react";
+import type { VoiceMessage } from "@/types";
 
 export default function App() {
-  const [messages, setMessages] = useState<VoiceMessage[]>(voiceMessages);
-  const [currentId, setCurrentId] = useState(voiceMessages[0].id);
-  const [paused, setPaused] = useState(false);
-  const [position, setPosition] = useState(voiceMessages[0].positionSeconds);
-
   useEffect(() => {
-    let active = true;
-    let timer: number | undefined;
-
-    async function refreshDaemonState() {
-      const daemonMessages = await fetchDaemonMessages();
-      if (!active || !daemonMessages) {
-        return false;
-      }
-
-      setMessages(daemonMessages);
-      setCurrentId((value) => {
-        const currentMessage = daemonMessages.find((message) => message.id === value);
-        const nextMessage = currentMessage ?? daemonMessages[0];
-        if (!currentMessage) {
-          setPosition(nextMessage.positionSeconds);
-        }
-        return nextMessage.id;
-      });
-      return true;
-    }
-
-    void refreshDaemonState().then((connected) => {
-      if (active && connected) {
-        timer = window.setInterval(refreshDaemonState, 2_000);
-      }
-    });
-
-    return () => {
-      active = false;
-      if (timer) {
-        window.clearInterval(timer);
-      }
-    };
+    voiceBridge.start();
+    return () => voiceBridge.stop();
   }, []);
 
-  const current = useMemo(
-    () => messages.find((message) => message.id === currentId) ?? messages[0],
-    [currentId, messages],
-  );
+  const messages = useVoiceSelector((state) => state.messages);
+  const currentId = useVoiceSelector((state) => state.currentId);
+  const position = useVoiceSelector((state) => state.positionSeconds);
+  const paused = useVoiceSelector((state) => state.paused);
 
-  const queuedMessages = useMemo(
-    () => messages.filter((message) => message.id !== current.id),
-    [current.id, messages],
-  );
+  const current = messages.find((message) => message.id === currentId) ?? messages[0];
+  const queuedMessages = current
+    ? messages.filter((message) => message.id !== current.id)
+    : [];
 
-  useEffect(() => {
-    if (paused) {
-      return;
-    }
-
-    const timer = window.setInterval(() => {
-      setPosition((value) => {
-        const nextValue = Math.min(value + 0.5, current.durationSeconds);
-        if (nextValue >= current.durationSeconds) {
-          setPaused(true);
-        }
-        return nextValue;
-      });
-    }, 500);
-
-    return () => window.clearInterval(timer);
-  }, [current.durationSeconds, current.id, paused]);
-
-  function selectMessage(message: VoiceMessage) {
-    setCurrentId(message.id);
-    setPosition(message.positionSeconds);
-    setPaused(false);
-    setMessages((items) =>
-      items.map((item) =>
-        item.id === message.id && item.state !== "skipped"
-          ? { ...item, state: "picked-up" }
-          : item,
-      ),
+  if (!current) {
+    return (
+      <div className="min-h-screen text-foreground">
+        <VoiceHeader waitingCount={0} />
+        <main className="mx-auto grid w-[calc(100%_-_2rem)] max-w-[45rem] gap-8">
+          <section className="rounded-lg border border-border bg-card p-5 text-muted-foreground">
+            Waiting for daemon state.
+          </section>
+        </main>
+      </div>
     );
-  }
-
-  function step(direction: 1 | -1) {
-    const index = messages.findIndex((message) => message.id === current.id);
-    const nextIndex = Math.min(Math.max(index + direction, 0), messages.length - 1);
-    selectMessage(messages[nextIndex]);
   }
 
   return (
     <div className="min-h-screen pb-36 text-foreground" data-paused={paused}>
-      <VoiceHeader
-        waitingCount={queuedMessages.length}
-      />
+      <VoiceHeader waitingCount={queuedMessages.length} />
       <main className="mx-auto grid w-[calc(100%_-_2rem)] max-w-[45rem] gap-8">
         <NowPlaying
           message={current}
           position={position}
-          onPositionChange={setPosition}
-          onPrimaryAction={() => setPaused(false)}
+          onPositionChange={voiceActions.seek}
+          onPrimaryAction={() => void activate(current)}
         />
-        <VoiceQueue messages={queuedMessages} onSelect={selectMessage} />
+        <VoiceQueue messages={queuedMessages} onSelect={(message) => void activate(message)} />
       </main>
       <MiniTransport
         current={current}
         paused={paused}
         position={position}
         queueCount={queuedMessages.length}
-        onNext={() => step(1)}
-        onPositionChange={setPosition}
-        onPrevious={() => step(-1)}
-        onTogglePause={() => setPaused((value) => !value)}
+        onNext={() => void voiceActions.next()}
+        onPositionChange={voiceActions.seek}
+        onPrevious={() => void voiceActions.previous()}
+        onTogglePause={() => {
+          if (paused) {
+            void voiceActions.play(current.id);
+          } else {
+            void voiceActions.pause();
+          }
+        }}
       />
     </div>
   );
+}
+
+function activate(message: VoiceMessage) {
+  return message.intent === "converse"
+    ? voiceActions.respond(message.id)
+    : voiceActions.play(message.id);
 }

--- a/crates/voice-ui/web/src/state/react.ts
+++ b/crates/voice-ui/web/src/state/react.ts
@@ -1,0 +1,23 @@
+import { useMemo, useSyncExternalStore } from "react";
+import type { Observable, Subscription } from "rxjs";
+import { voiceStore } from "./voice-store";
+import type { VoiceUiState } from "@/types";
+
+export function useVoiceSelector<T>(selector: (state: VoiceUiState) => T): T {
+  const selected$ = useMemo(() => voiceStore.select(selector), [selector]);
+
+  return useSyncExternalStore(
+    (onStoreChange) => subscribe(selected$, onStoreChange),
+    () => selector(voiceStore.snapshot()),
+    () => selector(voiceStore.snapshot()),
+  );
+}
+
+function subscribe<T>(observable: Observable<T>, onStoreChange: () => void) {
+  let subscription: Subscription | undefined;
+  subscription = observable.subscribe(() => {
+    onStoreChange();
+  });
+
+  return () => subscription?.unsubscribe();
+}

--- a/crates/voice-ui/web/src/state/voice-bridge.ts
+++ b/crates/voice-ui/web/src/state/voice-bridge.ts
@@ -1,0 +1,200 @@
+import { voiceStore } from "./voice-store";
+import type { UiCommandResult, UiEvent, UiSnapshot } from "@/types";
+
+const SNAPSHOT_ENDPOINT = "/api/ui/snapshot";
+const EVENTS_ENDPOINT = "/api/ui/events";
+const COMMAND_ENDPOINT = "/api/ui/commands";
+
+class VoiceBridge {
+  private eventSource: EventSource | null = null;
+  private generation = 0;
+  private readonly audio = new Audio();
+
+  constructor() {
+    this.audio.addEventListener("timeupdate", () => {
+      voiceStore.setPosition(this.audio.currentTime);
+    });
+    this.audio.addEventListener("ended", () => {
+      void this.command("next");
+    });
+  }
+
+  start() {
+    const generation = ++this.generation;
+    void this.bootstrap(generation);
+  }
+
+  stop() {
+    this.generation += 1;
+    this.eventSource?.close();
+    this.eventSource = null;
+    this.audio.pause();
+  }
+
+  async play(trackId?: string) {
+    const result = await this.command("play", trackId);
+    if (result.ok) {
+      await this.playCurrentPrompt();
+    }
+    return result;
+  }
+
+  async respond(trackId?: string) {
+    return this.command("respond", trackId);
+  }
+
+  async pause() {
+    this.audio.pause();
+    return this.command("pause");
+  }
+
+  async next() {
+    const result = await this.command("next");
+    if (result.ok) {
+      await this.playCurrentPrompt();
+    }
+    return result;
+  }
+
+  async previous() {
+    const result = await this.command("previous");
+    if (result.ok) {
+      await this.playCurrentPrompt();
+    }
+    return result;
+  }
+
+  async cancel(trackId?: string) {
+    return this.command("cancel", trackId);
+  }
+
+  async clearRecent(trackId: string) {
+    return this.command("clear-recent", trackId);
+  }
+
+  seek(seconds: number) {
+    this.audio.currentTime = Math.max(0, seconds);
+    voiceStore.setPosition(this.audio.currentTime);
+  }
+
+  private async bootstrap(generation: number) {
+    try {
+      const response = await fetch(SNAPSHOT_ENDPOINT, {
+        headers: { accept: "application/json" },
+      });
+      if (!response.ok) {
+        throw new Error(`snapshot failed: ${response.status}`);
+      }
+      const snapshot = (await response.json()) as UiSnapshot;
+      if (generation !== this.generation) {
+        return;
+      }
+      voiceStore.applySnapshot(snapshot);
+      this.connectEvents(generation);
+    } catch (error) {
+      if (generation === this.generation) {
+        voiceStore.setConnection(false, error instanceof Error ? error.message : String(error));
+        window.setTimeout(() => {
+          if (generation === this.generation) {
+            void this.bootstrap(generation);
+          }
+        }, 1_500);
+      }
+    }
+  }
+
+  private connectEvents(generation: number) {
+    this.eventSource?.close();
+    const source = new EventSource(EVENTS_ENDPOINT);
+    this.eventSource = source;
+
+    source.onopen = () => {
+      if (generation === this.generation) {
+        voiceStore.setConnection(true);
+      }
+    };
+
+    source.onerror = () => {
+      source.close();
+      if (generation === this.generation) {
+        voiceStore.setConnection(false, "event stream disconnected");
+        window.setTimeout(() => {
+          if (generation === this.generation) {
+            void this.bootstrap(generation);
+          }
+        }, 1_500);
+      }
+    };
+
+    for (const eventName of [
+      "snapshot",
+      "track_upserted",
+      "track_removed",
+      "active_changed",
+      "transport_changed",
+      "command_result",
+      "error",
+    ]) {
+      source.addEventListener(eventName, (event) => {
+        if (generation !== this.generation) {
+          return;
+        }
+        try {
+          voiceStore.applyEvent(JSON.parse((event as MessageEvent).data) as UiEvent);
+        } catch (error) {
+          voiceStore.setConnection(true, error instanceof Error ? error.message : String(error));
+        }
+      });
+    }
+  }
+
+  private async command(command: string, trackId?: string): Promise<UiCommandResult> {
+    const response = await fetch(`${COMMAND_ENDPOINT}/${command}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ trackId }),
+    });
+    if (!response.ok) {
+      return {
+        command,
+        ok: false,
+        trackId,
+        message: `command failed: ${response.status}`,
+      };
+    }
+    const result = (await response.json()) as UiCommandResult;
+    if (!result.ok && result.message) {
+      voiceStore.applyEvent({ type: "error", payload: { message: result.message } });
+    }
+    return result;
+  }
+
+  private async playCurrentPrompt() {
+    const state = voiceStore.snapshot();
+    const trackId = state.currentId;
+    const track = trackId ? state.snapshot.tracks[trackId] : undefined;
+    const promptUrl = track?.audio.promptUrl;
+    if (!promptUrl) {
+      return;
+    }
+
+    if (!this.audio.src.endsWith(promptUrl)) {
+      this.audio.src = promptUrl;
+      this.audio.currentTime = 0;
+    }
+    await this.audio.play();
+  }
+}
+
+export const voiceBridge = new VoiceBridge();
+
+export const voiceActions = {
+  play: (trackId?: string) => voiceBridge.play(trackId),
+  respond: (trackId?: string) => voiceBridge.respond(trackId),
+  pause: () => voiceBridge.pause(),
+  next: () => voiceBridge.next(),
+  previous: () => voiceBridge.previous(),
+  cancel: (trackId?: string) => voiceBridge.cancel(trackId),
+  clearRecent: (trackId: string) => voiceBridge.clearRecent(trackId),
+  seek: (seconds: number) => voiceBridge.seek(seconds),
+};

--- a/crates/voice-ui/web/src/state/voice-store.ts
+++ b/crates/voice-ui/web/src/state/voice-store.ts
@@ -1,0 +1,257 @@
+import { BehaviorSubject, Observable } from "rxjs";
+import { distinctUntilChanged, map } from "rxjs/operators";
+import { voiceMessages } from "@/data";
+import type {
+  TranscriptionSegment,
+  UiEvent,
+  UiSnapshot,
+  UiTrack,
+  UiTransport,
+  VoiceMessage,
+  VoiceState,
+  VoiceUiState,
+} from "@/types";
+
+const EMPTY_SNAPSHOT: UiSnapshot = {
+  connected: false,
+  ready: false,
+  daemonStatus: "disconnected",
+  transport: {
+    state: "idle",
+    paused: true,
+    positionSeconds: 0,
+  },
+  activeTrackId: null,
+  queueIds: [],
+  recentIds: [],
+  tracks: {},
+};
+
+const initialState: VoiceUiState = {
+  connected: false,
+  ready: false,
+  snapshot: EMPTY_SNAPSHOT,
+  messages: voiceMessages,
+  currentId: voiceMessages[0]?.id,
+  positionSeconds: voiceMessages[0]?.positionSeconds ?? 0,
+  paused: true,
+};
+
+export class VoiceStore {
+  private readonly stateSubject = new BehaviorSubject<VoiceUiState>(initialState);
+
+  readonly state$ = this.stateSubject.asObservable();
+
+  snapshot() {
+    return this.stateSubject.value;
+  }
+
+  select<T>(selector: (state: VoiceUiState) => T): Observable<T> {
+    return this.state$.pipe(map(selector), distinctUntilChanged());
+  }
+
+  applySnapshot(snapshot: UiSnapshot) {
+    this.publish(fromSnapshot(snapshot, this.snapshot()));
+  }
+
+  applyEvent(event: UiEvent) {
+    const state = this.snapshot();
+    switch (event.type) {
+      case "snapshot":
+        this.applySnapshot(event.payload);
+        break;
+      case "track_upserted": {
+        const snapshot = {
+          ...state.snapshot,
+          tracks: {
+            ...state.snapshot.tracks,
+            [event.payload.id]: event.payload,
+          },
+        };
+        this.applySnapshot(snapshot);
+        break;
+      }
+      case "track_removed": {
+        const { [event.payload.id]: _removed, ...tracks } = state.snapshot.tracks;
+        this.applySnapshot({
+          ...state.snapshot,
+          tracks,
+          queueIds: state.snapshot.queueIds.filter((id) => id !== event.payload.id),
+          recentIds: state.snapshot.recentIds.filter((id) => id !== event.payload.id),
+          activeTrackId:
+            state.snapshot.activeTrackId === event.payload.id
+              ? null
+              : state.snapshot.activeTrackId,
+        });
+        break;
+      }
+      case "active_changed":
+        this.applySnapshot({
+          ...state.snapshot,
+          activeTrackId: event.payload.activeTrackId ?? null,
+        });
+        break;
+      case "transport_changed":
+        this.applySnapshot({
+          ...state.snapshot,
+          transport: event.payload,
+        });
+        break;
+      case "command_result":
+        if (!event.payload.ok) {
+          this.publish({ ...state, error: event.payload.message ?? "Command failed" });
+        }
+        break;
+      case "error":
+        this.publish({ ...state, error: event.payload.message });
+        break;
+    }
+  }
+
+  setConnection(connected: boolean, error?: string) {
+    const state = this.snapshot();
+    this.publish({
+      ...state,
+      connected,
+      ready: connected && state.ready,
+      error,
+      snapshot: {
+        ...state.snapshot,
+        connected,
+        ready: connected && state.snapshot.ready,
+      },
+    });
+  }
+
+  setPosition(seconds: number) {
+    const state = this.snapshot();
+    this.publish({
+      ...state,
+      positionSeconds: Math.max(0, seconds),
+    });
+  }
+
+  private publish(state: VoiceUiState) {
+    this.stateSubject.next(state);
+  }
+}
+
+export const voiceStore = new VoiceStore();
+
+function fromSnapshot(snapshot: UiSnapshot, previous: VoiceUiState): VoiceUiState {
+  const messages = messagesFromSnapshot(snapshot);
+  const currentId =
+    snapshot.activeTrackId && snapshot.tracks[snapshot.activeTrackId]
+      ? snapshot.activeTrackId
+      : messages[0]?.id;
+  const current = messages.find((message) => message.id === currentId) ?? messages[0];
+  const sameTrack = previous.currentId === currentId;
+
+  return {
+    connected: snapshot.connected,
+    ready: snapshot.ready,
+    snapshot,
+    messages,
+    currentId,
+    positionSeconds: sameTrack
+      ? previous.positionSeconds
+      : current?.positionSeconds ?? snapshot.transport.positionSeconds,
+    paused: snapshot.transport.paused,
+  };
+}
+
+function messagesFromSnapshot(snapshot: UiSnapshot): VoiceMessage[] {
+  const ids = [
+    ...(snapshot.activeTrackId ? [snapshot.activeTrackId] : []),
+    ...snapshot.queueIds,
+    ...snapshot.recentIds,
+  ];
+  const seen = new Set<string>();
+
+  return ids
+    .filter((id) => {
+      if (seen.has(id)) {
+        return false;
+      }
+      seen.add(id);
+      return true;
+    })
+    .map((id) => snapshot.tracks[id])
+    .filter((track): track is UiTrack => Boolean(track))
+    .map(trackToMessage);
+}
+
+function trackToMessage(track: UiTrack): VoiceMessage {
+  const text = track.prompt || track.answer || "Voice message";
+  const durationSeconds = estimateDurationSeconds(text);
+
+  return {
+    id: track.id,
+    agentName: track.agent.name,
+    initial: track.agent.initial,
+    color: track.agent.color,
+    repo: track.agent.repo,
+    branch: track.agent.branch,
+    model: track.agent.model,
+    voice: track.agent.session || "daemon",
+    intent: track.intent === "respond" ? "converse" : "play",
+    state: voiceStateForTrack(track),
+    message: text,
+    transcript: transcriptForText(text, durationSeconds),
+    history: track.answer
+      ? [
+          {
+            id: `${track.id}-answer`,
+            speaker: "user",
+            label: "You",
+            at: track.completedAt ? new Date(track.completedAt * 1000).toISOString() : "",
+            text: track.answer,
+          },
+        ]
+      : [],
+    durationSeconds,
+    positionSeconds: 0,
+  };
+}
+
+function voiceStateForTrack(track: UiTrack): VoiceState {
+  switch (track.lifecycle) {
+    case "failed":
+    case "skipped":
+      return "skipped";
+    case "active":
+    case "listening":
+    case "completed":
+      return "picked-up";
+    default:
+      return track.intent === "respond" ? "awaiting-user" : "queued";
+  }
+}
+
+function transcriptForText(text: string, durationSeconds: number): TranscriptionSegment[] {
+  const sentences = splitSentences(text);
+  const segmentDuration = durationSeconds / sentences.length;
+
+  return sentences.map((sentence, index) => ({
+    startSecond: Math.round(index * segmentDuration),
+    endSecond:
+      index === sentences.length - 1
+        ? durationSeconds
+        : Math.max(Math.round((index + 1) * segmentDuration), index + 1),
+    text: sentence,
+  }));
+}
+
+function splitSentences(text: string): string[] {
+  const matches = text.match(/[^.!?]+[.!?]?/g)?.map((item) => item.trim()).filter(Boolean);
+  return matches && matches.length > 0 ? matches : [text || "Voice message"];
+}
+
+function estimateDurationSeconds(text: string): number {
+  const words = text.trim().split(/\s+/).filter(Boolean).length;
+  return Math.min(Math.max(Math.ceil(words * 0.55), 6), 45);
+}
+
+export function transportPosition(transport: UiTransport) {
+  return transport.positionSeconds;
+}

--- a/crates/voice-ui/web/src/types.ts
+++ b/crates/voice-ui/web/src/types.ts
@@ -33,6 +33,89 @@ export interface VoiceMessage {
   positionSeconds: number;
 }
 
+export type UiIntent = "play" | "respond";
+export type UiLifecycle =
+  | "queued"
+  | "preparing"
+  | "ready"
+  | "active"
+  | "listening"
+  | "completed"
+  | "failed"
+  | "skipped";
+export type UiTransportState = "idle" | "playing" | "paused" | "listening";
+
+export interface UiAgent {
+  name: string;
+  initial: string;
+  color: string;
+  repo: string;
+  branch: string;
+  model: string;
+  session: string;
+}
+
+export interface UiAudio {
+  promptUrl?: string | null;
+  answerUrl?: string | null;
+}
+
+export interface UiTrack {
+  id: string;
+  agent: UiAgent;
+  intent: UiIntent;
+  lifecycle: UiLifecycle;
+  prompt: string;
+  answer?: string | null;
+  audio: UiAudio;
+  createdAt: number;
+  completedAt?: number | null;
+}
+
+export interface UiTransport {
+  state: UiTransportState;
+  paused: boolean;
+  positionSeconds: number;
+}
+
+export interface UiSnapshot {
+  connected: boolean;
+  ready: boolean;
+  daemonStatus: string;
+  transport: UiTransport;
+  activeTrackId?: string | null;
+  queueIds: string[];
+  recentIds: string[];
+  tracks: Record<string, UiTrack>;
+}
+
+export type UiEvent =
+  | { type: "snapshot"; payload: UiSnapshot }
+  | { type: "track_upserted"; payload: UiTrack }
+  | { type: "track_removed"; payload: { id: string } }
+  | { type: "active_changed"; payload: { activeTrackId?: string | null } }
+  | { type: "transport_changed"; payload: UiTransport }
+  | { type: "command_result"; payload: UiCommandResult }
+  | { type: "error"; payload: { message: string } };
+
+export interface UiCommandResult {
+  command: string;
+  ok: boolean;
+  trackId?: string | null;
+  message?: string | null;
+}
+
+export interface VoiceUiState {
+  connected: boolean;
+  ready: boolean;
+  error?: string;
+  snapshot: UiSnapshot;
+  messages: VoiceMessage[];
+  currentId?: string;
+  positionSeconds: number;
+  paused: boolean;
+}
+
 export type DaemonItemStatus = "queued" | "processing" | "completed" | "failed";
 
 export interface DaemonQueueItem {

--- a/crates/voice-ui/web/src/types.ts
+++ b/crates/voice-ui/web/src/types.ts
@@ -123,6 +123,7 @@ export interface DaemonQueueItem {
   client_id: string;
   method: string;
   status: DaemonItemStatus;
+  held_for_ui?: boolean;
   created_at: number;
   text_preview?: string;
   result?: string;

--- a/docs/daemon-ui-goal.md
+++ b/docs/daemon-ui-goal.md
@@ -1,0 +1,65 @@
+# Daemon-backed Voice UI goal
+
+## Outcome
+
+Make draft PR #288 a working daemon-backed Voice UI integration. The daemon should serve the embedded app, expose UI state over HTTP and SSE, accept UI commands, keep playlist state outside React, and support enough end-to-end playback and response flow that the UI can be exercised without mock data.
+
+## Baseline
+
+Commit `8eebdf1` adds the first bridge: embedded assets, snapshot/events endpoints, command stubs, audio URLs, and an RxJS frontend store. Local checks and GitHub checks pass. The deeper mailbox behavior is incomplete: response commands only enter listening state, held prompt synthesis is not fully modeled, and there is no non-human E2E path for answer recording/transcription.
+
+## Constraints
+
+- Keep PR #288 draft until the integration is genuinely usable.
+- Preserve the legacy Unix socket/CLI path unless a focused compatibility change is needed.
+- The browser UI uses HTTP POST commands plus SSE state; do not make React own daemon state again.
+- Browser playback should use served WAVs so seek/rewind/pause are real media controls.
+- Do not require a human at the microphone for automated E2E. Use synthetic WAV input or a daemon test hook when needed.
+- Do not weaken existing tests, replace real protocol checks with mocks, or hide failures by narrowing the verifier.
+
+## Non-goals
+
+- Public deployment or production release.
+- Browser-side Automerge sync.
+- Rebuilding the visual design unless a behavior requires a small UI affordance.
+- Removing the legacy socket protocol wholesale in this slice.
+
+## Primary verifier
+
+An automated daemon/UI flow can start the daemon or an in-memory UI server, create at least one real UI track, observe it through `/api/ui/snapshot` and `/api/ui/events`, play prompt audio via `/api/ui/audio/...`, issue response-oriented commands, and end with state that matches a fresh snapshot. The verifier should run without a live microphone.
+
+## Supporting checks
+
+- `cargo test -p voice-daemon -p voice-protocol -p voice-ui`
+- `cargo check -p voice-daemon`
+- `npm run build` and `npm run check` in `crates/voice-ui`
+- `cargo fmt --check`
+- `git diff --check`
+- PR #288 checks remain green.
+
+## Iteration loop
+
+1. Inspect the smallest daemon/UI seam that blocks the primary verifier.
+2. Change one meaningful behavior: queue semantics, command execution, SSE state, audio serving, frontend bridge, or tests.
+3. Run the narrowest failing verifier first, then the supporting checks before committing.
+4. Record evidence and remaining gaps in `docs/daemon-ui-worklog.md`.
+5. Keep the PR draft unless the completion proof is satisfied.
+
+## Approval gates
+
+- Ask before marking PR #288 ready for review.
+- Ask before merging, force-pushing, deleting branches, or changing persistent user daemon files outside test-scoped paths.
+- Ask before introducing a major new runtime dependency or replacing the daemon protocol outside the UI surface.
+
+## Blocker standard
+
+Only mark blocked after the same external condition prevents progress for three consecutive goal turns and no smaller local verifier or implementation slice remains. Missing live microphone access is not a blocker; use synthetic/file-based audio paths.
+
+## Completion proof
+
+Before marking the goal complete, record:
+
+- The commit range and PR URL.
+- Exact commands and passing outputs for all supporting checks.
+- Evidence from the primary verifier, including request/track IDs and snapshot/event agreement.
+- A short list of residual risks, if any.

--- a/docs/daemon-ui-worklog.md
+++ b/docs/daemon-ui-worklog.md
@@ -36,3 +36,14 @@
   - `cargo test -p voice-daemon`
 - Remaining gap: need full supporting checks after this slice.
 - Remaining gap: no live microphone manual verification yet; automated no-mic path covers HTTP snapshot/command/audio behavior.
+
+## 2026-06-24 MCP default-held slice
+
+- Added `DaemonClient::speak_with_options_held_for_ui` and `DaemonClient::converse_held_for_ui`.
+- Added protocol tests that the held helpers send `wait: false` and `ui_hold: true`.
+- MCP `speak` and `converse` now default to held UI playlist items when connected to the daemon.
+- Added `immediate: true` to MCP tool schemas to preserve old immediate daemon playback/listen behavior.
+- Passing checks:
+  - `cargo test -p voice-protocol`
+  - `cargo check -p voice`
+- Remaining gap: need full supporting checks after this slice.

--- a/docs/daemon-ui-worklog.md
+++ b/docs/daemon-ui-worklog.md
@@ -24,3 +24,15 @@
   - `npm run build` in `crates/voice-ui`
 - Remaining gap: production `respond` still needs daemon-owned native mic/STT completion instead of only the test response path.
 - Remaining gap: held prompt audio still depends on pre-existing question WAVs or future synthesis wiring; the worker does not yet prepare prompt WAVs for held tracks automatically.
+
+## 2026-06-24 prompt and native-response slice
+
+- Added hidden internal UI worker id `__voice_ui_internal` and filtered it out of UI snapshots so implementation jobs do not show up as playlist entries.
+- `ui_hold` socket requests for `speak` and `converse` now enqueue a hidden `Synthesize` job to write `~/.voice/audio/<track>-q.wav` without daemon autoplay.
+- Production `respond` now starts a hidden internal `Listen` job through the existing worker. When STT completes, it copies the answer WAV from the internal listen id to the held track id and completes or fails the held track.
+- Kept the `VOICE_UI_TEST_RESPONSE_TEXT` path for no-mic automated E2E.
+- Added projection coverage that hidden internal worker entries are not rendered in UI snapshots.
+- Passing check:
+  - `cargo test -p voice-daemon`
+- Remaining gap: need full supporting checks after this slice.
+- Remaining gap: no live microphone manual verification yet; automated no-mic path covers HTTP snapshot/command/audio behavior.

--- a/docs/daemon-ui-worklog.md
+++ b/docs/daemon-ui-worklog.md
@@ -1,0 +1,26 @@
+# Daemon-backed Voice UI worklog
+
+## 2026-06-24
+
+- Baseline: branch `quod/daemon-backed-voice-ui`, draft PR #288, commit `8eebdf1`.
+- Local checks before goal activation passed: `npm run build`, `npm run check`, `cargo check -p voice-daemon`, `cargo test -p voice-daemon -p voice-protocol -p voice-ui`, `cargo fmt --check`, `git diff --check`.
+- GitHub checks before goal activation passed: `check`, `sidecar-python`, `python-helpers`.
+- Known gap: UI `respond` command currently changes transport state only. It does not record/transcribe and attach answer state to the selected track.
+- Known gap: UI playlist entries are projected from the legacy queue/recent state. Agent submissions are not yet fully held/synthesized into prompt WAVs without autoplay.
+- Next action: add daemon-side UI track mechanics and a no-mic verifier for prompt/answer audio state.
+
+## 2026-06-24 held-track slice
+
+- Added `held_for_ui` to protocol queue items and daemon queue entries. Old snapshots deserialize with the default `false`.
+- Added `RequestQueue::enqueue_ui_held`; worker `dequeue` skips held entries so mailbox tracks stay visible until command handling moves them.
+- Added `RequestQueue::complete_held_item` to move a held response track into recent history with a stored result.
+- Added explicit socket `ui_hold` support for non-waiting `speak`, `listen`, and `converse` requests. Existing CLI requests are unchanged because they do not send `ui_hold`.
+- Added `VOICE_AUDIO_DIR` override for isolated tests and local E2E.
+- Added env-gated no-mic response completion through `VOICE_UI_TEST_RESPONSE_TEXT`; normal `respond` still enters listening state.
+- Added in-process HTTP verifier: snapshot -> POST `/api/ui/commands/respond` -> snapshot -> GET `/api/ui/audio/:track_id/answer`.
+- Passing checks:
+  - `cargo test -p voice-daemon -p voice-protocol -p voice-ui`
+  - `npm run check` in `crates/voice-ui`
+  - `npm run build` in `crates/voice-ui`
+- Remaining gap: production `respond` still needs daemon-owned native mic/STT completion instead of only the test response path.
+- Remaining gap: held prompt audio still depends on pre-existing question WAVs or future synthesis wiring; the worker does not yet prepare prompt WAVs for held tracks automatically.

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -5,6 +5,10 @@ The `voice` CLI still works without it: `voice say -o output.wav ...` falls
 back to local synthesis, `voice mcp` initializes without a daemon, and
 `voice stream` requires a running daemon.
 
+The daemon also serves the local Voice UI at <http://127.0.0.1:8767/> by
+default. Override the bind address with `VOICE_UI_ADDR`, for example
+`VOICE_UI_ADDR=127.0.0.1:9876 voice daemon start`.
+
 Use the fast verifier when changing CLI, MCP, or daemon detection behavior:
 
 ```bash


### PR DESCRIPTION
## Summary

- serve the embedded Voice UI from `voice daemon start` at `127.0.0.1:8767`
- add UI-facing snapshot, SSE, command, and audio routes beside the legacy Unix socket protocol
- move browser playlist state into an RxJS-backed external store with a React `useSyncExternalStore` adapter

## Verification

- `npm run build` in `crates/voice-ui`
- `npm run check` in `crates/voice-ui`
- `cargo check -p voice-daemon`
- `cargo fmt --check`
- `cargo test -p voice-daemon -p voice-protocol -p voice-ui`

## Notes

- The UI protocol is intentionally separate from the existing daemon frame/RPC protocol.
- Browser playback uses served WAV URLs when available, so the UI can own pause and seeking.
- Existing CLI/MCP daemon behavior remains wired through the legacy socket path.
