### PR TITLE
Drop unused dependencies from four crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3923,7 +3923,6 @@ dependencies = [
  "dirs",
  "hound",
  "rodio",
- "serde",
  "serde_json",
  "tokio",
  "uuid",
@@ -3969,14 +3968,11 @@ dependencies = [
  "bytemuck",
  "candle-core",
  "candle-nn",
- "candle-transformers",
- "half",
  "hf-hub",
  "hound",
  "safetensors 0.8.0",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4004,12 +4000,9 @@ version = "0.2.0"
 dependencies = [
  "candle-core",
  "candle-nn",
- "candle-transformers",
  "hf-hub",
  "hound",
  "rubato",
- "safetensors 0.8.0",
- "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokenizers",
@@ -4055,7 +4048,6 @@ dependencies = [
  "candle-nn",
  "candle-transformers",
  "rand 0.10.1",
- "thiserror 2.0.18",
  "tokenizers",
 ]
 

--- a/crates/voice-daemon/Cargo.toml
+++ b/crates/voice-daemon/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/rgbkrk/voice"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
-serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"

--- a/crates/voice-kokoro/Cargo.toml
+++ b/crates/voice-kokoro/Cargo.toml
@@ -10,13 +10,10 @@ repository = "https://github.com/rgbkrk/voice"
 [dependencies]
 candle-core = { workspace = true }
 candle-nn = { workspace = true }
-candle-transformers = { workspace = true }
-half = { version = "2", features = ["num-traits"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 hf-hub = { workspace = true }
 safetensors = { workspace = true }
-thiserror = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 candle-core = { workspace = true, features = ["metal"] }

--- a/crates/voice-stt/Cargo.toml
+++ b/crates/voice-stt/Cargo.toml
@@ -12,9 +12,6 @@ voice-whisper = { path = "../voice-whisper" }
 voice-voxtral = { path = "../voice-voxtral" }
 candle-core = { workspace = true }
 candle-nn = { workspace = true }
-candle-transformers = { workspace = true }
-safetensors = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 hf-hub = { workspace = true }
 hound = { workspace = true }

--- a/crates/voice-whisper/Cargo.toml
+++ b/crates/voice-whisper/Cargo.toml
@@ -13,5 +13,4 @@ candle-nn = { workspace = true }
 candle-transformers = { workspace = true }
 byteorder = "1"
 tokenizers = { workspace = true }
-thiserror = { workspace = true }
 rand = "0.10"


### PR DESCRIPTION
Removes declared-but-unused dependencies from four crates. Each was flagged by `cargo-machete`, cross-checked with a per-crate source grep, and confirmed by a clean `cargo build --workspace`; `cargo-machete` reports clean afterward.

| Crate | Removed |
|---|---|
| voice-whisper | thiserror |
| voice-daemon | serde (only serde_json used directly) |
| voice-kokoro | candle-transformers, half, thiserror |
| voice-stt | candle-transformers, safetensors, serde |

`candle-transformers` stays in **voice-whisper** — that's where the Whisper model actually lives. The `safetensors` hits in `voice-stt/src` are the `"model.safetensors"` filename string and doc comments, not the crate.

Verified: `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`, tests on the four crates. Note CI is macOS-only; machete's scan is source-level and includes cfg-gated `use`, and none of these appear in any cfg block, so the Linux path is unaffected.
