### PR TITLE
Make MCP converse block for the reply instead of returning an id

### DIFF
--- a/crates/voice-cli/src/mcp.rs
+++ b/crates/voice-cli/src/mcp.rs
@@ -408,7 +408,7 @@ fn handle_tools_list() -> Result<Value, RpcErr> {
             // },
             {
                 "name": "converse",
-                "description": "Speak a prompt aloud, then listen for the human's spoken reply. Returns immediately with a converse_id; the daemon speaks and records in the background. Poll converse_result with that id to get the transcript once the human has answered. Never blocks on the human, so the call is safe to retry.",
+                "description": "Speak a prompt aloud, then wait for the human's spoken reply and return it. The MCP polls the daemon internally, so you get the answer from this one call - no separate poll needed in the common case. Returns {status:\"completed\", heard, spoke} once the human finishes. If they don't start speaking within a short grace window (they're busy), or the reply runs past the block ceiling, returns {status:\"pending\", converse_id} instead - poll converse_result with that id to collect the reply later. Idempotent and safe to retry.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -519,7 +519,44 @@ fn handle_tools_call(
         }
     }
 
-    // Delegate to the voice daemon if connected (speak/listen/converse).
+    // Converse blocks in the MCP: fire the daemon converse, then poll it here
+    // until the human answers (or we hand back a converse_id). The agent gets
+    // the reply from this one call instead of firing converse + N polls itself.
+    if name == "converse" && session.daemon.is_some() {
+        let raw = arguments.get("text").and_then(|v| v.as_str()).unwrap_or("");
+        let markdown = arguments
+            .get("markdown")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let text = preprocess_for_daemon(raw, markdown, &session.subs);
+        let voice = arguments
+            .get("voice")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let max_duration_ms = arguments.get("max_duration_ms").and_then(|v| v.as_u64());
+        let daemon = session.daemon.as_mut().unwrap();
+        match converse_blocking(daemon, &text, voice.as_deref(), max_duration_ms) {
+            Ok(value) => {
+                return Response::success(
+                    id,
+                    serde_json::json!({
+                        "content": [{
+                            "type": "text",
+                            "text": serde_json::to_string(&value).unwrap_or_else(|_| "{}".to_string())
+                        }]
+                    }),
+                );
+            }
+            Err(e) => {
+                // Daemon transport failed mid-converse: drop the connection and
+                // fall through to local handling, matching the other daemon ops.
+                eprintln!("voice mcp: converse error: {}, falling back to local", e);
+                session.daemon = None;
+            }
+        }
+    }
+
+    // Delegate to the voice daemon if connected (speak/listen/converse_result).
     // Config tools (set_voice/set_speed/list_voices) stay local.
     // The daemon queues requests and owns the audio hardware.
     if let Some(ref mut daemon) = session.daemon {
@@ -542,23 +579,6 @@ fn handle_tools_call(
             }
             "listen" => {
                 Some(daemon.listen(arguments.get("max_duration_ms").and_then(|v| v.as_u64())))
-            }
-            "converse" => {
-                // Returns a converse_id immediately. Fetch the spoken reply with
-                // `converse_result` once the human has answered — the tool call
-                // never blocks on the human, so it never gets retried mid-wait.
-                let raw = arguments.get("text").and_then(|v| v.as_str()).unwrap_or("");
-                let markdown = arguments
-                    .get("markdown")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false);
-                let text = preprocess_for_daemon(raw, markdown, &session.subs);
-                Some(daemon.converse(
-                    &text,
-                    arguments.get("voice").and_then(|v| v.as_str()),
-                    arguments.get("max_duration_ms").and_then(|v| v.as_u64()),
-                    voice_protocol::client::TtsRequestOptions::default(),
-                ))
             }
             "converse_result" => {
                 let converse_id = arguments
@@ -957,6 +977,125 @@ fn voice_speak(
     }))
 }
 
