### PR TITLE
Guard TTS sink-open against Bluetooth HFP rate switch

### DIFF
--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -538,13 +538,18 @@ fn generate_voxtral_audio(
         .map_err(|e| format!("generate Voxtral audio: {e}"))
 }
 
-/// Output rates at or below Kokoro/Voxtral's own synthesis rate (24 kHz). A
-/// Bluetooth headset drops its CoreAudio nominal rate into this band (8/16 kHz
-/// HFP) while an input stream is live; A2DP playback runs at 44.1/48 kHz. rodio
-/// caches the device rate exactly once at sink-open and resamples every appended
-/// buffer to it, so a rate captured mid-profile-flip gets clocked out at the wrong
-/// rate once the device settles. Treat anything in this band as "not a settled
-/// full-quality output yet."
+/// Rates at or below Kokoro/Voxtral's 24 kHz synthesis rate: the band a
+/// Bluetooth headset can report while its mic is live. Classic HFP is 8/16 kHz,
+/// but AirPods Pro were observed dropping to exactly 24 kHz mic-active in the
+/// daemon's own rate logs, versus 44.1/48 kHz for A2DP output. rodio caches the
+/// device rate once at sink-open and resamples every buffer to it, so a sink
+/// opened at one of these low rates gets clocked out too fast once the headset
+/// settles back to A2DP.
+///
+/// The 24 kHz ceiling is deliberate, not a stand-in for 16 kHz: it has to catch
+/// the observed AirPods mic-active rate. The cost is that a device genuinely
+/// stuck at exactly 24 kHz pays the settle timeout once, which in practice is a
+/// headset mid-profile and correct to wait on.
 const HFP_CLASS_MAX_HZ: u32 = 24_000;
 
 /// Read the default output device's current nominal sample rate without opening a

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -538,6 +538,88 @@ fn generate_voxtral_audio(
         .map_err(|e| format!("generate Voxtral audio: {e}"))
 }
 
