### PR TITLE
Remove overfit Whisper repetition guard

### DIFF
--- a/crates/voice-whisper/src/decoder.rs
+++ b/crates/voice-whisper/src/decoder.rs
@@ -250,32 +250,14 @@ impl WhisperDecoder {
                 .i(next_token as usize)?
                 .to_scalar::<f32>()? as f64;
 
+            // Termination is the model's job: stop on its end-of-text token, and
+            // cap at max_target_positions so degenerate output can't run forever.
+            // There is intentionally no token-pattern repetition guard here.
+            // distil-large-v3.5 rarely loops, decode_with_fallback re-rolls
+            // low-confidence output, and any pattern match aggressive enough to
+            // catch a real loop also truncates legitimate long-form speech.
             if next_token == self.eot_token || tokens.len() > self.config.max_target_positions {
                 break;
-            }
-
-            // Detect repetition: check if the second half of generated tokens
-            // is a repeat of a pattern from the first half. This catches both
-            // "the the the" and "it's going to do it's going to do" patterns.
-            let sample_begin = if self.language_token.is_some() { 4 } else { 3 };
-            let content = &tokens[sample_begin..];
-            if content.len() >= 20 {
-                // Check if the last 10 tokens match any earlier 10-token window
-                let check_len = 10;
-                let tail = &content[content.len() - check_len..];
-                let search_range = &content[..content.len() - check_len];
-                let has_repeat = search_range.windows(check_len).any(|window| window == tail);
-                if has_repeat {
-                    // Find the first occurrence of this repeated pattern
-                    // and truncate everything after it
-                    if let Some(first_pos) = search_range
-                        .windows(check_len)
-                        .position(|window| window == tail)
-                    {
-                        tokens.truncate(sample_begin + first_pos + check_len);
-                    }
-                    break;
-                }
             }
 
             sum_logprob += prob.ln();


### PR DESCRIPTION
The greedy Whisper decoder truncated a transcript whenever the last 10 tokens matched any earlier 10-token window, then stopped decoding the rest of the audio. On long-form dictation ("voice memo mode") that fires on ordinary repeated phrasing and drops everything spoken after the reuse. That is the "transcript is reduced" bug.

## Why it was there, why it can go

The guard (`decoder.rs`, added in c93359d) landed in the same commit that made `distil-large-v3` the default, a repeat-prone model. The default later moved to `distil-large-v3.5`, chosen specifically for far fewer repetition errors, but the guard was never revisited. It matched a window *anywhere earlier* in the transcript, not a consecutive loop, so legitimate phrase reuse tripped it.

I tried a narrower heuristic (consecutive-only loop detection), but any pattern match aggressive enough to catch a real loop also clips real speech. This is a model job, not a decoder job.

## What still bounds decoding

- Terminates on the model's end-of-text token
- Capped at `max_target_positions` so degenerate output can't run forever
- `decode_with_fallback` re-rolls low-confidence output at higher temperature

Net `-40` lines.

## Test plan

- [x] `cargo clippy -p voice-whisper --all-targets -- -D warnings`
- [x] `cargo fmt -p voice-whisper -- --check`
- [x] `cargo test -p voice-whisper`
- [ ] Dogfood: a long converse with natural pauses returns the full transcript
