### PR TITLE
Tighten Voice UI playback state

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 # voice — TTS & STT tool for AI agents
 
-`voice` speaks text aloud using Kokoro TTS and transcribes speech using Moonshine STT on Apple Silicon. Use it to talk to your user, listen for their response, or run a full voice conversation loop.
+`voice` speaks text aloud using Kokoro or Voxtral TTS and transcribes speech with Whisper STT on Apple Silicon. Prefer the daemon-backed UI queue for agent messages: MCP `speak` and `converse` requests are held in the Voice UI by default, while CLI `voice say` and `voice converse` remain immediate user-facing commands.
 
 ## Quick reference
 
@@ -36,6 +36,26 @@ voice converse "How are you today?"
 voice converse -v am_michael -s 1.2 "What do you think about that?"
 ```
 
+### Daemon UI queue
+
+```bash
+# Start the daemon locally. Without --tts-only it eagerly loads TTS and STT.
+voice daemon start
+
+# Inspect queued, current, and recent daemon items.
+voice daemon status
+voice daemon status --json
+
+# Open the browser UI served by the daemon.
+open http://127.0.0.1:8767/
+
+# Replay audio saved for a UI queue item.
+voice daemon replay --part question <queue_id>
+voice daemon replay --part answer <queue_id>
+```
+
+For agents, use `voice mcp`. Its `speak` and `converse` tools enqueue held UI messages unless `immediate=true` is supplied. Use held messages when the user should decide when to listen or respond; use `immediate=true` only for intentional interruption or direct playback.
+
 ### Listen (STT)
 
 ```bash
@@ -49,35 +69,33 @@ voice listen --continuous
 voice transcribe recording.wav
 ```
 
-### JSON-RPC server
+### MCP server
 
 ```bash
-# Start the server (for programmatic control)
-voice serve -v am_michael
+# Start the MCP server for agent integration.
+voice mcp
 ```
 
 ```jsonl
-# Speak
-→ {"jsonrpc":"2.0","method":"speak","params":{"text":"Hello"},"id":1}
-← {"jsonrpc":"2.0","result":{"duration_ms":1800,"chunks":1},"id":1}
+# Queue a held UI playback item.
+→ {"jsonrpc":"2.0","method":"tools/call","params":{"name":"speak","arguments":{"text":"Build finished."}},"id":1}
 
-# Listen (ding plays, records, auto-stops on silence)
-→ {"jsonrpc":"2.0","method":"listen","id":2}
-← {"jsonrpc":"2.0","result":{"text":"I heard you","tokens":4,"duration_ms":3200},"id":2}
+# Queue a held UI item that needs the user to respond.
+→ {"jsonrpc":"2.0","method":"tools/call","params":{"name":"converse","arguments":{"text":"Should I open the PR?"}},"id":2}
 
-# Cancel current playback or recording
-→ {"jsonrpc":"2.0","method":"cancel","id":3}
-
-# Other methods: set_voice, set_speed, list_voices, ping
+# Play immediately instead of queueing.
+→ {"jsonrpc":"2.0","method":"tools/call","params":{"name":"speak","arguments":{"text":"Urgent interrupt.","immediate":true}},"id":3}
 ```
 
 ## When to use
 
-- **Get attention**: Speak when a long task finishes, a build fails, or you need input
-- **Read content**: Pipe text through `voice say` to read back docs, errors, or summaries
+- **Leave a message**: Use MCP `speak` to add a held item to the daemon UI queue
+- **Ask for input**: Use MCP `converse` to add a response-needed item to the daemon UI queue
+- **Get attention immediately**: Use `immediate=true` only when interruption is intended
+- **Read content locally**: Pipe text through `voice say` to read back docs, errors, or summaries
 - **Confirm actions**: "Deploying to production" before doing something irreversible
 - **Listen for input**: Use `voice listen` to capture a spoken response from the user
-- **Voice conversation**: Use `voice converse` to speak then listen in one shot, or `voice serve` for programmatic control
+- **Voice conversation**: Use `voice converse` for a foreground CLI speak/listen turn
 - **Transcribe recordings**: Use `voice transcribe` to convert audio files to text
 
 ## Tips
@@ -96,16 +114,16 @@ voice serve -v am_michael
 - A ding sound plays when the mic is ready — wait for it before speaking
 - Bluetooth mics (AirPods) have ~0.5s latency; the ding helps you time it
 - Noise floor is calibrated automatically — works with MacBook mic or AirPods
-- Use `STT_MODEL=UsefulSensors/moonshine-tiny` for faster (but less accurate) transcription
-- Default model is `moonshine-base` (61M params, ~50× real-time on Apple Silicon)
+- Default model is `distil-whisper/distil-large-v3`
+- Use `STT_MODEL=distil-whisper/distil-medium.en` for a faster English-only fallback
 
-### JSON-RPC tips
+### Daemon/MCP tips
 
-- `voice serve` loads the TTS model at startup; STT model loads lazily on first `listen`
-- `cancel` interrupts the current speak or listen mid-operation
-- `speak` supports per-request `voice` and `speed` overrides without changing defaults
-- `listen` params are tunable: `noise_multiplier`, `calibration_ms`, `silence_timeout_ms`
-- Notifications (requests without `id`) are fire-and-forget — no response returned
+- `voice daemon start` eagerly loads TTS and STT. `voice daemon start --tts-only` skips eager STT load for lightweight servers.
+- The daemon serves the Voice UI at `http://127.0.0.1:8767/`.
+- MCP `speak` and `converse` default to held UI queue items.
+- Set MCP `immediate=true` to bypass the held UI queue and perform the action now.
+- Browser UI playback uses saved WAV files from `~/.voice/audio/<queue_id>-q.wav` and response audio from `~/.voice/audio/<queue_id>-a.wav`.
 
 ## Subcommands
 