+/// Output rates at or below Kokoro/Voxtral's own synthesis rate (24 kHz). A
+/// Bluetooth headset drops its CoreAudio nominal rate into this band (8/16 kHz
+/// HFP) while an input stream is live; A2DP playback runs at 44.1/48 kHz. rodio
+/// caches the device rate exactly once at sink-open and resamples every appended
+/// buffer to it, so a rate captured mid-profile-flip gets clocked out at the wrong
+/// rate once the device settles. Treat anything in this band as "not a settled
+/// full-quality output yet."
+const HFP_CLASS_MAX_HZ: u32 = 24_000;
+
+/// Read the default output device's current nominal sample rate without opening a
+/// stream. `None` when there is no output device or CoreAudio refuses the query.
+///
+/// cpal reads `kAudioDevicePropertyStreamFormat` live on every call, so this
+/// tracks the active Bluetooth profile rate rather than a cached value.
+fn default_output_rate() -> Option<u32> {
+    use rodio::cpal::traits::{DeviceTrait, HostTrait};
+    let device = rodio::cpal::default_host().default_output_device()?;
+    let config = device.default_output_config().ok()?;
+    Some(config.sample_rate())
+}
+
+/// Diagnostic: log the live default output device rate around the sink lifecycle
+/// so a Bluetooth profile flip (HFP<->A2DP) is visible in daemon logs.
+fn log_output_device_rate(when: &str) {
+    if let Some(rate) = default_output_rate() {
+        eprintln!("voice daemon: device output rate {when} {rate} Hz");
+    }
+}
+
+/// Wait for the default output device to leave the HFP-class rate band before
+/// opening a playback sink, but only when it is currently in that band.
+///
+/// rodio caches the device rate once at sink-open (see [`HFP_CLASS_MAX_HZ`]) and
+/// resamples every buffer to it. The sped-up failure needs exactly one shape:
+/// open while the headset reports a low HFP rate, then clock those resampled
+/// samples out at the higher A2DP rate once the profile settles. So the only
+/// hazard is a rate that is *currently* HFP-class.
+///
+/// A first read above the band (built-in speakers, stable A2DP, any non-Bluetooth
+/// output) is safe to open at right now, so this returns immediately with no added
+/// latency. Opening high and later settling to a nearby high rate is imperceptible;
+/// it is never the sped-up bug. Only when the current rate is HFP-class do we poll,
+/// waiting for the headset to finish renegotiating up out of HFP. If it never does
+/// within the timeout (an input stream held open elsewhere, or a genuinely low-rate
+/// device) we proceed anyway: playback at that low rate is correct-speed, just
+/// muffled, not sped up.
+fn wait_for_stable_output_rate() {
+    const POLL_INTERVAL: Duration = Duration::from_millis(150);
+    const TIMEOUT: Duration = Duration::from_millis(2_000);
+
+    match default_output_rate() {
+        // Already full-quality (or no device to probe — let the open path surface
+        // that error): open now.
+        Some(rate) if rate > HFP_CLASS_MAX_HZ => return,
+        None => return,
+        _ => {}
+    }
+
+    let started = Instant::now();
+    while started.elapsed() < TIMEOUT {
+        std::thread::sleep(POLL_INTERVAL);
+        match default_output_rate() {
+            // Left HFP, or the device vanished mid-poll: stop waiting.
+            Some(rate) if rate > HFP_CLASS_MAX_HZ => return,
+            None => return,
+            _ => {}
+        }
+    }
+}
+
+/// Open the default output sink after the device rate settles, logging the rate
+/// rodio committed to. Both TTS engines' speak playback goes through here so each
+/// gets the Bluetooth settle guard and the same diagnostic.
+fn open_stable_default_sink() -> Result<rodio::MixerDeviceSink, String> {
+    wait_for_stable_output_rate();
+    let mut stream = DeviceSinkBuilder::open_default_sink().map_err(|e| format!("audio: {}", e))?;
+    stream.log_on_drop(false);
+    let sink_rate = stream.config().sample_rate().get();
+    eprintln!("voice daemon: sink opened at {sink_rate} Hz");
+    Ok(stream)
+}
+
 fn speak(
     tts: &Arc<Mutex<TtsState>>,
     text: &str,
@@ -550,9 +632,7 @@ fn speak(
         }
 
         let started = Instant::now();
-        let mut stream =
-            DeviceSinkBuilder::open_default_sink().map_err(|e| format!("audio: {}", e))?;
-        stream.log_on_drop(false);
+        let stream = open_stable_default_sink()?;
         let player = Player::connect_new(stream.mixer());
         let channels = NonZero::new(1u16).unwrap();
         let rate = NonZero::new(voice_voxtral::SAMPLE_RATE).unwrap();
@@ -587,9 +667,11 @@ fn speak(
                 .map_err(|e| format!("generate Voxtral audio: {e}"))?
         };
 
+        log_output_device_rate("before drain");
         while !player.empty() {
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
+        log_output_device_rate("after drain");
 
         return Ok(serde_json::json!({
             "engine": resolved.engine,
@@ -617,8 +699,7 @@ fn speak(
         return Ok(serde_json::json!({"duration_ms": 0, "chunks": 0}).to_string());
     }
 
-    let mut stream = DeviceSinkBuilder::open_default_sink().map_err(|e| format!("audio: {}", e))?;
-    stream.log_on_drop(false);
+    let stream = open_stable_default_sink()?;
     let player = Player::connect_new(stream.mixer());
 
     let started = Instant::now();
@@ -654,9 +735,11 @@ fn speak(
         }
     }
 
+    log_output_device_rate("before drain");
     while !player.empty() {
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
+    log_output_device_rate("after drain");
 
     let duration_ms = started.elapsed().as_millis() as u64;
     Ok(serde_json::json!({
@@ -1145,6 +1228,7 @@ fn listen(
 
     let sample_rate = mic.config().sample_rate.get();
     let channels = mic.config().channel_count.get();
+    eprintln!("voice daemon: mic opened at {sample_rate} Hz");
 
     // Record with VAD
     let buffer: Arc<Mutex<Vec<f32>>> = Arc::new(Mutex::new(Vec::new()));


### PR DESCRIPTION
converse over Bluetooth headphones played the spoken prompt back badly sped up and high-pitched (~1.5-3x). Plain `speak` was fine. This guards the sink-open against the Bluetooth profile switch that causes it, and adds the device-rate logging that proved the mechanism.

## Root cause

rodio captures the output device's sample rate exactly once at sink-open (`stream.rs` `from_device`) and resamples every appended buffer to it (`mixer.rs` `UniformSourceIterator`). Over Bluetooth the CoreAudio nominal rate *is* the live profile rate: A2DP runs 44.1/48 kHz, and the device drops to an HFP-class rate (16/24 kHz) while an input stream is live.

So the failure needs one specific shape: a speak sink opens while the headset reports a low HFP rate, rodio bakes 24 kHz into the sink, and once the headset settles back to A2DP those resampled samples clock out at 48 kHz = 2x fast. Plain `speak` never opens a mic, so the headset stays in A2DP the whole time and the cached rate always matches the clock.

The trigger is external device state, not our own mic: the headset already in HFP (e.g. a game holding voice chat), or a prior converse's HFP to A2DP renegotiation still settling when the next speak opens. (An earlier draft of #299 blamed a "mic pre-open" in the converse path; that was wrong. `ensure_stt` warms the Whisper model, not the mic, and the mic only opens after `speak()` drains.)

## The fix

Before opening a speak sink, wait for the default output device to leave the HFP-class band (<= 24 kHz, at or below the synthesis rate), but only when it is currently in that band. Both TTS engines' open sites go through one `open_stable_default_sink()`.

- Device already at a full-quality rate (built-in speakers, stable A2DP, any non-Bluetooth output): opens immediately, zero added latency. Opening at an already-high rate is never the sped-up failure.
- Device currently HFP-class: polls for it to renegotiate up out of HFP, bounded by a 2s timeout. If it never recovers (an input stream held open elsewhere) it opens anyway and plays correct-speed but muffled, not fast.

## Evidence

Added device-rate logging at sink-open, around each drain, and at mic-open. One MCP converse over AirPods Pro, captured live:

```
sink opened at 48000 Hz                      speak: device A2DP 48 kHz, guard opened immediately
device output rate before drain 48000 Hz
device output rate after drain 48000 Hz      held 48 kHz through playout -> correct speed
mic opened at 24000 Hz                        opening the mic dropped the device to 24 kHz
```

That last line is the swing itself: opening the mic drops the AirPods 48 kHz -> 24 kHz in real time. A separate converse run with the device already at 24 kHz opened the sink at 24 kHz (its true rate) and played correct-speed rather than sped-up.

| Device at speak-open | Guard behavior | Result |
|---|---|---|
| 48 kHz A2DP | opens immediately, no wait | correct speed |
| <= 24 kHz HFP-class | opens at the true current rate | correct speed |

## Test plan

- [x] `cargo build -p voice-daemon`
- [x] `cargo clippy -p voice-daemon --all-targets -- -D warnings`
- [x] `cargo fmt -p voice-daemon -- --check`
- [x] `cargo test -p voice-daemon` (5 passed)
- [x] Dogfooded over AirPods Pro: converse plays at normal speed; diagnostic logs confirm the rate swing

Fixes #299.
