### PR TITLE
Complete the crates.io release list and version all path deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,10 +94,13 @@ jobs:
           publish voice-g2p
           publish voice-kokoro
           publish voice-whisper
+          publish voice-voxtral
+          publish voice-audio
 
           # Model-facing libraries
           publish voice-tts
           publish voice-stt
 
-          # voice (CLI) depends on the libraries above
+          # Daemon depends on the libraries above; CLI depends on the daemon
+          publish voice-daemon
           publish voice

--- a/crates/voice-cli/Cargo.toml
+++ b/crates/voice-cli/Cargo.toml
@@ -28,7 +28,7 @@ pubkey = "RWRmHACtt9SpjQB/l+dAoCe+3iqxq/Xe/90P6dyCW70axzy3UkWl+Ave"
 
 [dependencies]
 voice-tts = { version = "0.3.0", path = "../voice-tts" }
-voice-voxtral = { path = "../voice-voxtral" }
+voice-voxtral = { version = "0.1.0", path = "../voice-voxtral" }
 candle-core = { workspace = true }
 voice-g2p = { version = "0.2.2", path = "../voice-g2p" }
 voice-stt = { version = "0.2.0", path = "../voice-stt" }
@@ -39,10 +39,10 @@ pulldown-cmark = "0.13.1"
 ctrlc = "3.5.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
-voice-protocol = { path = "../voice-protocol" }
-voice-stream = { path = "../voice-stream" }
-voice-audio = { path = "../voice-audio" }
-voice-daemon = { path = "../voice-daemon" }
+voice-protocol = { version = "0.1.0", path = "../voice-protocol" }
+voice-stream = { version = "0.1.0", path = "../voice-stream" }
+voice-audio = { version = "0.1.0", path = "../voice-audio" }
+voice-daemon = { version = "0.1.0", path = "../voice-daemon" }
 dirs = "6"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/crates/voice-daemon/Cargo.toml
+++ b/crates/voice-daemon/Cargo.toml
@@ -12,13 +12,13 @@ tokio = { version = "1", features = ["full"] }
 serde_json = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"
-voice-protocol = { path = "../voice-protocol" }
-voice-tts = { path = "../voice-tts" }
-voice-voxtral = { path = "../voice-voxtral" }
-voice-stt = { path = "../voice-stt" }
-voice-g2p = { path = "../voice-g2p" }
-voice-stream = { path = "../voice-stream" }
-voice-audio = { path = "../voice-audio" }
+voice-protocol = { version = "0.1.0", path = "../voice-protocol" }
+voice-tts = { version = "0.3.0", path = "../voice-tts" }
+voice-voxtral = { version = "0.1.0", path = "../voice-voxtral" }
+voice-stt = { version = "0.2.0", path = "../voice-stt" }
+voice-g2p = { version = "0.2.2", path = "../voice-g2p" }
+voice-stream = { version = "0.1.0", path = "../voice-stream" }
+voice-audio = { version = "0.1.0", path = "../voice-audio" }
 candle-core = { workspace = true }
 rodio = { version = "0.22", features = ["experimental"] }
 hound = { workspace = true }

--- a/crates/voice-eval/Cargo.toml
+++ b/crates/voice-eval/Cargo.toml
@@ -6,6 +6,9 @@ rust-version = "1.95.0"
 description = "Local TTS intelligibility evaluation harness for voice"
 license = "MIT"
 repository = "https://github.com/rgbkrk/voice"
+# App-only eval harness, not a library. Nothing downstream depends on it, so it
+# stays out of the crates.io release to avoid maintaining a public version line.
+publish = false
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/crates/voice-protocol/Cargo.toml
+++ b/crates/voice-protocol/Cargo.toml
@@ -12,7 +12,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { version = "1", features = ["io-util", "net"] }
 dirs = "6"
-voice-stream = { path = "../voice-stream" }
+voice-stream = { version = "0.1.0", path = "../voice-stream" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["io-util", "rt", "macros"] }

--- a/crates/voice-stt/Cargo.toml
+++ b/crates/voice-stt/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT"
 repository = "https://github.com/rgbkrk/voice"
 
 [dependencies]
-voice-whisper = { path = "../voice-whisper" }
-voice-voxtral = { path = "../voice-voxtral" }
+voice-whisper = { version = "0.1.0", path = "../voice-whisper" }
+voice-voxtral = { version = "0.1.0", path = "../voice-voxtral" }
 candle-core = { workspace = true }
 candle-nn = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/voice-tts/Cargo.toml
+++ b/crates/voice-tts/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/rgbkrk/voice"
 
 [dependencies]
-voice-kokoro = { path = "../voice-kokoro", default-features = false }
+voice-kokoro = { version = "0.1.0", path = "../voice-kokoro", default-features = false }
 candle-core = { workspace = true }
 candle-nn = { workspace = true }
 safetensors = { workspace = true }


### PR DESCRIPTION
The release workflow published only 8 of the 12 workspace crates, and the ones it did publish would fail `cargo publish` anyway: they depend on the omitted crates through path-only deps, which the registry rejects.

`voice-stt` (published) pulls in `voice-voxtral` path-only. `voice-daemon` and the `voice` CLI pull in `voice-voxtral`, `voice-audio`, and `voice-daemon` the same way. None of those set `publish = false`, so they were publishable by default but left off the list, and the version-less path deps would have broken the listed jobs.

## Changes

- Add a `version` key to every internal path dep that crosses into a published crate: `voice-protocol`, `voice-tts`, `voice-stt`, `voice-daemon`, `voice-cli`. Both keys stay - `path` for local workspace builds, `version` for what crates.io resolves.
- Publish `voice-voxtral`, `voice-audio`, and `voice-daemon` from `release.yml`, ordered so every dep lands before its dependents. `voice` needs `voice-daemon`, which needs voxtral/audio, so all three must publish for the CLI to publish.
- Mark `voice-eval` `publish = false`. It's an app-only eval harness and nothing downstream depends on it, so it stays out of the release rather than carrying a public version line.

The publish list is now a valid topological sort: stream, protocol, g2p, kokoro, whisper, voxtral, audio, then tts, stt, then daemon, then voice.

Closes #306.
