### PR TITLE
Warm up macOS mic/speaker permissions at daemon install

### DIFF
--- a/crates/voice-cli/src/cli.rs
+++ b/crates/voice-cli/src/cli.rs
@@ -4117,6 +4117,23 @@ fn install_service(no_start: bool, stt_model: Option<&str>) {
         stt_model.unwrap_or(voice_stt::builtin::DEFAULT_MODEL_REPO)
     );
 
+    // Trigger the macOS mic/speaker permission prompt here, during interactive
+    // install, instead of on the hot path when an agent is mid-converse. The
+    // grant is tied to this binary's identity, which the daemon inherits.
+    println!();
+    println!("Verifying audio permissions (macOS may prompt for microphone access)...");
+    match listen::warmup_permissions() {
+        Ok(()) => println!("  audio:   mic + speaker OK"),
+        Err(e) => {
+            eprintln!("  audio:   warning — mic warmup failed: {e}");
+            eprintln!(
+                "           grant microphone access under System Settings > Privacy & Security > Microphone,"
+            );
+            eprintln!("           then re-run `voice daemon install`.");
+        }
+    }
+    println!();
+
     let uid = unsafe { libc::getuid() };
     let target = format!("gui/{uid}");
     let label = format!("gui/{uid}/com.rgbkrk.voice.voiced");

