### PR TITLE
Draft: Add Parakeet MLX STT feasibility harness

### DIFF
--- a/docs/parakeet-stt-feasibility.md
+++ b/docs/parakeet-stt-feasibility.md
@@ -160,12 +160,19 @@ uv run --with parakeet-mlx python eval/evaluate.py \
 
 The default engine remains the existing `voice` CLI path. The shell wrappers
 also keep their default Whisper model matrix unchanged; set `PARAKEET_MLX=1`
-to add an opt-in Parakeet pass:
+to add an opt-in Parakeet pass. The wrappers run that Parakeet pass through
+`uv run --with parakeet-mlx`, so a clean checkout needs `uv` but does not need a
+preinstalled `parakeet-mlx` console script:
 
 ```bash
 PARAKEET_MLX=1 ./eval/compare.sh target/debug/voice
 PARAKEET_MLX=1 ./eval/synth_eval.sh target/debug/voice
 ```
+
+Parakeet infrastructure failures are strict by default. If the Parakeet binary
+is missing or the subprocess exits nonzero, `eval/evaluate.py` records the item
+error and exits nonzero. Use `--allow-errors` only for exploratory scoring where
+empty/error transcripts should not fail the command.
 
 ## Streaming assessment
 

--- a/docs/parakeet-stt-feasibility.md
+++ b/docs/parakeet-stt-feasibility.md
@@ -1,0 +1,215 @@
+# Parakeet STT feasibility
+
+This note records the focused feasibility pass for using NVIDIA Parakeet as an
+alternative STT backend for `voice`.
+
+## Status
+
+Parakeet is feasible on this Mac today through MLX, but not yet as a native
+Rust/Candle backend. The practical near-term use is an external, explicit eval
+or final-pass transcription harness. It should not replace Whisper in
+`voice listen`, `voice transcribe`, or the daemon until a larger quality pass
+proves better behavior on live voice recordings.
+
+The local smoke on the existing `eval/recordings` fixtures did not show a
+clear quality win. Parakeet TDT v3 loaded and ran locally, but it missed the
+start of both fixture utterances. The current Whisper default
+`distil-whisper/distil-large-v3.5` also missed leading words on these fixtures,
+so the next quality slice should use freshly recorded Vodex-style utterances
+and inspect the fixture leading audio rather than overfitting to these two
+short files.
+
+## Current artifacts
+
+| Model | Runtime artifact | Size evidence | Status |
+| --- | --- | --- | --- |
+| `mlx-community/parakeet-tdt-0.6b-v3` | MLX `model.safetensors`, config, tokenizer | HF API reports `model.safetensors` as 2,508,288,736 bytes | Tested locally |
+| `mlx-community/parakeet-tdt-0.6b-v2` | MLX `model.safetensors`, config, tokenizer | HF API reports `model.safetensors` as 2,471,559,904 bytes | Artifact confirmed; local smoke attempted and interrupted |
+| `mlx-community/parakeet-ctc-1.1b` | MLX `model.safetensors`, config, tokenizer | HF API reports `model.safetensors` as 4,250,695,964 bytes | Artifact confirmed, not smoke-tested |
+| `nvidia/parakeet-tdt-0.6b-v3` | Transformers/HF safetensors plus `.nemo` | HF API reports `model.safetensors` as 2,508,311,120 bytes and `.nemo` as 2,509,332,480 bytes | Source artifact confirmed |
+
+Primary source pointers:
+
+- NVIDIA Parakeet TDT v3 model card:
+  https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3
+- NVIDIA Parakeet TDT v2 model card:
+  https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2
+- NVIDIA Parakeet CTC 1.1B model card:
+  https://huggingface.co/nvidia/parakeet-ctc-1.1b
+- MLX Community Parakeet collection:
+  https://huggingface.co/collections/mlx-community/parakeet
+- `parakeet-mlx` implementation:
+  https://github.com/senstella/parakeet-mlx
+- Apple MLX project:
+  https://opensource.apple.com/projects/mlx
+
+## Local smoke evidence
+
+Machine/runtime prerequisites:
+
+```bash
+which uv
+which ffmpeg
+uname -m
+```
+
+Observed:
+
+- `uv`: `/opt/homebrew/bin/uv`
+- `ffmpeg`: `/opt/homebrew/bin/ffmpeg`
+- architecture: `arm64`
+
+First-run Parakeet TDT v3 smoke:
+
+```bash
+rm -rf /tmp/voice-parakeet-smoke-v3
+mkdir -p /tmp/voice-parakeet-smoke-v3
+/usr/bin/time -p uvx --from parakeet-mlx parakeet-mlx \
+  eval/recordings/001.wav \
+  --model mlx-community/parakeet-tdt-0.6b-v3 \
+  --output-dir /tmp/voice-parakeet-smoke-v3 \
+  --output-format json \
+  --verbose
+```
+
+Result:
+
+- First run wall time including package/model download: `real 810.15`
+- Transcript: `Fox jumps over the lazy dog.`
+- Expected: `The quick brown fox jumps over the lazy dog.`
+- Output JSON: `/tmp/voice-parakeet-smoke-v3/001.json`
+- Cached model path:
+  `~/.cache/huggingface/hub/models--mlx-community--parakeet-tdt-0.6b-v3`
+- Cached model blob:
+  `blobs/05e01c7f396c298cf7d23f61da7b504adeab698f0aaeafd9c82d198625464592`
+  at 2,508,288,736 bytes
+
+Cached two-fixture Parakeet TDT v3 eval:
+
+```bash
+/usr/bin/time -p uv run --with parakeet-mlx python eval/evaluate.py \
+  --recordings eval/recordings \
+  --engine parakeet-mlx \
+  --json-out /tmp/voice-parakeet-eval-v3.json
+```
+
+Result:
+
+- Model: `mlx-community/parakeet-tdt-0.6b-v3`
+- Wall time: `real 5.30`
+- Audio duration: `17.1s`
+- Aggregate RTF: `0.2816`
+- Exact: `0/2`
+- Mean WER: `41.7%`
+- `001`: `Fox jumps over the lazy dog.`
+- `002`: `Shells by the seashore.`
+
+Parakeet TDT v2 attempted smoke:
+
+```bash
+/usr/bin/time -p uv run --with parakeet-mlx python eval/evaluate.py \
+  --recordings eval/recordings \
+  --engine parakeet-mlx \
+  --model mlx-community/parakeet-tdt-0.6b-v2 \
+  --json-out /tmp/voice-parakeet-eval-v2.json
+```
+
+Result:
+
+- Interrupted after `real 182.06` because no visible model-cache progress was
+  observed beyond a 40 KB repo stub.
+- No `parakeet-mlx` child process remained after interrupt.
+- v2 remains artifact-confirmed through Hugging Face, but not locally
+  smoke-tested in this branch.
+
+Current Rust Whisper comparison from this checkout:
+
+```bash
+cargo build -p voice
+/usr/bin/time -p python3 eval/evaluate.py \
+  --recordings eval/recordings \
+  --voice target/debug/voice \
+  --model distil-whisper/distil-large-v3.5 \
+  --json-out /tmp/voice-whisper-eval-large-v3-5.json
+```
+
+Result:
+
+- Build initially required `git lfs pull` because the Codex worktree had LFS
+  pointer files for embedded data; after that, `cargo build -p voice` passed.
+- Model: `distil-whisper/distil-large-v3.5`
+- Wall time: `real 7.67`
+- Audio duration: `17.1s`
+- Aggregate RTF: `0.4445`
+- Exact: `0/2`
+- Mean WER: `36.1%`
+- `001`: `The fox jumps over the lazy dog.`
+- `002`: `Shells by the seashore.`
+
+## Harness
+
+`eval/evaluate.py` now supports an explicit Parakeet MLX engine:
+
+```bash
+uv run --with parakeet-mlx python eval/evaluate.py \
+  --recordings eval/recordings \
+  --engine parakeet-mlx \
+  --model mlx-community/parakeet-tdt-0.6b-v3 \
+  --json-out eval/results/parakeet_mlx_v3.json
+```
+
+The default engine remains the existing `voice` CLI path. The shell wrappers
+also keep their default Whisper model matrix unchanged; set `PARAKEET_MLX=1`
+to add an opt-in Parakeet pass:
+
+```bash
+PARAKEET_MLX=1 ./eval/compare.sh target/debug/voice
+PARAKEET_MLX=1 ./eval/synth_eval.sh target/debug/voice
+```
+
+## Streaming assessment
+
+Treat Parakeet TDT v2/v3 MLX as final-pass transcription for now. The public
+`parakeet-mlx` CLI supports long-audio chunking with overlap, but it is not a
+streaming partial-transcript API for the current `voice` daemon/listen loop.
+
+NVIDIA's v2 model-card discussion points to chunked buffered inference and
+separately mentions dedicated cache-aware streaming architectures. That is not
+the same integration surface as the current foreground Whisper partial path in
+`voice-cli`, which owns VAD snapshots and calls `voice_stt::WhisperModel`
+directly.
+
+## Native Rust/Candle blockers
+
+A native implementation is plausible but non-trivial. It is not a loader swap.
+
+Main blockers:
+
+- FastConformer encoder in Candle: convolutional subsampling, depthwise
+  separable convolution modules, relative-position attention, global/local
+  attention masks, and efficient long-audio memory behavior.
+- Decoder choice:
+  - CTC is the shortest first native target because decoding is simpler.
+  - TDT/RNNT requires decoder, joint network, duration prediction, and greedy or
+    beam search with timestamp handling.
+- Tokenizer support: Parakeet MLX artifacts use `tokenizer.model` and
+  `vocab.txt`, not the Whisper `tokenizer.json` path currently embedded in
+  `voice-stt`.
+- Preprocessing parity: 16 kHz mono audio, mel/filterbank feature settings,
+  normalization, padding, and chunking need to match NeMo/Transformers configs.
+- Weight mapping: HF safetensors and `.nemo` names must be mapped into Candle
+  modules with shape checks and test fixtures.
+- Streaming/cache behavior: native final-pass transcription can come first;
+  low-latency partials would require buffered or cache-aware inference design.
+
+## Recommended next slice
+
+1. Record a small Vodex/live-voice fixture suite with leading-speech and
+   trailing-silence cases that reproduce the Whisper repetition problem.
+2. Run the new eval harness across `distil-large-v3.5`,
+   `mlx-community/parakeet-tdt-0.6b-v2`, `mlx-community/parakeet-tdt-0.6b-v3`,
+   and `mlx-community/parakeet-ctc-1.1b`.
+3. If Parakeet wins quality, add an explicit final-pass STT backend boundary
+   before daemon/listen integration.
+4. For native Rust, prototype a `voice-parakeet` crate against a CTC model
+   first, then decide whether TDT is worth the extra decoder work.