@@ -117,7 +135,9 @@ voice serve -v am_michael
 | `voice listen` | Record from mic, transcribe once |
 | `voice listen --continuous` | Record and transcribe segments continuously |
 | `voice transcribe <file>` | Transcribe a WAV file |
-| `voice serve` | Start JSON-RPC server on stdin/stdout |
+| `voice mcp` | Start MCP server on stdin/stdout |
+| `voice daemon start` | Start daemon, socket API, and browser UI |
+| `voice daemon status` | Inspect daemon queue state |
 
 ## Builtin voices (no network)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,7 +11,7 @@
 voice Hello, I finished the task.
 
 # Explicit say subcommand with options
-voice say -v am_michael "Switching to a male voice."
+voice say -v af_sky "Switching to a brighter voice."
 
 # Speak from a pipe
 echo "Build complete." | voice say
@@ -33,7 +33,7 @@ voice say --phonemes "həlˈO wˈɜɹld"
 voice converse "How are you today?"
 
 # With voice and speed options
-voice converse -v am_michael -s 1.2 "What do you think about that?"
+voice converse -v af_sky -s 1.2 "What do you think about that?"
 ```
 
 ### Daemon UI queue

--- a/crates/voice-daemon/src/ui_server.rs
+++ b/crates/voice-daemon/src/ui_server.rs
@@ -467,9 +467,10 @@ impl UiServerState {
         let snapshot = self.snapshot().await;
         let mut ids = snapshot.queue_ids.clone();
         ids.extend(snapshot.recent_ids.iter().cloned());
+        let command = if direction > 0 { "next" } else { "previous" };
         if ids.is_empty() {
             return UiCommandResult {
-                command: if direction > 0 { "next" } else { "previous" }.to_string(),
+                command: command.to_string(),
                 ok: false,
                 track_id: None,
                 message: Some("no tracks available".to_string()),
@@ -481,11 +482,26 @@ impl UiServerState {
             .as_ref()
             .and_then(|id| ids.iter().position(|candidate| candidate == id))
             .unwrap_or(0);
-        let next_index = (current_index as isize + direction)
-            .clamp(0, ids.len().saturating_sub(1) as isize) as usize;
+        let next_index = current_index as isize + direction;
+        if next_index < 0 || next_index >= ids.len() as isize {
+            *self.transport.lock().await = UiTransport {
+                state: UiTransportState::Idle,
+                paused: true,
+                position_seconds: 0,
+            };
+            let _ = self.events.send(UiEvent::TransportChanged(
+                self.transport.lock().await.clone(),
+            ));
+            return UiCommandResult {
+                command: command.to_string(),
+                ok: false,
+                track_id: snapshot.active_track_id,
+                message: None,
+            };
+        }
         self.set_active(
-            if direction > 0 { "next" } else { "previous" },
-            Some(ids[next_index].clone()),
+            command,
+            Some(ids[next_index as usize].clone()),
             UiTransportState::Playing,
             false,
         )
@@ -728,6 +744,53 @@ mod tests {
         assert_eq!(
             snapshot.tracks[&track_id].lifecycle,
             crate::ui_state::UiLifecycle::Queued
+        );
+    }
+
+    #[tokio::test]
+    async fn next_at_queue_end_stops_instead_of_replaying_last_track() {
+        let queue = Arc::new(RequestQueue::new());
+        let (event_tx, _) = broadcast::channel(8);
+        let state = UiServerState {
+            queue: queue.clone(),
+            active_track_id: Arc::new(Mutex::new(None)),
+            active_response_listens: Arc::new(Mutex::new(BTreeMap::new())),
+            transport: Arc::new(Mutex::new(UiTransport {
+                state: UiTransportState::Idle,
+                paused: true,
+                position_seconds: 0,
+            })),
+            events: event_tx,
+        };
+        let track_id = queue
+            .enqueue_ui_held(
+                "codex".to_string(),
+                VoiceRequest::Speak {
+                    text: "Only track.".to_string(),
+                    voice: None,
+                    speed: None,
+                    options: TtsOptions::default(),
+                },
+            )
+            .await;
+        *state.active_track_id.lock().await = Some(track_id.clone());
+        *state.transport.lock().await = UiTransport {
+            state: UiTransportState::Playing,
+            paused: false,
+            position_seconds: 0,
+        };
+
+        let result = state.step(1).await;
+        assert!(!result.ok, "{result:?}");
+        assert_eq!(result.track_id.as_deref(), Some(track_id.as_str()));
+        assert_eq!(*state.active_track_id.lock().await, Some(track_id));
+        assert_eq!(
+            *state.transport.lock().await,
+            UiTransport {
+                state: UiTransportState::Idle,
+                paused: true,
+                position_seconds: 0,
+            }
         );
     }
 

--- a/crates/voice-daemon/src/ui_server.rs
+++ b/crates/voice-daemon/src/ui_server.rs
@@ -12,6 +12,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::Deserialize;
+use std::collections::BTreeMap;
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -24,6 +25,7 @@ use voice_protocol::rpc::ItemStatus;
 struct UiServerState {
     queue: Arc<RequestQueue>,
     active_track_id: Arc<Mutex<Option<String>>>,
+    active_response_listens: Arc<Mutex<BTreeMap<String, Option<String>>>>,
     transport: Arc<Mutex<UiTransport>>,
     events: broadcast::Sender<UiEvent>,
 }
@@ -48,6 +50,7 @@ pub async fn serve(queue: Arc<RequestQueue>) {
     let state = UiServerState {
         queue,
         active_track_id: Arc::new(Mutex::new(None)),
+        active_response_listens: Arc::new(Mutex::new(BTreeMap::new())),
         transport: Arc::new(Mutex::new(UiTransport {
             state: UiTransportState::Idle,
             paused: true,
@@ -337,6 +340,10 @@ impl UiServerState {
     }
 
     async fn start_microphone_response(&self, track_id: String) {
+        self.active_response_listens
+            .lock()
+            .await
+            .insert(track_id.clone(), None);
         let state = self.clone();
         tokio::spawn(async move {
             let (listen_id, completion_rx) = state
@@ -348,10 +355,33 @@ impl UiServerState {
                     },
                 )
                 .await;
+            let still_active = {
+                let mut active_listens = state.active_response_listens.lock().await;
+                if let Some(active_listen_id) = active_listens.get_mut(&track_id) {
+                    *active_listen_id = Some(listen_id.clone());
+                    true
+                } else {
+                    false
+                }
+            };
+            if !still_active {
+                let _ = state.queue.cancel_item(&listen_id).await;
+                state.set_response_transport_idle().await;
+                state.broadcast_snapshot().await;
+                return;
+            }
             state.broadcast_snapshot().await;
 
             let finish = match completion_rx.await {
                 Ok(completion) => {
+                    if !state
+                        .take_active_response_listen(&track_id, &listen_id)
+                        .await
+                    {
+                        state.set_response_transport_idle().await;
+                        state.broadcast_snapshot().await;
+                        return;
+                    }
                     if completion.status == ItemStatus::Completed {
                         let _ = copy_answer_audio(&listen_id, &track_id).await;
                         state
@@ -366,6 +396,14 @@ impl UiServerState {
                     }
                 }
                 Err(_) => {
+                    if !state
+                        .take_active_response_listen(&track_id, &listen_id)
+                        .await
+                    {
+                        state.set_response_transport_idle().await;
+                        state.broadcast_snapshot().await;
+                        return;
+                    }
                     state
                         .queue
                         .fail_held_item(
@@ -377,14 +415,31 @@ impl UiServerState {
             };
 
             if finish {
-                *state.transport.lock().await = UiTransport {
-                    state: UiTransportState::Idle,
-                    paused: true,
-                    position_seconds: 0,
-                };
+                state.set_response_transport_idle().await;
                 state.broadcast_snapshot().await;
             }
         });
+    }
+
+    async fn take_active_response_listen(&self, track_id: &str, listen_id: &str) -> bool {
+        let mut active_listens = self.active_response_listens.lock().await;
+        let Some(Some(active_listen_id)) = active_listens.get(track_id) else {
+            return false;
+        };
+        if active_listen_id != listen_id {
+            return false;
+        }
+        active_listens.remove(track_id);
+        true
+    }
+
+    async fn set_response_transport_idle(&self) {
+        *self.active_track_id.lock().await = None;
+        *self.transport.lock().await = UiTransport {
+            state: UiTransportState::Idle,
+            paused: true,
+            position_seconds: 0,
+        };
     }
 
     async fn set_transport(
@@ -452,6 +507,23 @@ impl UiServerState {
                 message: Some("no active track".to_string()),
             };
         };
+
+        let response_listen_id = self.active_response_listens.lock().await.remove(&track_id);
+        if let Some(response_listen_id) = response_listen_id {
+            let listen_cancelled = if let Some(response_listen_id) = response_listen_id {
+                self.queue.cancel_item(&response_listen_id).await
+            } else {
+                true
+            };
+            self.set_response_transport_idle().await;
+            self.broadcast_snapshot().await;
+            return UiCommandResult {
+                command: "cancel".to_string(),
+                ok: listen_cancelled,
+                track_id: Some(track_id),
+                message: None,
+            };
+        }
 
         let ok = self.queue.cancel_item(&track_id).await;
         UiCommandResult {
@@ -550,6 +622,7 @@ mod tests {
         let state = UiServerState {
             queue: queue.clone(),
             active_track_id: Arc::new(Mutex::new(None)),
+            active_response_listens: Arc::new(Mutex::new(BTreeMap::new())),
             transport: Arc::new(Mutex::new(UiTransport {
                 state: UiTransportState::Idle,
                 paused: true,
@@ -594,6 +667,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancel_response_listen_keeps_visible_track_queued() {
+        let queue = Arc::new(RequestQueue::new());
+        let (event_tx, _) = broadcast::channel(8);
+        let state = UiServerState {
+            queue: queue.clone(),
+            active_track_id: Arc::new(Mutex::new(None)),
+            active_response_listens: Arc::new(Mutex::new(BTreeMap::new())),
+            transport: Arc::new(Mutex::new(UiTransport {
+                state: UiTransportState::Idle,
+                paused: true,
+                position_seconds: 0,
+            })),
+            events: event_tx,
+        };
+        let track_id = queue
+            .enqueue_ui_held(
+                "codex".to_string(),
+                VoiceRequest::Converse {
+                    text: "Should I keep listening?".to_string(),
+                    voice: None,
+                    max_duration_ms: None,
+                    options: TtsOptions::default(),
+                },
+            )
+            .await;
+        let (listen_id, completion_rx) = queue
+            .enqueue_and_wait(
+                UI_INTERNAL_CLIENT_ID.to_string(),
+                VoiceRequest::Listen {
+                    max_duration_ms: Some(1_000),
+                },
+            )
+            .await;
+        *state.active_track_id.lock().await = Some(track_id.clone());
+        *state.transport.lock().await = UiTransport {
+            state: UiTransportState::Listening,
+            paused: false,
+            position_seconds: 0,
+        };
+        state
+            .active_response_listens
+            .lock()
+            .await
+            .insert(track_id.clone(), Some(listen_id));
+
+        let result = state.cancel(Some(track_id.clone())).await;
+        assert!(result.ok, "{result:?}");
+
+        let completion = tokio::time::timeout(Duration::from_secs(1), completion_rx)
+            .await
+            .expect("listen cancellation should signal waiter")
+            .expect("listen waiter should receive cancellation");
+        assert_eq!(completion.status, ItemStatus::Failed);
+
+        let snapshot = state.snapshot().await;
+        assert_eq!(snapshot.active_track_id, None);
+        assert_eq!(snapshot.transport.state, UiTransportState::Idle);
+        assert_eq!(snapshot.queue_ids, vec![track_id.clone()]);
+        assert_eq!(
+            snapshot.tracks[&track_id].lifecycle,
+            crate::ui_state::UiLifecycle::Queued
+        );
+    }
+
+    #[tokio::test]
     async fn http_snapshot_command_and_audio_round_trip_without_microphone() {
         let _guard = ENV_LOCK.lock().unwrap();
         let audio_dir = std::env::temp_dir().join(format!(
@@ -611,6 +749,7 @@ mod tests {
         let state = UiServerState {
             queue: queue.clone(),
             active_track_id: Arc::new(Mutex::new(None)),
+            active_response_listens: Arc::new(Mutex::new(BTreeMap::new())),
             transport: Arc::new(Mutex::new(UiTransport {
                 state: UiTransportState::Idle,
                 paused: true,

--- a/crates/voice-ui/web/src/App.tsx
+++ b/crates/voice-ui/web/src/App.tsx
@@ -17,6 +17,9 @@ export default function App() {
   const currentId = useVoiceSelector((state) => state.currentId);
   const position = useVoiceSelector((state) => state.positionSeconds);
   const paused = useVoiceSelector((state) => state.paused);
+  const connected = useVoiceSelector((state) => state.connected);
+  const ready = useVoiceSelector((state) => state.ready);
+  const error = useVoiceSelector((state) => state.error);
 
   const current = messages.find((message) => message.id === currentId) ?? messages[0];
   const queuedMessages = current
@@ -29,7 +32,9 @@ export default function App() {
         <VoiceHeader waitingCount={0} />
         <main className="mx-auto grid w-[calc(100%_-_2rem)] max-w-[45rem] gap-8">
           <section className="rounded-lg border border-border bg-card p-5 text-muted-foreground">
-            Waiting for daemon state.
+            {connected && ready
+              ? "No voice messages."
+              : error ?? "Waiting for daemon state."}
           </section>
         </main>
       </div>

--- a/crates/voice-ui/web/src/App.tsx
+++ b/crates/voice-ui/web/src/App.tsx
@@ -74,6 +74,10 @@ export default function App() {
 }
 
 function activate(message: VoiceMessage) {
+  if (message.state === "listening") {
+    return voiceActions.cancel(message.id);
+  }
+
   return message.intent === "converse"
     ? voiceActions.respond(message.id)
     : voiceActions.play(message.id);

--- a/crates/voice-ui/web/src/components/voice/mini-transport.tsx
+++ b/crates/voice-ui/web/src/components/voice/mini-transport.tsx
@@ -25,6 +25,17 @@ export function MiniTransport({
   onPrevious: () => void;
   onTogglePause: () => void;
 }) {
+  const promptFinished = current.intent === "converse" && position >= current.durationSeconds;
+  const status = current.state === "listening"
+    ? "listening"
+    : promptFinished
+      ? "response needed"
+      : paused
+        ? "paused"
+        : current.intent === "converse"
+          ? "response needed"
+          : "playing";
+
   return (
     <footer
       className="fixed bottom-0 left-1/2 z-20 grid w-[calc(100%_-_2rem)] max-w-[45rem] -translate-x-1/2 grid-cols-[minmax(0,1fr)_minmax(16rem,21rem)_minmax(0,1fr)] items-center gap-4 rounded-t-lg border border-b-0 border-border bg-background/85 px-4 py-3 shadow-2xl backdrop-blur supports-[backdrop-filter]:bg-background/75 max-sm:grid-cols-1"
@@ -73,13 +84,7 @@ export function MiniTransport({
         </div>
       </div>
       <div className="relative justify-self-end text-right max-sm:hidden">
-        <strong className="block text-sm text-foreground">
-          {paused
-            ? "paused"
-            : current.intent === "converse"
-              ? "response needed"
-              : "playing"}
-        </strong>
+        <strong className="block text-sm text-foreground">{status}</strong>
         <span className="font-mono text-xs text-muted-foreground">{queueCount} waiting</span>
       </div>
     </footer>

--- a/crates/voice-ui/web/src/components/voice/now-playing.tsx
+++ b/crates/voice-ui/web/src/components/voice/now-playing.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties } from "react";
-import { Mic, Play } from "lucide-react";
+import { Mic, Play, Square } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Slider } from "@/components/ui/slider";
@@ -76,14 +76,19 @@ export function NowPlaying({
           />
           <Button
             className="h-12 w-full text-base text-neutral-950"
-            disabled={message.state === "listening"}
             style={{ backgroundColor: isConverse ? "hsl(var(--voice-converse))" : "hsl(var(--voice-play))" }}
             type="button"
             onClick={onPrimaryAction}
           >
-            {isConverse ? <Mic size={17} /> : <Play size={17} />}
+            {message.state === "listening" ? (
+              <Square size={17} />
+            ) : isConverse ? (
+              <Mic size={17} />
+            ) : (
+              <Play size={17} />
+            )}
             {message.state === "listening"
-              ? "Listening..."
+              ? "Stop listening"
               : isConverse
                 ? `Respond to ${message.agentName}`
                 : `Play ${message.agentName}`}

--- a/crates/voice-ui/web/src/components/voice/now-playing.tsx
+++ b/crates/voice-ui/web/src/components/voice/now-playing.tsx
@@ -21,15 +21,26 @@ export function NowPlaying({
   onPrimaryAction: () => void;
 }) {
   const isConverse = message.intent === "converse";
+  const promptFinished = isConverse && position >= message.durationSeconds;
+  const sectionLabel = message.state === "listening"
+    ? "Listening"
+    : promptFinished
+      ? "Response needed"
+      : "Now playing";
+  const heading = message.state === "listening"
+    ? "Listening for response"
+    : promptFinished
+      ? "Waiting for your response"
+      : "Current message";
 
   return (
     <section style={{ "--agent-color": message.color } as CSSProperties}>
       <div className="mb-3 flex items-end justify-between gap-4">
         <div>
           <p className="mb-1 text-xs font-bold uppercase tracking-[0.12em] text-muted-foreground">
-            Now playing
+            {sectionLabel}
           </p>
-          <h2 className="text-lg font-semibold">Current message</h2>
+          <h2 className="text-lg font-semibold">{heading}</h2>
         </div>
       </div>
       <Card className="relative overflow-hidden bg-card/95 shadow-[0_1px_0_rgba(255,255,255,0.04)_inset,0_18px_40px_-24px_rgba(0,0,0,0.8)]">
@@ -65,12 +76,17 @@ export function NowPlaying({
           />
           <Button
             className="h-12 w-full text-base text-neutral-950"
+            disabled={message.state === "listening"}
             style={{ backgroundColor: isConverse ? "hsl(var(--voice-converse))" : "hsl(var(--voice-play))" }}
             type="button"
             onClick={onPrimaryAction}
           >
             {isConverse ? <Mic size={17} /> : <Play size={17} />}
-            {isConverse ? `Respond to ${message.agentName}` : `Play ${message.agentName}`}
+            {message.state === "listening"
+              ? "Listening..."
+              : isConverse
+                ? `Respond to ${message.agentName}`
+                : `Play ${message.agentName}`}
           </Button>
         </CardContent>
       </Card>

--- a/crates/voice-ui/web/src/components/voice/queue-item.tsx
+++ b/crates/voice-ui/web/src/components/voice/queue-item.tsx
@@ -7,6 +7,7 @@ import { AgentAvatar } from "./agent-avatar";
 import { MessageIdentity } from "./message-identity";
 
 const stateLabels = {
+  listening: "listening",
   skipped: "skipped",
 } as const;
 
@@ -71,13 +72,18 @@ export function QueueItem({
           size="sm"
           type="button"
           variant="outline"
+          disabled={message.state === "listening"}
           onClick={(event) => {
             event.stopPropagation();
             onSelect();
           }}
         >
           {isConverse ? <MessageCircle size={14} /> : <Play size={14} />}
-          {isConverse ? "Respond" : "Play"}
+          {message.state === "listening"
+            ? "Listening"
+            : isConverse
+              ? "Respond"
+              : "Play"}
         </Button>
       </span>
     </div>

--- a/crates/voice-ui/web/src/components/voice/queue-item.tsx
+++ b/crates/voice-ui/web/src/components/voice/queue-item.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, KeyboardEvent } from "react";
-import { MessageCircle, Play } from "lucide-react";
+import { MessageCircle, Play, Square } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { VoiceMessage } from "@/types";
@@ -72,15 +72,20 @@ export function QueueItem({
           size="sm"
           type="button"
           variant="outline"
-          disabled={message.state === "listening"}
           onClick={(event) => {
             event.stopPropagation();
             onSelect();
           }}
         >
-          {isConverse ? <MessageCircle size={14} /> : <Play size={14} />}
+          {message.state === "listening" ? (
+            <Square size={14} />
+          ) : isConverse ? (
+            <MessageCircle size={14} />
+          ) : (
+            <Play size={14} />
+          )}
           {message.state === "listening"
-            ? "Listening"
+            ? "Stop"
             : isConverse
               ? "Respond"
               : "Play"}

--- a/crates/voice-ui/web/src/state/voice-bridge.ts
+++ b/crates/voice-ui/web/src/state/voice-bridge.ts
@@ -68,6 +68,9 @@ class VoiceBridge {
     const result = await this.command("next");
     if (result.ok) {
       await this.playCurrentPrompt(result.trackId);
+    } else {
+      this.audio.pause();
+      voiceStore.setPlaybackPaused(true);
     }
     return result;
   }
@@ -76,6 +79,9 @@ class VoiceBridge {
     const result = await this.command("previous");
     if (result.ok) {
       await this.playCurrentPrompt(result.trackId);
+    } else {
+      this.audio.pause();
+      voiceStore.setPlaybackPaused(true);
     }
     return result;
   }

--- a/crates/voice-ui/web/src/state/voice-bridge.ts
+++ b/crates/voice-ui/web/src/state/voice-bridge.ts
@@ -199,8 +199,19 @@ class VoiceBridge {
       this.audio.currentTime = 0;
       this.audioTrackId = trackId ?? null;
     }
-    voiceStore.setPlaybackPaused(false);
-    await this.audio.play();
+    try {
+      await this.audio.play();
+      voiceStore.setPlaybackPaused(false);
+    } catch (error) {
+      voiceStore.setPlaybackPaused(true);
+      voiceStore.applyEvent({
+        type: "error",
+        payload: {
+          message: error instanceof Error ? error.message : String(error),
+        },
+      });
+      void this.command("pause");
+    }
   }
 }
 

--- a/crates/voice-ui/web/src/state/voice-bridge.ts
+++ b/crates/voice-ui/web/src/state/voice-bridge.ts
@@ -9,13 +9,29 @@ class VoiceBridge {
   private eventSource: EventSource | null = null;
   private generation = 0;
   private readonly audio = new Audio();
+  private audioTrackId: string | null = null;
 
   constructor() {
+    this.audio.addEventListener("loadedmetadata", () => {
+      if (this.audioTrackId) {
+        voiceStore.setDuration(this.audioTrackId, this.audio.duration);
+      }
+    });
     this.audio.addEventListener("timeupdate", () => {
       voiceStore.setPosition(this.audio.currentTime);
     });
     this.audio.addEventListener("ended", () => {
-      void this.command("next");
+      const state = voiceStore.snapshot();
+      const current = state.messages.find((message) => message.id === state.currentId);
+      if (current) {
+        voiceStore.setPosition(current.durationSeconds);
+      }
+      if (current?.intent === "converse") {
+        voiceStore.setPlaybackPaused(true);
+        void this.command("pause");
+      } else {
+        void this.next();
+      }
     });
   }
 
@@ -34,7 +50,7 @@ class VoiceBridge {
   async play(trackId?: string) {
     const result = await this.command("play", trackId);
     if (result.ok) {
-      await this.playCurrentPrompt();
+      await this.playCurrentPrompt(result.trackId ?? trackId);
     }
     return result;
   }
@@ -51,7 +67,7 @@ class VoiceBridge {
   async next() {
     const result = await this.command("next");
     if (result.ok) {
-      await this.playCurrentPrompt();
+      await this.playCurrentPrompt(result.trackId);
     }
     return result;
   }
@@ -59,7 +75,7 @@ class VoiceBridge {
   async previous() {
     const result = await this.command("previous");
     if (result.ok) {
-      await this.playCurrentPrompt();
+      await this.playCurrentPrompt(result.trackId);
     }
     return result;
   }
@@ -169,9 +185,9 @@ class VoiceBridge {
     return result;
   }
 
-  private async playCurrentPrompt() {
+  private async playCurrentPrompt(trackIdOverride?: string | null) {
     const state = voiceStore.snapshot();
-    const trackId = state.currentId;
+    const trackId = trackIdOverride ?? state.currentId;
     const track = trackId ? state.snapshot.tracks[trackId] : undefined;
     const promptUrl = track?.audio.promptUrl;
     if (!promptUrl) {
@@ -181,7 +197,9 @@ class VoiceBridge {
     if (!this.audio.src.endsWith(promptUrl)) {
       this.audio.src = promptUrl;
       this.audio.currentTime = 0;
+      this.audioTrackId = trackId ?? null;
     }
+    voiceStore.setPlaybackPaused(false);
     await this.audio.play();
   }
 }

--- a/crates/voice-ui/web/src/state/voice-store.ts
+++ b/crates/voice-ui/web/src/state/voice-store.ts
@@ -105,6 +105,14 @@ export class VoiceStore {
             ...state,
             respondingTrackId: event.payload.trackId,
           });
+        } else if (event.payload.ok && event.payload.command === "cancel") {
+          this.publish({
+            ...state,
+            respondingTrackId:
+              event.payload.trackId && state.respondingTrackId === event.payload.trackId
+                ? undefined
+                : state.respondingTrackId,
+          });
         } else if (!event.payload.ok) {
           this.publish({ ...state, error: event.payload.message ?? "Command failed" });
         }

--- a/crates/voice-ui/web/src/state/voice-store.ts
+++ b/crates/voice-ui/web/src/state/voice-store.ts
@@ -33,8 +33,10 @@ const initialState: VoiceUiState = {
   snapshot: EMPTY_SNAPSHOT,
   messages: voiceMessages,
   currentId: voiceMessages[0]?.id,
+  respondingTrackId: undefined,
   positionSeconds: voiceMessages[0]?.positionSeconds ?? 0,
   paused: true,
+  durationOverrides: {},
 };
 
 export class VoiceStore {
@@ -98,7 +100,12 @@ export class VoiceStore {
         });
         break;
       case "command_result":
-        if (!event.payload.ok) {
+        if (event.payload.ok && event.payload.command === "respond" && event.payload.trackId) {
+          this.publish({
+            ...state,
+            respondingTrackId: event.payload.trackId,
+          });
+        } else if (!event.payload.ok) {
           this.publish({ ...state, error: event.payload.message ?? "Command failed" });
         }
         break;
@@ -131,6 +138,37 @@ export class VoiceStore {
     });
   }
 
+  setPlaybackPaused(paused: boolean) {
+    const state = this.snapshot();
+    this.publish({
+      ...state,
+      paused,
+    });
+  }
+
+  setDuration(trackId: string, seconds: number) {
+    if (!Number.isFinite(seconds) || seconds <= 0) {
+      return;
+    }
+    const rounded = Math.max(1, Math.round(seconds));
+    const state = this.snapshot();
+    if (state.durationOverrides[trackId] === rounded) {
+      return;
+    }
+    this.publish({
+      ...state,
+      durationOverrides: {
+        ...state.durationOverrides,
+        [trackId]: rounded,
+      },
+      messages: state.messages.map((message) =>
+        message.id === trackId
+          ? withDuration(message, rounded)
+          : message,
+      ),
+    });
+  }
+
   private publish(state: VoiceUiState) {
     this.stateSubject.next(state);
   }
@@ -151,12 +189,23 @@ function fromSnapshot(snapshot: UiSnapshot, previous: VoiceUiState): VoiceUiStat
     connected: snapshot.connected,
     ready: snapshot.ready,
     snapshot,
-    messages,
+    messages: messages.map((message) => {
+      const duration = previous.durationOverrides[message.id];
+      const withActualDuration = duration ? withDuration(message, duration) : message;
+      return previous.respondingTrackId === message.id
+        ? { ...withActualDuration, state: "listening" }
+        : withActualDuration;
+    }),
     currentId,
+    respondingTrackId:
+      previous.respondingTrackId && snapshot.tracks[previous.respondingTrackId]
+        ? previous.respondingTrackId
+        : undefined,
     positionSeconds: sameTrack
       ? previous.positionSeconds
       : current?.positionSeconds ?? snapshot.transport.positionSeconds,
     paused: snapshot.transport.paused,
+    durationOverrides: previous.durationOverrides,
   };
 }
 
@@ -211,6 +260,14 @@ function trackToMessage(track: UiTrack): VoiceMessage {
       : [],
     durationSeconds,
     positionSeconds: 0,
+  };
+}
+
+function withDuration(message: VoiceMessage, durationSeconds: number): VoiceMessage {
+  return {
+    ...message,
+    durationSeconds,
+    transcript: transcriptForText(message.message, durationSeconds),
   };
 }
 

--- a/crates/voice-ui/web/src/types.ts
+++ b/crates/voice-ui/web/src/types.ts
@@ -1,5 +1,5 @@
 export type VoiceIntent = "converse" | "play";
-export type VoiceState = "queued" | "awaiting-user" | "picked-up" | "skipped";
+export type VoiceState = "queued" | "awaiting-user" | "listening" | "picked-up" | "skipped";
 
 export interface TranscriptionSegment {
   startSecond: number;
@@ -112,8 +112,10 @@ export interface VoiceUiState {
   snapshot: UiSnapshot;
   messages: VoiceMessage[];
   currentId?: string;
+  respondingTrackId?: string;
   positionSeconds: number;
   paused: boolean;
+  durationOverrides: Record<string, number>;
 }
 
 export type DaemonItemStatus = "queued" | "processing" | "completed" | "failed";


### PR DESCRIPTION
## Summary
- Fix the Voice UI empty connected state so it no longer says it is waiting for daemon state when the daemon is ready and the queue is empty.
- Use browser media metadata to correct displayed prompt duration, stop response-needed prompt playback at the end instead of auto-stepping, and show listening/response-needed labels more accurately.
- Refresh the repo `SKILL.md` so agents use the current daemon UI/MCP queue model and Whisper STT wording.

## Verification
- `npm run check` in `crates/voice-ui`
- `npm run build` in `crates/voice-ui`
- `cargo install --path crates/voice-cli --locked --force`
- Restarted local LaunchAgent without `--tts-only`; verified TTS and STT eager load in `/tmp/voiced.err.log`
- Verified daemon status and `/api/ui/snapshot` are connected/ready
- Updated installed local skill at `/Users/kylekelley/.agents/skills/voice/SKILL.md` from repo `SKILL.md`

## Notes
- Browser plugin tab control dropped its tab handle during the last verification attempt, so the final UI changes are verified by TypeScript/build and local daemon install rather than a final Browser DOM snapshot.
- The remaining larger cleanup is a proper CLI affordance for held UI queue items instead of requiring MCP or a raw daemon frame.