+/// Fire a converse on the daemon, then poll it here until the human answers or
+/// we hand the id back. This is the smart wait the agent would otherwise do by
+/// hand: one blocking MCP call instead of converse + N `converse_result` polls.
+///
+/// - Human finishes → `{status: "completed", heard, spoke}`.
+/// - Mic open but no speech for `GRACE_MS` (human is busy) → `{status: "pending",
+///   converse_id, ...}`, so the agent can move on and poll `converse_result`.
+/// - Reply runs past `CEILING_MS` → same pending handoff.
+///
+/// The grace clock starts when the mic opens (phase `listening`), not at call
+/// time, so the spoken prompt's own duration never eats into it. Once the human
+/// has started speaking (`heard_speech`), grace no longer applies and we wait
+/// through the whole reply, bounded only by the ceiling.
+fn converse_blocking(
+    daemon: &mut voice_protocol::client::DaemonClient,
+    text: &str,
+    voice: Option<&str>,
+    max_duration_ms: Option<u64>,
+) -> Result<Value, String> {
+    const GRACE_MS: u128 = 8_000;
+    const CEILING_MS: u128 = 90_000;
+    const POLL_MS: u64 = 1_500;
+
+    let fired = daemon.converse(
+        text,
+        voice,
+        max_duration_ms,
+        voice_protocol::client::TtsRequestOptions::default(),
+    )?;
+    let converse_id = fired
+        .result
+        .as_ref()
+        .and_then(|r| r.get("converse_id"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "converse: daemon returned no converse_id".to_string())?
+        .to_string();
+
+    let start = Instant::now();
+    let mut listening_since: Option<Instant> = None;
+    loop {
+        // The daemon long-polls up to POLL_MS on non-terminal states, so this
+        // loop paces itself (~POLL_MS per turn) without a sleep.
+        let resp = daemon.converse_result(&converse_id, Some(POLL_MS))?;
+        let view = resp.result.unwrap_or_else(|| serde_json::json!({}));
+        let phase = view
+            .get("phase")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+
+        match phase {
+            "completed" => return Ok(converse_completed_value(&view)),
+            "failed" => {
+                return Err(view
+                    .get("error")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("converse failed")
+                    .to_string())
+            }
+            "listening" => {
+                let heard = view
+                    .get("heard_speech")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                if !heard {
+                    let since = *listening_since.get_or_insert_with(Instant::now);
+                    if since.elapsed().as_millis() >= GRACE_MS {
+                        return Ok(converse_pending_value(
+                            &converse_id,
+                            phase,
+                            "human hasn't started speaking",
+                        ));
+                    }
+                }
+                // heard: keep waiting through the reply.
+            }
+            _ => {
+                // queued / speaking (TTS playing) / transient unknown: keep waiting.
+            }
+        }
+
+        if start.elapsed().as_millis() >= CEILING_MS {
+            return Ok(converse_pending_value(
+                &converse_id,
+                phase,
+                "reply still in progress",
+            ));
+        }
+    }
+}
+
+/// Shape a completed converse view into the agent-facing result. The daemon
+/// nests the transcript as a JSON string under `result`; unwrap it so the agent
+/// sees structured `heard`/`spoke` rather than an escaped blob.
+fn converse_completed_value(view: &Value) -> Value {
+    let inner = view
+        .get("result")
+        .and_then(|v| v.as_str())
+        .and_then(|s| serde_json::from_str::<Value>(s).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+    serde_json::json!({
+        "status": "completed",
+        "heard": inner.get("heard").cloned().unwrap_or(Value::Null),
+        "spoke": inner.get("spoke").cloned().unwrap_or(Value::Null),
+    })
+}
+
+/// The handoff result when there is no transcript yet: give the agent the
+/// converse_id to poll `converse_result` with later.
+fn converse_pending_value(converse_id: &str, phase: &str, reason: &str) -> Value {
+    serde_json::json!({
+        "status": "pending",
+        "converse_id": converse_id,
+        "phase": phase,
+        "note": format!(
+            "No reply yet ({reason}). Poll converse_result with this converse_id to collect it."
+        ),
+    })
+}
+
 fn voice_converse(
     session: &mut Session,
     stdout: &mut io::Stdout,
@@ -1247,4 +1386,40 @@ fn write_response(stdout: &mut io::Stdout, resp: &Response) {
     let json = serde_json::to_string(resp).unwrap();
     let _ = writeln!(stdout, "{json}");
     let _ = stdout.flush();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{converse_completed_value, converse_pending_value};
+    use serde_json::json;
+
+    #[test]
+    fn completed_value_unwraps_nested_transcript() {
+        // The daemon nests the transcript as a JSON *string* under `result`.
+        let view = json!({
+            "phase": "completed",
+            "result": r#"{"heard":{"text":"hello"},"spoke":{"chunks":1}}"#,
+        });
+        let out = converse_completed_value(&view);
+        assert_eq!(out["status"], "completed");
+        assert_eq!(out["heard"]["text"], "hello");
+        assert_eq!(out["spoke"]["chunks"], 1);
+    }
+
+    #[test]
+    fn completed_value_tolerates_missing_result() {
+        let out = converse_completed_value(&json!({ "phase": "completed" }));
+        assert_eq!(out["status"], "completed");
+        assert!(out["heard"].is_null());
+        assert!(out["spoke"].is_null());
+    }
+
+    #[test]
+    fn pending_value_carries_the_id() {
+        let out = converse_pending_value("abc123", "listening", "human hasn't started speaking");
+        assert_eq!(out["status"], "pending");
+        assert_eq!(out["converse_id"], "abc123");
+        assert_eq!(out["phase"], "listening");
+        assert!(out["note"].as_str().unwrap().contains("converse_result"));
+    }
 }

--- a/crates/voice-daemon/src/queue.rs
+++ b/crates/voice-daemon/src/queue.rs
@@ -23,6 +23,12 @@ pub const CONVERSE_PHASE_LISTENING: u8 = 2;
 pub struct ConverseView {
     pub phase: &'static str,
     pub mic_active: bool,
+    /// True once the listen VAD has detected the human actually speaking (not
+    /// merely that the mic is open). Lets a caller distinguish "mic open, human
+    /// hasn't started" (safe to hand back and poll later) from "human is
+    /// mid-answer" (worth waiting on). Only meaningful while `phase` is
+    /// `listening`; false otherwise.
+    pub heard_speech: bool,
     pub result: Option<String>,
     pub error: Option<String>,
 }
@@ -195,6 +201,10 @@ pub struct RequestQueue {
     waiters: Mutex<HashMap<String, oneshot::Sender<CompletionResult>>>,
     /// Live speak/listen phase of the in-flight converse (see CONVERSE_PHASE_*).
     converse_phase: Arc<AtomicU8>,
+    /// Set true by the listen VAD when the human starts speaking during the
+    /// in-flight converse; reset false when a converse begins. Read by
+    /// `converse_result` to populate `ConverseView::heard_speech`.
+    converse_heard_speech: Arc<AtomicBool>,
     pub notify: Notify,
 }
 
@@ -207,6 +217,7 @@ impl RequestQueue {
             converse_results: Mutex::new(VecDeque::new()),
             waiters: Mutex::new(HashMap::new()),
             converse_phase: Arc::new(AtomicU8::new(CONVERSE_PHASE_IDLE)),
+            converse_heard_speech: Arc::new(AtomicBool::new(false)),
             notify: Notify::new(),
         }
     }
@@ -215,6 +226,13 @@ impl RequestQueue {
     /// CONVERSE_PHASE_* on it as a converse moves speak -> listen.
     pub fn converse_phase(&self) -> Arc<AtomicU8> {
         self.converse_phase.clone()
+    }
+
+    /// Handle to the in-flight converse speech-detected flag. The worker resets
+    /// it false as a converse begins and sets it true when the listen VAD hears
+    /// the human start speaking.
+    pub fn converse_heard_speech(&self) -> Arc<AtomicBool> {
+        self.converse_heard_speech.clone()
     }
 
     /// Snapshot of audio load taken before enqueue: (something is playing now,
@@ -242,12 +260,14 @@ impl RequestQueue {
                 ItemStatus::Failed => ConverseView {
                     phase: "failed",
                     mic_active: false,
+                    heard_speech: false,
                     result: None,
                     error: entry.result.clone(),
                 },
                 _ => ConverseView {
                     phase: "completed",
                     mic_active: false,
+                    heard_speech: false,
                     result: entry.result.clone(),
                     error: None,
                 },
@@ -265,6 +285,7 @@ impl RequestQueue {
             return ConverseView {
                 phase: if listening { "listening" } else { "speaking" },
                 mic_active: listening,
+                heard_speech: listening && self.converse_heard_speech.load(Ordering::SeqCst),
                 result: None,
                 error: None,
             };
@@ -274,6 +295,7 @@ impl RequestQueue {
             return ConverseView {
                 phase: "queued",
                 mic_active: false,
+                heard_speech: false,
                 result: None,
                 error: None,
             };
@@ -282,6 +304,7 @@ impl RequestQueue {
         ConverseView {
             phase: "unknown",
             mic_active: false,
+            heard_speech: false,
             result: None,
             error: None,
         }
@@ -720,6 +743,13 @@ mod tests {
         let view = queue.converse_result(&id).await;
         assert_eq!(view.phase, "listening");
         assert!(view.mic_active);
+        // Mic open but the human hasn't started: heard_speech stays false.
+        assert!(!view.heard_speech);
+
+        // VAD detects speech -> heard_speech flips true while still listening.
+        queue.converse_heard_speech().store(true, Ordering::SeqCst);
+        let view = queue.converse_result(&id).await;
+        assert!(view.heard_speech);
 
         queue
             .complete(Some(r#"{"heard":{"text":"yes"}}"#.to_string()))

--- a/crates/voice-daemon/src/socket.rs
+++ b/crates/voice-daemon/src/socket.rs
@@ -577,6 +577,7 @@ async fn dispatch(
                         "converse_id": converse_id,
                         "phase": view.phase,
                         "mic_active": view.mic_active,
+                        "heard_speech": view.heard_speech,
                     });
                     if let Some(result) = view.result {
                         obj["result"] = serde_json::Value::String(result);

--- a/crates/voice-daemon/src/worker.rs
+++ b/crates/voice-daemon/src/worker.rs
@@ -330,7 +330,7 @@ pub async fn run(
                     let cancelled = entry.cancelled.clone();
 
                     let result = tokio::task::spawn_blocking(move || {
-                        listen_bounded(&stt, max_ms, &cancelled)
+                        listen_bounded(&stt, max_ms, &cancelled, None)
                     })
                     .await;
 
@@ -373,6 +373,11 @@ pub async fn run(
                     let phase = queue.converse_phase();
                     phase.store(CONVERSE_PHASE_SPEAKING, Ordering::SeqCst);
                     let job_phase = phase.clone();
+                    // Speech-detected flag: reset now; the listen VAD sets it true
+                    // once the human actually starts talking.
+                    let heard_speech = queue.converse_heard_speech();
+                    heard_speech.store(false, Ordering::SeqCst);
+                    let job_heard = heard_speech.clone();
 
                     // Speak then listen, return combined JSON
                     let speak_result = tokio::task::spawn_blocking(move || {
@@ -392,7 +397,8 @@ pub async fn run(
                             .map_err(|_| "stt warmup panicked".to_string())??;
                         // Mic is about to open — caller can now see mic_active.
                         job_phase.store(CONVERSE_PHASE_LISTENING, Ordering::SeqCst);
-                        let heard_json = listen_bounded(&stt, max_duration_ms, &cancelled)?;
+                        let heard_json =
+                            listen_bounded(&stt, max_duration_ms, &cancelled, Some(job_heard))?;
                         // Parse both results and combine into the converse format
                         let spoke: serde_json::Value =
                             serde_json::from_str(&spoke_json).unwrap_or_default();
@@ -1162,6 +1168,7 @@ fn listen_bounded(
     stt: &Arc<Mutex<Option<voice_stt::WhisperModel>>>,
     max_duration_ms: Option<u64>,
     cancelled: &Arc<AtomicBool>,
+    heard_speech: Option<Arc<AtomicBool>>,
 ) -> Result<String, String> {
     let max_ms = max_duration_ms.unwrap_or(60000);
     let timeout = Duration::from_millis(max_ms.saturating_add(LISTEN_OPEN_GRACE_MS));
@@ -1171,7 +1178,7 @@ fn listen_bounded(
     let cancelled_for_thread = cancelled.clone();
 
     std::thread::spawn(move || {
-        let result = listen(&stt, max_duration_ms, &cancelled_for_thread);
+        let result = listen(&stt, max_duration_ms, &cancelled_for_thread, heard_speech);
         let _ = tx.send(result);
     });
 
@@ -1202,6 +1209,7 @@ fn listen(
     stt: &Arc<Mutex<Option<voice_stt::WhisperModel>>>,
     max_duration_ms: Option<u64>,
     cancelled: &Arc<AtomicBool>,
+    heard_speech: Option<Arc<AtomicBool>>,
 ) -> Result<String, String> {
     ensure_stt(stt)?;
 
@@ -1316,6 +1324,11 @@ fn listen(
             if !speech_detected {
                 eprintln!("voice daemon: speech detected (peak: {:.4})", peak);
                 speech_detected = true;
+                // Tell converse_result the human has started (vs mic merely open),
+                // so the MCP can wait through the reply instead of handing back early.
+                if let Some(flag) = &heard_speech {
+                    flag.store(true, Ordering::Relaxed);
+                }
             }
             last_speech = Instant::now();
         } else if speech_detected && last_speech.elapsed() > silence_timeout {


### PR DESCRIPTION
`converse` returned a `converse_id` immediately and left the agent to poll `converse_result` in a loop. The agent does that unconditionally, so the async split just burned tool-call round-trips (and tokens) for no benefit. This moves the poll loop into the MCP so `converse` behaves like a blocking API with a timeout: one call, one reply.

## Behavior

`converse` fires the daemon converse and waits on it internally:

| Daemon state | MCP does |
|---|---|
| speaking (TTS playing) | keep waiting |
| listening, no speech yet, < 8s grace | keep waiting |
| listening, no speech, ≥ 8s grace | return `{status:"pending", converse_id}` (human is busy) |
| listening, **speech detected** | wait through the whole reply |
| completed | return `{status:"completed", heard, spoke}` |
| past 90s ceiling | return `{status:"pending", converse_id}` |

`converse_result` is unchanged - it's the escape-hatch poll for the pending cases. The grace clock starts when the mic opens, so the spoken prompt's own duration never eats into it.

## The speech-detected signal

Telling "mic open, human silent" from "human mid-answer" needs a signal the daemon didn't expose (`mic_active` is just `phase == listening`). The listen VAD already computes speech detection; this surfaces it: the worker resets a per-converse `heard_speech` flag when a converse begins and sets it true when the VAD first fires, and `converse_result` reports it as `ConverseView.heard_speech`. That's what gates "wait through the reply" vs "hand back early."

## Deferred

Streaming partial transcripts (return part of a long answer mid-stream) need streaming STT we don't have yet. The state machine leaves room for it.

## Test plan

- [x] `cargo clippy -p voice -p voice-daemon --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p voice -p voice-daemon` (heard_speech reporting + MCP result-shaping helpers)
- [ ] Dogfood: converse where the human replies returns the transcript directly; converse where the human stays silent hands back a converse_id after the grace window