--- a/eval/compare.sh
+++ b/eval/compare.sh
@@ -41,7 +41,7 @@ done
 if [ "${PARAKEET_MLX:-0}" = "1" ]; then
     model="${PARAKEET_MODEL:-mlx-community/parakeet-tdt-0.6b-v3}"
     safe_model="${model//\//_}"
-    python3 eval/evaluate.py \
+    uv run --with parakeet-mlx python eval/evaluate.py \
         --recordings "$RECORDINGS" \
         --engine parakeet-mlx \
         --model "$model" \

--- a/eval/compare.sh
+++ b/eval/compare.sh
@@ -16,7 +16,7 @@ if [ ! -d "$RECORDINGS" ]; then
     exit 1
 fi
 
-# Models to test
+# Rust voice STT models to test
 MODELS=(
     "distil-whisper/distil-large-v3"
     "distil-whisper/distil-medium.en"
@@ -37,3 +37,14 @@ for model in "${MODELS[@]}"; do
         --json-out "$RESULTS_DIR/${safe_model}.json"
     echo ""
 done
+
+if [ "${PARAKEET_MLX:-0}" = "1" ]; then
+    model="${PARAKEET_MODEL:-mlx-community/parakeet-tdt-0.6b-v3}"
+    safe_model="${model//\//_}"
+    python3 eval/evaluate.py \
+        --recordings "$RECORDINGS" \
+        --engine parakeet-mlx \
+        --model "$model" \
+        --json-out "$RESULTS_DIR/parakeet_mlx_${safe_model}.json"
+    echo ""
+fi

--- a/eval/evaluate.py
+++ b/eval/evaluate.py
@@ -12,7 +12,11 @@ import subprocess
 import time
 import wave
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Sequence
+
+DEFAULT_VOICE_MODEL = "distil-whisper/distil-medium.en"
+DEFAULT_PARAKEET_MLX_MODEL = "mlx-community/parakeet-tdt-0.6b-v3"
 
 
 def normalize_text(text: str) -> str:
@@ -140,7 +144,7 @@ def recording_pairs(recordings: Path) -> list[tuple[str, Path, Path]]:
     return pairs
 
 
-def transcribe(voice: str, model: str, wav_path: Path) -> tuple[str, float, str | None]:
+def transcribe_voice(voice: str, model: str, wav_path: Path) -> tuple[str, float, str | None]:
     env = os.environ.copy()
     env["STT_MODEL"] = model
     start = time.perf_counter()
@@ -163,11 +167,108 @@ def transcribe(voice: str, model: str, wav_path: Path) -> tuple[str, float, str 
     return transcript, elapsed, None
 
 
-def evaluate(recordings: Path, voice: str, model: str) -> dict[str, object]:
+def parakeet_txt_output_path(output_dir: Path, wav_path: Path) -> Path:
+    return output_dir / f"{wav_path.stem}.txt"
+
+
+def build_parakeet_mlx_command(
+    parakeet_bin: str,
+    model: str,
+    wav_path: Path,
+    output_dir: Path,
+    cache_dir: Path | None,
+) -> list[str]:
+    command = [
+        parakeet_bin,
+        str(wav_path),
+        "--model",
+        model,
+        "--output-dir",
+        str(output_dir),
+        "--output-format",
+        "txt",
+        "--output-template",
+        "{filename}",
+    ]
+    if cache_dir is not None:
+        command.extend(["--cache-dir", str(cache_dir)])
+    return command
+
+
+def transcribe_parakeet_mlx(
+    parakeet_bin: str,
+    model: str,
+    wav_path: Path,
+    cache_dir: Path | None,
+) -> tuple[str, float, str | None]:
+    start = time.perf_counter()
+    with TemporaryDirectory(prefix="voice-parakeet-mlx-") as tmpdir:
+        output_dir = Path(tmpdir)
+        command = build_parakeet_mlx_command(
+            parakeet_bin,
+            model,
+            wav_path,
+            output_dir,
+            cache_dir,
+        )
+        try:
+            completed = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError as err:
+            return "", time.perf_counter() - start, str(err)
+
+        elapsed = time.perf_counter() - start
+        output_path = parakeet_txt_output_path(output_dir, wav_path)
+        transcript = ""
+        if output_path.exists():
+            transcript = output_path.read_text(encoding="utf-8").strip()
+        if completed.returncode != 0:
+            message = completed.stderr.strip() or f"exit status {completed.returncode}"
+            return transcript, elapsed, message
+        if not output_path.exists():
+            message = f"expected Parakeet MLX output not found: {output_path}"
+            return transcript, elapsed, message
+        return transcript, elapsed, None
+
+
+def transcribe(
+    engine: str,
+    voice: str,
+    parakeet_bin: str,
+    model: str,
+    wav_path: Path,
+    parakeet_cache_dir: Path | None,
+) -> tuple[str, float, str | None]:
+    if engine == "voice":
+        return transcribe_voice(voice, model, wav_path)
+    if engine == "parakeet-mlx":
+        return transcribe_parakeet_mlx(parakeet_bin, model, wav_path, parakeet_cache_dir)
+    raise ValueError(f"unsupported engine: {engine}")
+
+
+def evaluate(
+    recordings: Path,
+    engine: str,
+    voice: str,
+    parakeet_bin: str,
+    model: str,
+    parakeet_cache_dir: Path | None,
+) -> dict[str, object]:
     items = []
     for item_id, text_path, wav_path in recording_pairs(recordings):
         expected = text_path.read_text(encoding="utf-8").strip()
-        transcript, elapsed_seconds, error = transcribe(voice, model, wav_path)
+        transcript, elapsed_seconds, error = transcribe(
+            engine,
+            voice,
+            parakeet_bin,
+            model,
+            wav_path,
+            parakeet_cache_dir,
+        )
         duration_seconds = wav_duration_seconds(wav_path)
         score = score_pair(expected, transcript)
         item = {
@@ -198,8 +299,11 @@ def evaluate(recordings: Path, voice: str, model: str) -> dict[str, object]:
     )
 
     return {
+        "engine": engine,
         "model": model,
         "voice_binary": voice,
+        "parakeet_binary": parakeet_bin,
+        "parakeet_cache_dir": str(parakeet_cache_dir) if parakeet_cache_dir else None,
         "recordings": str(recordings),
         "total": total,
         "exact": exact,
@@ -223,7 +327,7 @@ def print_summary(summary: dict[str, object]) -> None:
     mean_cer = float(summary["mean_cer"])
     rtf = summary["rtf"]
 
-    print(f"=== Model: {summary['model']} ===")
+    print(f"=== Engine: {summary['engine']} | Model: {summary['model']} ===")
     for item in summary["items"]:
         status = "PASS" if item["exact"] else f"WER={float(item['wer']) * 100:.1f}%"
         print(f"  {item['id']} [{status}]")
@@ -246,15 +350,46 @@ def print_summary(summary: dict[str, object]) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--recordings", required=True, type=Path)
+    parser.add_argument(
+        "--engine",
+        choices=["voice", "parakeet-mlx"],
+        default="voice",
+        help="Transcription engine to evaluate.",
+    )
     parser.add_argument("--voice", default="./target/release/voice")
-    parser.add_argument("--model", default="distil-whisper/distil-medium.en")
+    parser.add_argument(
+        "--parakeet-bin",
+        default="parakeet-mlx",
+        help="Parakeet MLX CLI path when --engine parakeet-mlx is used.",
+    )
+    parser.add_argument(
+        "--parakeet-cache-dir",
+        type=Path,
+        help="Optional HuggingFace cache directory for Parakeet MLX models.",
+    )
+    parser.add_argument("--model")
     parser.add_argument("--json-out", type=Path)
     args = parser.parse_args()
 
     if not args.recordings.is_dir():
         parser.error(f"{args.recordings} is not a directory")
 
-    summary = evaluate(args.recordings, args.voice, args.model)
+    model = args.model
+    if model is None:
+        model = (
+            DEFAULT_PARAKEET_MLX_MODEL
+            if args.engine == "parakeet-mlx"
+            else DEFAULT_VOICE_MODEL
+        )
+
+    summary = evaluate(
+        args.recordings,
+        args.engine,
+        args.voice,
+        args.parakeet_bin,
+        model,
+        args.parakeet_cache_dir,
+    )
     print_summary(summary)
 
     if args.json_out is not None:

--- a/eval/evaluate.py
+++ b/eval/evaluate.py
@@ -9,6 +9,7 @@ import os
 import re
 import struct
 import subprocess
+import sys
 import time
 import wave
 from pathlib import Path
@@ -297,6 +298,7 @@ def evaluate(
     mean_cer = (
         sum(float(item["cer"]) for item in items) / total if total else 0.0
     )
+    error_count = sum(1 for item in items if "error" in item)
 
     return {
         "engine": engine,
@@ -307,6 +309,7 @@ def evaluate(
         "recordings": str(recordings),
         "total": total,
         "exact": exact,
+        "error_count": error_count,
         "mean_wer": mean_wer,
         "mean_cer": mean_cer,
         "total_audio_seconds": total_audio_seconds,
@@ -320,9 +323,16 @@ def evaluate(
     }
 
 
+def exit_code_for_summary(summary: dict[str, object], allow_errors: bool) -> int:
+    if allow_errors:
+        return 0
+    return 1 if int(summary.get("error_count", 0)) > 0 else 0
+
+
 def print_summary(summary: dict[str, object]) -> None:
     total = int(summary["total"])
     exact = int(summary["exact"])
+    error_count = int(summary.get("error_count", 0))
     mean_wer = float(summary["mean_wer"])
     mean_cer = float(summary["mean_cer"])
     rtf = summary["rtf"]
@@ -341,6 +351,7 @@ def print_summary(summary: dict[str, object]) -> None:
     print()
     print(
         f"  Exact: {exact}/{total}; "
+        f"Errors: {error_count}; "
         f"WER: {mean_wer * 100:.1f}%; "
         f"CER: {mean_cer * 100:.1f}%; "
         f"RTF: {rtf_text}"
@@ -366,6 +377,11 @@ def main() -> int:
         "--parakeet-cache-dir",
         type=Path,
         help="Optional HuggingFace cache directory for Parakeet MLX models.",
+    )
+    parser.add_argument(
+        "--allow-errors",
+        action="store_true",
+        help="Exit 0 even when transcription subprocesses fail.",
     )
     parser.add_argument("--model")
     parser.add_argument("--json-out", type=Path)
@@ -399,7 +415,16 @@ def main() -> int:
             encoding="utf-8",
         )
 
-    return 0
+    exit_code = exit_code_for_summary(summary, args.allow_errors)
+    if exit_code != 0:
+        error_count = int(summary.get("error_count", 0))
+        sys.stdout.flush()
+        print(
+            f"error: {error_count} transcription item(s) failed; "
+            "use --allow-errors for exploratory scoring",
+            file=sys.stderr,
+        )
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/eval/synth_eval.sh
+++ b/eval/synth_eval.sh
@@ -19,7 +19,7 @@ echo "=== Synthetic STT Evaluation ==="
 echo "Using: $VOICE"
 echo ""
 
-# Models to test
+# Rust voice STT models to test
 MODELS=(
     "distil-whisper/distil-large-v3"
     "distil-whisper/distil-medium.en"
@@ -50,3 +50,14 @@ for model in "${MODELS[@]}"; do
         --json-out "$RESULTS_DIR/synth_${safe_model}.json"
     echo ""
 done
+
+if [ "${PARAKEET_MLX:-0}" = "1" ]; then
+    model="${PARAKEET_MODEL:-mlx-community/parakeet-tdt-0.6b-v3}"
+    safe_model="${model//\//_}"
+    python3 eval/evaluate.py \
+        --recordings "$TMPDIR" \
+        --engine parakeet-mlx \
+        --model "$model" \
+        --json-out "$RESULTS_DIR/synth_parakeet_mlx_${safe_model}.json"
+    echo ""
+fi

--- a/eval/synth_eval.sh
+++ b/eval/synth_eval.sh
@@ -54,7 +54,7 @@ done
 if [ "${PARAKEET_MLX:-0}" = "1" ]; then
     model="${PARAKEET_MODEL:-mlx-community/parakeet-tdt-0.6b-v3}"
     safe_model="${model//\//_}"
-    python3 eval/evaluate.py \
+    uv run --with parakeet-mlx python eval/evaluate.py \
         --recordings "$TMPDIR" \
         --engine parakeet-mlx \
         --model "$model" \

--- a/eval/test_evaluate.py
+++ b/eval/test_evaluate.py
@@ -6,6 +6,7 @@ from eval.evaluate import (
     build_parakeet_mlx_command,
     char_error_rate,
     edit_distance,
+    exit_code_for_summary,
     normalize_text,
     parakeet_txt_output_path,
     score_pair,
@@ -96,6 +97,16 @@ class EvaluationMetricTests(unittest.TestCase):
         self.assertIn("{filename}", command)
         self.assertIn("--cache-dir", command)
         self.assertIn("/tmp/hf-cache", command)
+
+    def test_summary_with_errors_exits_nonzero_by_default(self):
+        summary = {"error_count": 1}
+
+        self.assertEqual(exit_code_for_summary(summary, allow_errors=False), 1)
+
+    def test_summary_with_errors_can_be_allowed_for_exploration(self):
+        summary = {"error_count": 1}
+
+        self.assertEqual(exit_code_for_summary(summary, allow_errors=True), 0)
 
 
 if __name__ == "__main__":

--- a/eval/test_evaluate.py
+++ b/eval/test_evaluate.py
@@ -3,9 +3,11 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from eval.evaluate import (
+    build_parakeet_mlx_command,
     char_error_rate,
     edit_distance,
     normalize_text,
+    parakeet_txt_output_path,
     score_pair,
     wav_duration_seconds,
     word_error_rate,
@@ -71,6 +73,29 @@ class EvaluationMetricTests(unittest.TestCase):
             path.write_bytes(b"RIFF" + riff_size.to_bytes(4, "little") + b"WAVE" + fmt + data)
 
             self.assertEqual(wav_duration_seconds(path), 2.0)
+
+    def test_parakeet_output_path_uses_wav_stem(self):
+        self.assertEqual(
+            parakeet_txt_output_path(Path("/tmp/out"), Path("recordings/001.wav")),
+            Path("/tmp/out/001.txt"),
+        )
+
+    def test_build_parakeet_mlx_command_uses_txt_output_and_optional_cache(self):
+        command = build_parakeet_mlx_command(
+            "parakeet-mlx",
+            "mlx-community/parakeet-tdt-0.6b-v3",
+            Path("eval/recordings/001.wav"),
+            Path("/tmp/out"),
+            Path("/tmp/hf-cache"),
+        )
+
+        self.assertEqual(command[0], "parakeet-mlx")
+        self.assertIn("--output-format", command)
+        self.assertIn("txt", command)
+        self.assertIn("--output-template", command)
+        self.assertIn("{filename}", command)
+        self.assertIn("--cache-dir", command)
+        self.assertIn("/tmp/hf-cache", command)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This is an external Parakeet feasibility harness and documentation slice, not a native Rust Parakeet backend.

- Adds `eval/evaluate.py --engine parakeet-mlx` so the existing WER/CER scorer can run MLX Parakeet on the same recording fixtures as the current `voice` CLI path.
- Adds opt-in `PARAKEET_MLX=1` support to `eval/compare.sh` and `eval/synth_eval.sh`; existing Whisper model matrices stay unchanged by default.
- Documents current Parakeet artifact status, local MLX smoke evidence, streaming constraints, Candle blockers, and a native Rust integration path in `docs/parakeet-stt-feasibility.md`.

## Feasibility status

- MLX-ready Parakeet artifacts exist today:
  - `mlx-community/parakeet-tdt-0.6b-v3`
  - `mlx-community/parakeet-tdt-0.6b-v2`
  - `mlx-community/parakeet-ctc-1.1b`
- `parakeet-mlx` runs locally on Apple Silicon without CUDA or NeMo runtime assumptions.
- Current best use in `voice` is an explicit eval/final-pass harness. This PR does not route `voice listen`, `voice transcribe`, or the daemon through Python/MLX.
- Native Candle support still needs a real Parakeet/FastConformer backend, tokenizer/preprocessor parity, and decoder work. CTC is the smallest native first target; TDT/RNNT is larger.

## Local smoke evidence

Parakeet TDT v3 first run:

```bash
/usr/bin/time -p uvx --from parakeet-mlx parakeet-mlx \
  eval/recordings/001.wav \
  --model mlx-community/parakeet-tdt-0.6b-v3 \
  --output-dir /tmp/voice-parakeet-smoke-v3 \
  --output-format json \
  --verbose
```

- First run including package/model download: `real 810.15`
- Transcript: `Fox jumps over the lazy dog.`
- Expected: `The quick brown fox jumps over the lazy dog.`
- Cache: `~/.cache/huggingface/hub/models--mlx-community--parakeet-tdt-0.6b-v3`
- Cached model blob size: `2,508,288,736` bytes

Cached Parakeet TDT v3 eval:

```bash
/usr/bin/time -p uv run --with parakeet-mlx python eval/evaluate.py \
  --recordings eval/recordings \
  --engine parakeet-mlx \
  --json-out /tmp/voice-parakeet-eval-v3.json
```

- Wall time: `real 5.30`
- Audio duration: `17.1s`
- RTF: `0.2816`
- Exact: `0/2`
- Mean WER: `41.7%`
- Outputs: `001 => Fox jumps over the lazy dog.`, `002 => Shells by the seashore.`

Current Rust Whisper default comparison:

```bash
git lfs pull
cargo build -p voice
/usr/bin/time -p python3 eval/evaluate.py \
  --recordings eval/recordings \
  --voice target/debug/voice \
  --model distil-whisper/distil-large-v3.5 \
  --json-out /tmp/voice-whisper-eval-large-v3-5.json
```

- `cargo build -p voice` passed after LFS data was fetched into this Codex worktree.
- Wall time: `real 7.67`
- Audio duration: `17.1s`
- RTF: `0.4445`
- Exact: `0/2`
- Mean WER: `36.1%`
- Outputs: `001 => The fox jumps over the lazy dog.`, `002 => Shells by the seashore.`

Parakeet TDT v2:

- Artifact confirmed through HF API.
- Local smoke was attempted with `mlx-community/parakeet-tdt-0.6b-v2` and interrupted after `real 182.06` because no visible model-cache progress occurred beyond a 40 KB repo stub.

## Verification

```bash
git diff --check
python3 -m unittest eval.test_evaluate
bash -n eval/compare.sh
bash -n eval/synth_eval.sh
git lfs pull
cargo build -p voice
uvx --from parakeet-mlx parakeet-mlx --help
uv run --with parakeet-mlx python eval/evaluate.py --recordings eval/recordings --engine parakeet-mlx --json-out /tmp/voice-parakeet-eval-v3.json
python3 eval/evaluate.py --recordings eval/recordings --voice target/debug/voice --model distil-whisper/distil-large-v3.5 --json-out /tmp/voice-whisper-eval-large-v3-5.json
```

## Review fixes

Follow-up commit `122a831` addresses the first adversarial review pass:

- Parakeet transcription infrastructure errors now set `error_count` and make `eval/evaluate.py` exit nonzero by default.
- `--allow-errors` is available only for exploratory runs that intentionally want empty/error transcripts scored without failing the process.
- `eval/compare.sh` and `eval/synth_eval.sh` now run the optional Parakeet leg through `uv run --with parakeet-mlx python eval/evaluate.py`, so a clean checkout with `uv` does not need a preinstalled `parakeet-mlx` script.

Review-fix verification:

```bash
git diff --check
python3 -m unittest eval.test_evaluate
bash -n eval/compare.sh
bash -n eval/synth_eval.sh
cargo build -p voice
uv run --with parakeet-mlx python -c "import shutil; print(shutil.which('parakeet-mlx'))"
python3 eval/evaluate.py --recordings eval/recordings --engine parakeet-mlx --parakeet-bin /tmp/missing-parakeet-mlx --json-out /tmp/voice-parakeet-missing-bin-after-fix.json
python3 eval/evaluate.py --recordings eval/recordings --engine parakeet-mlx --parakeet-bin /tmp/missing-parakeet-mlx --allow-errors --json-out /tmp/voice-parakeet-missing-bin-allow-errors.json
uv run --with parakeet-mlx python eval/evaluate.py --recordings eval/recordings --engine parakeet-mlx --json-out /tmp/voice-parakeet-eval-v3-after-fix.json
```

Missing-bin behavior after the fix:

- Default strict command exits `1`.
- It prints `error: 2 transcription item(s) failed; use --allow-errors for exploratory scoring`.
- The JSON contains `"error_count": 2`.
- The same missing-bin command exits `0` only when `--allow-errors` is set.

## Review status

Draft intentionally. This should get adversarial Codex review before it is marked ready, especially around the harness API shape and the feasibility conclusion.