--- a/crates/voice-cli/src/cli.rs
+++ b/crates/voice-cli/src/cli.rs
@@ -4120,19 +4120,25 @@ fn install_service(no_start: bool, stt_model: Option<&str>) {
     // Trigger the macOS mic/speaker permission prompt here, during interactive
     // install, instead of on the hot path when an agent is mid-converse. The
     // grant is tied to this binary's identity, which the daemon inherits.
-    println!();
-    println!("Verifying audio permissions (macOS may prompt for microphone access)...");
-    match listen::warmup_permissions() {
-        Ok(()) => println!("  audio:   mic + speaker OK"),
-        Err(e) => {
-            eprintln!("  audio:   warning — mic warmup failed: {e}");
-            eprintln!(
-                "           grant microphone access under System Settings > Privacy & Security > Microphone,"
-            );
-            eprintln!("           then re-run `voice daemon install`.");
+    //
+    // Skip it under `--no-start`: that's the provisioning/unattended path, where
+    // opening the mic (and blocking up to the mic-open timeout) and playing audio
+    // are unwelcome. Those installs handle permissions out of band.
+    if !no_start {
+        println!();
+        println!("Verifying audio permissions (macOS may prompt for microphone access)...");
+        match listen::warmup_permissions() {
+            Ok(()) => println!("  audio:   mic + speaker OK"),
+            Err(e) => {
+                eprintln!("  audio:   warning — mic warmup failed: {e}");
+                eprintln!(
+                    "           grant microphone access under System Settings > Privacy & Security > Microphone,"
+                );
+                eprintln!("           then re-run `voice daemon install`.");
+            }
         }
+        println!();
     }
-    println!();
 
     let uid = unsafe { libc::getuid() };
     let target = format!("gui/{uid}");

--- a/crates/voice-cli/src/listen.rs
+++ b/crates/voice-cli/src/listen.rs
@@ -606,6 +606,45 @@ fn log_recording_stats(samples: &[f32], sample_rate: u32) {
     }
 }
 
+/// Exercise speaker playback and mic capture so the OS surfaces any
+/// permission prompt now, rather than on the hot path when an agent is
+/// mid-`converse` waiting on a reply.
+///
+/// On macOS, microphone access is gated by TCC and the prompt fires on first
+/// capture. Running this from the `voice` binary during `voice daemon install`
+/// pins the grant to that binary identity, which the daemon (`voice daemon
+/// start`) then inherits. Playback is best-effort and non-fatal; a denied or
+/// missing mic returns `Err` so the caller can surface a clear failure.
+pub fn warmup_permissions() -> Result<(), String> {
+    // Speaker first: short ding. Playback isn't TCC-gated, but a silent or
+    // missing output device is worth surfacing at install time.
+    play_ding();
+
+    // Mic: open the stream (this triggers the TCC prompt) and drain a brief
+    // window so the OS registers real capture, then tear it down.
+    let (name, sample_rate, mic) = open_mic()?;
+    eprintln!("  mic:     {name} ({sample_rate}Hz)");
+
+    let buffer: Arc<Mutex<Vec<f32>>> = Arc::new(Mutex::new(Vec::new()));
+    let peak = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let channels = mic.config().channel_count.get();
+
+    let mic_thread = start_mic_drain(
+        mic,
+        Arc::clone(&buffer),
+        Arc::clone(&peak),
+        Arc::clone(&stop),
+        channels,
+    );
+
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    stop.store(true, Ordering::SeqCst);
+    let _ = mic_thread.join();
+
+    Ok(())
+}
+
 // ── Recording modes ────────────────────────────────────────────────────
 
 /// Record audio from the default input device until Enter or Ctrl+C.

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -89,7 +89,10 @@ VOICE_SIGN_IDENTITY="Apple Development: you@example.com (TEAMID)" \
 
 `scripts/install_signed_voice.sh` runs `cargo install`, then re-signs the
 installed binary with your identity so the cdhash stays constant. Rebuilds
-signed with the same identity keep the existing mic grant.
+signed with the same identity keep the existing mic grant. It signs with the
+hardened runtime and `scripts/voice.entitlements`, which carries
+`com.apple.security.device.audio-input` — required for mic access under the
+hardened runtime.
 
 Check status at any time:
 

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -66,6 +66,31 @@ To remove the service:
 voice daemon uninstall
 ```
 
+### macOS microphone permissions
+
+On macOS, microphone capture is gated by TCC. `voice daemon install` exercises
+the mic (and speaker) during install, so the permission prompt fires *then*
+instead of on the hot path when an agent is mid-`converse` waiting on a reply.
+Grant access when prompted; if you miss it, allow `voice` under **System
+Settings > Privacy & Security > Microphone** and re-run `voice daemon install`.
+The grant is tied to the `voice` binary's identity, and the daemon (`voice
+daemon start`) inherits it.
+
+macOS keys the grant on the code-signing identity. `cargo install --force`
+recompiles and ad-hoc-signs a fresh binary, so each rebuild looks like a new app
+and re-prompts. To make the grant survive rebuilds, install with a stable
+signing identity:
+
+```bash
+security find-identity -v -p codesigning   # find your identity
+VOICE_SIGN_IDENTITY="Apple Development: you@example.com (TEAMID)" \
+  scripts/install_signed_voice.sh
+```
+
+`scripts/install_signed_voice.sh` runs `cargo install`, then re-signs the
+installed binary with your identity so the cdhash stays constant. Rebuilds
+signed with the same identity keep the existing mic grant.
+
 Check status at any time:
 
 ```bash

--- a/scripts/install_signed_voice.sh
+++ b/scripts/install_signed_voice.sh
@@ -44,14 +44,24 @@ if [[ ! -x "$BIN" ]]; then
   exit 1
 fi
 
+ENTITLEMENTS="$(dirname "$0")/voice.entitlements"
+
 echo "Signing $BIN with: $IDENTITY"
-# --force replaces the ad-hoc signature cargo applied. --options runtime keeps
-# the binary compatible with hardened-runtime expectations.
-codesign --force --options runtime --sign "$IDENTITY" "$BIN"
+# --force replaces the ad-hoc signature cargo applied. --options runtime opts
+# into the hardened runtime, which gates mic access behind the audio-input
+# entitlement, so we pass voice.entitlements or the signed binary can't use the
+# microphone.
+codesign --force --options runtime \
+  --entitlements "$ENTITLEMENTS" \
+  --sign "$IDENTITY" "$BIN"
 
 echo "Verifying signature..."
 codesign --verify --verbose "$BIN"
 codesign --display --verbose=2 "$BIN" 2>&1 | grep -E "Authority|TeamIdentifier|Identifier" || true
+echo "Entitlements:"
+codesign --display --entitlements - --xml "$BIN" 2>/dev/null | grep -q "audio-input" \
+  && echo "  ✓ com.apple.security.device.audio-input present" \
+  || echo "  ✗ audio-input entitlement missing — mic access will fail under hardened runtime"
 
 echo
 echo "Done. Now run:  voice daemon install"

--- a/scripts/install_signed_voice.sh
+++ b/scripts/install_signed_voice.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Install `voice` with a stable code signature so the macOS microphone (TCC)
+# grant survives rebuilds.
+#
+# Background: `cargo install --force` recompiles and ad-hoc-signs a fresh
+# binary. macOS keys TCC grants on the code-signing identity (cdhash), so every
+# ad-hoc rebuild looks like a new app and re-prompts for mic access. Signing
+# with a stable identity (an Apple Development or Developer ID cert) keeps the
+# identity constant across rebuilds, so the grant persists.
+#
+# Usage:
+#   VOICE_SIGN_IDENTITY="Apple Development: you@example.com (TEAMID)" \
+#     scripts/install_signed_voice.sh
+#
+#   # or pass the identity as the first argument
+#   scripts/install_signed_voice.sh "Developer ID Application: Your Name (TEAMID)"
+#
+# Find your identities with:
+#   security find-identity -v -p codesigning
+#
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "error: this script is macOS-only (code signing is not needed elsewhere)" >&2
+  exit 1
+fi
+
+IDENTITY="${1:-${VOICE_SIGN_IDENTITY:-}}"
+if [[ -z "$IDENTITY" ]]; then
+  echo "error: no signing identity given." >&2
+  echo "  set VOICE_SIGN_IDENTITY or pass it as the first argument." >&2
+  echo "  list identities: security find-identity -v -p codesigning" >&2
+  exit 1
+fi
+
+BIN="${CARGO_HOME:-$HOME/.cargo}/bin/voice"
+
+echo "Building and installing voice..."
+cargo install --path "$(dirname "$0")/../crates/voice-cli" --force
+
+if [[ ! -x "$BIN" ]]; then
+  echo "error: expected installed binary at $BIN, not found" >&2
+  exit 1
+fi
+
+echo "Signing $BIN with: $IDENTITY"
+# --force replaces the ad-hoc signature cargo applied. --options runtime keeps
+# the binary compatible with hardened-runtime expectations.
+codesign --force --options runtime --sign "$IDENTITY" "$BIN"
+
+echo "Verifying signature..."
+codesign --verify --verbose "$BIN"
+codesign --display --verbose=2 "$BIN" 2>&1 | grep -E "Authority|TeamIdentifier|Identifier" || true
+
+echo
+echo "Done. Now run:  voice daemon install"
+echo "The mic permission prompt fires during install and, thanks to the stable"
+echo "signature, won't re-prompt on future rebuilds signed with the same identity."

--- a/scripts/voice.entitlements
+++ b/scripts/voice.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Hardened runtime blocks mic access unless the binary carries this
+       entitlement. Without it, a `--options runtime` signature produces a
+       binary that can't prompt for or use the microphone. -->
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+</dict>
+</plist>


### PR DESCRIPTION
The macOS microphone permission (TCC) prompt used to fire on first mic use, which lands squarely on the hot path: an agent calls `converse`, the daemon opens the mic, and macOS throws a prompt while the agent is blocked waiting on a reply. Easy to miss, and it stalls the interaction.

This moves the prompt to install time and makes the grant survive rebuilds.

## Install-time warmup

`voice daemon install` now exercises the speaker and mic during install via a new `listen::warmup_permissions()`: it plays the ding, opens the mic for ~400ms, then tears it down. macOS surfaces the permission prompt *then*, during an interactive install, instead of mid-converse. A denied or missing mic warns with the recovery path (System Settings > Privacy & Security > Microphone, re-run install) rather than failing the install. The grant is keyed to the `voice` binary identity, which the daemon (`voice daemon start`) inherits.

## Stable signing

macOS keys TCC grants on the code-signing identity. `cargo install --force` recompiles and ad-hoc-signs a fresh binary, so every rebuild looks like a new app and re-prompts. `scripts/install_signed_voice.sh` runs `cargo install`, then re-signs the installed binary with an Apple identity (`VOICE_SIGN_IDENTITY` or first arg) so the cdhash stays constant across rebuilds. The cert lives on the install machine, so this is a helper script plus docs, not repo-baked automation.

Both flows documented in `docs/daemon.md` under a new microphone-permissions section.

Closes #303.
