### PR TITLE
Remove dead code and a stray scratch artifact

### DIFF
--- a/crates/voice-cli/src/jsonrpc.rs
+++ b/crates/voice-cli/src/jsonrpc.rs
@@ -82,8 +82,6 @@ struct RpcError {
 
 // Standard JSON-RPC error codes
 const PARSE_ERROR: i64 = -32700;
-#[allow(dead_code)]
-const INVALID_REQUEST: i64 = -32600;
 const METHOD_NOT_FOUND: i64 = -32601;
 const INVALID_PARAMS: i64 = -32602;
 const INTERNAL_ERROR: i64 = -32603;

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -1160,31 +1160,6 @@ pub fn listen_continuous() {
     }
 }
 
-/// Run continuous listen for JSON-RPC, yielding segment results.
-///
-/// Returns a receiver of SegmentResult. The caller (jsonrpc dispatch)
-/// sends notifications per result and a final response on completion.
-#[allow(dead_code)]
-pub fn listen_continuous_for_rpc(
-    model: voice_stt::WhisperModel,
-    silence_timeout_ms: u64,
-    max_duration_ms: u64,
-    noise_multiplier: f32,
-    calibration_ms: u64,
-) -> Result<mpsc::Receiver<SegmentResult>, String> {
-    let (segments_rx, _sample_rate, _handle) = record_continuous(
-        silence_timeout_ms,
-        0.01, // silence_threshold
-        max_duration_ms,
-        500,    // min_segment_ms
-        30_000, // max_segment_ms
-        noise_multiplier,
-        calibration_ms,
-    )?;
-
-    Ok(transcribe_segments(model, segments_rx))
-}
-
 // ── Audio processing ───────────────────────────────────────────────────
 
 /// Trim leading and trailing silence from audio samples.

--- a/crates/voice-kokoro/src/istftnet.rs
+++ b/crates/voice-kokoro/src/istftnet.rs
@@ -929,25 +929,6 @@ impl Decoder {
 // Helper functions
 // ---------------------------------------------------------------------------
 
-/// Cumulative sum along dimension 1.
-#[allow(dead_code)]
-fn cumsum_dim1(x: &Tensor) -> Result<Tensor> {
-    let (_b, seq_len, _d) = x.dims3()?;
-    if seq_len <= 1 {
-        return Ok(x.clone());
-    }
-
-    // Build cumsum by iterative addition
-    let mut slices = Vec::with_capacity(seq_len);
-    slices.push(x.narrow(1, 0, 1)?);
-    for i in 1..seq_len {
-        let prev = &slices[i - 1];
-        let curr = x.narrow(1, i, 1)?;
-        slices.push((prev + curr)?);
-    }
-    Tensor::cat(&slices, 1)
-}
-
 /// Nearest-neighbor 1D upsampling for a 2D tensor [B, T] -> [B, T*factor]
 fn upsample_nearest_1d_single(x: &Tensor, factor: usize) -> Result<Tensor> {
     let (b, t) = x.dims2()?;

--- a/transcript.txt
+++ b/transcript.txt
@@ -1,1 +1,0 @@
-All right, today we're going to work on the CodeMir CRDT bridge. So right now, SourceText has its own dedicated path that bypasses both the store and the old updated cell source function.


### PR DESCRIPTION
Removes experimentation leftovers, each confirmed unused across the workspace. Clippy `-D warnings` on the full workspace confirms nothing became newly dead.

| Removed | Where | Why |
|---|---|---|
| `cumsum_dim1()` | voice-kokoro/src/istftnet.rs | `#[allow(dead_code)]`, zero callers |
| `listen_continuous_for_rpc()` | voice-cli/src/listen.rs | abandoned JSON-RPC streaming scaffold, no callers |
| `const INVALID_REQUEST` | voice-cli/src/jsonrpc.rs | never emitted; the live copy is in voice-protocol |
| `transcript.txt` | repo root | tracked scratch transcript |

`listen_continuous_for_rpc`'s helpers (`record_continuous`, `transcribe_segments`, `SegmentResult`) stay in use by the live `listen_continuous`, so they're untouched.

## Not in this pass (need a decision)

Left out of this PR because they're not pure deletions:
- Gating the daemon's device-rate diagnostics behind a debug flag.
- Removing per-crate unused deps (several are workspace-inherited / possibly platform-conditional; wants a `cargo machete` + Linux check).
- `TtsState.default_voice_name` write-only field.
- The publish-list gap (some crates missing from release.yml + path-only deps).
